### PR TITLE
Simplify ServiceEnvironmentConstants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,13 @@ subprojects {
             events 'skipped', 'passed', 'failed'
         }
         finalizedBy jacocoTestReport
+
+        environment 'API_HOST', 'localhost'
+        environment 'API_SCHEME', 'https'
+
     }
+
+
 
     jacocoTestReport {
         reports {

--- a/create-doi-request/src/test/java/no/unit/nva/doirequest/create/CreateDoiRequestHandlerTest.java
+++ b/create-doi-request/src/test/java/no/unit/nva/doirequest/create/CreateDoiRequestHandlerTest.java
@@ -24,7 +24,6 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.PublicationGenerator;
 import no.unit.nva.publication.RequestUtil;
-import no.unit.nva.publication.ServiceEnvironmentConstants;
 import no.unit.nva.publication.exception.TransactionFailedException;
 import no.unit.nva.publication.model.MessageDto;
 import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
@@ -57,7 +56,6 @@ public class CreateDoiRequestHandlerTest extends ResourcesDynamoDbLocalTest {
     private static final Instant DOI_REQUEST_UPDATE_TIME = Instant.parse("2013-02-02T10:15:30.00Z");
     public static final int SINGLE_MESSAGE = 0;
     public static final String ALLOW_ALL_ORIGINS = "*";
-    public static final String SOME_VALID_HOST = "localhost";
     private CreateDoiRequestHandler handler;
     private ResourceService resourceService;
     private Clock mockClock;
@@ -76,7 +74,7 @@ public class CreateDoiRequestHandlerTest extends ResourcesDynamoDbLocalTest {
         outputStream = new ByteArrayOutputStream();
         context = mock(Context.class);
         Environment environment = mockEnvironment();
-        ServiceEnvironmentConstants.updateEnvironment(environment);
+
         handler = new CreateDoiRequestHandler(resourceService, doiRequestService, messageService, environment);
     }
 
@@ -170,7 +168,6 @@ public class CreateDoiRequestHandlerTest extends ResourcesDynamoDbLocalTest {
     private Environment mockEnvironment() {
         Environment environment = mock(Environment.class);
         when(environment.readEnv(ApiGatewayHandler.ALLOWED_ORIGIN_ENV)).thenReturn(ALLOW_ALL_ORIGINS);
-        when(environment.readEnv(ServiceEnvironmentConstants.HOST_ENV_VARIABLE_NAME)).thenReturn(SOME_VALID_HOST);
         return environment;
     }
 

--- a/create-message/src/test/java/no/unit/nva/publication/messages/create/CreateMessageHandlerTest.java
+++ b/create-message/src/test/java/no/unit/nva/publication/messages/create/CreateMessageHandlerTest.java
@@ -71,7 +71,6 @@ public class CreateMessageHandlerTest extends ResourcesDynamoDbLocalTest {
         messageService = new MessageService(client, Clock.systemDefaultZone());
         doiRequestService = new DoiRequestService(client, Clock.systemDefaultZone());
         environment = setupEnvironment();
-        ServiceEnvironmentConstants.updateEnvironment(environment);
         handler = new CreateMessageHandler(client, environment);
         output = new ByteArrayOutputStream();
         samplePublication = createSamplePublication();
@@ -159,10 +158,6 @@ public class CreateMessageHandlerTest extends ResourcesDynamoDbLocalTest {
     private Environment setupEnvironment() {
         Environment environment = mock(Environment.class);
         when(environment.readEnv(ApiGatewayHandler.ALLOWED_ORIGIN_ENV)).thenReturn(ALLOW_ALL_ORIGIN);
-        when(environment.readEnv(ServiceEnvironmentConstants.HOST_ENV_VARIABLE_NAME))
-            .thenReturn(SOME_VALID_HOST);
-        when(environment.readEnv(ServiceEnvironmentConstants.NETWORK_SCHEME_ENV_VARIABLE_NAME))
-            .thenReturn(HTTPS);
         return environment;
     }
 

--- a/list-doi-requests/src/test/java/no/unit/nva/doirequest/list/ListDoiRequestsHandlerTest.java
+++ b/list-doi-requests/src/test/java/no/unit/nva/doirequest/list/ListDoiRequestsHandlerTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 import no.unit.nva.model.DoiRequestMessage;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
-import no.unit.nva.publication.ServiceEnvironmentConstants;
 import no.unit.nva.publication.exception.BadRequestException;
 import no.unit.nva.publication.exception.TransactionFailedException;
 import no.unit.nva.publication.model.MessageDto;
@@ -68,7 +67,6 @@ public class ListDoiRequestsHandlerTest extends ResourcesDynamoDbLocalTest {
     private static final Instant DOI_REQUEST_UPDATE_TIME = Instant.parse("2013-02-02T10:15:30.00Z");
     private static final URI SOME_OTHER_PUBLISHER = URI.create("https://some-other-publisher.com");
     public static final String ALLOW_ALL_ORIGIN = "*";
-    public static final String SOME_VALID_HOST = "localhost";
     private ListDoiRequestsHandler handler;
     private ResourceService resourceService;
     private Clock mockClock;
@@ -86,7 +84,6 @@ public class ListDoiRequestsHandlerTest extends ResourcesDynamoDbLocalTest {
         outputStream = new ByteArrayOutputStream();
         context = mock(Context.class);
         Environment environment = mockEnvironment();
-        ServiceEnvironmentConstants.updateEnvironment(environment);
 
         doiRequestService = new DoiRequestService(client, mockClock);
         messageService = new MessageService(client, mockClock);
@@ -255,8 +252,6 @@ public class ListDoiRequestsHandlerTest extends ResourcesDynamoDbLocalTest {
     private Environment mockEnvironment() {
         Environment environment = mock(Environment.class);
         when(environment.readEnv(ApiGatewayHandler.ALLOWED_ORIGIN_ENV)).thenReturn(ALLOW_ALL_ORIGIN);
-        when(environment.readEnv(ServiceEnvironmentConstants.HOST_ENV_VARIABLE_NAME)).thenReturn(SOME_VALID_HOST);
-
         return environment;
     }
 

--- a/list-messages/src/test/java/no/unit/nva/pubication/messages/list/ListMessagesHandlerTest.java
+++ b/list-messages/src/test/java/no/unit/nva/pubication/messages/list/ListMessagesHandlerTest.java
@@ -29,7 +29,6 @@ import java.util.stream.IntStream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.PublicationGenerator;
-import no.unit.nva.publication.ServiceEnvironmentConstants;
 import no.unit.nva.publication.exception.TransactionFailedException;
 import no.unit.nva.publication.model.MessageDto;
 import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
@@ -70,7 +69,6 @@ public class ListMessagesHandlerTest extends ResourcesDynamoDbLocalTest {
         resourceService = new ResourceService(client, Clock.systemDefaultZone());
         messageService = new MessageService(client, Clock.systemDefaultZone());
         Environment environment = mockEnvironment();
-        ServiceEnvironmentConstants.updateEnvironment(environment);
         handler = new ListMessagesHandler(environment, messageService);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/ServiceEnvironmentConstants.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/ServiceEnvironmentConstants.java
@@ -1,62 +1,19 @@
 package no.unit.nva.publication;
 
 import nva.commons.core.Environment;
-import nva.commons.core.JacocoGenerated;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class ServiceEnvironmentConstants {
 
-    public static final String HOST_ENV_VARIABLE_NAME = "API_HOST";
-    public static final String NETWORK_SCHEME_ENV_VARIABLE_NAME = "API_SCHEME";
-
+    public static final Environment ENVIRONMENT = new Environment();
     public static final String URI_EMPTY_FRAGMENT = null;
     public static final String PATH_SEPARATOR = "/";
     public static final String MESSAGE_PATH = "/messages";
-    public static final String MISSING_ENV_VARIABLE_MESSAGE =
-        ServiceEnvironmentConstants.class.getName() + "is missing an env variable";
-    private static final Logger logger = LoggerFactory.getLogger(ServiceEnvironmentConstants.class);
-    private static final String DEFAULT_SCHEME = "https";
+    private static final String HOST_ENV_VARIABLE_NAME = "API_HOST";
+    public static final String API_HOST = ENVIRONMENT.readEnv(HOST_ENV_VARIABLE_NAME);
+    private static final String NETWORK_SCHEME_ENV_VARIABLE_NAME = "API_SCHEME";
+    public static final String API_SCHEME = ENVIRONMENT.readEnv(NETWORK_SCHEME_ENV_VARIABLE_NAME);
 
-    private static ServiceEnvironmentConstants INSTANCE = defaultInstance();
+    private ServiceEnvironmentConstants() {
 
-    public final String host;
-    public final String scheme;
-
-
-    private ServiceEnvironmentConstants(Environment environment) {
-        host = environment.readEnv(HOST_ENV_VARIABLE_NAME);
-        scheme = environment.readEnvOpt(NETWORK_SCHEME_ENV_VARIABLE_NAME).orElse(DEFAULT_SCHEME);
     }
-
-    /**
-     * Update constants with a new Environment instance if necessary (e.g. during testing). Normally, it should not be
-     * necessary to update the environment when running the code in production.
-     *
-     * @param environment a new Environment.
-     */
-    public static void updateEnvironment(Environment environment) {
-        synchronized (ServiceEnvironmentConstants.class) {
-            INSTANCE = new ServiceEnvironmentConstants(environment);
-        }
-    }
-
-    public static ServiceEnvironmentConstants getInstance() {
-        return INSTANCE;
-    }
-
-    @JacocoGenerated
-    private static ServiceEnvironmentConstants defaultInstance() {
-        try {
-            return new ServiceEnvironmentConstants(new Environment());
-        } catch (Exception e) {
-            return handleDefaultInstanceFailure(e);
-        }
-    }
-
-    private static ServiceEnvironmentConstants handleDefaultInstanceFailure(Exception exception) {
-        logger.warn(MISSING_ENV_VARIABLE_MESSAGE, exception);
-        return null;
-    }
-
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/MessageDto.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/MessageDto.java
@@ -145,8 +145,8 @@ public class MessageDto {
 
     public static URI constructMessageId(SortableIdentifier messageIdentifier) {
         if (nonNull(messageIdentifier)) {
-            String scheme = ServiceEnvironmentConstants.getInstance().scheme;
-            String host = ServiceEnvironmentConstants.getInstance().host;
+            String scheme = ServiceEnvironmentConstants.API_SCHEME;
+            String host = ServiceEnvironmentConstants.API_HOST;
             String messagePath = MESSAGE_PATH + PATH_SEPARATOR + messageIdentifier.toString();
             return attempt(() -> newUri(scheme, host, messagePath)).orElseThrow();
         }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
@@ -25,7 +25,6 @@ import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.PublicationGenerator;
-import no.unit.nva.publication.ServiceEnvironmentConstants;
 import no.unit.nva.publication.exception.TransactionFailedException;
 import no.unit.nva.publication.model.MessageDto;
 import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
@@ -33,7 +32,6 @@ import no.unit.nva.publication.storage.model.Message;
 import no.unit.nva.publication.storage.model.MessageStatus;
 import no.unit.nva.publication.storage.model.UserInstance;
 import nva.commons.apigateway.exceptions.NotFoundException;
-import nva.commons.core.Environment;
 import nva.commons.core.attempt.Try;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +54,6 @@ public class MessageServiceTest extends ResourcesDynamoDbLocalTest {
     public static final String SAMPLE_HOST = "https://localhost/messages/";
 
     public static final int FIRST_ELEMENT = 0;
-    public static final String SOME_VALID_HOST = "localhost";
 
     private MessageService messageService;
     private ResourceService resourceService;
@@ -65,8 +62,6 @@ public class MessageServiceTest extends ResourcesDynamoDbLocalTest {
     public void initialize() {
         super.init();
         Clock clock = mockClock();
-        Environment environment = setupEnvironment();
-        ServiceEnvironmentConstants.updateEnvironment(environment);
         messageService = new MessageService(client, clock);
         resourceService = new ResourceService(client, clock);
     }
@@ -226,13 +221,6 @@ public class MessageServiceTest extends ResourcesDynamoDbLocalTest {
 
     public ResourceConversation constructExpectedMessages(List<Message> messagesForPublication1) {
         return ResourceConversation.fromMessageList(messagesForPublication1).orElseThrow();
-    }
-
-    private Environment setupEnvironment() {
-        var env = mock(Environment.class);
-        when(env.readEnv(ServiceEnvironmentConstants.HOST_ENV_VARIABLE_NAME))
-            .thenReturn(SOME_VALID_HOST);
-        return env;
     }
 
     private MessageDto[] constructExpectedMessagesDtos(List<Message> insertedMessages) {


### PR DESCRIPTION
ServiceEnvironmentConstants was a quite complicated effort for reading env variables directly to constants that would be available in the whole platform. Now it is simplified with the help of setting testing values for the env variables in testing through gradle.