### PR TITLE
CristinFilenameEventEmitter becomes FilenameEventEmitter

### DIFF
--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/CristinEntriesEventEmitter.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/CristinEntriesEventEmitter.java
@@ -90,7 +90,7 @@ public class CristinEntriesEventEmitter extends EventHandler<ImportRequest, Stri
     }
 
     private void validateEvent(AwsEventBridgeEvent<ImportRequest> event) {
-        if (!event.getDetailType().equalsIgnoreCase(CristinFilenameEventEmitter.EVENT_DETAIL_TYPE)) {
+        if (!event.getDetailType().equalsIgnoreCase(FilenameEventEmitter.EVENT_DETAIL_TYPE)) {
             throw new IllegalArgumentException(WRONG_DETAIL_TYPE_ERROR + event.getDetailType());
         }
     }

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FilenameEventEmitter.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FilenameEventEmitter.java
@@ -29,6 +29,13 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 import software.amazon.awssdk.services.s3.S3Client;
 
+/**
+ * {@link FilenameEventEmitter} accepts an {@link ImportRequest}, it lists all the files in the S3 location defined in
+ * the {@link ImportRequest} and it emits on event per filename.
+ * <p>Each event has as event detail-type the value {@link FilenameEventEmitter#EVENT_DETAIL_TYPE } and detail
+ * (event-body) an {@link ImportRequest} where s3Location is the URI of the respective file and the rest of the fields
+ * are copied from the input.
+ */
 public class FilenameEventEmitter implements RequestStreamHandler {
 
     public static final String WRONG_OR_EMPTY_S3_LOCATION_ERROR = "S3 location does not exist or is empty:";

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FilenameEventEmitter.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FilenameEventEmitter.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 /**
  * {@link FilenameEventEmitter} accepts an {@link ImportRequest}, it lists all the files in the S3 location defined in
  * the {@link ImportRequest} and it emits on event per filename.
+ *
  * <p>Each event has as event detail-type the value {@link FilenameEventEmitter#EVENT_DETAIL_TYPE } and detail
  * (event-body) an {@link ImportRequest} where s3Location is the URI of the respective file and the rest of the fields
  * are copied from the input.

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ImportRequest.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ImportRequest.java
@@ -11,6 +11,15 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonSerializable;
 import nva.commons.core.JsonUtils;
 
+/**
+ * An {@link ImportRequest} contains 3 fields.
+ * <p>1. The {@link ImportRequest#s3Location} field is a URI to an S3 bucket of the form "s3://somebucket/some/path/".
+ * <p>2. The {@link ImportRequest#importEventType} field is a String denoting the event type that is going to be
+ * created for each entry contained in the files of the folder. Pay attention that each file may contain multiple
+ * entries.
+ * <p>3. The {@link ImportRequest#publicationsOwner} is a temporary field for deciding the publication owner
+ * until this field is calculated by the code automatically.
+ */
 public class ImportRequest implements JsonSerializable {
 
     public static final String ILLEGAL_ARGUMENT_MESSAGE = "Illegal argument:";
@@ -23,7 +32,6 @@ public class ImportRequest implements JsonSerializable {
     private final URI s3Location;
     @JsonProperty(PUBLICATIONS_OWNER)
     private final String publicationsOwner;
-
     // This field will be set as the event detail-type by the handler that emits one event per entry
     // and it will be expected by the specialized handler that will process the entry. E.g. DataMigrationHandler.
     @JsonProperty(IMPORT_EVENT_TYPE)

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ImportRequest.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ImportRequest.java
@@ -13,10 +13,13 @@ import nva.commons.core.JsonUtils;
 
 /**
  * An {@link ImportRequest} contains 3 fields.
+ *
  * <p>1. The {@link ImportRequest#s3Location} field is a URI to an S3 bucket of the form "s3://somebucket/some/path/".
+ *
  * <p>2. The {@link ImportRequest#importEventType} field is a String denoting the event type that is going to be
  * created for each entry contained in the files of the folder. Pay attention that each file may contain multiple
  * entries.
+ *
  * <p>3. The {@link ImportRequest#publicationsOwner} is a temporary field for deciding the publication owner
  * until this field is calculated by the code automatically.
  */

--- a/s3-import-commons/src/test/java/no/unit/nva/publication/s3imports/CristinEntriesEventEmitterTest.java
+++ b/s3-import-commons/src/test/java/no/unit/nva/publication/s3imports/CristinEntriesEventEmitterTest.java
@@ -37,10 +37,10 @@ public class CristinEntriesEventEmitterTest {
     public static final String UNEXPECTED_DETAIL_TYPE = "unexpected detail type";
 
     public static final String SOME_USER = PublicationGenerator.randomString();
-    public static final ImportRequest EXISTING_FILE = new ImportRequest("s3://some/s3/folder/location.file", SOME_USER);
-    public static final ImportRequest NON_EXISTING_FILE = new ImportRequest("s3://some/s3/nonexisting.file", SOME_USER);
+    public static final String IMPORT_EVENT_TYPE = "importEventType";
+    public static final ImportRequest EXISTING_FILE = newImportRequest("s3://some/s3/folder/location.file");
+    public static final ImportRequest NON_EXISTING_FILE = newImportRequest("s3://some/s3/nonexisting.file");
     public static final String LINE_SEPARATOR = System.lineSeparator();
-
     public static final SampleObject[] FILE_01_CONTENTS = randomContents().toArray(SampleObject[]::new);
     public static final Context CONTEXT = Mockito.mock(Context.class);
     public static final String SOME_OTHER_BUS = "someOtherBus";
@@ -122,6 +122,12 @@ public class CristinEntriesEventEmitterTest {
         }
     }
 
+    private static ImportRequest newImportRequest(String s3location) {
+        return new ImportRequest(s3location,
+                                 SOME_USER,
+                                 IMPORT_EVENT_TYPE);
+    }
+
     private static Map<String, InputStream> filesWithContentsAsJsonObjectsLists() {
         return Map.of(EXISTING_FILE.extractPathFromS3Location(), contentsAsJsonObjectsList());
     }
@@ -178,7 +184,7 @@ public class CristinEntriesEventEmitterTest {
 
     private InputStream createRequestEventForFile(ImportRequest detail) {
         AwsEventBridgeEvent<ImportRequest> request = new AwsEventBridgeEvent<>();
-        request.setDetailType(CristinFilenameEventEmitter.EVENT_DETAIL_TYPE);
+        request.setDetailType(FilenameEventEmitter.EVENT_DETAIL_TYPE);
         request.setDetail(detail);
         return toInputStream(request);
     }

--- a/template.yaml
+++ b/template.yaml
@@ -1207,7 +1207,7 @@ Resources:
   CristinEntriesEventEmitter:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: s3-import.commons
+      CodeUri: s3-import-commons
       Handler: no.unit.nva.publication.s3imports.CristinEntriesEventEmitter::handleRequest
       Runtime: java11
       MemorySize: 4096
@@ -1286,7 +1286,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: s3-import-commons
-      Handler: no.unit.nva.publication.s3imports.CristinFilenameEventEmitter::handleRequest
+      Handler: no.unit.nva.publication.s3imports.FilenameEventEmitter::handleRequest
       Runtime: java11
       MemorySize: 4096
       Timeout: 300 # 5 min timeout


### PR DESCRIPTION
CristinFilenameEventEmitter acquires a more generic functionality of emitting files for any kind import event. It sends in the body an import event type which later can server as event detail-type. (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events.html)