### PR TITLE
NP-978: User access rights

### DIFF
--- a/publication-commons/src/test/resources/features/AnonymousAccessRights.feature
+++ b/publication-commons/src/test/resources/features/AnonymousAccessRights.feature
@@ -39,7 +39,6 @@ Feature: Anonymous access rights
     Then CREATE returns a response that this action is not allowed
 
   Scenario Outline: Anonymous user tries to update/delete material
-    Given a publication with ID "PubId"
     When <non-read-action> is called on behalf of the Anonymous user for the publication "PubId"
     Then <non-read-action> returns a response that this action is not allowed
 
@@ -47,6 +46,7 @@ Feature: Anonymous access rights
       | non-read-action |
       | UPDATE          |
       | DELETE          |
+      | PUBLISH         |
 
   Scenario: Anonymous users can see published material when they list publications
     Given that DynamoDBPublicationService has a LIST method
@@ -63,4 +63,4 @@ Feature: Anonymous access rights
     And the owner of "PubID" is the user with username "theCreator"
     When LIST is called on behalf of the Anonymous user for the user "theCreator"
     Then the "PubId" publication is NOT in the result-set
- 
+

--- a/publication-commons/src/test/resources/features/UserAccessRights.feature
+++ b/publication-commons/src/test/resources/features/UserAccessRights.feature
@@ -1,0 +1,118 @@
+Feature: User access rights
+
+
+  Background:
+    Given that there is a database "PUBLICATIONS" with publications
+    And that DynamoDBPublicationService exists
+    And the DynamoDBPublicationService has a READ method
+    And the READ method requires a user with non empty username
+    And the READ method requires a non empty publication ID
+    And the DynamoDBPublicationService has an UPDATE method
+    And the UPDATE method requires a user with non empty username
+    And the UPDATE method requires a non empty publication ID
+    And the DynamoDBPublicationService has an DELETE method
+    And the DELETE method requires a user with non empty username
+    And the DELETE method requires a non empty publication ID
+    And the DynamoDBPublicationService has a CREATE method
+    And the CREATE method requires a user with non empty username
+    And the CREATE method requires a non empty publication object
+    And the DynamoDBPublicationService has a PUBLISH method
+    And the PUBLISH method requires a user with non empty username
+    And the PUBLISH method requires a non empty publication ID
+    And there is a user with username "theUser"
+    And the user "theUser" is affiliated with the institution "theInstitution"
+    And the user's role is USER
+    And the user "theUser" does not have any other role
+
+
+  Scenario: Users read published material
+    Given a publication with ID "PubId"
+    And the publication "PubId" has status PUBLISHED
+    When READ is called on behalf of the Anonymous user for the publication "PubId"
+    Then READ returns the publication "PubId"
+
+  Scenario: Users can see published material when they list publications
+    Given that DynamoDBPublicationService has a LIST method
+    And that LIST requires a user with non empty username
+    And that LIST requires a publication owner's username
+    When LIST is called on behalf of the "theUser" for the user "theCreator"
+    Then LIST returns all published publications whose owner is the user "theCreator"
+
+  Scenario: Users cannot create a publication
+    Given a new publication entry "newPublication"
+    When CREATE is called on behalf of the user "theUser"
+    Then CREATE returns an error message that this action is not allowed for the user "theUser"
+
+  Scenario: User cannot read unpublished publication that is not shared with them
+    Given a publication with id "pubID"
+    And the publication "pubID" is NOT published
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has not given read access the publication "pubID" to "theUser"
+    When READ is called on behalf of the user "theUser" for the publication "pubID"
+    Then READ returns an error response that the publication "pubID" was not found
+
+  Scenario: User reads unpublished publication that is shared with them
+    Given a publication with id "pubID"
+    And the publication "pubID" is NOT published
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has given read access to the publication "pubId" to "theUser"
+    When READ is called on behalf of the user "theUser" for the publication "pubID"
+    Then READ returns the publication "pubID"
+
+  Scenario: Users cannot update unpublished publications if they have not been given write access
+    Given a publication with id "pubID"
+    And the publication "pubID" is NOT published
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has NOT given write access to the publication "pubId" to "theUser"
+    When UPDATE is called on behalf of the user "theUser" for the publication "pubID"
+    Then UPDATE returns that this action is not allowed for the user "theUser"
+
+  Scenario: Users can update unpublished publications if they have been given write access
+    Given a publication with id "pubID"
+    And the publication "pubID" is NOT published
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has given write access to the publication "pubId" to "theUser"
+    When UPDATE is called on behalf of the user "theUser" for the publication "pubID"
+    Then UPDATE updates the publication "pubID" stored in "PUBLICATIONS"
+    And UPDATE returns the previously stored version of the publication "pubID"
+
+  Scenario: Users cannot update published publications
+    Given a publication with id "pubID"
+    And the publication "pubID" is published
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has given write access to the publication "pubId" to "theUser"
+    When UPDATE is called on behalf of the user "theUser" for the publication "pubID"
+    Then UPDATE returns that this action is not allowed for the user "theUser"
+
+
+  Scenario Outline: Not allowed actions for Users
+    Given the DynamoDBPublicationService has an <action> method
+    Given a publication with id "pubID"
+    And the publication "pubID" is <status>
+    And the owner of the publication "pubID" is the user "theCreator"
+    And "theCreator" has given <accessType> access to the publication "pubId" to "theUser"
+    When <action> is called on behalf of the user "theUser" for the publication "pubID"
+    Then <action> returns that this action is not allowed for the user "theUser"
+    Examples:
+      | status        | accessType | action  |
+      | NOT published | no         | DELETE  |
+      | NOT published | no         | PUBLISH |
+      | NOT published | no         | CHOWN   |
+      | NOT published | read       | DELETE  |
+      | NOT published | read       | PUBLISH |
+      | NOT published | read       | CHOWN   |
+      | NOT published | write      | DELETE  |
+      | NOT published | write      | PUBLISH |
+      | NOT published | write      | CHOWN   |
+      | published     | no         | DELETE  |
+      | published     | no         | PUBLISH |
+      | published     | no         | CHOWN   |
+      | published     | read       | DELETE  |
+      | published     | read       | PUBLISH |
+      | published     | read       | CHOWN   |
+      | published     | write      | DELETE  |
+      | published     | write      | PUBLISH |
+      | published     | write      | CHOWN   |
+
+
+

--- a/publication-commons/src/test/resources/features/UserAccessRights.feature
+++ b/publication-commons/src/test/resources/features/UserAccessRights.feature
@@ -25,25 +25,25 @@ Feature: User access rights
     And the user "theUser" does not have any other role
 
 
-  Scenario: Users read published material
+  Scenario: USER users read published material
     Given a publication with ID "PubId"
     And the publication "PubId" has status PUBLISHED
-    When READ is called on behalf of the Anonymous user for the publication "PubId"
+    When READ is called on behalf of the user "theUser" for the publication "PubId"
     Then READ returns the publication "PubId"
 
-  Scenario: Users can see published material when they list publications
+  Scenario: USER users can see published material when they list publications
     Given that DynamoDBPublicationService has a LIST method
     And that LIST requires a user with non empty username
     And that LIST requires a publication owner's username
     When LIST is called on behalf of the "theUser" for the user "theCreator"
     Then LIST returns all published publications whose owner is the user "theCreator"
 
-  Scenario: Users cannot create a publication
+  Scenario: USER users cannot create a publication
     Given a new publication entry "newPublication"
     When CREATE is called on behalf of the user "theUser"
     Then CREATE returns an error message that this action is not allowed for the user "theUser"
 
-  Scenario: User cannot read unpublished publication that is not shared with them
+  Scenario: USER users cannot read unpublished publication that is not shared with them
     Given a publication with id "pubID"
     And the publication "pubID" is NOT published
     And the owner of the publication "pubID" is the user "theCreator"
@@ -51,7 +51,7 @@ Feature: User access rights
     When READ is called on behalf of the user "theUser" for the publication "pubID"
     Then READ returns an error response that the publication "pubID" was not found
 
-  Scenario: User reads unpublished publication that is shared with them
+  Scenario: USER users read unpublished publication that is shared with them
     Given a publication with id "pubID"
     And the publication "pubID" is NOT published
     And the owner of the publication "pubID" is the user "theCreator"
@@ -59,7 +59,7 @@ Feature: User access rights
     When READ is called on behalf of the user "theUser" for the publication "pubID"
     Then READ returns the publication "pubID"
 
-  Scenario: Users cannot update unpublished publications if they have not been given write access
+  Scenario: USER users cannot update unpublished publications if they have not been given write access
     Given a publication with id "pubID"
     And the publication "pubID" is NOT published
     And the owner of the publication "pubID" is the user "theCreator"
@@ -67,7 +67,7 @@ Feature: User access rights
     When UPDATE is called on behalf of the user "theUser" for the publication "pubID"
     Then UPDATE returns that this action is not allowed for the user "theUser"
 
-  Scenario: Users can update unpublished publications if they have been given write access
+  Scenario: USER users can update unpublished publications if they have been given write access
     Given a publication with id "pubID"
     And the publication "pubID" is NOT published
     And the owner of the publication "pubID" is the user "theCreator"
@@ -76,7 +76,7 @@ Feature: User access rights
     Then UPDATE updates the publication "pubID" stored in "PUBLICATIONS"
     And UPDATE returns the previously stored version of the publication "pubID"
 
-  Scenario: Users cannot update published publications
+  Scenario: USER users cannot update published publications
     Given a publication with id "pubID"
     And the publication "pubID" is published
     And the owner of the publication "pubID" is the user "theCreator"
@@ -85,7 +85,7 @@ Feature: User access rights
     Then UPDATE returns that this action is not allowed for the user "theUser"
 
 
-  Scenario Outline: Not allowed actions for Users
+  Scenario Outline: Not allowed actions for USER users
     Given the DynamoDBPublicationService has an <action> method
     Given a publication with id "pubID"
     And the publication "pubID" is <status>


### PR DESCRIPTION
Changes:

User access rights: Description of user access rights
Anonymous user rights: Add description for explicitly prohibiting an anonymous user to publish a publication.

**UPDATE**:
According to the discussion I had with @garshol  publication sharing is a non-MVP feature.
Therefore I made the following changes
Last changes: 

1. Tagged features that are not MVP as `@notmvp'
2. Updated the features so that in the current scope (MVP), a USER has basically the same rights as an ANONYMOUS user 
