### PR TITLE
Dynamo persistence called too soon

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DynamoDBPublicationService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DynamoDBPublicationService.java
@@ -91,8 +91,7 @@ public class DynamoDBPublicationService implements PublicationService {
         } catch (Exception e) {
             throw new DynamoDBException(ERROR_WRITING_TO_TABLE, e);
         }
-        // TODO at this point, we either need to wait for the response or simply return the item that is sent to Dynamo
-        return getPublication(publication.getIdentifier());
+        return publication;
     }
 
     @Override
@@ -138,7 +137,7 @@ public class DynamoDBPublicationService implements PublicationService {
         } catch (Exception e) {
             throw new DynamoDBException(ERROR_WRITING_TO_TABLE, e);
         }
-        return getPublication(identifier);
+        return publication;
     }
 
     protected Item publicationToItem(Publication publication) throws ApiGatewayException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DynamoDBPublicationService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DynamoDBPublicationService.java
@@ -91,6 +91,7 @@ public class DynamoDBPublicationService implements PublicationService {
         } catch (Exception e) {
             throw new DynamoDBException(ERROR_WRITING_TO_TABLE, e);
         }
+        // TODO at this point, we either need to wait for the response or simply return the item that is sent to Dynamo
         return getPublication(publication.getIdentifier());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/DynamoDBPublicationServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/DynamoDBPublicationServiceTest.java
@@ -15,6 +15,9 @@ import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,6 +62,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.mockito.Mockito;
 
@@ -103,9 +107,8 @@ class DynamoDBPublicationServiceTest {
     @Test
     @DisplayName("notImplemented Methods Throws NotImplementedException")
     public void notImplementedMethodsThrowsNotImplementedException() {
-        assertThrows(NotImplementedException.class, () -> {
-            publicationService.getPublicationsByPublisher(null);
-        });
+        assertThrows(NotImplementedException.class, () -> publicationService
+                .getPublicationsByPublisher(null));
     }
 
     @Test
@@ -146,7 +149,7 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void getPublicationReturnsExistingPublicationWhenInputIsExistingIdentifier() throws Exception {
-        Publication storedPublication = publication();
+        Publication storedPublication = publicationWithIdentifier();
         publicationService.createPublication(storedPublication);
         Publication retrievedPublication = publicationService.getPublication(storedPublication.getIdentifier());
         assertEquals(retrievedPublication, storedPublication);
@@ -163,7 +166,7 @@ class DynamoDBPublicationServiceTest {
     @Test
     public void updateExistingCustomerWithNewOwner() throws Exception {
         String newOwner = "New Owner";
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publicationService.createPublication(publication);
 
         publication.setOwner(newOwner);
@@ -174,17 +177,18 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void updateExistingCustomerChangesModifiedDate() throws Exception {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         Publication createdPublication = publicationService.createPublication(publication);
-
+        Instant initialInstant = createdPublication.getModifiedDate();
         Publication updatedPublication = publicationService.updatePublication(
             publication.getIdentifier(), publication);
-        assertNotEquals(createdPublication.getModifiedDate(), updatedPublication.getModifiedDate());
+        Instant updatedInstant = updatedPublication.getModifiedDate();
+        assertNotEquals(initialInstant, updatedInstant);
     }
 
     @Test
     public void updateExistingCustomerPreservesCreatedDate() throws Exception {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publicationService.createPublication(publication);
 
         Publication updatedPublication = publicationService.updatePublication(
@@ -194,12 +198,11 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void updateExistingCustomerWithDifferentIdentifiersThrowsException() throws Exception {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publicationService.createPublication(publication);
         UUID differentIdentifier = UUID.randomUUID();
-
-        InputException exception = assertThrows(InputException.class,
-            () -> publicationService.updatePublication(differentIdentifier, publication));
+        Executable executable = () -> publicationService.updatePublication(differentIdentifier, publication);
+        InputException exception = assertThrows(InputException.class, executable);
         String expectedMessage = String.format(DynamoDBPublicationService.IDENTIFIERS_NOT_EQUAL,
             differentIdentifier, publication.getIdentifier());
         assertEquals(expectedMessage, exception.getMessage());
@@ -218,7 +221,7 @@ class DynamoDBPublicationServiceTest {
     @Test
     @DisplayName("nonEmpty Table Returns Publications")
     public void nonEmptyTableReturnsPublications() throws ApiGatewayException {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publicationService.createPublication(publication);
 
         List<PublicationSummary> publications = publicationService.getPublicationsByOwner(
@@ -268,62 +271,42 @@ class DynamoDBPublicationServiceTest {
     @Test
     public void createPublicationTableErrorThrowsException() {
         Table failingTable = mock(Table.class);
-        Index index = mock(Index.class);
         when(failingTable.putItem(any(Item.class))).thenThrow(RuntimeException.class);
-        DynamoDBPublicationService failingService = new DynamoDBPublicationService(
-            objectMapper,
-            failingTable,
-            index
-        );
-        DynamoDBException exception = assertThrows(DynamoDBException.class,
-            () -> failingService.createPublication(publication()));
+        DynamoDBPublicationService failingService = generateFailingService(failingTable, mock(Index.class));
+        Executable executable = () -> failingService.createPublication(publicationWithIdentifier());
+        DynamoDBException exception = assertThrows(DynamoDBException.class, executable);
         assertEquals(ERROR_WRITING_TO_TABLE, exception.getMessage());
     }
 
     @Test
     public void getPublicationTableErrorThrowsException() {
         Table failingTable = mock(Table.class);
-        Index index = mock(Index.class);
         when(failingTable.query(any(QuerySpec.class))).thenThrow(RuntimeException.class);
-        DynamoDBPublicationService failingService = new DynamoDBPublicationService(
-            objectMapper,
-            failingTable,
-            index
-        );
-        DynamoDBException exception = assertThrows(DynamoDBException.class,
-            () -> failingService.getPublication(UUID.randomUUID()));
+        DynamoDBPublicationService failingService = generateFailingService(failingTable, mock(Index.class));
+        Executable executable = () -> failingService.getPublication(UUID.randomUUID());
+        DynamoDBException exception = assertThrows(DynamoDBException.class, executable);
         assertEquals(ERROR_READING_FROM_TABLE, exception.getMessage());
     }
 
     @Test
     public void getPublicationsByOwnerTableErrorThrowsException() {
-        Table table = mock(Table.class);
-        Index failingIdex = mock(Index.class);
-        when(failingIdex.query(any(QuerySpec.class))).thenThrow(RuntimeException.class);
-        DynamoDBPublicationService failingService = new DynamoDBPublicationService(
-            objectMapper,
-            table,
-            failingIdex
-        );
-        DynamoDBException exception = assertThrows(DynamoDBException.class,
-            () -> failingService.getPublicationsByOwner(OWNER, PUBLISHER_ID));
+        Index failingIndex = mock(Index.class);
+        when(failingIndex.query(any(QuerySpec.class))).thenThrow(RuntimeException.class);
+        DynamoDBPublicationService failingService = generateFailingService(mock(Table.class), failingIndex);
+        Executable executable = () -> failingService.getPublicationsByOwner(OWNER, PUBLISHER_ID);
+        DynamoDBException exception = assertThrows(DynamoDBException.class, executable);
         assertEquals(ERROR_READING_FROM_TABLE, exception.getMessage());
     }
 
     @Test
     public void updatePublicationTableErrorThrowsException() {
         Table failingTable = mock(Table.class);
-        Index index = mock(Index.class);
         when(failingTable.putItem(any(Item.class))).thenThrow(RuntimeException.class);
-        DynamoDBPublicationService failingService = new DynamoDBPublicationService(
-            objectMapper,
-            failingTable,
-            index
-        );
-        Publication publication = publication();
+        DynamoDBPublicationService failingService = generateFailingService(failingTable, mock(Index.class));
+        Publication publication = publicationWithIdentifier();
         publication.setIdentifier(UUID.randomUUID());
-        DynamoDBException exception = assertThrows(DynamoDBException.class,
-            () -> failingService.updatePublication(publication.getIdentifier(), publication));
+        Executable executable = () -> failingService.updatePublication(publication.getIdentifier(), publication);
+        DynamoDBException exception = assertThrows(DynamoDBException.class, executable);
         assertEquals(ERROR_WRITING_TO_TABLE, exception.getMessage());
     }
 
@@ -331,13 +314,10 @@ class DynamoDBPublicationServiceTest {
     public void publicationToItemThrowsExceptionWhenInvalidJson() throws JsonProcessingException {
         ObjectMapper failingObjectMapper = mock(ObjectMapper.class);
         when(failingObjectMapper.writeValueAsString(any(Publication.class))).thenThrow(JsonProcessingException.class);
-        DynamoDBPublicationService failingService = new DynamoDBPublicationService(
-            failingObjectMapper,
-            db.getTable(),
-            db.getByPublisherIndex()
-        );
-        InputException exception = assertThrows(InputException.class,
-            () -> failingService.publicationToItem(publication()));
+        DynamoDBPublicationService failingService = generateFailingService(failingObjectMapper,
+                db.getTable(), db.getByPublisherIndex());
+        Executable executable = () -> failingService.publicationToItem(publicationWithIdentifier());
+        InputException exception = assertThrows(InputException.class, executable);
         assertEquals(DynamoDBPublicationService.ERROR_MAPPING_PUBLICATION_TO_ITEM, exception.getMessage());
     }
 
@@ -345,14 +325,14 @@ class DynamoDBPublicationServiceTest {
     public void itemToPublicationThrowsExceptionWhenInvalidJson() {
         Item item = mock(Item.class);
         when(item.toJSON()).thenThrow(new IllegalStateException());
-        DynamoDBException exception = assertThrows(DynamoDBException.class,
-            () -> publicationService.itemToPublication(item));
+        Executable executable = () -> publicationService.itemToPublication(item);
+        DynamoDBException exception = assertThrows(DynamoDBException.class, executable);
         assertEquals(ERROR_MAPPING_ITEM_TO_PUBLICATION, exception.getMessage());
     }
 
     @Test
     public void canPublishPublicationReturnsAccepted() throws Exception {
-        Publication publicationToPublish = publicationService.createPublication(publication());
+        Publication publicationToPublish = publicationService.createPublication(publicationWithIdentifier());
 
         PublishPublicationStatusResponse actual = publicationService
             .publishPublication(publicationToPublish.getIdentifier());
@@ -364,7 +344,7 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void publishedPublicationHasPublishedDate() throws Exception {
-        Publication publicationToPublish = publicationService.createPublication(publication());
+        Publication publicationToPublish = publicationService.createPublication(publicationWithIdentifier());
         publicationService.publishPublication(publicationToPublish.getIdentifier());
         Publication publishedPublication = publicationService.getPublication(publicationToPublish.getIdentifier());
         assertNotNull(publishedPublication.getPublishedDate());
@@ -372,7 +352,7 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void publishedPublicationHasStatusPublished() throws Exception {
-        Publication publicationToPublish = publicationService.createPublication(publication());
+        Publication publicationToPublish = publicationService.createPublication(publicationWithIdentifier());
         publicationService.publishPublication(publicationToPublish.getIdentifier());
         Publication publishedPublication = publicationService.getPublication(publicationToPublish.getIdentifier());
         assertEquals(PublicationStatus.PUBLISHED, publishedPublication.getStatus());
@@ -380,7 +360,7 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void publicationAlreadyPublishedReturnsNoContent() throws Exception {
-        Publication publicationToPublish = publicationService.createPublication(publication());
+        Publication publicationToPublish = publicationService.createPublication(publicationWithIdentifier());
 
         // publish
         publicationService.publishPublication(publicationToPublish.getIdentifier());
@@ -395,35 +375,38 @@ class DynamoDBPublicationServiceTest {
 
     @Test
     public void publishPublicationWithMissingMainTitleReturnsConflict() throws Exception {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publication.getEntityDescription().setMainTitle(null);
         Publication publicationToPublish = publicationService.createPublication(publication);
-
-        InvalidPublicationException exception = assertThrows(InvalidPublicationException.class,
-            () -> publicationService.publishPublication(publicationToPublish.getIdentifier()));
-
-        String errorMessage = String.format(
-            InvalidPublicationException.ERROR_MESSAGE_TEMPLATE,
-            PublishPublicationValidator.MAIN_TITLE);
+        Executable executable = () -> publicationService.publishPublication(publicationToPublish.getIdentifier());
+        InvalidPublicationException exception = assertThrows(InvalidPublicationException.class, executable);
+        String errorMessage = String.format(InvalidPublicationException.ERROR_MESSAGE_TEMPLATE,
+                PublishPublicationValidator.MAIN_TITLE);
         assertEquals(errorMessage, exception.getMessage());
         assertEquals(SC_CONFLICT, exception.getStatusCode());
     }
 
     @Test
     public void publishPublicationWithMissingLinkAndFileReturnsConflict() throws Exception {
-        Publication publication = publication();
+        Publication publication = publicationWithIdentifier();
         publication.setLink(null);
         publication.setFileSet(new FileSet.Builder().withFiles(List.of()).build());
         Publication publicationToPublish = publicationService.createPublication(publication);
-
-        InvalidPublicationException exception = assertThrows(InvalidPublicationException.class,
-            () -> publicationService.publishPublication(publicationToPublish.getIdentifier()));
-
+        Executable executable = () -> publicationService.publishPublication(publicationToPublish.getIdentifier());
+        InvalidPublicationException exception = assertThrows(InvalidPublicationException.class, executable);
         String errorMessage = String.format(
             InvalidPublicationException.ERROR_MESSAGE_TEMPLATE,
             PublishPublicationValidator.LINK_OR_FILE);
         assertEquals(errorMessage, exception.getMessage());
         assertEquals(SC_CONFLICT, exception.getStatusCode());
+    }
+
+    @Test
+    public void createPublicationReturnsPublicationWithIdentifierWhenInputIsValid() throws ApiGatewayException {
+        Publication publication = publicationWithoutIdentifier();
+        assertThat(publication.getIdentifier(), is(nullValue()));
+        Publication actual = publicationService.createPublication(publication);
+        assertThat(actual.getIdentifier(), is(not(nullValue())));
     }
 
     private List<PublicationSummary> publicationSummariesWithDuplicateUuuIds() {
@@ -455,10 +438,18 @@ class DynamoDBPublicationServiceTest {
             .build();
     }
 
-    private Publication publication() {
+    private Publication publicationWithIdentifier() {
+        return generatePublication(UUID.randomUUID());
+    }
+
+    private Publication publicationWithoutIdentifier() {
+        return generatePublication(null);
+    }
+
+    private Publication generatePublication(UUID uuid) {
         Instant oneMinuteInThePast = Instant.now().minusSeconds(60L);
         return new Publication.Builder()
-            .withIdentifier(UUID.randomUUID())
+            .withIdentifier(uuid)
             .withCreatedDate(oneMinuteInThePast)
             .withModifiedDate(oneMinuteInThePast)
             .withOwner(OWNER)
@@ -478,5 +469,16 @@ class DynamoDBPublicationServiceTest {
                     .build()))
                 .build())
             .build();
+    }
+
+    private DynamoDBPublicationService generateFailingService(Table table, Index index) {
+        return generateFailingService(objectMapper, table, index);
+    }
+    private DynamoDBPublicationService generateFailingService(ObjectMapper mapper, Table table, Index index) {
+        return new DynamoDBPublicationService(
+                mapper,
+                table,
+                index
+        );
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/DynamoDBPublicationServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/DynamoDBPublicationServiceTest.java
@@ -474,6 +474,7 @@ class DynamoDBPublicationServiceTest {
     private DynamoDBPublicationService generateFailingService(Table table, Index index) {
         return generateFailingService(objectMapper, table, index);
     }
+
     private DynamoDBPublicationService generateFailingService(ObjectMapper mapper, Table table, Index index) {
         return new DynamoDBPublicationService(
                 mapper,


### PR DESCRIPTION
- return publication directly from 
  - DynamoDBPublicationService.createPublication
  - DynamoDBPublicationService.updatePublication
- Add test to check that a UUID is actually added when an Item is added
- Structure test for modified date so that it checks that the date is changed, rather than the object is different
- Refactor tests in DynamoDBPublicationServiceTest to current standard regarding assertThrows