### PR TITLE
NP-2571: map cristin contributors to nva-contributors

### DIFF
--- a/cristin-import/build.gradle
+++ b/cristin-import/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
 test {
     environment "MAX_SLEEP_TIME", "1"
+    environment "CREATE_CONTRIBUTOR_ID", "true"
 }
 
 configurations.testImplementation.canBeResolved = true

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/MappingConstants.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/MappingConstants.java
@@ -1,11 +1,23 @@
 package no.unit.nva.cristin.lambda.constants;
 
+import java.net.URI;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+
 public final class MappingConstants {
 
-    public static String MAIN_CATEGORY_BOOK = "BOK";
-    public static String SECONDARY_CATEGORY_ANTHOLOGY = "ANTOLOGI";
+    public static final Environment ENVIRONMENT = new Environment();
+    public static final boolean SHOULD_CREATE_CONTRIBUTOR_ID = createCristinContributorId();
+    public static final URI CRISTIN_API = URI.create("https://api.cristin.no/person/");
 
     private MappingConstants() {
 
+    }
+
+    @JacocoGenerated
+    private static boolean createCristinContributorId() {
+        return ENVIRONMENT.readEnvOpt("CREATE_CONTRIBUTOR_ID")
+                   .map(Boolean::parseBoolean)
+                   .orElse(false);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributor.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributor.java
@@ -1,0 +1,70 @@
+package no.unit.nva.cristin.mapper;
+
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.SHOULD_CREATE_CONTRIBUTOR_ID;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import no.unit.nva.cristin.lambda.constants.MappingConstants;
+import no.unit.nva.model.Contributor;
+import no.unit.nva.model.Identity;
+import no.unit.nva.model.Role;
+import no.unit.nva.model.exceptions.MalformedContributorException;
+import no.unit.nva.publication.s3imports.UriWrapper;
+import nva.commons.core.JacocoGenerated;
+
+@Data
+@Builder(
+    builderClassName = "CristinObjectBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class CristinContributor {
+
+    public static final String NAME_DELIMITER = ", ";
+    @JsonProperty("personlopenr")
+    private Integer identifier;
+    @JsonProperty("fornavn")
+    private String givenName;
+    @JsonProperty("etternavn")
+    private String familyName;
+    @JsonProperty("rekkefolgenr")
+    private Integer contributorOrder;
+    @JsonProperty("VARBEID_PERSON_STED")
+    private List<CristinContributorsAffiliation> affiliations;
+
+    @JacocoGenerated
+    public CristinContributor() {
+
+    }
+
+    public Contributor toNvaContributor() throws MalformedContributorException {
+        String fullName = getFamilyName() + NAME_DELIMITER + getGivenName();
+        Identity identity = new Identity.Builder()
+                                .withName(fullName)
+                                .withId(constructId())
+                                .build();
+
+        return new Contributor.Builder()
+                   .withIdentity(identity)
+                   .withCorrespondingAuthor(false)
+                   .withRole(Role.CREATOR)
+                   .withSequence(contributorOrder)
+                   .build();
+    }
+
+    private URI constructId() {
+        return SHOULD_CREATE_CONTRIBUTOR_ID
+                   ? new UriWrapper(MappingConstants.CRISTIN_API)
+                         .addChild(Path.of(identifier.toString()))
+                         .getUri()
+                   : null;
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRole.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRole.java
@@ -1,0 +1,26 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(
+    builderClassName = "CristinObjectBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class CristinContributorRole {
+
+    @JsonProperty("rollekode")
+    private CristinContributorRoleCode roleCode;
+
+    public CristinContributorRole() {
+
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRoleCode.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRoleCode.java
@@ -1,0 +1,43 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public enum CristinContributorRoleCode {
+    CREATOR,
+    EDITOR;
+
+    public static final String EDITOR_NOR = "REDAKTØR";
+    public static final String CREATOR_NOR = "FORFATTER";
+    public static final String UNKNOWN_ROLE_ERROR = "Unmapped alias for roleCode: ";
+    private static final Map<String, CristinContributorRoleCode> ALIASES_MAP = constructAliasesMap();
+    private static final Map<CristinContributorRoleCode, String> DEFAULT_NAMES = constructDefaultNames();
+
+    @JsonCreator
+    public static CristinContributorRoleCode fromString(String roleCode) {
+        return Optional.ofNullable(ALIASES_MAP.get(roleCode))
+                   .orElseThrow(() -> new RuntimeException(UNKNOWN_ROLE_ERROR + roleCode));
+    }
+
+    @JsonValue
+    public String getStringValue() {
+        return DEFAULT_NAMES.get(this);
+    }
+
+    private static Map<CristinContributorRoleCode, String> constructDefaultNames() {
+        return Map.of(
+            EDITOR, EDITOR_NOR,
+            CREATOR, CREATOR_NOR);
+    }
+
+    private static Map<String, CristinContributorRoleCode> constructAliasesMap() {
+        Map<String, CristinContributorRoleCode> aliasesMap = new ConcurrentHashMap<>();
+        aliasesMap.put(EDITOR_NOR, EDITOR);
+        aliasesMap.put(CREATOR_NOR, CREATOR);
+        return Collections.unmodifiableMap(aliasesMap);
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
@@ -1,0 +1,43 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(
+    builderClassName = "CristinObjectBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class CristinContributorsAffiliation {
+
+    @JsonProperty("institusjonsnr")
+    private Integer institutionIdentifier;
+    @JsonProperty("avdnr")
+    private Integer departmentIdentifier;
+    @JsonProperty("undavdnr")
+    private Integer subdepartmentIdentifier;
+    @JsonProperty("gruppenr")
+    private Integer groupNumber;
+    @JsonProperty("stedkode_opprinnelig")
+    private String originalInsitutionCode;
+    @JsonProperty("institusjonsnavn_opprinnelig")
+    private String originalInstitutionName;
+    @JsonProperty("avdelingsnavn_opprinnelig")
+    private String oringalDepartmentName;
+    @JsonProperty("stednavn_opprinnelig")
+    private String originalPlaceName; //TODO:  what is a place?
+    @JsonProperty
+    private List<CristinContributorRole> roles;
+
+    public CristinContributorsAffiliation() {
+
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
@@ -31,7 +31,7 @@ public class CristinContributorsAffiliation {
     @JsonProperty("institusjonsnavn_opprinnelig")
     private String originalInstitutionName;
     @JsonProperty("avdelingsnavn_opprinnelig")
-    private String oringalDepartmentName;
+    private String originalDepartmentName;
     @JsonProperty("stednavn_opprinnelig")
     private String originalPlaceName; //TODO:  what is a place?
     @JsonProperty

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -1,0 +1,30 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Map;
+
+public enum CristinMainCategory {
+    BOOK;
+
+    private static final Map<String, CristinMainCategory> ALIASES_MAP = createAliasesMap();
+    private static final Map<CristinMainCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
+
+    @JsonCreator
+    public static CristinMainCategory fromString(String category) {
+        return ALIASES_MAP.get(category);
+    }
+
+    @JsonValue
+    public String getValue() {
+        return DEFAULT_NAMES_MAP.get(this);
+    }
+
+    private static Map<String, CristinMainCategory> createAliasesMap() {
+        return Map.of("BOK", BOOK);
+    }
+
+    private static Map<CristinMainCategory, String> defaultNamesMap() {
+        return Map.of(BOOK, "BOK");
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -21,9 +21,10 @@ import nva.commons.core.JsonSerializable;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class CristinObject implements JsonSerializable {
 
+    public static final String PUBLICATION_OWNER_FIELD = "publicationOwner";
     public static String IDENTIFIER_ORIGIN = "Cristin";
     @JsonProperty("id")
-    private String id;
+    private Integer id;
     @JsonProperty("arstall")
     private String publicationYear;
     @JsonProperty("dato_opprettet")
@@ -31,9 +32,12 @@ public class CristinObject implements JsonSerializable {
     @JsonProperty("VARBEID_SPRAK")
     private List<CristinTitle> cristinTitles;
     @JsonProperty("varbeidhovedkatkode")
-    private String mainCategory;
+    private CristinMainCategory mainCategory;
     @JsonProperty("varbeidunderkatkode")
-    private String secondaryCategory;
+    private CristinSecondaryCategory secondaryCategory;
+    @JsonProperty("VARBEID_PERSON")
+    private List<CristinContributor> contributors;
+
     @JsonProperty
     private String publicationOwner;
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -1,0 +1,30 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Map;
+
+public enum CristinSecondaryCategory {
+    ANTHOLOGY;
+
+    private static final Map<String, CristinSecondaryCategory> ALIASES_MAP = createAliasesMap();
+    private static final Map<CristinSecondaryCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
+
+    @JsonCreator
+    public static CristinSecondaryCategory fromString(String category) {
+        return ALIASES_MAP.get(category);
+    }
+
+    @JsonValue
+    public String getValue() {
+        return DEFAULT_NAMES_MAP.get(this);
+    }
+
+    private static Map<String, CristinSecondaryCategory> createAliasesMap() {
+        return Map.of("ANTOLOGI", ANTHOLOGY);
+    }
+
+    private static Map<CristinSecondaryCategory, String> defaultNamesMap() {
+        return Map.of(ANTHOLOGY, "ANTOLOGI");
+    }
+}

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -39,8 +39,7 @@ public class CristinDataGenerator {
     private static final List<String> LANGUAGE_CODES = List.of("nb", "no", "en");
 
     public Stream<CristinObject> randomObjects() {
-        return IntStream.range(0, 100)
-                   .boxed()
+        return IntStream.range(0, 100).boxed()
                    .map(this::newCristinObject);
     }
 
@@ -53,7 +52,7 @@ public class CristinDataGenerator {
     public CristinObject randomBookAnthology() {
         CristinObject cristinObject = CristinObject
                                           .builder()
-                                          .withCristinTitles(List.of(newCristinTitle(FIRST_TITLE)))
+                                          .withCristinTitles(List.of(randomCristinTitle(FIRST_TITLE)))
                                           .withEntryCreationDate(LocalDate.now())
                                           .withMainCategory(CristinMainCategory.BOOK)
                                           .withSecondaryCategory(CristinSecondaryCategory.ANTHOLOGY)
@@ -94,24 +93,20 @@ public class CristinDataGenerator {
         return randomArrayElement(CristinSecondaryCategory.values());
     }
 
-    private <T> T randomArrayElement(T[] array) {
-        return array[RANDOM.nextInt(array.length)];
-    }
-
     private CristinMainCategory randomMainCategory() {
         return randomArrayElement(CristinMainCategory.values());
     }
 
     private List<CristinContributor> randomContributors() {
-        return IntStream.range(0, smallRandomNumber()).boxed()
+        return smallSample()
                    .map(this::randomContributor)
                    .collect(Collectors.toList());
     }
 
-    private CristinContributor randomContributor(Integer i) {
+    private CristinContributor randomContributor(Integer contributorIndex) {
         return CristinContributor.builder()
-                   .withContributorOrder(i)
-                   .withIdentifier(i)
+                   .withContributorOrder(contributorIndex)
+                   .withIdentifier(contributorIndex)
                    .withGivenName(randomString())
                    .withFamilyName(randomString())
                    .withAffiliations(randomAffiliations())
@@ -119,8 +114,8 @@ public class CristinDataGenerator {
     }
 
     private List<CristinContributorsAffiliation> randomAffiliations() {
-        return IntStream.range(0, smallRandomNumber()).boxed()
-                   .map(i -> randomAffiliation())
+        return smallSample()
+                   .map(ignored -> randomAffiliation())
                    .collect(Collectors.toList());
     }
 
@@ -160,13 +155,12 @@ public class CristinDataGenerator {
     }
 
     private List<CristinTitle> randomTitles() {
-        return IntStream.range(0, smallRandomNumber())
-                   .boxed()
-                   .map(this::newCristinTitle)
+        return smallSample()
+                   .map(this::randomCristinTitle)
                    .collect(Collectors.toList());
     }
 
-    private CristinTitle newCristinTitle(int index) {
+    private CristinTitle randomCristinTitle(int index) {
         CristinTitle title = new CristinTitle();
         title.setTitle(randomString());
         title.setLanguagecode(randomLanguageCode());
@@ -177,6 +171,14 @@ public class CristinDataGenerator {
             title.setStatusOriginal(CristinTitle.NOT_ORIGINAL_TITLE);
         }
         return title;
+    }
+
+    private <T> T randomArrayElement(T[] array) {
+        return array[RANDOM.nextInt(array.length)];
+    }
+
+    private Stream<Integer> smallSample() {
+        return IntStream.range(0, smallRandomNumber()).boxed();
     }
 
     private String randomLanguageCode() {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -128,7 +128,7 @@ public class CristinDataGenerator {
                    .withOriginalInsitutionCode(randomString())
                    .withOriginalInstitutionName(randomString())
                    .withOriginalPlaceName(randomString())
-                   .withOringalDepartmentName(randomString())
+                   .withOriginalDepartmentName(randomString())
                    .withDepartmentIdentifier(largeRandomNumber())
                    .withRoles(randomAffiliationRoles())
                    .build();

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -134,7 +134,7 @@ public class CristinEntryEventConsumerTest extends ResourcesDynamoDbLocalTest {
         resourceService = resourceServiceThrowingExceptionWhenSavingResource();
         handler = new CristinEntryEventConsumer(resourceService, s3Client);
 
-        String cristinIdentifier = VALID_CRISTIN_ENTRY_EVENT_OBJECT.getDetail().getContents().getId();
+        Integer cristinIdentifier = VALID_CRISTIN_ENTRY_EVENT_OBJECT.getDetail().getContents().getId();
         Executable action = () -> handler.handleRequest(stringToStream(validEventToJsonString()), outputStream,
                                                         CONTEXT);
 
@@ -150,11 +150,11 @@ public class CristinEntryEventConsumerTest extends ResourcesDynamoDbLocalTest {
         resourceService = resourceServiceThrowingExceptionWhenSavingResource();
         handler = new CristinEntryEventConsumer(resourceService, s3Client);
 
-        String cristinIdentifier = Optional.of(VALID_CRISTIN_ENTRY_EVENT_OBJECT)
-                                       .map(AwsEventBridgeEvent::getDetail)
-                                       .map(FileContentsEvent::getContents)
-                                       .map(CristinObject::getId)
-                                       .orElseThrow();
+        Integer cristinIdentifier = Optional.of(VALID_CRISTIN_ENTRY_EVENT_OBJECT)
+                                        .map(AwsEventBridgeEvent::getDetail)
+                                        .map(FileContentsEvent::getContents)
+                                        .map(CristinObject::getId)
+                                        .orElseThrow();
         Executable action = () -> handler.handleRequest(stringToStream(validEventToJsonString()), outputStream,
                                                         CONTEXT);
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/ContributionReference.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/ContributionReference.java
@@ -1,0 +1,41 @@
+package no.unit.nva.cristin.mapper;
+
+import java.util.Objects;
+
+/**
+ * Helper class when testing for correct mapping of Contribution sequences. During the mapping from Cristin objects to
+ * NVA objects, we assume that we can identify uniquely a contribution by a resource identifier (Cristin result
+ * identifier), a Cristin person identifier and a sequence number. That is to say, we expect to be able to identify a
+ * Contribution sequence by saying that the "X person is the ith contributor in the Y publication".
+ */
+public class ContributionReference {
+
+    private final Integer cristinResultId;
+    private final Integer cristinPersonId;
+    private final Integer sequence;
+
+    public ContributionReference(Integer cristinResultId, Integer cristinPersonId, Integer sequence) {
+        this.cristinResultId = cristinResultId;
+        this.cristinPersonId = cristinPersonId;
+        this.sequence = sequence;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cristinResultId, cristinPersonId, sequence);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ContributionReference)) {
+            return false;
+        }
+        ContributionReference that = (ContributionReference) o;
+        return Objects.equals(cristinResultId, that.cristinResultId)
+               && Objects.equals(cristinPersonId, that.cristinPersonId)
+               && Objects.equals(sequence, that.sequence);
+    }
+}

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinContributorRoleCodeTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinContributorRoleCodeTest.java
@@ -1,0 +1,19 @@
+package no.unit.nva.cristin.mapper;
+
+import static no.unit.nva.publication.PublicationGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+class CristinContributorRoleCodeTest {
+
+    @Test
+    public void fromStringShouldThrowExceptionWithInvalidRoleWhenInvalidRoleIsProvided() {
+        String roleCode = randomString();
+        Executable action = () -> CristinContributorRoleCode.fromString(roleCode);
+        RuntimeException exception = assertThrows(RuntimeException.class, action);
+        assertThat(exception.getMessage(), containsString(roleCode));
+    }
+}

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.mapper;
 
+import static no.unit.nva.cristin.mapper.CristinObject.IDENTIFIER_ORIGIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -7,6 +8,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -19,7 +21,9 @@ import java.util.stream.Stream;
 import no.unit.nva.cristin.AbstractCristinImportTest;
 import no.unit.nva.cristin.CristinDataGenerator;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.Identity;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.PublicationStatus;
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 public class CristinMapperTest extends AbstractCristinImportTest {
 
+    public static final String NAME_DELIMITER = ", ";
     private CristinDataGenerator cristinDataGenerator;
 
     @BeforeEach
@@ -46,14 +51,15 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
     @Test
     public void mapReturnsResourceWithCristinIdStoredInAdditionalIdentifiers() {
-        Set<String> expectedIds = cristinObjects().map(CristinObject::getId).collect(Collectors.toSet());
+        Set<Integer> expectedIds = cristinObjects().map(CristinObject::getId).collect(Collectors.toSet());
 
-        Set<String> actualIds = cristinObjects()
-                                    .map(CristinObject::toPublication)
-                                    .map(Publication::getAdditionalIdentifiers)
-                                    .flatMap(Collection::stream)
-                                    .map(AdditionalIdentifier::getValue)
-                                    .collect(Collectors.toSet());
+        Set<Integer> actualIds = cristinObjects()
+                                     .map(CristinObject::toPublication)
+                                     .map(Publication::getAdditionalIdentifiers)
+                                     .flatMap(Collection::stream)
+                                     .map(AdditionalIdentifier::getValue)
+                                     .map(Integer::parseInt)
+                                     .collect(Collectors.toSet());
 
         assertThat(expectedIds.size(), is(equalTo(NUMBER_OF_LINES_IN_RESOURCES_FILE)));
         assertThat(actualIds, is(equalTo(expectedIds)));
@@ -144,6 +150,83 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
         assertThat(actualPublicationInstance, is(instanceOf(BookAnthology.class)));
         assertThat(actualPublicationContext, is(instanceOf(Book.class)));
+    }
+
+    @Test
+    public void mapReturnsResourceWhereNvaContributorsNamesAreConcatenationsOfCristinFirstAndFamilyNames() {
+
+        List<String> expectedContributorNames = cristinObjects()
+                                                    .map(CristinObject::getContributors)
+                                                    .flatMap(Collection::stream)
+                                                    .map(this::formatNameAccordingToNvaPattern)
+                                                    .collect(Collectors.toList());
+
+        List<String> actualContributorNames = cristinObjects()
+                                                  .map(CristinObject::toPublication)
+                                                  .map(Publication::getEntityDescription)
+                                                  .map(EntityDescription::getContributors)
+                                                  .flatMap(Collection::stream)
+                                                  .map(Contributor::getIdentity)
+                                                  .map(Identity::getName)
+                                                  .collect(Collectors.toList());
+        assertThat(actualContributorNames, containsInAnyOrder(expectedContributorNames.toArray(String[]::new)));
+    }
+
+    @Test
+    public void mapReturnsResourceWhereNvaContributorSequentIsEqualToCristinContributorSequence() {
+
+        var expectedContributions = cristinObjects()
+                                        .map(this::extractContributions)
+                                        .flatMap(Collection::stream)
+                                        .collect(Collectors.toSet());
+
+        var actualContributions = cristinObjects()
+                                      .map(CristinObject::toPublication)
+                                      .map(this::extractContributions)
+                                      .flatMap(Collection::stream)
+                                      .collect(Collectors.toSet());
+
+        assertThat(expectedContributions, is(equalTo(actualContributions)));
+    }
+
+    private List<ContributionReference> extractContributions(Publication publication) {
+
+        AdditionalIdentifier cristinIdentifier = publication.getAdditionalIdentifiers().stream()
+                                                     .filter(this::isCristinIdentifier)
+                                                     .collect(SingletonCollector.collect());
+        Integer cristinIdentifierValue = Integer.parseInt(cristinIdentifier.getValue());
+
+        return publication.getEntityDescription()
+                   .getContributors().stream()
+                   .map(contributor -> extractContributionReference(cristinIdentifierValue, contributor))
+                   .collect(Collectors.toList());
+    }
+
+    private boolean isCristinIdentifier(AdditionalIdentifier identifier) {
+        return identifier.getSource().equals(IDENTIFIER_ORIGIN);
+    }
+
+    private ContributionReference extractContributionReference(Integer cristinIdentifierValue,
+                                                               Contributor contributor) {
+        return new ContributionReference(cristinIdentifierValue, extractPersonId(contributor),
+                                         contributor.getSequence());
+    }
+
+    private Integer extractPersonId(Contributor contributor) {
+        String personIdentifier = Path.of(contributor.getIdentity().getId().getPath()).getFileName().toString();
+        return Integer.parseInt(personIdentifier);
+    }
+
+    private List<ContributionReference> extractContributions(CristinObject cristinObject) {
+        final Integer cristinResourceIdentifier = cristinObject.getId();
+        return cristinObject.getContributors().stream()
+                   .map(c -> new ContributionReference(cristinResourceIdentifier, c.getIdentifier(),
+                                                       c.getContributorOrder()))
+                   .collect(Collectors.toList());
+    }
+
+    private String formatNameAccordingToNvaPattern(CristinContributor cristinContributor) {
+        return cristinContributor.getFamilyName() + NAME_DELIMITER + cristinContributor.getGivenName();
     }
 
     private CristinTitle mainTitle(List<CristinTitle> titles) {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -203,6 +203,14 @@ public class CristinMapperTest extends AbstractCristinImportTest {
                    .collect(Collectors.toList());
     }
 
+    private List<ContributionReference> extractContributions(CristinObject cristinObject) {
+        final Integer cristinResourceIdentifier = cristinObject.getId();
+        return cristinObject.getContributors().stream()
+                   .map(c -> new ContributionReference(cristinResourceIdentifier, c.getIdentifier(),
+                                                       c.getContributorOrder()))
+                   .collect(Collectors.toList());
+    }
+
     private boolean isCristinIdentifier(AdditionalIdentifier identifier) {
         return identifier.getSource().equals(IDENTIFIER_ORIGIN);
     }
@@ -216,14 +224,6 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     private Integer extractPersonId(Contributor contributor) {
         String personIdentifier = Path.of(contributor.getIdentity().getId().getPath()).getFileName().toString();
         return Integer.parseInt(personIdentifier);
-    }
-
-    private List<ContributionReference> extractContributions(CristinObject cristinObject) {
-        final Integer cristinResourceIdentifier = cristinObject.getId();
-        return cristinObject.getContributors().stream()
-                   .map(c -> new ContributionReference(cristinResourceIdentifier, c.getIdentifier(),
-                                                       c.getContributorOrder()))
-                   .collect(Collectors.toList());
     }
 
     private String formatNameAccordingToNvaPattern(CristinContributor cristinContributor) {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -169,22 +169,23 @@ public class CristinMapperTest extends AbstractCristinImportTest {
                                                   .map(Contributor::getIdentity)
                                                   .map(Identity::getName)
                                                   .collect(Collectors.toList());
+
         assertThat(actualContributorNames, containsInAnyOrder(expectedContributorNames.toArray(String[]::new)));
     }
 
     @Test
-    public void mapReturnsResourceWhereNvaContributorSequentIsEqualToCristinContributorSequence() {
+    public void mapReturnsResourceWhereNvaContributorSequenceIsEqualToCristinContributorSequence() {
 
-        var expectedContributions = cristinObjects()
-                                        .map(this::extractContributions)
-                                        .flatMap(Collection::stream)
-                                        .collect(Collectors.toSet());
+        Set<ContributionReference> expectedContributions = cristinObjects()
+                                                               .map(this::extractContributions)
+                                                               .flatMap(Collection::stream)
+                                                               .collect(Collectors.toSet());
 
-        var actualContributions = cristinObjects()
-                                      .map(CristinObject::toPublication)
-                                      .map(this::extractContributions)
-                                      .flatMap(Collection::stream)
-                                      .collect(Collectors.toSet());
+        Set<ContributionReference> actualContributions = cristinObjects()
+                                                             .map(CristinObject::toPublication)
+                                                             .map(this::extractContributions)
+                                                             .flatMap(Collection::stream)
+                                                             .collect(Collectors.toSet());
 
         assertThat(expectedContributions, is(equalTo(actualContributions)));
     }


### PR DESCRIPTION
Sorry for the big PR. 

Much of the code is basically new fields reflecting the data in the Json files and generating the necessary testing data.

The JIRA task description:
Map: name, role, sequence,  set corresponding=false if corresponding is not found in Cristin

Later: Id. Put CristinID at the end of URI instead of ARPId
```
{
    "type" : "Contributor",
    "identity" : {
         "type" : "Identity",
          "id" : "https://api.test.nva.aws.unit.no/person/90390302",
           "name" : "Øiseth, Ole Vidar"
     },
     "role" : "Creator",
      "sequence" : 3,
      "correspondingAuthor" : false
}
```