### PR TITLE
NP-2576: report unknown categories to s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ allprojects {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
@@ -31,7 +32,7 @@ allprojects {
         awsSdkVersion = '1.11.973'
         awsSdk2Version = '2.16.46'
         nvaDatamodelVersion = "0.11.14"
-        nvaCommonsVersion = '1.5.14'
+        nvaCommonsVersion = '1.5.17'
         nvaTestUtilsVersion = "50fa3b208398e9877f702a71ad7b16ea65b139d7"
         junit5Version = '5.6.0'
         jacksonVersion = '2.12.3'

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -41,7 +41,6 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Js
     public static final String EVENT_DETAIL_TYPE = "import.cristin.entry-event";
     public static final String FILE_ENDING = ".json";
     public static final String EMPTY_FRAGMENT = null;
-    public static final String ID_FIELD = "id";
     public static final String UNKNOWN_CRISTIN_ID = "unknownCristinId_";
     public static final String DO_NOT_WRITE_ID_IN_EXPCETION_MESSAGE = null;
     private static final Logger logger = LoggerFactory.getLogger(CristinEntryEventConsumer.class);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -5,6 +5,7 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -21,13 +22,14 @@ import no.unit.nva.publication.s3imports.ImportResult;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.JsonUtils;
 import nva.commons.core.attempt.Failure;
 import nva.commons.core.attempt.Try;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<CristinObject>, Publication> {
+public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<JsonNode>, Publication> {
 
     public static final String WRONG_DETAIL_TYPE_ERROR_TEMPLATE =
         "Unexpected detail-type: %s. Expected detail-type is: %s.";
@@ -57,24 +59,34 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Cr
         this.s3Client = s3Client;
     }
 
-    public static URI constructErrorFileUri(AwsEventBridgeEvent<FileContentsEvent<CristinObject>> event) {
+    public static URI constructErrorFileUri(AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event) {
+        CristinObject cristinObject = parseCristinObject(event);
         Path parentFolder = extractFolderPath(event.getDetail());
         String scheme = event.getDetail().getFileUri().getScheme();
         String bucketName = event.getDetail().getFileUri().getHost();
-        String filename = event.getDetail().getContents().getId() + FILE_ENDING;
+        String filename = cristinObject.getId() + FILE_ENDING;
         Path filePath = Path.of(parentFolder.toString(), filename);
         return attempt(() -> new URI(scheme, bucketName, filePath.toString(), EMPTY_FRAGMENT)).orElseThrow();
     }
 
+    protected static CristinObject parseCristinObject(AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event) {
+        CristinObject cristinObject =
+            attempt(() -> event.getDetail().getContents())
+                .map(jsonNode -> JsonUtils.objectMapperNoEmpty.convertValue(jsonNode, CristinObject.class))
+                .orElseThrow();
+        cristinObject.setPublicationOwner(event.getDetail().getPublicationsOwner());
+        return cristinObject;
+    }
+
     @Override
-    protected Publication processInput(FileContentsEvent<CristinObject> input,
-                                       AwsEventBridgeEvent<FileContentsEvent<CristinObject>> event,
+    protected Publication processInput(FileContentsEvent<JsonNode> input,
+                                       AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event,
                                        Context context) {
         validateEvent(event);
-        CristinObject cristinObject = extractCristinObject(input);
-        Publication publication = cristinObject.toPublication();
-        Try<Publication> attemptSave = persistInDatabase(publication);
-        return attemptSave.orElseThrow(fail -> handleSavingError(fail, event));
+        CristinObject cristinObject = parseCristinObject(event);
+        Try<Publication> attemptSave = attempt(cristinObject::toPublication)
+                                           .flatMap(this::persistInDatabase);
+        return attemptSave.orElseThrow(fail -> handleSavingError(fail, event, cristinObject));
     }
 
     @JacocoGenerated
@@ -85,7 +97,7 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Cr
                    .build();
     }
 
-    private static Path extractFolderPath(FileContentsEvent<CristinObject> event) {
+    private static Path extractFolderPath(FileContentsEvent<JsonNode> event) {
         return Optional.of(event)
                    .map(FileContentsEvent::getFileUri)
                    .map(URI::getPath)
@@ -94,13 +106,7 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Cr
                    .orElseThrow();
     }
 
-    private CristinObject extractCristinObject(FileContentsEvent<CristinObject> input) {
-        CristinObject cristinObject = input.getContents().copy().build();
-        cristinObject.setPublicationOwner(input.getPublicationsOwner());
-        return cristinObject;
-    }
-
-    private void validateEvent(AwsEventBridgeEvent<FileContentsEvent<CristinObject>> event) {
+    private void validateEvent(AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event) {
         if (!EVENT_DETAIL_TYPE.equals(event.getDetailType())) {
             String errorMessage = String.format(WRONG_DETAIL_TYPE_ERROR_TEMPLATE,
                                                 event.getDetailType(),
@@ -136,18 +142,19 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Cr
     }
 
     private RuntimeException handleSavingError(Failure<Publication> fail,
-                                               AwsEventBridgeEvent<FileContentsEvent<CristinObject>> event) {
-        String errorMessage = ERROR_SAVING_CRISTIN_RESULT + event.getDetail().getContents().getId();
+                                               AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event,
+                                               CristinObject cristinObject) {
+        String errorMessage = ERROR_SAVING_CRISTIN_RESULT + cristinObject.getId();
         logger.error(errorMessage, fail.getException());
         saveReportToS3(fail, event);
         return new RuntimeException(errorMessage, fail.getException());
     }
 
     private void saveReportToS3(Failure<Publication> fail,
-                                AwsEventBridgeEvent<FileContentsEvent<CristinObject>> event) {
+                                AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event) {
         URI errorFileUri = constructErrorFileUri(event);
         S3Driver s3Driver = new S3Driver(s3Client, errorFileUri.getHost());
-        ImportResult<AwsEventBridgeEvent<FileContentsEvent<CristinObject>>> reportContent =
+        ImportResult<AwsEventBridgeEvent<FileContentsEvent<JsonNode>>> reportContent =
             ImportResult.reportFailure(event, fail.getException());
         s3Driver.insertFile(Path.of(errorFileUri.getPath()), reportContent.toJsonString());
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -42,7 +42,7 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Js
     public static final String FILE_ENDING = ".json";
     public static final String EMPTY_FRAGMENT = null;
     public static final String UNKNOWN_CRISTIN_ID_ERROR_REPORT_PREFIX = "unknownCristinId_";
-    public static final String DO_NOT_WRITE_ID_IN_EXPCETION_MESSAGE = null;
+    public static final String DO_NOT_WRITE_ID_IN_EXCEPTION_MESSAGE = null;
     public static final String ERRORS_FOLDER = "errors";
     private static final Logger logger = LoggerFactory.getLogger(CristinEntryEventConsumer.class);
     private final ResourceService resourceService;
@@ -132,7 +132,7 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Js
 
     private RuntimeException handleSavingError(Failure<Publication> fail,
                                                AwsEventBridgeEvent<FileContentsEvent<JsonNode>> event) {
-        String cristinObjectId = extractCristinObjectId(event).orElse(DO_NOT_WRITE_ID_IN_EXPCETION_MESSAGE);
+        String cristinObjectId = extractCristinObjectId(event).orElse(DO_NOT_WRITE_ID_IN_EXCEPTION_MESSAGE);
         String errorMessage = ERROR_SAVING_CRISTIN_RESULT + cristinObjectId;
         logger.error(errorMessage, fail.getException());
         saveReportToS3(fail, event);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/dtos/CristinObjectEvent.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/dtos/CristinObjectEvent.java
@@ -2,19 +2,19 @@ package no.unit.nva.cristin.lambda.dtos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
-import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.publication.s3imports.FileContentsEvent;
 
 /**
  * Wrapper class for using in Lambda functions.
  */
 
-public class CristinObjectEvent extends FileContentsEvent<CristinObject> {
+public class CristinObjectEvent extends FileContentsEvent<JsonNode> {
 
     @JsonCreator
     public CristinObjectEvent(@JsonProperty(FILE_URI) URI fileUri,
-                              @JsonProperty(CONTENTS_FIELD) CristinObject contents,
+                              @JsonProperty(CONTENTS_FIELD) JsonNode contents,
                               @JsonProperty(PUBLICATIONS_OWNER_FIELD) String publicationsOwner) {
 
         super(fileUri, contents, publicationsOwner);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import nva.commons.core.SingletonCollector;
 
 public enum CristinMainCategory {
-    BOOK("BOK"), UNMAPPED;
+    BOOK("BOK", "BOOK"), UNMAPPED;
 
     public static final int DEFAULT_VALUE = 0;
     private final List<String> aliases;

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 
 public enum CristinMainCategory {
-    BOOK, TEMPORARILY_UNKNOWN, UNMAPPED;
+    BOOK, UNMAPPED;
 
     private static final Map<String, CristinMainCategory> KNOWN_ALIASES_MAP = createKnownAliasesMap();
     private static final Map<CristinMainCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
@@ -30,7 +30,6 @@ public enum CristinMainCategory {
 
     private static Map<CristinMainCategory, String> defaultNamesMap() {
         return Map.of(BOOK, "BOK",
-                      TEMPORARILY_UNKNOWN, "TEMPORARILY_UNKNOWN",
                       UNMAPPED, "UNMAPPED");
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -1,35 +1,36 @@
 package no.unit.nva.cristin.mapper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import nva.commons.core.SingletonCollector;
 
 public enum CristinMainCategory {
-    BOOK, UNMAPPED;
+    BOOK("BOK"), UNMAPPED;
 
-    private static final Map<String, CristinMainCategory> KNOWN_ALIASES_MAP = createKnownAliasesMap();
-    private static final Map<CristinMainCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
+    public static final int DEFAULT_VALUE = 0;
+    private final List<String> aliases;
+
+    CristinMainCategory(String... mapping) {
+        aliases = Arrays.asList(mapping);
+    }
 
     @JsonCreator
     public static CristinMainCategory fromString(String category) {
-        return KNOWN_ALIASES_MAP.getOrDefault(category, UNMAPPED);
+        return Arrays.stream(values())
+                   .filter(item -> item.aliases.contains(category))
+                   .collect(SingletonCollector.collectOrElse(UNMAPPED));
     }
 
-    @JsonValue
     public String getValue() {
-        return DEFAULT_NAMES_MAP.get(this);
+        if (Objects.nonNull(aliases) && !aliases.isEmpty()) {
+            return aliases.get(DEFAULT_VALUE);
+        }
+        return this.name();
     }
 
     public boolean isUnknownCategory() {
         return UNMAPPED.equals(this);
-    }
-
-    private static Map<String, CristinMainCategory> createKnownAliasesMap() {
-        return Map.of("BOK", BOOK);
-    }
-
-    private static Map<CristinMainCategory, String> defaultNamesMap() {
-        return Map.of(BOOK, "BOK",
-                      UNMAPPED, "UNMAPPED");
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 
 public enum CristinMainCategory {
-    BOOK;
+    BOOK, TEMPORARILY_UNKNOWN, UNMAPPED;
 
-    private static final Map<String, CristinMainCategory> ALIASES_MAP = createAliasesMap();
+    private static final Map<String, CristinMainCategory> KNOWN_ALIASES_MAP = createKnownAliasesMap();
     private static final Map<CristinMainCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
 
     @JsonCreator
     public static CristinMainCategory fromString(String category) {
-        return ALIASES_MAP.get(category);
+        return KNOWN_ALIASES_MAP.getOrDefault(category, UNMAPPED);
     }
 
     @JsonValue
@@ -20,11 +20,17 @@ public enum CristinMainCategory {
         return DEFAULT_NAMES_MAP.get(this);
     }
 
-    private static Map<String, CristinMainCategory> createAliasesMap() {
+    public boolean isUnknownCategory() {
+        return UNMAPPED.equals(this);
+    }
+
+    private static Map<String, CristinMainCategory> createKnownAliasesMap() {
         return Map.of("BOK", BOOK);
     }
 
     private static Map<CristinMainCategory, String> defaultNamesMap() {
-        return Map.of(BOOK, "BOK");
+        return Map.of(BOOK, "BOK",
+                      TEMPORARILY_UNKNOWN, "TEMPORARILY_UNKNOWN",
+                      UNMAPPED, "UNMAPPED");
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -38,8 +38,8 @@ public class CristinMapper {
     public static final String DUMMY_FILENAME = "NonExistent";
     public static final String SOME_LANGUAGE = "nb";
     public static final File NON_EXISTENT_FILE = createNonExistentFile();
-    public static final String UNIT_ORG = "https://api.dev.nva.aws.unit"
-                                          + ".no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934";
+    public static final URI HARDCODED_NVA_CUSTOMER =
+        URI.create("https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934");
     public static final String ERROR_PARSING_SECONDARY_CATEGORY = "Error parsing secodary category";
     public static final String ERROR_PARSING_MAIN_CATEGORY = "Error parsing main category";
     public static final String ERROR_PARSING_MAIN_OR_SECONDARY_CATEGORIES = "Error parsing main or secondary "
@@ -81,8 +81,7 @@ public class CristinMapper {
     }
 
     private Organization extractOrganization() {
-        URI customerUri = URI.create(UNIT_ORG);
-        return new Organization.Builder().withId(customerUri).build();
+        return new Organization.Builder().withId(HARDCODED_NVA_CUSTOMER).build();
     }
 
     private Instant extractEntryCreationDate() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -40,6 +40,10 @@ public class CristinMapper {
     public static final File NON_EXISTENT_FILE = createNonExistentFile();
     public static final String UNIT_ORG = "https://api.dev.nva.aws.unit"
                                           + ".no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934";
+    public static final String ERROR_PARSING_SECONDARY_CATEGORY = "Error parsing secodary category";
+    public static final String ERROR_PARSING_MAIN_CATEGORY = "Error parsing main category";
+    public static final String ERROR_PARSING_MAIN_OR_SECONDARY_CATEGORIES = "Error parsing main or secondary "
+                                                                            + "categories";
     private final CristinObject cristinObject;
 
     public CristinMapper(CristinObject cristinObject) {
@@ -129,10 +133,17 @@ public class CristinMapper {
 
     private PublicationInstance<? extends Pages> buildPublicationInstance() {
         if (isBook() && isAnthology()) {
-            return new BookAnthology.Builder().build();
-        } else {
-            return null;
+            return createBuildAnthology();
+        } else if (cristinObject.getMainCategory().isUnknownCategory()) {
+            throw new UnsupportedOperationException(ERROR_PARSING_MAIN_CATEGORY);
+        } else if (cristinObject.getSecondaryCategory().isUnknownCategory()) {
+            throw new UnsupportedOperationException(ERROR_PARSING_SECONDARY_CATEGORY);
         }
+        throw new RuntimeException(ERROR_PARSING_MAIN_OR_SECONDARY_CATEGORIES);
+    }
+
+    private BookAnthology createBuildAnthology() {
+        return new BookAnthology.Builder().build();
     }
 
     private boolean isAnthology() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -40,7 +40,7 @@ public class CristinMapper {
     public static final File NON_EXISTENT_FILE = createNonExistentFile();
     public static final URI HARDCODED_NVA_CUSTOMER =
         URI.create("https://api.dev.nva.aws.unit.no/customer/f54c8aa9-073a-46a1-8f7c-dde66c853934");
-    public static final String ERROR_PARSING_SECONDARY_CATEGORY = "Error parsing secodary category";
+    public static final String ERROR_PARSING_SECONDARY_CATEGORY = "Error parsing secondary category";
     public static final String ERROR_PARSING_MAIN_CATEGORY = "Error parsing main category";
     public static final String ERROR_PARSING_MAIN_OR_SECONDARY_CATEGORIES = "Error parsing main or secondary "
                                                                             + "categories";

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -51,4 +51,7 @@ public class CristinObject implements JsonSerializable {
         return new CristinMapper(this).generatePublication();
     }
 
+    public void hardcodePublicationOwner(String publicationsOwner) {
+        this.setPublicationOwner(publicationsOwner);
+    }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -22,6 +22,8 @@ import nva.commons.core.JsonSerializable;
 public class CristinObject implements JsonSerializable {
 
     public static final String PUBLICATION_OWNER_FIELD = "publicationOwner";
+    public static final String MAIN_CATEGORY_FIELD = "varbeidhovedkatkode";
+    public static final String SECONDARY_CATEGORY_FIELD = "varbeidunderkatkode";
     public static String IDENTIFIER_ORIGIN = "Cristin";
     @JsonProperty("id")
     private Integer id;
@@ -31,9 +33,9 @@ public class CristinObject implements JsonSerializable {
     private LocalDate entryCreationDate;
     @JsonProperty("VARBEID_SPRAK")
     private List<CristinTitle> cristinTitles;
-    @JsonProperty("varbeidhovedkatkode")
+    @JsonProperty(MAIN_CATEGORY_FIELD)
     private CristinMainCategory mainCategory;
-    @JsonProperty("varbeidunderkatkode")
+    @JsonProperty(SECONDARY_CATEGORY_FIELD)
     private CristinSecondaryCategory secondaryCategory;
     @JsonProperty("VARBEID_PERSON")
     private List<CristinContributor> contributors;
@@ -49,7 +51,4 @@ public class CristinObject implements JsonSerializable {
         return new CristinMapper(this).generatePublication();
     }
 
-    public CristinObjectBuilder copy() {
-        return this.toBuilder();
-    }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 
 public enum CristinSecondaryCategory {
-    ANTHOLOGY;
+    ANTHOLOGY, TEMPORARILY_UNKNOWN, UNMAPPED;
 
-    private static final Map<String, CristinSecondaryCategory> ALIASES_MAP = createAliasesMap();
+    private static final Map<String, CristinSecondaryCategory> KNOWN_ALIASES_MAP = knownAliases();
     private static final Map<CristinSecondaryCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
 
     @JsonCreator
     public static CristinSecondaryCategory fromString(String category) {
-        return ALIASES_MAP.get(category);
+        return KNOWN_ALIASES_MAP.getOrDefault(category, UNMAPPED);
     }
 
     @JsonValue
@@ -20,11 +20,17 @@ public enum CristinSecondaryCategory {
         return DEFAULT_NAMES_MAP.get(this);
     }
 
-    private static Map<String, CristinSecondaryCategory> createAliasesMap() {
+    public boolean isUnknownCategory() {
+        return UNMAPPED.equals(this);
+    }
+
+    private static Map<String, CristinSecondaryCategory> knownAliases() {
         return Map.of("ANTOLOGI", ANTHOLOGY);
     }
 
     private static Map<CristinSecondaryCategory, String> defaultNamesMap() {
-        return Map.of(ANTHOLOGY, "ANTOLOGI");
+        return Map.of(ANTHOLOGY, "ANTOLOGI",
+                      TEMPORARILY_UNKNOWN, "TEMPORARILY_UNKNOWN",
+                      UNMAPPED, "UNMAPPED");
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 
 public enum CristinSecondaryCategory {
-    ANTHOLOGY, TEMPORARILY_UNKNOWN, UNMAPPED;
+    ANTHOLOGY, UNMAPPED;
 
     private static final Map<String, CristinSecondaryCategory> KNOWN_ALIASES_MAP = knownAliases();
     private static final Map<CristinSecondaryCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
@@ -30,7 +30,6 @@ public enum CristinSecondaryCategory {
 
     private static Map<CristinSecondaryCategory, String> defaultNamesMap() {
         return Map.of(ANTHOLOGY, "ANTOLOGI",
-                      TEMPORARILY_UNKNOWN, "TEMPORARILY_UNKNOWN",
                       UNMAPPED, "UNMAPPED");
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import nva.commons.core.SingletonCollector;
 
 public enum CristinSecondaryCategory {
-    ANTHOLOGY("ANTOLOGI"), UNMAPPED;
+    ANTHOLOGY("ANTOLOGI", "ANTHOLOGY"), UNMAPPED;
 
     public static final int DEFAULT_VALUE = 0;
     private final List<String> aliases;

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -2,34 +2,38 @@ package no.unit.nva.cristin.mapper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import nva.commons.core.SingletonCollector;
 
 public enum CristinSecondaryCategory {
-    ANTHOLOGY, UNMAPPED;
+    ANTHOLOGY("ANTOLOGI"), UNMAPPED;
 
-    private static final Map<String, CristinSecondaryCategory> KNOWN_ALIASES_MAP = knownAliases();
-    private static final Map<CristinSecondaryCategory, String> DEFAULT_NAMES_MAP = defaultNamesMap();
+    public static final int DEFAULT_VALUE = 0;
+    private final List<String> aliases;
+
+    CristinSecondaryCategory(String... aliases) {
+        this.aliases = Arrays.asList(aliases);
+    }
 
     @JsonCreator
     public static CristinSecondaryCategory fromString(String category) {
-        return KNOWN_ALIASES_MAP.getOrDefault(category, UNMAPPED);
+        return Arrays.stream(values())
+                   .filter(enumValue -> enumValue.aliases.contains(category))
+                   .collect(SingletonCollector.collectOrElse(UNMAPPED));
     }
 
     @JsonValue
     public String getValue() {
-        return DEFAULT_NAMES_MAP.get(this);
+        if (Objects.nonNull(aliases) && !aliases.isEmpty()) {
+            return aliases.get(DEFAULT_VALUE);
+        }
+        return this.name();
     }
 
     public boolean isUnknownCategory() {
         return UNMAPPED.equals(this);
     }
 
-    private static Map<String, CristinSecondaryCategory> knownAliases() {
-        return Map.of("ANTOLOGI", ANTHOLOGY);
-    }
-
-    private static Map<CristinSecondaryCategory, String> defaultNamesMap() {
-        return Map.of(ANTHOLOGY, "ANTOLOGI",
-                      UNMAPPED, "UNMAPPED");
-    }
 }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -50,6 +50,7 @@ public class CristinDataGenerator {
     public static final int NUMBER_OF_KNOWN_SECONDARY_CATEGORIES = 1;
     private static final List<String> LANGUAGE_CODES = List.of("nb", "no", "en");
     private static final int NUMBER_OF_KNOWN_MAIN_CATEGORIES = 1;
+    public static final String ID_FIELD = "id";
 
     public Stream<CristinObject> randomObjects() {
         return IntStream.range(0, 100).boxed()
@@ -95,12 +96,18 @@ public class CristinDataGenerator {
         return newCristinObject(0).toJsonString();
     }
 
-    public JsonNode customMainCategory(String customMainCategory) throws JsonProcessingException {
+    public JsonNode objectWithCustomMainCategory(String customMainCategory) throws JsonProcessingException {
         return cristinObjectWithUnexpectedValue(customMainCategory, MAIN_CATEGORY_FIELD);
     }
 
-    public JsonNode customSecondaryCategory(String customSecondaryCategory) throws JsonProcessingException {
+    public JsonNode objectWithCustomSecondaryCategory(String customSecondaryCategory) throws JsonProcessingException {
         return cristinObjectWithUnexpectedValue(customSecondaryCategory, SECONDARY_CATEGORY_FIELD);
+    }
+
+    public JsonNode objectWithoutId() throws JsonProcessingException {
+        ObjectNode cristinObject = cristinObjectAsObjectNode();
+        cristinObject.remove(ID_FIELD);
+        return cristinObject;
     }
 
     private static <T> T randomElement(List<T> elements) {
@@ -133,11 +140,15 @@ public class CristinDataGenerator {
 
     private JsonNode cristinObjectWithUnexpectedValue(String customSecondaryCategory, String secondaryCategoryField)
         throws JsonProcessingException {
-        CristinObject cristinObject = newCristinObject(0);
-        assertThat(cristinObject, doesNotHaveEmptyValuesIgnoringFields(Set.of(PUBLICATION_OWNER_FIELD)));
-        ObjectNode json = (ObjectNode) JsonUtils.objectMapperNoEmpty.readTree(cristinObject.toJsonString());
+        ObjectNode json = cristinObjectAsObjectNode();
         json.put(secondaryCategoryField, customSecondaryCategory);
         return json;
+    }
+
+    private ObjectNode cristinObjectAsObjectNode() throws JsonProcessingException {
+        CristinObject cristinObject = newCristinObject(0);
+        assertThat(cristinObject, doesNotHaveEmptyValuesIgnoringFields(Set.of(PUBLICATION_OWNER_FIELD)));
+        return (ObjectNode) JsonUtils.objectMapperNoEmpty.readTree(cristinObject.toJsonString());
     }
 
     private <T> JsonNode convertToJsonNode(T inputData) {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -57,6 +57,10 @@ public class CristinDataGenerator {
                    .map(this::newCristinObject);
     }
 
+    public CristinObject randomObject() {
+        return newCristinObject(largeRandomNumber());
+    }
+
     public String randomDataAsString() {
         return randomObjects()
                    .map(this::toJsonString)

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -5,6 +5,7 @@ import static no.unit.nva.cristin.CristinDataGenerator.randomString;
 import static no.unit.nva.cristin.lambda.CristinEntryEventConsumer.ERRORS_FOLDER;
 import static no.unit.nva.cristin.lambda.CristinEntryEventConsumer.ERROR_SAVING_CRISTIN_RESULT;
 import static no.unit.nva.cristin.lambda.CristinEntryEventConsumer.FILE_ENDING;
+import static no.unit.nva.cristin.lambda.CristinEntryEventConsumer.UNKNOWN_CRISTIN_ID_ERROR_REPORT_PREFIX;
 import static no.unit.nva.cristin.mapper.CristinMapper.HARDCODED_NVA_CUSTOMER;
 import static nva.commons.core.JsonUtils.objectMapperNoEmpty;
 import static nva.commons.core.attempt.Try.attempt;
@@ -281,6 +282,7 @@ public class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         ImportResult<AwsEventBridgeEvent<FileContentsEvent<JsonNode>>> actualReport =
             objectMapperNoEmpty.readValue(errorReport, IMPORT_RESULT_JAVA_TYPE);
 
+        assertThat(errorReportFile, containsString(UNKNOWN_CRISTIN_ID_ERROR_REPORT_PREFIX));
         assertThat(actualReport.getInput().getDetail().getContents(), is(equalTo(cristinObjectWithoutId)));
     }
 


### PR DESCRIPTION
I tried to keep the PR small, but I felt that refactoring to increase the readability would make it easier.

Presently the only known category is Book-Anthology.  Any other category will be reported as an error in S3.
Because of the fact that the CRISTIN categories are enums that reflect our incomplete knowledge of the actual categories, we have to parse the contents of the event inside the handler in order to be able to report the original content in the error report file.