### PR TITLE
Np 2575 dummy file for all resources

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/MappingConstants.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/MappingConstants.java
@@ -1,6 +1,7 @@
 package no.unit.nva.cristin.lambda.constants;
 
 import java.net.URI;
+import java.util.UUID;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
@@ -10,6 +11,9 @@ public final class MappingConstants {
     public static final boolean SHOULD_CREATE_CONTRIBUTOR_ID = createCristinContributorId();
     public static final URI CRISTIN_PERSONS_URI = URI.create("https://api.cristin.no/person/");
     public static final URI CRISTIN_ORG_URI = readCristinOrgUriFromEnvOrDefault();
+    //NIL UUID is ignored by the Json serializer and cannot be used
+    public static final UUID DUMMY_UUID = new UUID(0, 1);
+    public static final String PUBLIC_DOMAIN_LICENSE = "CC0";
 
     private MappingConstants() {
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -1,5 +1,7 @@
 package no.unit.nva.cristin.mapper;
 
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.DUMMY_UUID;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.PUBLIC_DOMAIN_LICENSE;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.time.Instant;
@@ -7,6 +9,7 @@ import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -14,6 +17,9 @@ import java.util.stream.Stream;
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.File;
+import no.unit.nva.model.FileSet;
+import no.unit.nva.model.License;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
@@ -29,6 +35,11 @@ import nva.commons.core.attempt.Try;
 
 public class CristinMapper {
 
+    public static final String DUMMY_FILENAME = "NonExistent";
+    public static final String SOME_LANGUAGE = "nb";
+    public static final File NON_EXISTENT_FILE = createNonExistentFile();
+    public static final String UNIT_ORG = "https://api.dev.nva.aws.unit"
+                                          + ".no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934";
     private final CristinObject cristinObject;
 
     public CristinMapper(CristinObject cristinObject) {
@@ -43,11 +54,30 @@ public class CristinMapper {
                    .withPublisher(extractOrganization())
                    .withOwner(cristinObject.getPublicationOwner())
                    .withStatus(PublicationStatus.DRAFT)
+                   .withFileSet(createFileSetPointingToTheNilFile())
+                   .build();
+    }
+
+    private static File createNonExistentFile() {
+        License publicDomainLicense = new License.Builder()
+                                          .withIdentifier(PUBLIC_DOMAIN_LICENSE)
+                                          .withLabels(Map.of(SOME_LANGUAGE, PUBLIC_DOMAIN_LICENSE))
+                                          .build();
+        return new File.Builder()
+                   .withName(DUMMY_FILENAME)
+                   .withIdentifier(DUMMY_UUID)
+                   .withLicense(publicDomainLicense)
+                   .build();
+    }
+
+    private FileSet createFileSetPointingToTheNilFile() {
+        return new FileSet.Builder()
+                   .withFiles(List.of(NON_EXISTENT_FILE))
                    .build();
     }
 
     private Organization extractOrganization() {
-        URI customerUri = URI.create("https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934");
+        URI customerUri = URI.create(UNIT_ORG);
         return new Organization.Builder().withId(customerUri).build();
     }
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -1,6 +1,8 @@
 package no.unit.nva.cristin.mapper;
 
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.CRISTIN_ORG_URI;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.DUMMY_UUID;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.PUBLIC_DOMAIN_LICENSE;
 import static no.unit.nva.cristin.mapper.CristinObject.IDENTIFIER_ORIGIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -18,6 +20,7 @@ import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.cristin.AbstractCristinImportTest;
@@ -25,7 +28,10 @@ import no.unit.nva.cristin.CristinDataGenerator;
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.File;
+import no.unit.nva.model.FileSet;
 import no.unit.nva.model.Identity;
+import no.unit.nva.model.License;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
@@ -43,9 +49,6 @@ import org.junit.jupiter.api.Test;
 public class CristinMapperTest extends AbstractCristinImportTest {
 
     public static final String NAME_DELIMITER = ", ";
-    public static final String FIRST_ORG_NUMBER_IN_TEST_RESOURCE_FILE = "195.65.54.32";
-    public static final String SECOND_ORG_NUMBER_IN_TEST_RESOURCE_FILE = "1.2.3.4";
-    public static final String THIRD_ORG_NUMBER_IN_RESOURCE_FILE = "0.0.0.0";
     private CristinDataGenerator cristinDataGenerator;
 
     @BeforeEach
@@ -233,6 +236,37 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
         assertThat(actualPublicationDates,
                    containsInAnyOrder(expectedPublicationDates.toArray(PublicationDate[]::new)));
+    }
+
+    @Test
+    public void mapReturnsPublicationWithFileSetContainingSingleFileWithIdentifierEqualToNilUUID() {
+        Set<UUID> actualFileIdentifiers = cristinObjects()
+                                              .map(CristinObject::toPublication)
+                                              .map(Publication::getFileSet)
+                                              .map(FileSet::getFiles)
+                                              .flatMap(Collection::stream)
+                                              .map(File::getIdentifier)
+                                              .collect(Collectors.toSet());
+
+        Set<UUID> expectedIdentifiers = Set.of(DUMMY_UUID);
+
+        assertThat(actualFileIdentifiers, is(equalTo(expectedIdentifiers)));
+    }
+
+    @Test
+    public void mapReturnsPublicationWithFileSetContainingSingleFileWithPublicDomainLicense() {
+        Set<String> actualLicenseIdentifiers = cristinObjects()
+                                                   .map(CristinObject::toPublication)
+                                                   .map(Publication::getFileSet)
+                                                   .map(FileSet::getFiles)
+                                                   .flatMap(Collection::stream)
+                                                   .map(File::getLicense)
+                                                   .map(License::getIdentifier)
+                                                   .collect(Collectors.toSet());
+
+        Set<String> expectedLicenseIdentifiers = Set.of(PUBLIC_DOMAIN_LICENSE);
+
+        assertThat(actualLicenseIdentifiers, is(equalTo(expectedLicenseIdentifiers)));
     }
 
     private PublicationDate yearStringToPublicationDate(String yearString) {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -199,12 +199,13 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapReturnsResourceWhereNvaContributorHasAffiliationsWithUriCreatedBasedOnReferenceUriAndUnitNumbers() {
 
-        var expectedAffiliations = cristinObjects()
-                                       .flatMap(cristinEntries -> cristinEntries.getContributors().stream())
-                                       .flatMap(contributor -> contributor.getAffiliations().stream())
-                                       .map(this::explicitFormattingOfCristinAffiliationCode)
-                                       .map(this::addCristinOrgHostPrefix)
-                                       .map(URI::create);
+        List<URI> expectedAffiliations = cristinObjects()
+                                             .flatMap(cristinEntries -> cristinEntries.getContributors().stream())
+                                             .flatMap(contributor -> contributor.getAffiliations().stream())
+                                             .map(this::explicitFormattingOfCristinAffiliationCode)
+                                             .map(this::addCristinOrgHostPrefix)
+                                             .map(URI::create)
+                                             .collect(Collectors.toList());
 
         List<URI> actualAffiliations = cristinObjects().map(CristinObject::toPublication)
                                            .map(Publication::getEntityDescription)
@@ -216,6 +217,27 @@ public class CristinMapperTest extends AbstractCristinImportTest {
                                            .collect(Collectors.toList());
 
         assertThat(actualAffiliations, containsInAnyOrder(expectedAffiliations.toArray(URI[]::new)));
+    }
+
+    @Test
+    public void mapReturnsPublicationWithPublicationDateEqualToCristinPublicationDate() {
+        List<PublicationDate> expectedPublicationDates = cristinObjects()
+                                                             .map(CristinObject::getPublicationYear)
+                                                             .map(this::yearStringToPublicationDate)
+                                                             .collect(Collectors.toList());
+        List<PublicationDate> actualPublicationDates = cristinObjects()
+                                                           .map(CristinObject::toPublication)
+                                                           .map(Publication::getEntityDescription)
+                                                           .map(EntityDescription::getDate)
+                                                           .collect(Collectors.toList());
+
+        assertThat(actualPublicationDates,
+                   containsInAnyOrder(expectedPublicationDates.toArray(PublicationDate[]::new)));
+    }
+
+    private PublicationDate yearStringToPublicationDate(String yearString) {
+        return new PublicationDate.Builder().withYear(
+            yearString).build();
     }
 
     //We do not use any more complex logic to make the tests fail if anything changes

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ServiceWithTransactions.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ServiceWithTransactions.java
@@ -6,6 +6,7 @@ import static no.unit.nva.publication.service.impl.ResourceServiceUtils.PRIMARY_
 import static nva.commons.core.JsonUtils.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Delete;
 import com.amazonaws.services.dynamodbv2.model.Put;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
@@ -14,6 +15,7 @@ import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsResult;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import no.unit.nva.publication.exception.BadRequestException;
 import no.unit.nva.publication.exception.TransactionFailedException;
@@ -39,9 +41,10 @@ public abstract class ServiceWithTransactions {
     private static final int RESOURCE_INDEX_IN_QUERY_RESULT_WHEN_DOI_REQUEST_NOT_EXISTS = 0;
     
     protected static <T extends DynamoEntry> TransactWriteItem newPutTransactionItem(T data, String tableName) {
-        
+
+        Map<String, AttributeValue> item = data.toDynamoFormat();
         Put put = new Put()
-                      .withItem(data.toDynamoFormat())
+                      .withItem(item)
                       .withTableName(tableName)
                       .withConditionExpression(KEY_NOT_EXISTS_CONDITION)
                       .withExpressionAttributeNames(PRIMARY_KEY_EQUALITY_CONDITION_ATTRIBUTE_NAMES);

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ServiceWithTransactions.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ServiceWithTransactions.java
@@ -6,7 +6,6 @@ import static no.unit.nva.publication.service.impl.ResourceServiceUtils.PRIMARY_
 import static nva.commons.core.JsonUtils.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Delete;
 import com.amazonaws.services.dynamodbv2.model.Put;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
@@ -15,7 +14,6 @@ import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsResult;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import no.unit.nva.publication.exception.BadRequestException;
 import no.unit.nva.publication.exception.TransactionFailedException;
@@ -42,9 +40,8 @@ public abstract class ServiceWithTransactions {
     
     protected static <T extends DynamoEntry> TransactWriteItem newPutTransactionItem(T data, String tableName) {
 
-        Map<String, AttributeValue> item = data.toDynamoFormat();
         Put put = new Put()
-                      .withItem(item)
+                      .withItem(data.toDynamoFormat())
                       .withTableName(tableName)
                       .withConditionExpression(KEY_NOT_EXISTS_CONDITION)
                       .withExpressionAttributeNames(PRIMARY_KEY_EQUALITY_CONDITION_ATTRIBUTE_NAMES);


### PR DESCRIPTION
Create a dummy file for all imported Cristin Resources, so that they can be published and therefore indexed and looked up. This will enable the PO to give more detailed feedback on the mapping of the fieds