### PR TITLE
Np 1162 customer id from request context

### DIFF
--- a/create-publication/src/main/java/no/unit/nva/publication/create/CreatePublicationHandler.java
+++ b/create-publication/src/main/java/no/unit/nva/publication/create/CreatePublicationHandler.java
@@ -13,7 +13,6 @@ import no.unit.nva.api.PublicationResponse;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Organization.Builder;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.util.OrgNumberMapper;
 import no.unit.nva.publication.RequestUtil;
 import no.unit.nva.publication.service.PublicationService;
 import no.unit.nva.publication.service.impl.DynamoDBPublicationService;
@@ -72,7 +71,7 @@ public class CreatePublicationHandler extends ApiGatewayHandler<CreatePublicatio
             RequestUtil.getOwner(requestInfo),
             null, //TODO: set handle
             null, //TODO: set link
-            createPublisher(RequestUtil.getOrgNumber(requestInfo)));
+            createPublisher(RequestUtil.getCustomerId(requestInfo)));
 
         Publication createdPublication = publicationService.createPublication(newPublication);
 
@@ -92,9 +91,9 @@ public class CreatePublicationHandler extends ApiGatewayHandler<CreatePublicatio
         return URI.create(String.format(LOCATION_TEMPLATE, apiScheme, apiHost, identifier));
     }
 
-    private Organization createPublisher(String orgNumber) {
+    private Organization createPublisher(URI publisherId) {
         return new Builder()
-            .withId(OrgNumberMapper.toCristinId(orgNumber))
+            .withId(publisherId)
             .build();
     }
 

--- a/create-publication/src/main/java/no/unit/nva/publication/create/CreatePublicationHandler.java
+++ b/create-publication/src/main/java/no/unit/nva/publication/create/CreatePublicationHandler.java
@@ -71,7 +71,7 @@ public class CreatePublicationHandler extends ApiGatewayHandler<CreatePublicatio
             RequestUtil.getOwner(requestInfo),
             null, //TODO: set handle
             null, //TODO: set link
-            createPublisher(RequestUtil.getCustomerId(requestInfo)));
+            createPublisherFromCustomerId(RequestUtil.getCustomerId(requestInfo)));
 
         Publication createdPublication = publicationService.createPublication(newPublication);
 
@@ -90,10 +90,10 @@ public class CreatePublicationHandler extends ApiGatewayHandler<CreatePublicatio
     protected URI getLocation(UUID identifier) {
         return URI.create(String.format(LOCATION_TEMPLATE, apiScheme, apiHost, identifier));
     }
-
-    private Organization createPublisher(URI publisherId) {
+    
+    private Organization createPublisherFromCustomerId(URI customerId) {
         return new Builder()
-            .withId(publisherId)
+            .withId(customerId)
             .build();
     }
 

--- a/create-publication/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/create-publication/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -142,7 +142,7 @@ public class CreatePublicationHandlerTest {
             AUTHORIZER, Map.of(
                 CLAIMS, Map.of(
                     RequestUtil.CUSTOM_FEIDE_ID, TEST_FEIDE_ID,
-                    RequestUtil.CUSTOM_ORG_NUMBER, TEST_ORG_NUMBER
+                    RequestUtil.CUSTOM_CUSTOMER_ID, TEST_ORG_NUMBER
                 )
             )
         );

--- a/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
@@ -1,6 +1,7 @@
 package no.unit.nva.publication;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
 import no.unit.nva.publication.exception.InputException;
 import nva.commons.exceptions.ApiGatewayException;
 import nva.commons.handlers.RequestInfo;
@@ -20,7 +21,7 @@ public final class RequestUtil {
     public static final String PAGESIZE_IS_NOT_A_VALID_POSITIVE_INTEGER = "pageSize is not a valid positive integer: ";
     public static final String AUTHORIZER_CLAIMS = "/authorizer/claims/";
     public static final String CUSTOM_FEIDE_ID = "custom:feideId";
-    public static final String CUSTOM_ORG_NUMBER = "custom:orgNumber";
+    public static final String CUSTOM_CUSTOMER_ID = "custom:customerId";
     public static final String MISSING_CLAIM_IN_REQUEST_CONTEXT =
         "Missing claim in requestContext: ";
     public static final String PAGESIZE = "pagesize";
@@ -53,18 +54,18 @@ public final class RequestUtil {
     }
 
     /**
-     * Get orgNumber from requestContext authorizer claims.
+     * Get customerId from requestContext authorizer claims.
      *
      * @param requestInfo requestInfo.
-     * @return the orgNumber
+     * @return the customerId
      * @throws ApiGatewayException exception thrown if value is missing
      */
-    public static String getOrgNumber(RequestInfo requestInfo) throws ApiGatewayException {
-        JsonNode jsonNode = requestInfo.getRequestContext().at(AUTHORIZER_CLAIMS + CUSTOM_ORG_NUMBER);
+    public static URI getCustomerId(RequestInfo requestInfo) throws ApiGatewayException {
+        JsonNode jsonNode = requestInfo.getRequestContext().at(AUTHORIZER_CLAIMS + CUSTOM_CUSTOMER_ID);
         if (!jsonNode.isMissingNode()) {
-            return jsonNode.textValue();
+            return URI.create(jsonNode.textValue());
         }
-        throw new InputException(MISSING_CLAIM_IN_REQUEST_CONTEXT + CUSTOM_ORG_NUMBER, null);
+        throw new InputException(MISSING_CLAIM_IN_REQUEST_CONTEXT + CUSTOM_CUSTOMER_ID, null);
     }
 
     /**

--- a/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
@@ -16,7 +16,6 @@ import static java.lang.Integer.parseInt;
 public final class RequestUtil {
 
     public static final String IDENTIFIER = "identifier";
-    public static final String MISSING_AUTHORIZATION_IN_HEADERS = "Missing Authorization in Headers";
     public static final String IDENTIFIER_IS_NOT_A_VALID_UUID = "Identifier is not a valid UUID: ";
     public static final String PAGESIZE_IS_NOT_A_VALID_POSITIVE_INTEGER = "pageSize is not a valid positive integer: ";
     public static final String AUTHORIZER_CLAIMS = "/authorizer/claims/";

--- a/publication-commons/src/test/java/no/unit/nva/publication/RequestUtilTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/RequestUtilTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
 import no.unit.nva.publication.exception.InputException;
@@ -37,27 +38,27 @@ public class RequestUtilTest {
     }
 
     @Test
-    public void canGetOrgNumberFromRequest() throws Exception {
+    public void canGetCustomerIdFromRequest() throws Exception {
         RequestInfo requestInfo = new RequestInfo();
-        requestInfo.setRequestContext(getRequestContextForClaim(RequestUtil.CUSTOM_ORG_NUMBER, VALUE));
+        requestInfo.setRequestContext(getRequestContextForClaim(RequestUtil.CUSTOM_CUSTOMER_ID, VALUE));
 
-        String orgNumber = RequestUtil.getOrgNumber(requestInfo);
+        URI customerId = RequestUtil.getCustomerId(requestInfo);
 
-        assertEquals(VALUE, orgNumber);
+        assertEquals(URI.create(VALUE), customerId);
     }
 
     @Test
-    public void getOrgNumberOnMissingNodeRequestThrowsException() throws Exception {
+    public void getCustomerIdOnMissingNodeRequestThrowsException() throws Exception {
         RequestInfo requestInfo = new RequestInfo();
         requestInfo.setRequestContext(getRequestContextWithMissingNode());
 
-        assertThrows(InputException.class, () -> RequestUtil.getOrgNumber(requestInfo));
+        assertThrows(InputException.class, () -> RequestUtil.getCustomerId(requestInfo));
     }
 
     @Test
-    public void getOrgNumberOnInvalidRequestThrowsException() {
+    public void getCustomerIdOnInvalidRequestThrowsException() {
         RequestInfo requestInfo = new RequestInfo();
-        assertThrows(InputException.class, () -> RequestUtil.getOrgNumber(requestInfo));
+        assertThrows(InputException.class, () -> RequestUtil.getCustomerId(requestInfo));
     }
 
     @Test

--- a/publications-by-owner/src/main/java/no/unit/nva/publication/owner/PublicationsByOwnerHandler.java
+++ b/publications-by-owner/src/main/java/no/unit/nva/publication/owner/PublicationsByOwnerHandler.java
@@ -4,8 +4,8 @@ import static nva.commons.utils.JsonUtils.objectMapper;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.net.URI;
 import java.util.List;
-import no.unit.nva.model.util.OrgNumberMapper;
 import no.unit.nva.publication.RequestUtil;
 import no.unit.nva.publication.model.PublicationSummary;
 import no.unit.nva.publication.service.PublicationService;
@@ -48,15 +48,15 @@ public class PublicationsByOwnerHandler extends ApiGatewayHandler<Void, Publicat
         throws ApiGatewayException {
 
         String owner = RequestUtil.getOwner(requestInfo);
-        String orgNumber = RequestUtil.getOrgNumber(requestInfo);
+        URI customerId = RequestUtil.getCustomerId(requestInfo);
 
-        logger.info(String.format("Requested publications for owner with feideId=%s and publisher with orgNumber=%s",
+        logger.info(String.format("Requested publications for owner with feideId=%s and publisher with customerId=%s",
             owner,
-            orgNumber));
+            customerId));
 
         List<PublicationSummary> publicationsByOwner = publicationService.getPublicationsByOwner(
             owner,
-            OrgNumberMapper.toCristinId(orgNumber)
+            customerId
         );
 
         return new PublicationsByOwnerResponse(publicationsByOwner);

--- a/publications-by-owner/src/test/java/no/unit/nva/publication/owner/PublicationsByOwnerHandlerTest.java
+++ b/publications-by-owner/src/test/java/no/unit/nva/publication/owner/PublicationsByOwnerHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import no.unit.nva.publication.RequestUtil;
 import no.unit.nva.publication.exception.ErrorResponseException;
 import no.unit.nva.publication.model.PublicationSummary;
 import no.unit.nva.publication.service.PublicationService;
@@ -139,7 +140,7 @@ public class PublicationsByOwnerHandlerTest {
         event.put("requestContext",
             singletonMap("authorizer",
                 singletonMap("claims",
-                    Map.of("custom:feideId", OWNER, "custom:orgNumber", VALID_ORG_NUMBER))));
+                    Map.of(RequestUtil.CUSTOM_FEIDE_ID, OWNER, RequestUtil.CUSTOM_CUSTOMER_ID, VALID_ORG_NUMBER))));
         event.put("headers", singletonMap(HttpHeaders.CONTENT_TYPE,
             ContentType.APPLICATION_JSON.getMimeType()));
         return new ByteArrayInputStream(objectMapper.writeValueAsBytes(event));


### PR DESCRIPTION
Using custom:customerId instead of custom:orgNumber from request context when creating Publisher for new Publication.