### PR TITLE
NP-1672 Add handling for Content-Range header

### DIFF
--- a/modify-publication/src/main/java/no/unit/nva/publication/modify/ModifyPublicationHandler.java
+++ b/modify-publication/src/main/java/no/unit/nva/publication/modify/ModifyPublicationHandler.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
-import static java.util.Objects.nonNull;
 import static nva.commons.utils.JsonUtils.objectMapper;
 import static org.apache.http.HttpHeaders.CONTENT_RANGE;
 
@@ -56,7 +55,7 @@ public class ModifyPublicationHandler extends ApiGatewayHandler<UpdatePublicatio
     protected PublicationResponse processInput(UpdatePublicationRequest input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
 
-        validateRequest(requestInfo);
+        validateNotPartialContentRequest(requestInfo);
 
         UUID identifier = RequestUtil.getIdentifier(requestInfo);
         Publication existingPublication = publicationService.getPublication(identifier);
@@ -71,8 +70,8 @@ public class ModifyPublicationHandler extends ApiGatewayHandler<UpdatePublicatio
         return PublicationMapper.convertValue(updatedPublication, PublicationResponse.class);
     }
 
-    private void validateRequest(RequestInfo requestInfo) throws PartialContentException {
-        if (nonNull(requestInfo.getHeader(CONTENT_RANGE))) {
+    private void validateNotPartialContentRequest(RequestInfo requestInfo) throws PartialContentException {
+        if (requestInfo.getHeaders().containsKey(CONTENT_RANGE)) {
             throw new PartialContentException();
         }
     }

--- a/modify-publication/src/main/java/no/unit/nva/publication/modify/exception/PartialContentException.java
+++ b/modify-publication/src/main/java/no/unit/nva/publication/modify/exception/PartialContentException.java
@@ -1,0 +1,21 @@
+package no.unit.nva.publication.modify.exception;
+
+import nva.commons.exceptions.ApiGatewayException;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
+public class PartialContentException extends ApiGatewayException {
+
+    public static final String PARTIAL_CONTENT_MESSAGE = "The request contained a Content-Range header indicating that "
+            + "the request contains partial content, this method (PUT) only accepts full representations, "
+            + "c.f. <https://tools.ietf.org/html/rfc7231#section-4.3.4>";
+
+    public PartialContentException() {
+        super(PARTIAL_CONTENT_MESSAGE);
+    }
+
+    @Override
+    protected Integer statusCode() {
+        return SC_BAD_REQUEST;
+    }
+}

--- a/modify-publication/src/test/java/no/unit/nva/publication/modify/ModifyPublicationHandlerTest.java
+++ b/modify-publication/src/test/java/no/unit/nva/publication/modify/ModifyPublicationHandlerTest.java
@@ -237,7 +237,8 @@ public class ModifyPublicationHandlerTest {
             .build();
     }
 
-    private InputStream generateInputStreamWithValidBodyAndPathParametersInvalidHeader() throws JsonProcessingException {
+    private InputStream generateInputStreamWithValidBodyAndPathParametersInvalidHeader() throws
+            JsonProcessingException {
         UUID identifier = UUID.randomUUID();
         return new HandlerRequestBuilder<Publication>(objectMapper)
                 .withBody(createPublication(identifier))


### PR DESCRIPTION
Please refer to RFC 7231 whenever you define a new API so that we avoid having to make changes like this in future.

If a Content-Range header is present on a PUT request, according to RFC 7231 §4.3.4, the service should return 400 BAD REQUEST as the request indicates that the request contains partial content. 