### PR TITLE
Import from s3 writes only to stack table

### DIFF
--- a/data-import-from-s3/src/main/java/no/unit/nva/dataimport/ImportRequest.java
+++ b/data-import-from-s3/src/main/java/no/unit/nva/dataimport/ImportRequest.java
@@ -14,12 +14,10 @@ public class ImportRequest implements JsonSerializable {
 
     public static final String PATH_DELIMITER = "/";
     public static final String S3_LOCATION_FIELD = "s3Location";
-    public static final String TABLE_FIELD = "table";
     public static final String MISSING_FIELD_MESSAGE_PATTERN = "\"%s\"  field is missing";
     @JsonProperty("s3Location")
     private URI s3Location;
-    @JsonProperty("table")
-    private String table;
+
 
     //Default serializer necessary for AWS's serializer.
     @JacocoGenerated
@@ -27,10 +25,7 @@ public class ImportRequest implements JsonSerializable {
 
     }
 
-    public ImportRequest(String s3location,
-                         String table) {
-
-        this.table = table;
+    public ImportRequest(String s3location) {
         this.s3Location = Optional.ofNullable(s3location).map(URI::create).orElse(null);
     }
 
@@ -41,9 +36,8 @@ public class ImportRequest implements JsonSerializable {
      * @return the input as an {@link ImportRequest}
      */
     public static ImportRequest fromMap(Map<String, String> request) {
-        String s3Location = extractFieldFromMap(request, S3_LOCATION_FIELD);
-        String table = extractFieldFromMap(request, TABLE_FIELD);
-        return new ImportRequest(s3Location, table);
+        String s3Location = extractFieldFromMap(request);
+        return new ImportRequest(s3Location);
     }
 
     /**
@@ -55,9 +49,6 @@ public class ImportRequest implements JsonSerializable {
         Map<String, String> map = new ConcurrentHashMap<>();
         if (nonNull(getS3Location())) {
             map.put(S3_LOCATION_FIELD, getS3Location());
-        }
-        if (nonNull(getTable())) {
-            map.put(TABLE_FIELD, getTable());
         }
         return map;
     }
@@ -72,15 +63,6 @@ public class ImportRequest implements JsonSerializable {
         this.s3Location = URI.create(s3Location);
     }
 
-    @JacocoGenerated
-    public String getTable() {
-        return table;
-    }
-
-    @JacocoGenerated
-    public void setTable(String table) {
-        this.table = table;
-    }
 
     public String extractBucketFromS3Location() {
         return s3Location.getHost();
@@ -96,7 +78,7 @@ public class ImportRequest implements JsonSerializable {
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(getS3Location(), getTable());
+        return Objects.hash(getS3Location());
     }
 
     @JacocoGenerated
@@ -109,8 +91,7 @@ public class ImportRequest implements JsonSerializable {
             return false;
         }
         ImportRequest request = (ImportRequest) o;
-        return Objects.equals(getS3Location(), request.getS3Location())
-               && Objects.equals(getTable(), request.getTable());
+        return Objects.equals(getS3Location(), request.getS3Location());
     }
 
     @Override
@@ -119,16 +100,16 @@ public class ImportRequest implements JsonSerializable {
         return toJsonString();
     }
 
-    private static String extractFieldFromMap(Map<String, String> request, String fieldName) {
+    private static String extractFieldFromMap(Map<String, String> request) {
         return request.keySet().stream()
-                   .filter(fieldName::equalsIgnoreCase)
+                   .filter(S3_LOCATION_FIELD::equalsIgnoreCase)
                    .findFirst()
                    .map(request::get)
-                   .orElseThrow(() -> errorForMissingField(fieldName));
+                   .orElseThrow(ImportRequest::errorForMissingField);
     }
 
-    private static IllegalArgumentException errorForMissingField(String fieldName) {
-        return new IllegalArgumentException(String.format(MISSING_FIELD_MESSAGE_PATTERN, fieldName));
+    private static IllegalArgumentException errorForMissingField() {
+        return new IllegalArgumentException(String.format(MISSING_FIELD_MESSAGE_PATTERN, S3_LOCATION_FIELD));
     }
 
     private String removeRoot(String path) {

--- a/data-import-from-s3/src/test/java/no/unit/nva/dataimport/ImportRequestTest.java
+++ b/data-import-from-s3/src/test/java/no/unit/nva/dataimport/ImportRequestTest.java
@@ -12,11 +12,10 @@ class ImportRequestTest {
     public static final String BUCKET_NAME = "orestis-export";
     public static final String FOLDER_PATH = "AWSDynamoDB/01617869890675-2abaf414/data/";
     public static final String S3_LOCATION = "s3://" + BUCKET_NAME + "/" + FOLDER_PATH;
-    public static final String SOME_TABLE = "someTable";
 
     @Test
     public void importRequestAcceptsS3UriAsInput() throws JsonProcessingException {
-        ImportRequest request = new ImportRequest(S3_LOCATION, SOME_TABLE);
+        ImportRequest request = new ImportRequest(S3_LOCATION);
         String jsonString = JsonUtils.objectMapperNoEmpty.writeValueAsString(request);
         ImportRequest deserializedRequest = JsonUtils.objectMapper.readValue(jsonString, ImportRequest.class);
         assertThat(deserializedRequest, is(equalTo(request)));
@@ -24,14 +23,14 @@ class ImportRequestTest {
 
     @Test
     public void getBucketReturnsBucketNameOfS3Uri() {
-        ImportRequest request = new ImportRequest(S3_LOCATION, SOME_TABLE);
+        ImportRequest request = new ImportRequest(S3_LOCATION);
         String bucket = request.extractBucketFromS3Location();
         assertThat(bucket, is(equalTo(BUCKET_NAME)));
     }
 
     @Test
     public void getFolderPathReturnsPathInsideTheBucketOfS3Uri() {
-        ImportRequest request = new ImportRequest(S3_LOCATION, SOME_TABLE);
+        ImportRequest request = new ImportRequest(S3_LOCATION);
         String folderPath = request.extractPathFromS3Location();
         assertThat(folderPath, is(equalTo(FOLDER_PATH)));
     }

--- a/template.yaml
+++ b/template.yaml
@@ -1265,6 +1265,7 @@ Resources:
       Environment:
         Variables:
           AWC_ACCOUNT_ID: !Ref AWS::AccountId
+          TABLE_NAME: !Ref NvaResourcesTable
 
   ImportCristinDataFromS3:
     DependsOn:


### PR DESCRIPTION
Previously the handler could write on any table in the account. This is not necessary, so I simplified the code so that the table is always the one defined in the stack