### PR TITLE
Lint fetch publication and remove DynamoDbLocal from where not necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url "https://jitpack.io" }
+        maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
     }
 
     project.ext {

--- a/create-doi-request/build.gradle
+++ b/create-doi-request/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     // compileOnly because under current deployment model, these dependencies are included

--- a/create-message/build.gradle
+++ b/create-message/build.gradle
@@ -1,6 +1,3 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
 
 dependencies {
 

--- a/create-publication/build.gradle
+++ b/create-publication/build.gradle
@@ -1,7 +1,3 @@
-repositories {
-    // Repository for running Embedded DynamoDB locally.
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
 
 dependencies {
     //This package is added by SAM template in the runtime environment

--- a/create-publication/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/create-publication/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -36,9 +36,7 @@ import nva.commons.core.Environment;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-@EnableRuleMigrationSupport
 public class CreatePublicationHandlerTest {
 
     public static final String HTTPS = "https";
@@ -52,7 +50,9 @@ public class CreatePublicationHandlerTest {
     public static final String HEADERS = "headers";
     public static final String BODY = "body";
     public static final JavaType PARAMETERIZED_GATEWAY_RESPONSE_TYPE = objectMapper.getTypeFactory()
-        .constructParametricType(GatewayResponse.class, PublicationResponse.class);
+                                                                           .constructParametricType(
+                                                                               GatewayResponse.class,
+                                                                               PublicationResponse.class);
     private ResourceService publicationServiceMock;
     private CreatePublicationHandler handler;
     private ByteArrayOutputStream outputStream;
@@ -85,7 +85,7 @@ public class CreatePublicationHandlerTest {
         handler.handleRequest(inputStream, outputStream, context);
 
         GatewayResponse<PublicationResponse> actual = objectMapper.readValue(outputStream.toByteArray(),
-            PARAMETERIZED_GATEWAY_RESPONSE_TYPE);
+                                                                             PARAMETERIZED_GATEWAY_RESPONSE_TYPE);
 
         GatewayResponse<PublicationResponse> expected = new GatewayResponse<>(
             PublicationMapper.convertValue(publication, PublicationResponse.class),
@@ -104,7 +104,7 @@ public class CreatePublicationHandlerTest {
         InputStream inputStream = emptyCreatePublicationRequest();
         handler.handleRequest(inputStream, outputStream, context);
         GatewayResponse<PublicationResponse> actual = objectMapper.readValue(outputStream.toByteArray(),
-            PARAMETERIZED_GATEWAY_RESPONSE_TYPE);
+                                                                             PARAMETERIZED_GATEWAY_RESPONSE_TYPE);
 
         assertEquals(HttpStatus.SC_CREATED, actual.getStatusCode());
         assertNotNull(actual.getBodyObject(PublicationResponse.class));
@@ -146,13 +146,13 @@ public class CreatePublicationHandlerTest {
 
     private Publication createPublication() {
         return new Publication.Builder()
-            .withIdentifier(new SortableIdentifier(UUID.randomUUID().toString()))
-            .withModifiedDate(Instant.now())
-            .withOwner("owner")
-            .withPublisher(new Organization.Builder()
-                .withId(URI.create("http://example.org/publisher/1"))
-                .build()
-            )
-            .build();
+                   .withIdentifier(new SortableIdentifier(UUID.randomUUID().toString()))
+                   .withModifiedDate(Instant.now())
+                   .withOwner("owner")
+                   .withPublisher(new Organization.Builder()
+                                      .withId(URI.create("http://example.org/publisher/1"))
+                                      .build()
+                   )
+                   .build();
     }
 }

--- a/data-import-from-s3/build.gradle
+++ b/data-import-from-s3/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 

--- a/data-migration/build.gradle
+++ b/data-migration/build.gradle
@@ -1,5 +1,4 @@
 
-
 dependencies {
 
     implementation project(":storage-model")

--- a/data-migration/build.gradle
+++ b/data-migration/build.gradle
@@ -1,7 +1,4 @@
-repositories {
-    // Repository for running Embedded DynamoDB locally.
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 

--- a/delete-draft-publication-handler/build.gradle
+++ b/delete-draft-publication-handler/build.gradle
@@ -1,7 +1,3 @@
-repositories {
-    // Repository for running Embedded DynamoDB locally.
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
 
 dependencies {
     //This package is added by SAM template in the runtime environment

--- a/delete-draft-publication-handler/src/test/java/no/unit/nva/publication/delete/DeleteDraftPublicationHandlerTest.java
+++ b/delete-draft-publication-handler/src/test/java/no/unit/nva/publication/delete/DeleteDraftPublicationHandlerTest.java
@@ -21,10 +21,8 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.mockito.Mockito;
 
-@EnableRuleMigrationSupport
 public class DeleteDraftPublicationHandlerTest extends ResourcesDynamoDbLocalTest {
 
     public static final String WILDCARD = "*";

--- a/delete-publication-event-producer/build.gradle
+++ b/delete-publication-event-producer/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     }
 
     implementation group: 'com.github.bibsysdev', name: 'eventhandlers', version: project.ext.nvaCommonsVersion
-
-    implementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version: project.ext.nvaAwsLambdaJavaEvents
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: project.ext.awsLambdaCore
 
     compileOnly( group: 'com.amazonaws', name: 'aws-java-sdk-api-gateway', version: project.ext.awsSdkVersion) {

--- a/delete-publication/build.gradle
+++ b/delete-publication/build.gradle
@@ -1,21 +1,14 @@
-repositories {
-    // Repository for running Embedded DynamoDB locally.
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
 
 dependencies {
     //This package is added by SAM template in the runtime environment
     compileOnly project(':publication-commons')
     testImplementation project(':publication-commons')
 
+    implementation group: 'com.github.bibsysdev', name: 'apigateway', version: project.ext.nvaCommonsVersion
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: project.ext.nvaDatamodelVersion
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
 
-
     testImplementation project(":publication-testing")
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 }
 
 configurations.testImplementation.canBeResolved = true

--- a/delete-publication/src/test/java/no/unit/nva/publication/delete/DeletePublicationHandlerTest.java
+++ b/delete-publication/src/test/java/no/unit/nva/publication/delete/DeletePublicationHandlerTest.java
@@ -6,7 +6,7 @@ import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +16,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.time.Clock;
-import java.util.Map;
 import java.util.UUID;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
@@ -29,13 +28,12 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JsonUtils;
 import org.apache.http.HttpStatus;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.mockito.Mockito;
 import org.zalando.problem.Problem;
 
-@EnableRuleMigrationSupport
 public class DeletePublicationHandlerTest extends ResourcesDynamoDbLocalTest {
 
     public static final String IDENTIFIER = "identifier";
@@ -82,7 +80,7 @@ public class DeletePublicationHandlerTest extends ResourcesDynamoDbLocalTest {
         handler.handleRequest(inputStream, outputStream, context);
 
         GatewayResponse<Void> gatewayResponse = GatewayResponse.fromOutputStream(outputStream);
-        assertEquals(HttpStatus.SC_ACCEPTED, gatewayResponse.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_ACCEPTED, gatewayResponse.getStatusCode());
     }
 
     @Test
@@ -168,11 +166,4 @@ public class DeletePublicationHandlerTest extends ResourcesDynamoDbLocalTest {
         publicationService.markPublicationForDeletion(userInstance, publication.getIdentifier());
     }
 
-    private Map<String, Object> getClaims(String owner) {
-        return Map.of(
-            REQUEST_CONTEXT, Map.of(
-                AUTHORIZER, Map.of(
-                    CLAIMS, Map.of(
-                        CUSTOM_FEIDE_ID, owner))));
-    }
 }

--- a/fetch-publication/build.gradle
+++ b/fetch-publication/build.gradle
@@ -1,20 +1,18 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     //This package is added by SAM template in the runtime environment
-    compileOnly project(':publication-commons')
-    testImplementation project(':publication-commons')
+    implementation(project(':publication-commons')){
+        exclude group: "software.amazon.ion", module:"ion-java"
+    }
 
+    implementation group: 'com.github.bibsysdev', name: 'apigateway', version: project.ext.nvaCommonsVersion
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: project.ext.nvaDatamodelVersion
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
 
+    testImplementation group: 'org.zalando', name: 'problem', version: project.ext.zalandoProblemVersion
     testImplementation project(':publication-testing')
 
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion) {
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 }
 
 

--- a/fetch-publication/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/fetch-publication/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.HttpURLConnection;
 import java.time.Clock;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.DoiRequest;
@@ -22,7 +23,6 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import org.apache.http.HttpStatus;
 
 public class FetchPublicationHandler extends ApiGatewayHandler<Void, JsonNode> {
 
@@ -69,7 +69,7 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, JsonNode> {
 
     @Override
     protected Integer getSuccessStatusCode(Void input, JsonNode output) {
-        return HttpStatus.SC_OK;
+        return HttpURLConnection.HTTP_OK;
     }
 
     @JacocoGenerated

--- a/list-doi-requests/build.gradle
+++ b/list-doi-requests/build.gradle
@@ -1,22 +1,13 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 
-    compileOnly project(":publication-commons")
-    testImplementation project(":publication-commons")
-
+    implementation project(":publication-commons")
     implementation project(":storage-model")
 
     implementation group: 'com.github.bibsysdev', name: 'apigateway', version: project.ext.nvaCommonsVersion
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
     testImplementation project (':publication-testing')
-
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 
 }
 

--- a/list-messages/build.gradle
+++ b/list-messages/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 
@@ -12,13 +10,7 @@ dependencies {
     implementation group: 'com.github.bibsysdev', name: 'apigateway', version: project.ext.nvaCommonsVersion
     implementation group: 'com.github.bibsysdev', name: 'core', version: project.ext.nvaCommonsVersion
 
-
     testImplementation project(":publication-testing")
-
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 }
 
 configurations.testImplementation.canBeResolved = true

--- a/modify-publication/build.gradle
+++ b/modify-publication/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
+
 }
 
 dependencies {
@@ -9,11 +9,5 @@ dependencies {
 
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
     implementation(group: 'com.github.bibsysdev', name: 'logutils', version: project.ext.nvaCommonsVersion)
-
-
     testImplementation project(':publication-testing')
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 }

--- a/modify-publication/build.gradle
+++ b/modify-publication/build.gradle
@@ -1,7 +1,3 @@
-repositories {
-
-}
-
 dependencies {
     //This package is added by SAM template in the runtime environment
     compileOnly project(':publication-commons')

--- a/publication-commons/build.gradle
+++ b/publication-commons/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     api project(":storage-model")
@@ -30,10 +28,6 @@ dependencies {
 
 
     testImplementation project(":publication-testing")
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion) {
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
     testImplementation group: 'com.github.bibsysdev', name: 'logutils', version: project.ext.nvaCommonsVersion
 
 }

--- a/publication-doi-commons/build.gradle
+++ b/publication-doi-commons/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     implementation group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: project.ext.nvaDatamodelVersion
@@ -11,10 +9,6 @@ dependencies {
     }
 
     testImplementation project(":publication-testing")
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 }
 
 configurations.testImplementation.canBeResolved = true

--- a/publication-testing/build.gradle
+++ b/publication-testing/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     api project(":publication-doi-commons")

--- a/publications-by-owner/build.gradle
+++ b/publications-by-owner/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     //This package is added by SAM template in the runtime environment
@@ -9,8 +7,5 @@ dependencies {
 
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
     testImplementation project(':publication-testing')
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
+
 }

--- a/publish-publication/build.gradle
+++ b/publish-publication/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
     //This package is added by SAM template in the runtime environment
@@ -10,8 +8,5 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
 
     testImplementation project(':publication-testing')
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
+
 }

--- a/storage-model/build.gradle
+++ b/storage-model/build.gradle
@@ -1,7 +1,5 @@
 
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 
@@ -17,10 +15,6 @@ dependencies {
     testImplementation group: 'com.github.javafaker', name: 'javafaker', version: project.ext.javaFakerVersion
     testImplementation(group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: project.ext.nvaDatamodelVersion)
 
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
 
 
 

--- a/update-doi-request/build.gradle
+++ b/update-doi-request/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 
@@ -18,12 +16,6 @@ dependencies {
     implementation group:'com.github.BIBSYSDEV.nva-user-access-service', name:'user-access-rights', version:'0.3.0'
 
     testImplementation project (':publication-testing')
-
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
-
 
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: project.ext.awsSdkVersion
 

--- a/update-doi-status/build.gradle
+++ b/update-doi-status/build.gradle
@@ -1,6 +1,4 @@
-repositories {
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
-}
+
 
 dependencies {
 
@@ -13,8 +11,5 @@ dependencies {
     implementation group: 'com.github.bibsysdev', name: 'logutils', version: project.ext.nvaCommonsVersion
 
     testImplementation project(":publication-testing")
-    testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.dynamoDbLocalVersion){
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-dynamodb'
-        exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
-    }
+
 }


### PR DESCRIPTION
Coninuing to edit dependencies according to gradle-lint's  suggestions. In this PR I removed the package for DynamoDBLocal which although it does not affect the performance (because it is in `testImplementation`), it does affect the gradle lint report and creates noise.
To proceed further with the cleaning it is therefore necessary to remove it from all modules where it it not needed.