### PR TITLE
Add CFN linter

### DIFF
--- a/.github/workflows/cfn-linter.yaml
+++ b/.github/workflows/cfn-linter.yaml
@@ -1,0 +1,18 @@
+name: Lint CloudFormation Templates
+
+on: [push]
+
+jobs:
+  cloudformation-linter:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: cfn-lint
+      uses: scottbrenner/cfn-lint-action@master
+      with:
+        entrypoint: /bin/sh
+        args: "-c \"cat template.yaml | sed '/CODEBUILD_RESOLVED_SOURCE_VERSION/d' | cfn-lint -\""

--- a/template.yaml
+++ b/template.yaml
@@ -41,10 +41,6 @@ Parameters:
     Type: String
     Description: Reference to index containing publications by owner
     Default: ByPublisher
-  PublicationsDoiRequestsByStatusIndexName:
-    Type: String
-    Description: Reference to index containing publications by owner
-    Default: doiRequestsByStatus
   PublishedPublicationsIndexName:
     Type: String
     Description: Reference to index containing published publications


### PR DESCRIPTION
Use a cloudformation linter. 

It deletes the line where we use the `envsubst` for settings some variables for avoiding linting errors on that particular line. 