### PR TITLE
Np 2261 write to dynamo

### DIFF
--- a/cristin-import/build.gradle
+++ b/cristin-import/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'io.freefair.lombok'
 
 dependencies {
+    implementation project(":publication-constants")
+    implementation project(":publication-commons")
 
-    testImplementation project(":publication-testing")
     implementation(group: 'com.github.bibsysdev', name: 'nva-datamodel-java', version: project.ext.nvaDatamodelVersion) {
         exclude group: 'com.github.bibsysdev', module: 'nva-commons'
     }
 
     implementation group: 'com.github.bibsysdev', name: 's3', version: project.ext.nvaCommonsVersion
     implementation group: 'com.github.bibsysdev', name: 'core', version: project.ext.nvaCommonsVersion
+    implementation group: 'com.github.bibsysdev', name: 'apigateway', version: project.ext.nvaCommonsVersion
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: project.ext.jacksonVersion
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project.ext.jacksonVersion
@@ -16,11 +18,18 @@ dependencies {
     runtimeOnly group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310", version: project.ext.jacksonVersion
     runtimeOnly group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: project.ext.jacksonVersion
 
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion
+    implementation group: 'software.amazon.awssdk', name: 'eventbridge', version: '2.16.46'
     implementation(group: 'software.amazon.awssdk', name: 's3', version: project.ext.awsSdk2Version)
 
+    testImplementation project (":storage-model")
+    testImplementation project(":publication-testing")
     testImplementation group: 'org.mockito', name: 'mockito-core', version: project.ext.mockitoVersion
     testImplementation group: 'com.github.bibsysdev', name: 'nva-testutils', version: project.ext.nvaTestUtilsVersion
 
+    compileOnly(project(":storage-model")){
+        because "PMD complains for no/unit/nva/publication/storage/model/daos/DynamoEntry"
+    }
     compileOnly group: 'org.zalando', name: 'problem', version: project.ext.zalandoProblemVersion
     compileOnly group: 'com.amazonaws', name: 'aws-lambda-java-core', version: project.ext.awsLambdaCore
     compileOnly group: 'com.github.bibsysdev', name: 'identifiers', version: project.ext.nvaCommonsVersion
@@ -29,4 +38,20 @@ dependencies {
         because "PMD complains about software/amazon/awssdk/auth/credentials/AwsCredentialsProvider "
     }
 
+}
+
+configurations.testImplementation.canBeResolved = true
+
+task copyNativeDeps(type: Copy) {
+    from(configurations.testImplementation) {
+        include "*.dylib"
+        include "*.so"
+        include "*.dll"
+    }
+    into 'build/dynamodb-local'
+}
+
+test.dependsOn copyNativeDeps
+test.doFirst {
+    systemProperty "java.library.path", 'build/dynamodb-local'
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinImportHandler.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinImportHandler.java
@@ -1,23 +1,22 @@
 package no.unit.nva.cristin.lambda;
 
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.time.Clock;
 import java.util.stream.Stream;
-import no.unit.nva.cristin.mapper.CristinMapper;
 import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.cristin.reader.S3CristinRecordsReader;
 import no.unit.nva.model.Publication;
+import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
-import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonUtils;
 import nva.commons.core.ioutils.IoUtils;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -25,9 +24,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class CristinImportHandler implements RequestStreamHandler {
 
     private final S3Client s3Client;
+    private final AmazonDynamoDB dynamoDbClient;
 
-    public CristinImportHandler(S3Client s3Client) {
+    public CristinImportHandler(S3Client s3Client, AmazonDynamoDB dynamoDbClient) {
         this.s3Client = s3Client;
+
+        this.dynamoDbClient = dynamoDbClient;
     }
 
     @Override
@@ -35,32 +37,21 @@ public class CristinImportHandler implements RequestStreamHandler {
         ImportRequest request = ImportRequest.fromJson(IoUtils.streamToString(input));
         String bucket = request.extractBucketFromS3Location();
         String path = request.extractPathFromS3Location();
-        Stream<Publication> publications = extractPublicationsFromS3Location(bucket, path);
-        List<JsonNode> result = publications
-                                    .map(this::serializeWithTypes)
-                                    .collect(Collectors.toList());
-        writeToDynamo();
+        extractPublicationsFromS3Location(bucket, path)
+            .forEach(this::writeToDynamo);
 
-        writeOutput(result, output);
+        writeOutput(request, output);
     }
 
-    @JacocoGenerated
-    private void writeToDynamo() {
-        //TODO: write toDynamo
-    }
-
-    // Workaround for the fact that Jackson serializer does not put types when serializing object collections.
-    private JsonNode serializeWithTypes(Publication p) {
-        return JsonUtils.objectMapperWithEmpty.convertValue(p, JsonNode.class);
+    private void writeToDynamo(Publication publication) {
+        ResourceService resourceService = new ResourceService(dynamoDbClient, Clock.systemDefaultZone());
+        attempt(() -> resourceService.createPublication(publication)).orElseThrow();
     }
 
     private Stream<Publication> extractPublicationsFromS3Location(String bucket, String path) {
         S3Driver s3Driver = new S3Driver(s3Client, bucket);
         S3CristinRecordsReader reader = new S3CristinRecordsReader(s3Driver);
-        List<CristinObject> resources = reader.readResources(Path.of(path)).collect(Collectors.toList());
-        return resources.stream()
-                   .map(CristinMapper::new)
-                   .map(CristinMapper::generatePublication);
+        return reader.readResources(Path.of(path)).map(CristinObject::toPublication);
     }
 
     private <O> void writeOutput(O outputObject, OutputStream outputStream) throws IOException {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -9,11 +9,13 @@ import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
 
 public class CristinMapper {
 
+    public static final String SOME_REAL_OWNER = "og@unit.no";
     private final CristinObject cristinObject;
 
     public CristinMapper(CristinObject cristinObject) {
@@ -25,7 +27,14 @@ public class CristinMapper {
                    .withAdditionalIdentifiers(Set.of(extractIdentifier()))
                    .withEntityDescription(generateEntityDescription())
                    .withCreatedDate(extractEntryCreationDate())
+                   .withPublisher(extractOrganization())
+                   .withOwner(SOME_REAL_OWNER)
                    .build();
+    }
+
+    private Organization extractOrganization() {
+        URI customerUri = URI.create("https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934");
+        return new Organization.Builder().withId(customerUri).build();
     }
 
     private Instant extractEntryCreationDate() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import no.unit.nva.model.Publication;
 
 @Data
 @Builder
@@ -25,5 +26,9 @@ public class CristinObject {
 
     public CristinObject() {
 
+    }
+
+    public Publication toPublication() {
+        return new CristinMapper(this).generatePublication();
     }
 }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/AbstractCristinImportTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/AbstractCristinImportTest.java
@@ -12,10 +12,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import no.unit.nva.cristin.mapper.CristinObject;
+import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
 import nva.commons.core.attempt.Try;
 import nva.commons.core.ioutils.IoUtils;
 
-public class AbstractCristinImportTest {
+public class AbstractCristinImportTest extends ResourcesDynamoDbLocalTest {
 
     public static final String SAMPLE_INPUT_01 = "input01.gz";
     public static final Integer NUMBER_OF_LINES_IN_RESOURCES_FILE = 100;

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinImportHandlerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinImportHandlerTest.java
@@ -4,11 +4,13 @@ import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.mockito.Mockito.mock;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.ItemUtils;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,8 +18,11 @@ import no.unit.nva.cristin.AbstractCristinImportTest;
 import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.publication.storage.model.DatabaseConstants;
+import no.unit.nva.publication.storage.model.daos.ResourceDao;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.core.JsonUtils;
+import nva.commons.core.attempt.Try;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -32,27 +37,41 @@ public class CristinImportHandlerTest extends AbstractCristinImportTest {
 
     @BeforeEach
     public void init() {
+        super.init();
+        AmazonDynamoDB dynamoDbClient = client;
         S3Client s3Client = new FakeS3Client(RESOURCE_FILE);
-        handler = new CristinImportHandler(s3Client);
+        handler = new CristinImportHandler(s3Client, dynamoDbClient);
         outputStream = new ByteArrayOutputStream();
     }
 
     @Test
-    public void handlerReturnsPublicationsWhenInputIsS3LocationWithCristinResources() throws IOException {
+    public void handlerWritesPublicationsToDynamoDbsFromCristinResourcesInSpecifiedS3Location() throws IOException {
         ImportRequest request = new ImportRequest(SOME_S3_LOCATION);
 
         handler.handleRequest(request.toInputStream(), outputStream, CONTEXT);
-        String outputString = outputStream.toString(StandardCharsets.UTF_8);
 
-        List<Publication> generatedPublications = attempt(
-            () -> JsonUtils.objectMapperWithEmpty.readValue(outputString, Publication[].class))
-                                                      .map(Arrays::asList)
-                                                      .orElseThrow();
-
-        List<String> actualCristinIds = extractCristinIds(generatedPublications);
         List<String> expectedCristinIds = expectedCristinIds();
+        ScanRequest scanRequest = new ScanRequest()
+                                      .withTableName(DatabaseConstants.RESOURCES_TABLE_NAME)
+                                      .withIndexName(DatabaseConstants.RESOURCES_BY_IDENTIFIER_INDEX_NAME);
+        var actualCristinIds = client.scan(scanRequest)
+                                   .getItems()
+                                   .stream()
+                                   .map(ItemUtils::toItem)
+                                   .map(Item::toJSON)
+                                   .map(attempt(this::parseJson))
+                                   .map(Try::orElseThrow)
+                                   .map(Publication::getAdditionalIdentifiers)
+                                   .flatMap(Collection::stream)
+                                   .map(AdditionalIdentifier::getValue)
+                                   .collect(Collectors.toList());
 
         assertThat(actualCristinIds, containsInAnyOrder(expectedCristinIds.toArray(String[]::new)));
+    }
+
+    private Publication parseJson(String json) throws com.fasterxml.jackson.core.JsonProcessingException {
+        ResourceDao dao = JsonUtils.objectMapperWithEmpty.readValue(json, ResourceDao.class);
+        return dao.getData().toPublication();
     }
 
     private List<String> extractCristinIds(List<Publication> generatedPublications) {


### PR DESCRIPTION
This is a first version of converting CRISTIN records and writing them to dynamo.

The driver loads all Cristin records from a bucket converts them to Publications and writes them to Dynamo. Obviously this does not scale but all the logic is now in place (Except from the mapping that is a quite complex procedure).

The next steps are the following:
1. Deploy the following lambda to the cloud.
2. Split the functionality in two lambdas, One lambda gets all filenames from the bucket and emits an event for each bucket. The other lambda will accept the event and process each file separately. In this way we increase both scalability and parallelization.
3. Improve the mapping procedure to include more fields and replace the hard-coded values with correct ones.