### PR TITLE
Use variable AWS_REGION when setting up DDB

### DIFF
--- a/list-publications/src/main/java/no/unit/nva/publication/query/ListPublishedPublicationsHandler.java
+++ b/list-publications/src/main/java/no/unit/nva/publication/query/ListPublishedPublicationsHandler.java
@@ -67,9 +67,6 @@ public class ListPublishedPublicationsHandler extends ApiGatewayHandler<Void, Pu
         AmazonDynamoDB amazonDynamoDB = AmazonDynamoDBClientBuilder.standard()
                 .withRegion(environment.readEnv(AWS_REGION))
                 .build();
-        return new DynamoDBPublicationService(
-                amazonDynamoDB,
-                objectMapper,
-                environment);
+        return new DynamoDBPublicationService(amazonDynamoDB, objectMapper, environment);
     }
 }

--- a/list-publications/src/main/java/no/unit/nva/publication/query/ListPublishedPublicationsHandler.java
+++ b/list-publications/src/main/java/no/unit/nva/publication/query/ListPublishedPublicationsHandler.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.query;
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.unit.nva.publication.RequestUtil;
@@ -20,6 +21,7 @@ import static nva.commons.utils.JsonUtils.objectMapper;
 
 public class ListPublishedPublicationsHandler extends ApiGatewayHandler<Void, PublishedPublicationsResponse> {
 
+    public static final String AWS_REGION = "AWS_REGION";
     private final PublicationService publicationService;
 
     /**
@@ -27,10 +29,7 @@ public class ListPublishedPublicationsHandler extends ApiGatewayHandler<Void, Pu
      */
     @JacocoGenerated
     public ListPublishedPublicationsHandler() {
-        this(new DynamoDBPublicationService(
-                AmazonDynamoDBClientBuilder.defaultClient(),
-                objectMapper,
-                new Environment()),
+        this(getPublicationService(),
             new Environment());
     }
 
@@ -61,5 +60,16 @@ public class ListPublishedPublicationsHandler extends ApiGatewayHandler<Void, Pu
     @Override
     protected Integer getSuccessStatusCode(Void input, PublishedPublicationsResponse output) {
         return HttpStatus.SC_OK;
+    }
+
+    private static DynamoDBPublicationService getPublicationService() {
+        Environment environment = new Environment();
+        AmazonDynamoDB amazonDynamoDB = AmazonDynamoDBClientBuilder.standard()
+                .withRegion(environment.readEnv(AWS_REGION))
+                .build();
+        return new DynamoDBPublicationService(
+                amazonDynamoDB,
+                objectMapper,
+                environment);
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -304,7 +304,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -330,7 +330,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -356,7 +356,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -382,7 +382,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -410,7 +410,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -438,7 +438,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
-          AWS_REGION: ${AWS::REGION}
+          AWS_REGION: !Ref "AWS::REGION"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref PublicationsTableName

--- a/template.yaml
+++ b/template.yaml
@@ -304,6 +304,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -329,6 +330,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -354,6 +356,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -379,6 +382,7 @@ Resources:
           TABLE_NAME: !Ref PublicationsTableName
           BY_PUBLISHER_INDEX_NAME: !Ref PublicationsByOwnerIndexName
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -406,6 +410,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref PublicationsTableName
@@ -433,6 +438,7 @@ Resources:
           BY_PUBLISHED_PUBLICATIONS_INDEX_NAME: !Ref PublishedPublicationsIndexName
           API_SCHEME: https
           API_HOST: !Ref CustomDomain
+          AWS_REGION: ${AWS::REGION}
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref PublicationsTableName


### PR DESCRIPTION
In order to avoid slow startup times, AWS code guru suggests setting the REGION on the AmazonDynamoDB object, this is an attempt to do this without too much fiddling.

Feel free to say "No" as I don't believe this solution is in fact any better than using the default client.