### PR TITLE
NP-1828: add checks for mandatory fields

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -297,6 +297,8 @@
       <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+      <property name="ignoreMethodNamesRegex"
+        value="(^get.*$)|(^set.*$)|(^copy.*$)|(^with.*$)|(^build.*$)"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/PublicationMapper.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/PublicationMapper.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.doi;
 
+import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.not;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
@@ -9,9 +10,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import no.unit.nva.publication.doi.dto.Contributor;
 import no.unit.nva.publication.doi.dto.DoiRequest;
 import no.unit.nva.publication.doi.dto.DoiRequestStatus;
 import no.unit.nva.publication.doi.dto.Publication;
@@ -91,23 +95,69 @@ public class PublicationMapper {
      * @return Publication doi.Publication
      */
     public Publication fromDynamodbStreamRecordDao(DynamodbStreamRecordImageDao dao) {
+
         return Builder.newBuilder()
-            .withId(transformIdentifierToId(namespacePublication, dao.getIdentifier()))
-            .withInstitutionOwner(URI.create(dao.getPublisherId()))
+            .withId(transformIdentifierToId(namespacePublication, dao))
+            .withInstitutionOwner(extractPublisherId(dao))
             .withMainTitle(dao.getMainTitle())
             .withType(extractPublicationInstanceType(dao))
-            .withPublicationDate(new PublicationDate(dao.getPublicationReleaseDate()))
+            .withPublicationDate(extractPublicationDate(dao))
             .withDoi(extractDoiUrl(dao))
             .withDoiRequest(extractDoiRequest(dao))
-            .withModifiedDate(Instant.parse(dao.getModifiedDate()))
-            .withStatus(PublicationStatus.lookup(dao.getStatus()))
-            .withContributor(ContributorMapper.fromIdentityDaos(dao.getContributorIdentities()))
+            .withModifiedDate(extractModifiedDate(dao))
+            .withStatus(extractPublicationStatus(dao))
+            .withContributor(extractContributors(dao))
             .build();
     }
 
+    private static URI transformIdentifierToId(String namespace, DynamodbStreamRecordImageDao streamRecord) {
+        if (nonNull(namespace) && nonNull(streamRecord.getIdentifier())) {
+            return URI.create(namespace + streamRecord.getIdentifier());
+        }
+        return null;
+    }
+
+    private List<Contributor> extractContributors(DynamodbStreamRecordImageDao dao) {
+        if (nonNull(dao.getContributorIdentities())) {
+            return ContributorMapper.fromIdentityDaos(dao.getContributorIdentities());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private PublicationStatus extractPublicationStatus(DynamodbStreamRecordImageDao dao) {
+        return Optional.ofNullable(dao.getStatus())
+            .map(PublicationStatus::lookup)
+            .orElse(null);
+    }
+
+    private Instant extractModifiedDate(DynamodbStreamRecordImageDao dao) {
+        return nonNull(dao.getModifiedDate()) ? Instant.parse(dao.getModifiedDate()) : null;
+    }
+
+    private PublicationDate extractPublicationDate(DynamodbStreamRecordImageDao dao) {
+        return Optional.ofNullable(dao.getPublicationReleaseDate())
+            .map(PublicationDate::fromJsonNode)
+            .orElse(null);
+    }
+
+    private URI extractPublisherId(DynamodbStreamRecordImageDao dao) {
+        return Optional.ofNullable(dao.getPublisherId())
+            .map(URI::create)
+            .orElse(null);
+    }
+
     private DoiRequest extractDoiRequest(DynamodbStreamRecordImageDao dao) {
-        var jsonPointers = new DynamodbStreamRecordJsonPointers(DynamodbImageType.NONE);
         JsonNode doiRequest = dao.getDoiRequest();
+        if (nodeExists(doiRequest)) {
+            return createNewDoiRequestObject(doiRequest);
+        } else {
+            return null;
+        }
+    }
+
+    private DoiRequest createNewDoiRequestObject(JsonNode doiRequest) {
+        var jsonPointers = new DynamodbStreamRecordJsonPointers(DynamodbImageType.NONE);
         var status = extractDoiRequestStatus(jsonPointers, doiRequest);
         var modifiedDate = extractDoiRequestModifiedDate(jsonPointers, doiRequest);
 
@@ -117,33 +167,39 @@ public class PublicationMapper {
             .build();
     }
 
+    private boolean nodeExists(JsonNode doiRequest) {
+        return nonNull(doiRequest) && !doiRequest.isMissingNode();
+    }
+
     private Instant extractDoiRequestModifiedDate(DynamodbStreamRecordJsonPointers jsonPointers, JsonNode doiRequest) {
-        var textValue = doiRequest.at(jsonPointers.getDoiRequestModifiedDateJsonPointer()).textValue();
-        return Instant.parse(textValue);
+        return Optional.of(jsonPointers.getDoiRequestModifiedDateJsonPointer())
+            .map(doiRequest::at)
+            .map(JsonNode::textValue)
+            .map(Instant::parse)
+            .orElse(null);
     }
 
     private DoiRequestStatus extractDoiRequestStatus(DynamodbStreamRecordJsonPointers jsonPointers,
                                                      JsonNode doiRequest) {
-        var textValue = doiRequest.at(jsonPointers.getDoiRequestStatusJsonPointer()).textValue();
-        return DoiRequestStatus.lookup(textValue);
-    }
 
-    private static URI transformIdentifierToId(String namespace, String identifier) {
-        return URI.create(namespace + identifier);
+        return Optional.ofNullable(jsonPointers.getDoiRequestStatusJsonPointer())
+            .map(doiRequest::at)
+            .map(JsonNode::textValue)
+            .map(DoiRequestStatus::lookup)
+            .orElse(null);
     }
 
     private boolean acceptStreamViewTypes(String streamViewType, StreamViewType... streamViewTypes) {
         return Arrays.stream(streamViewTypes)
             .map(StreamViewType::getValue)
-            .filter(s -> s.equals(streamViewType))
-            .findFirst()
-            .isPresent();
+            .anyMatch(s -> s.equals(streamViewType));
     }
 
     private Optional<Publication> fromDynamodbStreamRecordImage(Map<String, AttributeValue> image) {
         if (image == null || image.isEmpty()) {
             return Optional.empty();
         }
+
         var jsonNode = objectMapper.convertValue(image, JsonNode.class);
         return Optional.of(fromDynamodbStreamRecordImage(jsonNode));
     }

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
@@ -24,6 +24,7 @@ public class DoiRequest extends Validatable {
         this.modifiedDate = modifiedDate;
     }
 
+    @Override
     public void validate() {
         requireFieldIsNotNull(status, "DoiRequest.status");
         requireFieldIsNotNull(modifiedDate, "DoiRequest.modifiedDate");

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
@@ -7,6 +7,8 @@ import nva.commons.utils.JacocoGenerated;
 
 public class DoiRequest extends Validatable {
 
+    public static final String DOI_REQUEST_STATUS_FIELD_INFO = "DoiRequest.status";
+    public static final String DOI_REQUEST_MODIFIED_DATE_FIELD_INFO = "DoiRequest.modifiedDate";
     private final DoiRequestStatus status;
     private final Instant modifiedDate;
 
@@ -26,8 +28,8 @@ public class DoiRequest extends Validatable {
 
     @Override
     public void validate() {
-        requireFieldIsNotNull(status, "DoiRequest.status");
-        requireFieldIsNotNull(modifiedDate, "DoiRequest.modifiedDate");
+        requireFieldIsNotNull(status, DOI_REQUEST_STATUS_FIELD_INFO);
+        requireFieldIsNotNull(modifiedDate, DOI_REQUEST_MODIFIED_DATE_FIELD_INFO);
     }
 
     public DoiRequestStatus getStatus() {

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/DoiRequest.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import java.util.Objects;
 import nva.commons.utils.JacocoGenerated;
 
-public class DoiRequest {
+public class DoiRequest extends Validatable {
 
     private final DoiRequestStatus status;
     private final Instant modifiedDate;
@@ -13,14 +13,20 @@ public class DoiRequest {
     /**
      * Constructor for basic deserialization of DoiRequest.
      *
-     * @param status        doi request status
-     * @param modifiedDate  modified date of doi request
+     * @param status       doi request status
+     * @param modifiedDate modified date of doi request
      */
     public DoiRequest(
         @JsonProperty("status") DoiRequestStatus status,
         @JsonProperty("modifiedDate") Instant modifiedDate) {
+        super();
         this.status = status;
         this.modifiedDate = modifiedDate;
+    }
+
+    public void validate() {
+        requireFieldIsNotNull(status, "DoiRequest.status");
+        requireFieldIsNotNull(modifiedDate, "DoiRequest.modifiedDate");
     }
 
     public DoiRequestStatus getStatus() {
@@ -70,7 +76,9 @@ public class DoiRequest {
         }
 
         public DoiRequest build() {
-            return new DoiRequest(status, modifiedDate);
+            DoiRequest doiRequest = new DoiRequest(status, modifiedDate);
+            doiRequest.validate();
+            return doiRequest;
         }
     }
 }

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
@@ -64,6 +64,7 @@ public class Publication extends Validatable {
     /**
      * Validates.
      */
+    @Override
     public void validate() {
         requireFieldIsNotNull(id, "Publication.id");
         requireFieldIsNotNull(institutionOwner, "Publication.institutionOwner");

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
@@ -8,18 +8,18 @@ import java.util.List;
 import java.util.Objects;
 import nva.commons.utils.JacocoGenerated;
 
-public class Publication {
+public class Publication extends Validatable {
 
     private final URI id;
     private final URI institutionOwner;
-    private final URI doi;
-    private final DoiRequest doiRequest;
     private final Instant modifiedDate;
     private final PublicationType type;
     private final String mainTitle;
     private final PublicationStatus status;
-    private final List<Contributor> contributor;
     private final PublicationDate publicationDate;
+    private final List<Contributor> contributor;
+    private final URI doi;
+    private final DoiRequest doiRequest;
 
     /**
      * doi.Publication DTO to be used to as payload format.
@@ -48,6 +48,7 @@ public class Publication {
                        @JsonProperty("status") PublicationStatus status,
                        @JsonProperty("contributors") List<Contributor> contributors,
                        @JsonProperty("publication_date") PublicationDate publicationDate) {
+        super();
         this.id = id;
         this.institutionOwner = institutionOwner;
         this.doi = doi;
@@ -58,6 +59,19 @@ public class Publication {
         this.status = status;
         this.contributor = contributors;
         this.publicationDate = publicationDate;
+    }
+
+    /**
+     * Validates.
+     */
+    public void validate() {
+        requireFieldIsNotNull(id, "Publication.id");
+        requireFieldIsNotNull(institutionOwner, "Publication.institutionOwner");
+        requireFieldIsNotNull(modifiedDate, "Publication.modifiedDate");
+        requireFieldIsNotNull(type, "Publication.type");
+        requireFieldIsNotNull(mainTitle, "Publication.mainTitle");
+        requireFieldIsNotNull(status, "Publication.status");
+        requireFieldIsNotNull(publicationDate, "Publication.publicationDate");
     }
 
     protected Publication(Builder builder) {
@@ -108,7 +122,7 @@ public class Publication {
     /**
      * Flag used during EventBridge pattern matching.
      *
-     * @return  true if modifiedDate is same as doiRequest.modifiedDate
+     * @return true if modifiedDate is same as doiRequest.modifiedDate
      */
     @JsonProperty("sameModifiedDateForDoiRequest")
     public boolean isSameModifiedDateForDoiRequest() {
@@ -218,7 +232,9 @@ public class Publication {
         }
 
         public Publication build() {
-            return new Publication(this);
+            Publication publication = new Publication(this);
+            publication.validate();
+            return publication;
         }
     }
 }

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Publication.java
@@ -10,6 +10,13 @@ import nva.commons.utils.JacocoGenerated;
 
 public class Publication extends Validatable {
 
+    public static final String PUBLICATION_ID_FIELD_INFO = "Publication.id";
+    public static final String PUBLICATION_INSTITUTION_OWNER_FIELD_INFO = "Publication.institutionOwner";
+    public static final String PUBLICATION_MODIFIED_DATE_FIELD_INFO = "Publication.modifiedDate";
+    public static final String PUBLICATION_TYPE_FIELD_INFO = "Publication.type";
+    public static final String PUBLICATION_MAIN_TITLE_FIELD_INFO = "Publication.mainTitle";
+    public static final String PUBLICATION_STATUS_FIELD_INFO = "Pblication.status";
+    public static final String PUBLICATION_PUBLICATION_DATE_FIELD_INFO = "Publication.publicationDate";
     private final URI id;
     private final URI institutionOwner;
     private final Instant modifiedDate;
@@ -66,13 +73,13 @@ public class Publication extends Validatable {
      */
     @Override
     public void validate() {
-        requireFieldIsNotNull(id, "Publication.id");
-        requireFieldIsNotNull(institutionOwner, "Publication.institutionOwner");
-        requireFieldIsNotNull(modifiedDate, "Publication.modifiedDate");
-        requireFieldIsNotNull(type, "Publication.type");
-        requireFieldIsNotNull(mainTitle, "Publication.mainTitle");
-        requireFieldIsNotNull(status, "Publication.status");
-        requireFieldIsNotNull(publicationDate, "Publication.publicationDate");
+        requireFieldIsNotNull(id, PUBLICATION_ID_FIELD_INFO);
+        requireFieldIsNotNull(institutionOwner, PUBLICATION_INSTITUTION_OWNER_FIELD_INFO);
+        requireFieldIsNotNull(modifiedDate, PUBLICATION_MODIFIED_DATE_FIELD_INFO);
+        requireFieldIsNotNull(type, PUBLICATION_TYPE_FIELD_INFO);
+        requireFieldIsNotNull(mainTitle, PUBLICATION_MAIN_TITLE_FIELD_INFO);
+        requireFieldIsNotNull(status, PUBLICATION_STATUS_FIELD_INFO);
+        requireFieldIsNotNull(publicationDate, PUBLICATION_PUBLICATION_DATE_FIELD_INFO);
     }
 
     protected Publication(Builder builder) {

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
@@ -15,6 +15,7 @@ public class PublicationDate extends Validatable {
     public static final JsonPointer YEAR_JSON_POINTER = JsonPointer.compile("/date/m/year/s");
     public static final JsonPointer MONTH_JSON_POINTER = JsonPointer.compile("/date/m/month/s");
     public static final JsonPointer DAY_JSON_POINTER = JsonPointer.compile("/date/m/day/s");
+    public static final String PUBLICATION_DATE_YEAR_FIELD_INFO = "PublicationDate.year";
 
     private final String year;
     private final String month;
@@ -64,7 +65,7 @@ public class PublicationDate extends Validatable {
 
     @Override
     public void validate() {
-        requireFieldIsNotNull(year, "PublicationDate.year");
+        requireFieldIsNotNull(year, PUBLICATION_DATE_YEAR_FIELD_INFO);
     }
 
     @JsonIgnore

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Objects;
 import nva.commons.utils.JacocoGenerated;
 
-public class PublicationDate {
+public class PublicationDate extends Validatable {
 
     public static final JsonPointer YEAR_JSON_POINTER = JsonPointer.compile("/date/m/year/s");
     public static final JsonPointer MONTH_JSON_POINTER = JsonPointer.compile("/date/m/month/s");
@@ -31,6 +31,7 @@ public class PublicationDate {
     public PublicationDate(@JsonProperty("year") String year,
                            @JsonProperty("month") String month,
                            @JsonProperty("day") String day) {
+        super();
         this.year = year;
         this.month = month;
         this.day = day;
@@ -41,8 +42,12 @@ public class PublicationDate {
      *
      * @param doiPublicationDto JsonNode representation of a doiPublicationDto
      */
-    public PublicationDate(JsonNode doiPublicationDto) {
-        this(extractYear(doiPublicationDto), extractMonth(doiPublicationDto), extractDay(doiPublicationDto));
+    public static PublicationDate fromJsonNode(JsonNode doiPublicationDto) {
+        PublicationDate publcationDate = new PublicationDate(extractYear(doiPublicationDto),
+            extractMonth(doiPublicationDto),
+            extractDay(doiPublicationDto));
+        publcationDate.validate();
+        return publcationDate;
     }
 
     public String getYear() {
@@ -55,6 +60,10 @@ public class PublicationDate {
 
     public String getDay() {
         return day;
+    }
+
+    public void validate() {
+        requireFieldIsNotNull(year, "PublicationDate.year");
     }
 
     @JsonIgnore

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/PublicationDate.java
@@ -62,6 +62,7 @@ public class PublicationDate extends Validatable {
         return day;
     }
 
+    @Override
     public void validate() {
         requireFieldIsNotNull(year, "PublicationDate.year");
     }

--- a/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Validatable.java
+++ b/publication-doi-commons/src/main/java/no/unit/nva/publication/doi/dto/Validatable.java
@@ -1,0 +1,23 @@
+package no.unit.nva.publication.doi.dto;
+
+import static java.util.Objects.isNull;
+
+public abstract class Validatable {
+
+    public static final String MANDATORY_FIELD_ERROR_PREFIX = "Mandatory field is missing: ";
+    protected final String errorMessagePrefix =
+        String.format(MANDATORY_FIELD_ERROR_PREFIX + " %s: ", this.getClass().getSimpleName());
+
+    protected Validatable() {
+
+    }
+
+    protected <T> void requireFieldIsNotNull(T value, String fieldName) {
+        if (isNull(value)) {
+            String errorMessage = errorMessagePrefix + fieldName;
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    protected abstract void validate();
+}

--- a/publication-doi-commons/src/test/java/no/unit/nva/publication/doi/dto/PublicationDateTest.java
+++ b/publication-doi-commons/src/test/java/no/unit/nva/publication/doi/dto/PublicationDateTest.java
@@ -18,25 +18,10 @@ class PublicationDateTest {
 
     @Test
     void testJsonNodeConstructor() {
-        var actual = new PublicationDate(getPublicationWithDate());
+        var actual = PublicationDate.fromJsonNode(getPublicationWithDate());
         assertThat(actual.getYear(), is(equalTo("1999")));
         assertThat(actual.getMonth(), is(equalTo("07")));
         assertThat(actual.getDay(), is(equalTo("09")));
-    }
-
-    @Test
-    void testIsPopulated() {
-        var actual = new PublicationDate(getPublicationWithDate());
-        assertThat(actual.isPopulated(), is(true));
-
-        actual = new PublicationDate(getPublicationRandomMissingYearMonthOrDay());
-        assertThat(actual.isPopulated(), is(true));
-
-        actual = new PublicationDate(getPublicationWithMissingYearMonthAndDay());
-        assertThat(actual.isPopulated(), is(false));
-
-        actual = new PublicationDate(null);
-        assertThat(actual.isPopulated(), is(false));
     }
 
     private ObjectNode getPublicationWithDate() {

--- a/publication-doi-commons/src/test/resources/dynamoStream_event_with_old_image.json
+++ b/publication-doi-commons/src/test/resources/dynamoStream_event_with_old_image.json
@@ -1,0 +1,442 @@
+{
+  "eventID": "e88441fb-8048-42bf-a9a9-b3fdc1c58920",
+  "eventName": "MODIFY",
+  "eventVersion": "1.1",
+  "eventSource": "aws:dynamodb",
+  "awsRegion": "eu-west-1",
+  "dynamodb": {
+    "approximateCreationDateTime": "2020-08-14T09:32:26.000+0000",
+    "keys": {
+      "identifier": {
+        "s": "123345"
+      },
+      "modifiedDate": {
+        "s": "2020-08-12T10:30:10.019991Z"
+      }
+    },
+    "newImage": {
+      "owner": {
+        "s": "sg@unit.no"
+      },
+      "identifier": {
+        "s": "98761177-e28c-4686-af62-d7745ddfb307"
+      },
+      "entityDescription": {
+        "m": {
+          "date": {
+            "m": {
+              "year": {
+                "s": "1989"
+              },
+              "month": {
+                "s": "7"
+              },
+              "day": {
+                "s": "17"
+              },
+              "type": {
+                "s": "PublicationDate"
+              }
+            }
+          },
+          "reference": {
+            "m": {
+              "publicationInstance": {
+                "m": {
+                  "volume": {
+                    "s": "100"
+                  },
+                  "pages": {
+                    "m": {
+                      "type": {
+                        "s": "Range"
+                      }
+                    }
+                  },
+                  "issue": {
+                    "s": "8"
+                  },
+                  "peerReviewed": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "JournalLeader"
+                  }
+                }
+              },
+              "type": {
+                "s": "Reference"
+              },
+              "publicationContext": {
+                "m": {
+                  "openAccess": {
+                    "bool": false
+                  },
+                  "peerReviewed": {
+                    "bool": false
+                  },
+                  "onlineIssn": {
+                    "s": "2470-0029"
+                  },
+                  "title": {
+                    "s": "Physical Review D"
+                  },
+                  "type": {
+                    "s": "Journal"
+                  }
+                }
+              },
+              "doi": {
+                "s": "http://example.net/doi/prefix/suffix/d0fbf12d-343b-47df-9fb7-dc6d53dac2d9"
+              }
+            }
+          },
+          "metadataSource": {
+            "s": "https://www.crossref.org/"
+          },
+          "mainTitle": {
+            "s": "Waiting for the Barbarians"
+          },
+          "language": {
+            "s": "http://lexvo.org/id/iso639-3/eng"
+          },
+          "contributors": {
+            "l": [
+              {
+                "m": {
+                  "sequence": {
+                    "n": "1"
+                  },
+                  "identity": {
+                    "m": {
+                      "name": {
+                        "s": "Mr Bane Eyes"
+                      },
+                      "arpId": {
+                        "s": "8665285477"
+                      },
+                      "orcId": {
+                        "s": "2396666334"
+                      },
+                      "type": {
+                        "s": "Identity"
+                      }
+                    }
+                  },
+                  "correspondingAuthor": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "Contributor"
+                  }
+                }
+              },
+              {
+                "m": {
+                  "sequence": {
+                    "n": "1"
+                  },
+                  "identity": {
+                    "m": {
+                      "name": {
+                        "s": "Red Morph"
+                      },
+                      "arpId": {
+                        "s": "3608644706"
+                      },
+                      "orcId": {
+                        "s": "1060667815"
+                      },
+                      "type": {
+                        "s": "Identity"
+                      }
+                    }
+                  },
+                  "correspondingAuthor": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "Contributor"
+                  }
+                }
+              },
+              {
+                "m": {
+                  "sequence": {
+                    "n": "1"
+                  },
+                  "identity": {
+                    "m": {
+                      "name": {
+                        "s": "General Cerebra Spirit"
+                      },
+                      "arpId": {
+                        "s": "6081271417"
+                      },
+                      "orcId": {
+                        "s": "7507217001"
+                      },
+                      "type": {
+                        "s": "Identity"
+                      }
+                    }
+                  },
+                  "correspondingAuthor": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "Contributor"
+                  }
+                }
+              }
+            ]
+          },
+          "type": {
+            "s": "EntityDescription"
+          },
+          "alternativeTitles": {
+            "m": {}
+          },
+          "tags": {
+            "l": []
+          }
+        }
+      },
+      "publisherId": {
+        "s": "http://example.net/nva/institution/6c1438b1-f842-4c1a-acfe-a14c50968e52"
+      },
+      "createdDate": {
+        "s": "2020-08-14T10:28:52.565586Z"
+      },
+      "publisherOwnerDate": {
+        "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#kiva@unit.no#2020-08-12T10:30:10.019991Z"
+      },
+      "modifiedDate": {
+        "s": "2020-11-18T15:26:41.942893Z"
+      },
+      "publisher": {
+        "m": {
+          "id": {
+            "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+          },
+          "type": {
+            "s": "Organization"
+          }
+        }
+      },
+      "type": {
+        "s": "Publication"
+      },
+      "fileSet": {
+        "m": {
+          "files": {
+            "l": []
+          },
+          "type": {
+            "s": "FileSet"
+          }
+        }
+      },
+      "status": {
+        "s": "PUBLISHED"
+      },
+      "doiRequest": {
+        "m": {
+          "status": {
+            "s": "APPROVED"
+          },
+          "type": {
+            "s": "DoiRequest"
+          },
+          "modifiedDate": {
+            "s": "2020-11-18T15:26:41.942893Z"
+          }
+        }
+      }
+    },
+    "oldImage": {
+      "owner": {
+        "s": "sg@unit.no"
+      },
+      "identifier": {
+        "s": "654321"
+      },
+      "entityDescription": {
+        "m": {
+          "date": {
+            "m": {
+              "year": {
+                "s": "1989"
+              },
+              "month": {
+                "s": "7"
+              },
+              "day": {
+                "s": "17"
+              },
+              "type": {
+                "s": "PublicationDate"
+              }
+            }
+          },
+          "reference": {
+            "m": {
+              "publicationInstance": {
+                "m": {
+                  "volume": {
+                    "s": "100"
+                  },
+                  "pages": {
+                    "m": {
+                      "type": {
+                        "s": "Range"
+                      }
+                    }
+                  },
+                  "issue": {
+                    "s": "8"
+                  },
+                  "peerReviewed": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "JournalArticle"
+                  }
+                }
+              },
+              "type": {
+                "s": "Reference"
+              },
+              "publicationContext": {
+                "m": {
+                  "openAccess": {
+                    "bool": false
+                  },
+                  "peerReviewed": {
+                    "bool": false
+                  },
+                  "onlineIssn": {
+                    "s": "2470-0029"
+                  },
+                  "title": {
+                    "s": "Physical Review D"
+                  },
+                  "type": {
+                    "s": "Journal"
+                  }
+                }
+              },
+              "doi": {
+                "s": "https://doi.org/10.1103/physrevd.100.085005"
+              }
+            }
+          },
+          "metadataSource": {
+            "s": "https://www.crossref.org/"
+          },
+          "mainTitle": {
+            "s": "Conformality loss and quantum criticality in topological Higgs electrodynamics in 2+1 dimensions"
+          },
+          "language": {
+            "s": "http://lexvo.org/id/iso639-3/eng"
+          },
+          "contributors": {
+            "l": [
+              {
+                "m": {
+                  "sequence": {
+                    "n": "1"
+                  },
+                  "identity": {
+                    "m": {
+                      "name": {
+                        "s": "Nogueira, Flavio S."
+                      },
+                      "arpId": {
+                        "s": "451001"
+                      },
+                      "orcId": {},
+                      "type": {
+                        "s": "Identity"
+                      }
+                    }
+                  },
+                  "correspondingAuthor": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "Contributor"
+                  }
+                }
+              }
+            ]
+          },
+          "type": {
+            "s": "EntityDescription"
+          },
+          "alternativeTitles": {
+            "m": {}
+          },
+          "tags": {
+            "l": []
+          }
+        }
+      },
+      "publisherId": {
+        "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+      },
+      "createdDate": {
+        "s": "2020-08-14T10:28:52.565586Z"
+      },
+      "publisherOwnerDate": {
+        "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#kiva@unit.no#2020-08-12T10:30:10.019991Z"
+      },
+      "modifiedDate": {
+        "s": "2020-08-14T10:30:10.019991Z"
+      },
+      "publisher": {
+        "m": {
+          "id": {
+            "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+          },
+          "type": {
+            "s": "Organization"
+          }
+        }
+      },
+      "type": {
+        "s": "Publication"
+      },
+      "fileSet": {
+        "m": {
+          "files": {
+            "l": []
+          },
+          "type": {
+            "s": "FileSet"
+          }
+        }
+      },
+      "status": {
+        "s": "Draft"
+      },
+      "doiRequest": {
+        "m": {
+          "status": {
+            "s": "REQUESTED"
+          },
+          "type": {
+            "s": "DoiRequest"
+          },
+          "modifiedDate": {
+            "s": "2020-08-14T10:30:10.019991Z"
+          }
+        }
+      }
+    },
+    "sequenceNumber": "605204800000000056657663004",
+    "sizeBytes": 1435,
+    "streamViewType": "OLD_IMAGE"
+  },
+  "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/nva_resources/stream/2020-08-13T08:41:25.491"
+}

--- a/publication-doi-commons/src/test/resources/dynamoStream_publication_without_date.json
+++ b/publication-doi-commons/src/test/resources/dynamoStream_publication_without_date.json
@@ -1,0 +1,282 @@
+{
+  "dynamodb": {
+    "approximateCreationDateTime": 1605555075000,
+    "keys": {
+      "identifier": {
+        "s": "620fee96-87e3-4e9b-84f3-3a563fe3def8"
+      },
+      "modifiedDate": {
+        "s": "2020-11-10T15:40:31.609333Z"
+      }
+    },
+    "newImage": {
+      "owner": {
+        "s": "og@unit.no"
+      },
+      "identifier": {
+        "s": "620fee96-87e3-4e9b-84f3-3a563fe3def8"
+      },
+      "publisherOwnerDate": {
+        "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-11-10T15:40:31.609333Z"
+      },
+      "type": {
+        "s": "Publication"
+      },
+      "doiRequest": {
+        "m": {
+          "date": {
+            "s": "2020-11-10T14:34:24.232877Z"
+          },
+          "modifiedDate": {
+            "s": "2020-11-10T14:34:24.232877Z"
+          },
+          "messages": {
+            "l": [
+              {
+                "m": {
+                  "author": {
+                    "s": "og@unit.no"
+                  },
+                  "text": {
+                    "s": "Oresitis asks for DOIIII"
+                  },
+                  "type": {
+                    "s": "DoiRequestMessage"
+                  },
+                  "timestamp": {
+                    "s": "2020-11-10T14:34:24.232923Z"
+                  }
+                }
+              }
+            ]
+          },
+          "type": {
+            "s": "DoiRequest"
+          },
+          "status": {
+            "s": "APPROVED"
+          }
+        }
+      },
+      "fileSet": {
+        "m": {
+          "files": {
+            "l": [
+              {
+                "m": {
+                  "identifier": {
+                    "s": "c3d46a31-013a-440d-a77c-c437f9ae10c8"
+                  },
+                  "license": {
+                    "m": {
+                      "identifier": {
+                        "s": "CC0"
+                      },
+                      "type": {
+                        "s": "License"
+                      },
+                      "labels": {
+                        "m": {
+                          "nb": {
+                            "s": "CC0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "size": {
+                    "n": "129655"
+                  },
+                  "publisherAuthority": {
+                    "bool": false
+                  },
+                  "name": {
+                    "s": "DTOandBOs.pdf"
+                  },
+                  "administrativeAgreement": {
+                    "bool": false
+                  },
+                  "mimeType": {
+                    "s": "application/pdf"
+                  },
+                  "embargoDate": {
+                    "s": "2020-11-10T14:33:00Z"
+                  },
+                  "type": {
+                    "s": "File"
+                  }
+                }
+              }
+            ]
+          },
+          "type": {
+            "s": "FileSet"
+          }
+        }
+      },
+      "entityDescription": {
+        "m": {
+          "date": {
+            "m": {
+              "type": {
+                "s": "PublicationDate"
+              }
+            }
+          },
+          "reference": {
+            "m": {
+              "type": {
+                "s": "Reference"
+              },
+              "publicationInstance": {
+                "m": {
+                  "articleNumber": {
+                    "s": "123"
+                  },
+                  "peerReviewed": {
+                    "bool": true
+                  },
+                  "type": {
+                    "s": "JournalArticle"
+                  }
+                }
+              },
+              "publicationContext": {
+                "m": {
+                  "level": {
+                    "s": "LEVEL_2"
+                  },
+                  "openAccess": {
+                    "bool": false
+                  },
+                  "peerReviewed": {
+                    "bool": false
+                  },
+                  "type": {
+                    "s": "Journal"
+                  },
+                  "title": {
+                    "s": "Information Systems"
+                  },
+                  "onlineIssn": {
+                    "s": "0306-4379"
+                  },
+                  "url": {
+                    "s": "http://www.elsevier.com/wps/find/journaldescription.cws_home/236/description#description"
+                  }
+                }
+              },
+              "doi": {
+                "s": ""
+              }
+            }
+          },
+          "mainTitle": {
+            "s": "Orestis Title"
+          },
+          "language": {
+            "s": "http://lexvo.org/id/iso639-3/eng"
+          },
+          "contributors": {
+            "l": [
+              {
+                "m": {
+                  "sequence": {
+                    "n": "1"
+                  },
+                  "identity": {
+                    "m": {
+                      "arpId": {
+                        "s": "1582627888604"
+                      },
+                      "name": {
+                        "s": "Gkorgkas,Orestis Stylianos"
+                      },
+                      "orcId": {
+                        "s": "0000-0001-8310-5489"
+                      },
+                      "type": {
+                        "s": "Identity"
+                      }
+                    }
+                  },
+                  "correspondingAuthor": {
+                    "bool": false
+                  },
+                  "affiliations": {
+                    "l": [
+                      {
+                        "m": {
+                          "id": {
+                            "s": "https://api.cristin.no/v2/institutions/20202"
+                          },
+                          "type": {
+                            "s": "Organization"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": {
+                    "s": "Contributor"
+                  }
+                }
+              }
+            ]
+          },
+          "abstract": {
+            "s": "Orestis description"
+          },
+          "type": {
+            "s": "EntityDescription"
+          },
+          "npiSubjectHeading": {
+            "s": "1039"
+          },
+          "tags": {
+            "l": [
+              {
+                "s": "hello"
+              },
+              {
+                "s": "world"
+              }
+            ]
+          }
+        }
+      },
+      "publisherId": {
+        "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+      },
+      "createdDate": {
+        "s": "2020-11-10T14:18:32.670614Z"
+      },
+      "modifiedDate": {
+        "s": "2020-11-10T15:40:31.609333Z"
+      },
+      "publisher": {
+        "m": {
+          "id": {
+            "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934ffgg"
+          },
+          "type": {
+            "s": "Organization"
+          }
+        }
+      },
+      "publishedDate": {
+        "s": "2020-11-10T14:33:32.569641Z"
+      },
+      "doiRequestStatusDate": {
+        "s": "APPROVED#2020-11-10T14:34:24.232877Z"
+      },
+      "status": {
+        "s": "Published"
+      }
+    },
+    "sequenceNumber": "1054408700000000001537662819",
+    "sizeBytes": 1922,
+    "streamViewType": "NEW_IMAGE"
+  },
+  "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/nva_resources/stream/2020-08-19T09:27:44.804"
+}

--- a/publication-event-dtopublicationdoi-producer/build.gradle
+++ b/publication-event-dtopublicationdoi-producer/build.gradle
@@ -15,6 +15,9 @@ dependencies {
         because "PMD complains for the com/amazonaws/regions/Regions class"
     }
 
+
+   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.junit5Version
+
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.1.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion

--- a/publication-event-dtopublicationdoi-producer/build.gradle
+++ b/publication-event-dtopublicationdoi-producer/build.gradle
@@ -8,12 +8,12 @@ dependencies {
     }
 
     implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
-
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version: '3.2.0'
-    implementation group: 'software.amazon.awssdk', name: 'eventbridge', version: project.ext.awsSdk2Version
-    implementation group: 'software.amazon.awssdk', name: 'url-connection-client', version: project.ext.awsSdk2Version
-    implementation group: 'software.amazon.awssdk', name: 'sqs', version: project.ext.awsSdk2Version
+
+    compileOnly( group: 'com.amazonaws', name: 'aws-java-sdk-api-gateway', version: awsSdkVersion) {
+        because "PMD complains for the com/amazonaws/regions/Regions class"
+    }
 
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.1.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion

--- a/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
+++ b/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
@@ -44,7 +44,7 @@ public class DynamoDbFanoutPublicationDtoProducer
                                              AwsEventBridgeEvent<DynamodbEvent.DynamodbStreamRecord> event,
                                              Context context) {
         PublicationHolder result = fromDynamodbStreamRecords(input);
-        //temporary logging until develop stack if fixed.
+        //temporary logging until event consumers are built
         logResults(result);
         return result;
     }

--- a/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
+++ b/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
@@ -1,8 +1,8 @@
 package no.unit.nva.doi.event.producer;
 
-import static nva.commons.utils.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
@@ -50,8 +50,13 @@ public class DynamoDbFanoutPublicationDtoProducer
     }
 
     private void logResults(PublicationHolder result) {
-        String jsonString = attempt(() -> JsonUtils.objectMapper.writeValueAsString(result)).orElse(fail -> null);
-        logger.info("Output is: " + jsonString);
+
+        try {
+            String jsonString = JsonUtils.objectMapper.writeValueAsString(result);
+            logger.info("Output is: " + jsonString);
+        } catch (JsonProcessingException e) {
+            logger.info("Could not serialize output");
+        }
     }
 
     private PublicationHolder fromDynamodbStreamRecords(DynamodbEvent.DynamodbStreamRecord record) {

--- a/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
+++ b/publication-event-dtopublicationdoi-producer/src/main/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducer.java
@@ -22,9 +22,9 @@ public class DynamoDbFanoutPublicationDtoProducer
 
     public static final String TYPE_DTO_DOI_PUBLICATION = "doi.publication";
     public static final PublicationHolder NO_OUTPUT_NO_EVENT = null;
-    private static final Logger logger = LoggerFactory.getLogger(DynamoDbFanoutPublicationDtoProducer.class);
     public static final String CREATED = "Created";
     public static final String SKIPPED_CREATING = "Skipped creating";
+    private static final Logger logger = LoggerFactory.getLogger(DynamoDbFanoutPublicationDtoProducer.class);
     private final PublicationMapper publicationMapper;
 
     @JacocoGenerated
@@ -47,6 +47,7 @@ public class DynamoDbFanoutPublicationDtoProducer
     private PublicationHolder fromDynamodbStreamRecords(DynamodbEvent.DynamodbStreamRecord record) {
         var dto = mapToPublicationDto(record);
         logMappingResults(dto.orElse(null));
+
         return dto
             .map(publication -> new PublicationHolder(TYPE_DTO_DOI_PUBLICATION, publication))
             .orElse(NO_OUTPUT_NO_EVENT);
@@ -59,8 +60,22 @@ public class DynamoDbFanoutPublicationDtoProducer
     private Optional<Publication> mapToPublicationDto(DynamodbEvent.DynamodbStreamRecord record) {
         return Optional.ofNullable(record)
             .map(publicationMapper::fromDynamodbStreamRecord)
-            .filter(this::isEffectiveChange)
+            .filter(this::shouldPropagateEvent)
             .map(publicationMapping -> publicationMapping.getNewPublication().orElseThrow());
+    }
+
+    private boolean shouldPropagateEvent(PublicationMapping publicationMapping) {
+        boolean isChange = isEffectiveChange(publicationMapping);
+        boolean publicationHasDoiRequest = publicationHasDoiRequest(publicationMapping);
+
+        return isChange && publicationHasDoiRequest;
+    }
+
+    private boolean publicationHasDoiRequest(PublicationMapping publicationMapping) {
+        return publicationMapping
+            .getNewPublication()
+            .map(Publication::getDoiRequest)
+            .isPresent();
     }
 
     private boolean isEffectiveChange(PublicationMapping publicationMapping) {

--- a/publication-event-dtopublicationdoi-producer/src/test/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducerTest.java
+++ b/publication-event-dtopublicationdoi-producer/src/test/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducerTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,15 +14,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
 import no.unit.nva.publication.doi.dto.PublicationHolder;
+import no.unit.nva.publication.doi.dto.Validatable;
 import nva.commons.utils.IoUtils;
 import nva.commons.utils.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 class DynamoDbFanoutPublicationDtoProducerTest {
 
     public static final String EXAMPLE_NAMESPACE = "https://example.net/unittest/namespace/";
     public static final String DOI_PUBLICATION_TYPE = "doi.publication";
+    public static final String PUBLICATION_WIHOUT_ID = "dynamodbevent_publication_without_id.json";
+    public static final String PUBLICATION_MISSING_PUBLISHER_ID = "dynamodbevent_publication_missing_publisher_id.json";
+    public static final String PUBLICATION_MISSING_MODIFIED_DATE = "dynamodbevent_publication_missing_modifed_date"
+        + ".json";
     private static final Path DYNAMODB_STREAM_EVENT_OLD_AND_NEW_PRESENT_DIFFERENT =
         Path.of("dynamodbevent_old_and_new_present_different.json");
     private static final Path DYNAMODB_STREAM_EVENT_OLD_AND_NEW_PRESENT_EQUAL =
@@ -28,6 +36,15 @@ class DynamoDbFanoutPublicationDtoProducerTest {
     private static final Path DYNAMODB_STREAM_EVENT_OLD_ONLY = Path.of("dynamodbevent_old_only.json");
     private static final Path DYNAMODB_STREAM_EVENT_NEW_ONLY = Path.of("dynamodbevent_new_only.json");
     private static final ObjectMapper objectMapper = JsonUtils.objectMapper;
+    private static final String PUBLICATION_MISSING_PUBLICATION_TYPE =
+        "dynamodbevent_publication_missing_publication_type.json";
+    private static final String PUBLICATION_MISSING_MAIN_TITLE = "dynamodbevent_publication_missing_main_title.json";
+    private static final String PUBLICATION_MISSING_PUBLICATION_STATUS =
+        "dynamodbevent_publication_missing_publication_status.json";
+    private static final String PUBLICATION_WITHOUT_DOI_REQUEST = "dynamodbevent_publication_wiithout_doi_request.json";
+    private static final String NULL_AS_STRING = "null";
+    public static final String PUBLICATION_MISSING_DOI_REQUEST_MODIFIED_DATE =
+        "dynamodbevent_publiction_missing_doi_request_modfied_date.json";
     private DynamoDbFanoutPublicationDtoProducer handler;
     private Context context;
     private ByteArrayOutputStream outputStream;
@@ -43,11 +60,59 @@ class DynamoDbFanoutPublicationDtoProducerTest {
     }
 
     @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingId() {
+        final String missingField = "id";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_WIHOUT_ID);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingPublisherId() {
+        final String missingField = "institutionOwner";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_MISSING_PUBLISHER_ID);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingModifiedDate() {
+        final String modifiedDateField = "modifiedDate";
+        publicationMissingMandatoryFieldThrowsException(modifiedDateField, PUBLICATION_MISSING_MODIFIED_DATE);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingPublicationType() {
+        final String missingField = "type";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_MISSING_PUBLICATION_TYPE);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingMainTitle() {
+        final String missingField = "mainTitle";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_MISSING_MAIN_TITLE);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenPublicationIsMissingPublicationStatus() {
+        final String missingField = "status";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_MISSING_PUBLICATION_STATUS);
+    }
+
+    @Test
+    public void handleRequestThrowsExceptionWhenDoiRequestIsMissingModifiedDate() {
+        final String missingField = "DoiRequest.modifiedDate";
+        publicationMissingMandatoryFieldThrowsException(missingField, PUBLICATION_MISSING_DOI_REQUEST_MODIFIED_DATE);
+    }
+
+    @Test
+    public void handleRequestReturnsEmptyInputWhenThereIsNoDoiRequest() {
+        var eventInputStream = IoUtils.inputStreamFromResources(Path.of(PUBLICATION_WITHOUT_DOI_REQUEST));
+        handler.handleRequest(eventInputStream, outputStream, context);
+        assertThat(outputStream.toString(), is(NULL_AS_STRING));
+    }
+
+    @Test
     void processInputCreatingDtosWhenOnlyNewImageIsPresentInDao() throws JsonProcessingException {
         var eventInputStream = IoUtils.inputStreamFromResources(DYNAMODB_STREAM_EVENT_NEW_ONLY);
         handler.handleRequest(eventInputStream, outputStream, context);
         PublicationHolder actual = outputToPublicationHolder(outputStream);
-
         assertThat(actual.getType(), is(equalTo(DOI_PUBLICATION_TYPE)));
         assertThat(actual.getItem(), notNullValue());
     }
@@ -79,10 +144,18 @@ class DynamoDbFanoutPublicationDtoProducerTest {
         assertThat(actual, nullValue());
     }
 
+    private void publicationMissingMandatoryFieldThrowsException(String expectedFieldName,
+                                                                 String resourceFilename) {
+        var event = IoUtils.inputStreamFromResources(Path.of(resourceFilename));
+        Executable action = () -> handler.handleRequest(event, outputStream, context);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, action);
+        assertThat(exception.getMessage(), containsString(Validatable.MANDATORY_FIELD_ERROR_PREFIX));
+        assertThat(exception.getMessage(), containsString(expectedFieldName));
+    }
+
     private PublicationHolder outputToPublicationHolder(ByteArrayOutputStream outputStream)
         throws JsonProcessingException {
         String outputString = outputStream.toString();
-        PublicationHolder actual = objectMapper.readValue(outputString, PublicationHolder.class);
-        return actual;
+        return objectMapper.readValue(outputString, PublicationHolder.class);
     }
 }

--- a/publication-event-dtopublicationdoi-producer/src/test/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducerTest.java
+++ b/publication-event-dtopublicationdoi-producer/src/test/java/no/unit/nva/doi/event/producer/DynamoDbFanoutPublicationDtoProducerTest.java
@@ -1,5 +1,12 @@
 package no.unit.nva.doi.event.producer;
 
+import static no.unit.nva.publication.doi.dto.DoiRequest.DOI_REQUEST_MODIFIED_DATE_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_ID_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_INSTITUTION_OWNER_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_MAIN_TITLE_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_MODIFIED_DATE_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_STATUS_FIELD_INFO;
+import static no.unit.nva.publication.doi.dto.Publication.PUBLICATION_TYPE_FIELD_INFO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -120,13 +127,13 @@ class DynamoDbFanoutPublicationDtoProducerTest {
 
     private static Stream<Arguments> missingFieldTestParameters() {
         return Stream.of(
-            Arguments.of("id", PUBLICATION_WIHOUT_ID),
-            Arguments.of("institutionOwner", PUBLICATION_MISSING_PUBLISHER_ID),
-            Arguments.of("modifiedDate", PUBLICATION_MISSING_MODIFIED_DATE),
-            Arguments.of("type", PUBLICATION_MISSING_PUBLICATION_TYPE),
-            Arguments.of("mainTitle", PUBLICATION_MISSING_MAIN_TITLE),
-            Arguments.of("status", PUBLICATION_MISSING_PUBLICATION_STATUS),
-            Arguments.of("DoiRequest.modifiedDate", PUBLICATION_MISSING_DOI_REQUEST_MODIFIED_DATE)
+            Arguments.of(PUBLICATION_ID_FIELD_INFO, PUBLICATION_WIHOUT_ID),
+            Arguments.of(PUBLICATION_INSTITUTION_OWNER_FIELD_INFO, PUBLICATION_MISSING_PUBLISHER_ID),
+            Arguments.of(PUBLICATION_MODIFIED_DATE_FIELD_INFO, PUBLICATION_MISSING_MODIFIED_DATE),
+            Arguments.of(PUBLICATION_TYPE_FIELD_INFO, PUBLICATION_MISSING_PUBLICATION_TYPE),
+            Arguments.of(PUBLICATION_MAIN_TITLE_FIELD_INFO, PUBLICATION_MISSING_MAIN_TITLE),
+            Arguments.of(PUBLICATION_STATUS_FIELD_INFO, PUBLICATION_MISSING_PUBLICATION_STATUS),
+            Arguments.of(DOI_REQUEST_MODIFIED_DATE_FIELD_INFO, PUBLICATION_MISSING_DOI_REQUEST_MODIFIED_DATE)
         );
     }
 

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_new_only.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_new_only.json
@@ -1,569 +1,360 @@
 {
   "version": "0",
-  "id": "c2c057c1-67fe-1208-fc21-0401596631ba",
-  "detail-type": "The detail type",
-  "source": "some source",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
   "account": "884807050265",
-  "time": "2020-10-09T09:34:33Z",
+  "time": "2020-10-30T13:21:40Z",
   "region": "eu-west-1",
   "resources": [
-    "NOT IMPORTANT"
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
   ],
   "detail": {
-    "eventID": "56e841a6b5d7d07a2fda05691836a41b",
-    "eventName": "MODIFY",
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
     "eventVersion": "1.1",
     "eventSource": "aws:dynamodb",
     "awsRegion": "eu-west-1",
     "dynamodb": {
-      "approximateCreationDateTime": 1597397546000,
+      "approximateCreationDateTime": 1604064096000,
       "keys": {
         "identifier": {
-          "s": "123345"
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
         },
         "modifiedDate": {
-          "s": "2020-08-12T10:30:10.019991Z"
+          "s": "2020-09-24T11:15:17.671542Z"
         }
       },
-      "oldImage": null,
       "newImage": {
         "owner": {
-          "s": "sg@unit.no",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "og@unit.no"
         },
         "identifier": {
-          "s": "654321",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "entityDescription": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "date": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "type": {
-                  "s": "PublicationDate",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "reference": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "publicationInstance": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "volume": {
-                      "s": "100",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "pages": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": {
-                        "type": {
-                          "s": "Range",
-                          "n": null,
-                          "b": null,
-                          "m": null,
-                          "l": null,
-                          "null": null,
-                          "bool": null,
-                          "ss": null,
-                          "ns": null,
-                          "bs": null
-                        }
-                      },
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "issue": {
-                      "s": "8",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "JournalArticle",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "type": {
-                  "s": "Reference",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "publicationContext": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "openAccess": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "onlineIssn": {
-                      "s": "2470-0029",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "title": {
-                      "s": "Physical Review D",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "Journal",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "doi": {
-                  "s": "https://doi.org/10.1103/physrevd.100.085005",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "metadataSource": {
-              "s": "https://www.crossref.org/",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "mainTitle": {
-              "s": "Conformality loss and quantum criticality in topological Higgs electrodynamics in 2+1 dimensions",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "language": {
-              "s": "http://lexvo.org/id/iso639-3/eng",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "contributors": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "EntityDescription",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "alternativeTitles": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {},
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "tags": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisherId": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "createdDate": {
-          "s": "2020-08-14T10:28:52.565586Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
         },
         "publisherOwnerDate": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#kiva@unit.no#2020-08-12T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "modifiedDate": {
-          "s": "2020-08-14T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisher": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "id": {
-              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "Organization",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
         },
         "type": {
-          "s": "Publication",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "fileSet": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "files": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "FileSet",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "status": {
-          "s": "DRAFT",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "Publication"
         },
         "doiRequest": {
-          "s": null,
-          "n": null,
-          "b": null,
           "m": {
-            "status": {
-              "s": "REQUESTED",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "DoiRequest",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
             },
             "modifiedDate": {
-              "s": "2020-08-14T10:30:10.019991Z",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
             }
           }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
         }
       },
-      "sequenceNumber": "605204800000000056657663004",
-      "sizeBytes": 1435,
-      "streamViewType": "NEW_AND_OLD_IMAGES"
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
     },
-    "userIdentity": null,
-    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/nva_resources/stream/2020-08-13T08:41:25.491"
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
   }
 }

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_and_new_present_different.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_and_new_present_different.json
@@ -1,1101 +1,591 @@
 {
   "version": "0",
-  "id": "c2c057c1-67fe-1208-fc21-0401596631ba",
-  "detail-type": "The detail type",
-  "source": "some source",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
   "account": "884807050265",
-  "time": "2020-10-09T09:34:33Z",
+  "time": "2020-10-30T13:21:40Z",
   "region": "eu-west-1",
   "resources": [
-    "NOT IMPORTANT"
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
   ],
   "detail": {
-    "eventID": "56e841a6b5d7d07a2fda05691836a41b",
-    "eventName": "MODIFY",
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
     "eventVersion": "1.1",
     "eventSource": "aws:dynamodb",
     "awsRegion": "eu-west-1",
     "dynamodb": {
-      "approximateCreationDateTime": 1597397546000,
+      "approximateCreationDateTime": 1604064096000,
       "keys": {
         "identifier": {
-          "s": "123345"
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
         },
         "modifiedDate": {
-          "s": "2020-08-12T10:30:10.019991Z"
-        }
-      },
-      "newImage": {
-        "owner": {
-          "s": "sg@unit.no",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "identifier": {
-          "s": "654321",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "entityDescription": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "date": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "type": {
-                  "s": "PublicationDate",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "reference": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "publicationInstance": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "volume": {
-                      "s": "100",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "pages": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": {
-                        "type": {
-                          "s": "Range",
-                          "n": null,
-                          "b": null,
-                          "m": null,
-                          "l": null,
-                          "null": null,
-                          "bool": null,
-                          "ss": null,
-                          "ns": null,
-                          "bs": null
-                        }
-                      },
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "issue": {
-                      "s": "8",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "JournalArticle",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "type": {
-                  "s": "Reference",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "publicationContext": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "openAccess": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "onlineIssn": {
-                      "s": "2470-0029",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "title": {
-                      "s": "Physical Review D",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "Journal",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "doi": {
-                  "s": "https://doi.org/10.1103/physrevd.100.085005",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "metadataSource": {
-              "s": "https://www.crossref.org/",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "mainTitle": {
-              "s": "Conformality loss and quantum criticality in topological Higgs electrodynamics in 2+2 dimensions",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "language": {
-              "s": "http://lexvo.org/id/iso639-3/eng",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "contributors": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "EntityDescription",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "alternativeTitles": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {},
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "tags": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisherId": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "createdDate": {
-          "s": "2020-08-14T10:28:52.565586Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisherOwnerDate": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#kiva@unit.no#2020-08-12T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "modifiedDate": {
-          "s": "2020-08-14T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisher": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "id": {
-              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "Organization",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "type": {
-          "s": "Publication",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "fileSet": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "files": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "FileSet",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "status": {
-          "s": "DRAFT",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "doiRequest": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "status": {
-              "s": "REQUESTED",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "DoiRequest",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "modifiedDate": {
-              "s": "2020-08-14T10:30:10.019991Z",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          }
+          "s": "2020-09-24T11:15:17.671542Z"
         }
       },
       "oldImage": {
         "owner": {
-          "s": "sg@unit.no",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "og@unit.no"
         },
         "identifier": {
-          "s": "654321",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "entityDescription": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "date": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "type": {
-                  "s": "PublicationDate",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "reference": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {
-                "publicationInstance": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "volume": {
-                      "s": "100",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "pages": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": {
-                        "type": {
-                          "s": "Range",
-                          "n": null,
-                          "b": null,
-                          "m": null,
-                          "l": null,
-                          "null": null,
-                          "bool": null,
-                          "ss": null,
-                          "ns": null,
-                          "bs": null
-                        }
-                      },
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "issue": {
-                      "s": "8",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "JournalArticle",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "type": {
-                  "s": "Reference",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "publicationContext": {
-                  "s": null,
-                  "n": null,
-                  "b": null,
-                  "m": {
-                    "openAccess": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "peerReviewed": {
-                      "s": null,
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": false,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "onlineIssn": {
-                      "s": "2470-0029",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "title": {
-                      "s": "Physical Review D",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    },
-                    "type": {
-                      "s": "Journal",
-                      "n": null,
-                      "b": null,
-                      "m": null,
-                      "l": null,
-                      "null": null,
-                      "bool": null,
-                      "ss": null,
-                      "ns": null,
-                      "bs": null
-                    }
-                  },
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                },
-                "doi": {
-                  "s": "https://doi.org/10.1103/physrevd.100.085005",
-                  "n": null,
-                  "b": null,
-                  "m": null,
-                  "l": null,
-                  "null": null,
-                  "bool": null,
-                  "ss": null,
-                  "ns": null,
-                  "bs": null
-                }
-              },
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "metadataSource": {
-              "s": "https://www.crossref.org/",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "mainTitle": {
-              "s": "Conformality loss and quantum criticality in topological Higgs electrodynamics in 2+1 dimensions",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "language": {
-              "s": "http://lexvo.org/id/iso639-3/eng",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "contributors": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "EntityDescription",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "alternativeTitles": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": {},
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "tags": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisherId": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "createdDate": {
-          "s": "2020-08-14T10:28:52.565586Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
         },
         "publisherOwnerDate": {
-          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#kiva@unit.no#2020-08-12T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "modifiedDate": {
-          "s": "2020-08-14T10:30:10.019991Z",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "publisher": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "id": {
-              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "Organization",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
         },
         "type": {
-          "s": "Publication",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "fileSet": {
-          "s": null,
-          "n": null,
-          "b": null,
-          "m": {
-            "files": {
-              "s": null,
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": [],
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "FileSet",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            }
-          },
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
-        },
-        "status": {
-          "s": "DRAFT",
-          "n": null,
-          "b": null,
-          "m": null,
-          "l": null,
-          "null": null,
-          "bool": null,
-          "ss": null,
-          "ns": null,
-          "bs": null
+          "s": "Publication"
         },
         "doiRequest": {
-          "s": null,
-          "n": null,
-          "b": null,
           "m": {
-            "status": {
-              "s": "REQUESTED",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
-            },
-            "type": {
-              "s": "DoiRequest",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
             },
             "modifiedDate": {
-              "s": "2020-08-14T10:30:10.019991Z",
-              "n": null,
-              "b": null,
-              "m": null,
-              "l": null,
-              "null": null,
-              "bool": null,
-              "ss": null,
-              "ns": null,
-              "bs": null
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
             }
           }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": null,
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
         }
       },
-      "sequenceNumber": "605204800000000056657663004",
-      "sizeBytes": 1435,
-      "streamViewType": "NEW_AND_OLD_IMAGES"
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
     },
-    "userIdentity": null,
-    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/nva_resources/stream/2020-08-13T08:41:25.491"
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
   }
 }

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_and_new_present_equal.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_and_new_present_equal.json
@@ -60,6 +60,9 @@
               "n": null,
               "b": null,
               "m": {
+                "year": {
+                  "s": "2017"
+                },
                 "type": {
                   "s": "PublicationDate",
                   "n": null,
@@ -593,6 +596,9 @@
               "n": null,
               "b": null,
               "m": {
+                "year": {
+                  "s": "2017"
+                },
                 "type": {
                   "s": "PublicationDate",
                   "n": null,

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_only.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_old_only.json
@@ -61,6 +61,9 @@
               "n": null,
               "b": null,
               "m": {
+                "year": {
+                  "s": "2017"
+                },
                 "type": {
                   "s": "PublicationDate",
                   "n": null,

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_main_title.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_main_title.json
@@ -1,0 +1,358 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": null,
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_modifed_date.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_modifed_date.json
@@ -1,0 +1,358 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": null,
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publication_status.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publication_status.json
@@ -1,0 +1,358 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": null
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publication_type.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publication_type.json
@@ -1,0 +1,358 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": null
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publisher_id.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_missing_publisher_id.json
@@ -1,0 +1,356 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": null,
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": null,
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_wiithout_doi_request.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_wiithout_doi_request.json
@@ -1,0 +1,321 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_without_id.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publication_without_id.json
@@ -1,0 +1,356 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": null,
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": null,
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "modifiedDate": {
+              "s": "2020-09-24T11:15:17.671542Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}

--- a/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publiction_missing_doi_request_modfied_date.json
+++ b/publication-event-dtopublicationdoi-producer/src/test/resources/dynamodbevent_publiction_missing_doi_request_modfied_date.json
@@ -1,0 +1,357 @@
+{
+  "version": "0",
+  "id": "d437a46a-e515-761c-e31d-5e23c5a0a247",
+  "detail-type": "dynamodb-stream-event",
+  "source": "aws-dynamodb-stream-eventbridge-fanout",
+  "account": "884807050265",
+  "time": "2020-10-30T13:21:40Z",
+  "region": "eu-west-1",
+  "resources": [
+    "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  ],
+  "detail": {
+    "eventID": "63951b991a8fc9942126c906a0b70d87",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+      "approximateCreationDateTime": 1604064096000,
+      "keys": {
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        }
+      },
+      "newImage": {
+        "owner": {
+          "s": "og@unit.no"
+        },
+        "identifier": {
+          "s": "42d5f94a-f756-484a-aee0-d01a44d24e91"
+        },
+        "publisherOwnerDate": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934#og@unit.no#2020-09-24T11:15:17.671542Z"
+        },
+        "type": {
+          "s": "Publication"
+        },
+        "doiRequest": {
+          "m": {
+            "date": {
+              "s": "2020-10-22T13:09:17.317127Z"
+            },
+            "messages": {
+              "l": [
+                {
+                  "m": {
+                    "author": {
+                      "s": "og@unit.no"
+                    },
+                    "text": {
+                      "s": "doiiii"
+                    },
+                    "type": {
+                      "s": "DoiRequestMessage"
+                    },
+                    "timestamp": {
+                      "s": "2020-10-22T13:09:17.317166Z"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "DoiRequest"
+            },
+            "status": {
+              "s": "REQUESTED"
+            }
+          }
+        },
+        "fileSet": {
+          "m": {
+            "files": {
+              "l": [
+                {
+                  "m": {
+                    "identifier": {
+                      "s": "9728965a-7ceb-4678-b351-343006255bfc"
+                    },
+                    "license": {
+                      "m": {
+                        "identifier": {
+                          "s": "CC0"
+                        },
+                        "type": {
+                          "s": "License"
+                        },
+                        "labels": {
+                          "m": {
+                            "nb": {
+                              "s": "CC0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "size": {
+                      "n": "129655"
+                    },
+                    "publisherAuthority": {
+                      "bool": true
+                    },
+                    "name": {
+                      "s": "DTOandBOs.pdf"
+                    },
+                    "administrativeAgreement": {
+                      "bool": false
+                    },
+                    "embargoDate": {
+                      "s": "2020-09-24T11:14:00Z"
+                    },
+                    "mimeType": {
+                      "s": "application/pdf"
+                    },
+                    "type": {
+                      "s": "File"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "FileSet"
+            }
+          }
+        },
+        "entityDescription": {
+          "m": {
+            "date": {
+              "m": {
+                "year": {
+                  "s": "2017"
+                },
+                "type": {
+                  "s": "PublicationDate"
+                }
+              }
+            },
+            "reference": {
+              "m": {
+                "publicationInstance": {
+                  "m": {
+                    "volume": {
+                      "s": "64"
+                    },
+                    "pages": {
+                      "m": {
+                        "end": {
+                          "s": "92"
+                        },
+                        "type": {
+                          "s": "Range"
+                        },
+                        "begin": {
+                          "s": "75"
+                        }
+                      }
+                    },
+                    "peerReviewed": {
+                      "bool": true
+                    },
+                    "type": {
+                      "s": "JournalArticle"
+                    }
+                  }
+                },
+                "type": {
+                  "s": "Reference"
+                },
+                "publicationContext": {
+                  "m": {
+                    "openAccess": {
+                      "bool": false
+                    },
+                    "peerReviewed": {
+                      "bool": false
+                    },
+                    "title": {
+                      "s": "Information Systems"
+                    },
+                    "type": {
+                      "s": "Journal"
+                    },
+                    "printIssn": {
+                      "s": "0306-4379"
+                    }
+                  }
+                },
+                "doi": {
+                  "s": "https://doi.org/10.1016/j.is.2016.09.004"
+                }
+              }
+            },
+            "metadataSource": {
+              "s": "https://www.crossref.org/"
+            },
+            "mainTitle": {
+              "s": "This is a long and boring title"
+            },
+            "description": {
+              "s": "sdfsfd"
+            },
+            "language": {
+              "s": "http://lexvo.org/id/iso639-3/eng"
+            },
+            "abstract": {
+              "s": "ksdfkds"
+            },
+            "contributors": {
+              "l": [
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "1"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Gkorgkas, Orestis"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "2"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Writerson, Writer"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "3"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Authorson, Author"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                },
+                {
+                  "m": {
+                    "sequence": {
+                      "n": "4"
+                    },
+                    "identity": {
+                      "m": {
+                        "name": {
+                          "s": "Nørvåg, Kjetil"
+                        },
+                        "type": {
+                          "s": "Identity"
+                        }
+                      }
+                    },
+                    "correspondingAuthor": {
+                      "bool": false
+                    },
+                    "type": {
+                      "s": "Contributor"
+                    }
+                  }
+                }
+              ]
+            },
+            "type": {
+              "s": "EntityDescription"
+            },
+            "npiSubjectHeading": {
+              "s": "1039"
+            },
+            "alternativeTitles": {
+              "m": {}
+            },
+            "tags": {
+              "l": []
+            }
+          }
+        },
+        "publisherId": {
+          "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+        },
+        "createdDate": {
+          "s": "2020-09-24T11:13:36.013058Z"
+        },
+        "modifiedDate": {
+          "s": "2020-09-24T11:15:17.671542Z"
+        },
+        "publisher": {
+          "m": {
+            "id": {
+              "s": "https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934"
+            },
+            "type": {
+              "s": "Organization"
+            }
+          }
+        },
+        "publishedDate": {
+          "s": "2020-09-24T11:15:17.671525Z"
+        },
+        "doiRequestStatusDate": {
+          "s": "REQUESTED#2020-10-22T13:09:17.317127Z"
+        },
+        "status": {
+          "s": "Published"
+        }
+      },
+      "sequenceNumber": "200000000025410353361",
+      "sizeBytes": 2124,
+      "streamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:884807050265:table/rono_nva_resources/stream/2020-10-30T11:40:11.302"
+  }
+}


### PR DESCRIPTION
This is a re-write of the PR #103 which is now closed. These are the absolutely minimum changes for making the  `DynamoDbFanoutPublicationDtoProducer` work.  About half of the changed files are just json test files. 

I chose to not use the  JSR380 validation because it does not cover the case where a field is present but invalid. For example a Publication with a non-null but invalid DoiRequest will be invalid. In any case, should we choose to use this library the refactoring would be easy with no changes in tests because all new tests have been written on handler level. 

I think the idea of using Immutables should be tested but it is out of scope of this PR which is to make the doi-request-chain work with minimal changes. My main concern right now with using Immutables in this PR, is the dependency to the generated classes and how this will affect the other modules. However, given that the new tests are written on a handler  level, the introduction of Immutables will be easy if we choose to go that way.