### PR TITLE
NP-2616: refactor UpdatePublicationHandler tests

### DIFF
--- a/update-publication/build.gradle
+++ b/update-publication/build.gradle
@@ -29,3 +29,19 @@ dependencies {
     testImplementation group: 'com.github.bibsysdev', name: 'nva-testutils', version: project.ext.nvaTestUtilsVersion
 }
 
+configurations.testImplementation.canBeResolved = true
+
+task copyNativeDeps(type: Copy) {
+    from(configurations.testImplementation) {
+        include "*.dylib"
+        include "*.so"
+        include "*.dll"
+    }
+    into 'build/dynamodb-local'
+}
+
+test.dependsOn copyNativeDeps
+test.doFirst {
+    systemProperty "java.library.path", 'build/dynamodb-local'
+}
+

--- a/update-publication/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/update-publication/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -100,7 +100,7 @@ public class UpdatePublicationHandlerTest extends ResourcesDynamoDbLocalTest {
 
         updatePublicationHandler.handleRequest(inputStream, output, context);
         GatewayResponse<PublicationResponse> gatewayResponse = GatewayResponse.fromOutputStream(output);
-        PublicationResponse body = gatewayResponse.getBodyObject(PublicationResponse.class);
+        final PublicationResponse body = gatewayResponse.getBodyObject(PublicationResponse.class);
         assertEquals(SC_OK, gatewayResponse.getStatusCode());
         assertThat(gatewayResponse.getHeaders(), hasKey(CONTENT_TYPE));
         assertThat(gatewayResponse.getHeaders(), hasKey(ACCESS_CONTROL_ALLOW_ORIGIN));

--- a/update-publication/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/update-publication/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1,8 +1,8 @@
 package no.unit.nva.publication.update;
 
-import static java.util.Collections.singletonMap;
-import static no.unit.nva.model.PublicationStatus.PUBLISHED;
+import static no.unit.nva.publication.PublicationGenerator.randomString;
 import static no.unit.nva.publication.RequestUtil.IDENTIFIER_IS_NOT_A_VALID_UUID;
+import static no.unit.nva.publication.service.impl.ReadResourceService.RESOURCE_NOT_FOUND_MESSAGE;
 import static no.unit.nva.publication.update.UpdatePublicationHandler.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static no.unit.nva.publication.update.UpdatePublicationHandler.ALLOWED_ORIGIN_ENV;
 import static nva.commons.apigateway.ApiGatewayHandler.MESSAGE_FOR_RUNTIME_EXCEPTIONS_HIDING_IMPLEMENTATION_DETAILS_TO_API_CLIENTS;
@@ -18,7 +18,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
@@ -28,62 +27,59 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.nio.file.Path;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import no.unit.nva.api.PublicationResponse;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.publication.PublicationGenerator;
+import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
-import no.unit.nva.publication.storage.model.UserInstance;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.Environment;
-import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.JsonUtils;
 import nva.commons.logutils.LogUtils;
 import nva.commons.logutils.TestAppender;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.stubbing.Answer;
 import org.zalando.problem.Problem;
 
-public class UpdatePublicationHandlerTest {
+public class UpdatePublicationHandlerTest extends ResourcesDynamoDbLocalTest {
 
     public static final String IDENTIFIER = "identifier";
     public static final JavaType PARAMETERIZED_GATEWAY_RESPONSE_PUBLICATION_RESPONSE_TYPE =
         objectMapper.getTypeFactory().constructParametricType(GatewayResponse.class, PublicationResponse.class);
     public static final JavaType PARAMETERIZED_GATEWAY_RESPONSE_PROBLEM_TYPE =
         objectMapper.getTypeFactory().constructParametricType(GatewayResponse.class, Problem.class);
-    public static final String OWNER = "owner";
-    public static final URI ANY_URI = URI.create("http://example.org/publisher/1");
+
     public static final String RESOURCE_NOT_FOUND_ERROR_TEMPLATE = "Resource not found: %s";
     public static final String SOME_MESSAGE = "SomeMessage";
-    
+
     private ResourceService publicationService;
     private Context context;
 
     private ByteArrayOutputStream output;
     private UpdatePublicationHandler updatePublicationHandler;
-    
+
     private Publication publication;
-    
+    private Environment environment;
+
     /**
      * Set up environment.
      */
     @BeforeEach
     public void setUp() {
-        Environment environment = mock(Environment.class);
+        super.init();
+
+        environment = mock(Environment.class);
         when(environment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
 
-        publicationService = mock(ResourceService.class);
+        publicationService = new ResourceService(client, Clock.systemDefaultZone());
         context = mock(Context.class);
 
         output = new ByteArrayOutputStream();
@@ -91,37 +87,28 @@ public class UpdatePublicationHandlerTest {
             new UpdatePublicationHandler(publicationService, environment);
         publication = createPublication();
     }
-    
+
     @Test
-    @DisplayName("handler returns OK Response on ReportBasic input")
-    public void handlerReturnsOkResponseOnReportBasicInput() throws IOException, ApiGatewayException {
-        Path reportBasic = Path.of("ReportBasicTest.json");
-        Publication modifiedPublication = objectMapper
-                                              .readValue(IoUtils.stringFromResources(reportBasic), Publication.class);
-        serviceSucceedsAndReturnsModifiedPublication(modifiedPublication);
-        InputStream inputStream = generateInputStreamWithValidBodyAndHeadersAndPathParameters(
-            modifiedPublication.getIdentifier()).build();
+    public void handlerUpdatesPublicationWhenInputIsValidAndUserIsResourceOwner() throws IOException,
+                                                                                         ApiGatewayException {
+        publication = PublicationGenerator.publicationWithoutIdentifier();
+        Publication savedPublication = publicationService.createPublication(publication);
+
+        Publication publicationUpdate = updateTitle(savedPublication);
+
+        InputStream inputStream = ownerUpdatesOwnPublication(publicationUpdate.getIdentifier(), publicationUpdate);
+
         updatePublicationHandler.handleRequest(inputStream, output, context);
-        GatewayResponse<PublicationResponse> gatewayResponse = toGatewayResponse();
-        assertEquals(SC_OK, gatewayResponse.getStatusCode());
-    }
-    
-    @Test
-    @DisplayName("handler Returns OK Response On Valid Input")
-    public void handlerReturnsOKResponseOnValidInput() throws IOException, ApiGatewayException {
-        PublicationStatus expectedStatus = PUBLISHED;
-        Publication modifiedPublication = clonePublicationAndUpdateStatus(expectedStatus);
-        serviceSucceedsAndReturnsModifiedPublication(modifiedPublication);
-        InputStream inputStream = generateInputStreamWithValidBodyAndHeadersAndPathParameters(
-            modifiedPublication.getIdentifier()).build();
-        updatePublicationHandler.handleRequest(inputStream, output, context);
-        GatewayResponse<PublicationResponse> gatewayResponse = toGatewayResponse();
+        GatewayResponse<PublicationResponse> gatewayResponse = GatewayResponse.fromOutputStream(output);
+        PublicationResponse body = gatewayResponse.getBodyObject(PublicationResponse.class);
         assertEquals(SC_OK, gatewayResponse.getStatusCode());
         assertThat(gatewayResponse.getHeaders(), hasKey(CONTENT_TYPE));
         assertThat(gatewayResponse.getHeaders(), hasKey(ACCESS_CONTROL_ALLOW_ORIGIN));
-        assertThat(getGatewayResponseBodyStatus(gatewayResponse), is(equalTo(expectedStatus)));
+
+        assertThat(body.getEntityDescription().getMainTitle(),
+                   is(equalTo(publicationUpdate.getEntityDescription().getMainTitle())));
     }
-    
+
     @Test
     @DisplayName("handler Returns BadRequest Response On Missing Path Param")
     public void handlerReturnsBadRequestResponseOnMissingPathParam() throws IOException {
@@ -131,43 +118,45 @@ public class UpdatePublicationHandlerTest {
         assertEquals(SC_BAD_REQUEST, gatewayResponse.getStatusCode());
         assertThat(getProblemDetail(gatewayResponse), containsString(IDENTIFIER_IS_NOT_A_VALID_UUID));
     }
-    
+
     @Test
     @DisplayName("handler Returns InternalServerError Response On Unexpected Exception")
     public void handlerReturnsInternalServerErrorResponseOnUnexpectedException()
         throws IOException, ApiGatewayException {
-        serviceFailsOnModifyRequestWithRuntimeError();
-        var event =
-            generateInputStreamWithValidBodyAndHeadersAndPathParameters(publication.getIdentifier()).build();
+        publicationService = serviceFailsOnModifyRequestWithRuntimeError();
+        updatePublicationHandler = new UpdatePublicationHandler(publicationService, environment);
+
+        Publication savedPublication = publicationService.createPublication(publication);
+        InputStream event = ownerUpdatesOwnPublication(savedPublication.getIdentifier(), savedPublication);
         updatePublicationHandler.handleRequest(event, output, context);
         GatewayResponse<Problem> gatewayResponse = toGatewayResponseProblem();
         assertEquals(SC_INTERNAL_SERVER_ERROR, gatewayResponse.getStatusCode());
         assertThat(getProblemDetail(gatewayResponse), containsString(
             MESSAGE_FOR_RUNTIME_EXCEPTIONS_HIDING_IMPLEMENTATION_DETAILS_TO_API_CLIENTS));
     }
-    
+
     @Test
     @DisplayName("handler logs error details on unexpected exception")
     public void handlerLogsErrorDetailsOnUnexpectedException()
         throws IOException, ApiGatewayException {
         final TestAppender appender = createAppenderForLogMonitoring();
-        publicationServiceThrowsException();
-        var event =
-            generateInputStreamWithValidBodyAndHeadersAndPathParameters(publication.getIdentifier()).build();
+        publicationService = serviceFailsOnModifyRequestWithRuntimeError();
+        updatePublicationHandler = new UpdatePublicationHandler(publicationService, environment);
+        Publication savedPublication = publicationService.createPublication(publication);
+
+        InputStream event = ownerUpdatesOwnPublication(savedPublication.getIdentifier(), savedPublication);
         updatePublicationHandler.handleRequest(event, output, context);
         GatewayResponse<Problem> gatewayResponse = toGatewayResponseProblem();
         assertEquals(SC_INTERNAL_SERVER_ERROR, gatewayResponse.getStatusCode());
         assertThat(appender.getMessages(), containsString(SOME_MESSAGE));
     }
-    
+
     @Test
     public void handlerReturnsBadRequestWhenIdentifierInPathDiffersFromIdentifierInBody() throws IOException {
-        SortableIdentifier someIdentifier = SortableIdentifier.next();
+
         SortableIdentifier someOtherIdentifier = SortableIdentifier.next();
-        
-        var event = generateInputStreamWithValidBodyAndHeadersAndPathParameters(someIdentifier)
-                        .withPathParameters(Map.of(IDENTIFIER, someOtherIdentifier.toString()))
-                        .build();
+
+        InputStream event = ownerUpdatesOwnPublication(someOtherIdentifier, publication);
 
         updatePublicationHandler.handleRequest(event, output, context);
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -175,123 +164,81 @@ public class UpdatePublicationHandlerTest {
         assertThat(gatewayResponse.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
         assertThat(problem.getDetail(), containsString(UpdatePublicationHandler.IDENTIFIER_MISMATCH_ERROR_MESSAGE));
     }
-    
+
     @Test
     @DisplayName("Handler returns NotFound response when resource does not exist")
-    void handlerReturnsNotFoundResponseWhenResourceDoesNotExist() throws IOException, ApiGatewayException {
-        SortableIdentifier identifier = SortableIdentifier.next();
-        String expectedDetail = serviceFailsOnGetRequestWithNotFoundError(identifier);
-        var event =
-            generateInputStreamWithValidBodyAndHeadersAndPathParameters(identifier).build();
-        updatePublicationHandler.handleRequest(
-            event, output, context);
+    void handlerReturnsNotFoundResponseWhenResourceDoesNotExist() throws IOException {
+        InputStream event = ownerUpdatesOwnPublication(publication.getIdentifier(), publication);
+
+        updatePublicationHandler.handleRequest(event, output, context);
         GatewayResponse<Problem> gatewayResponse = toGatewayResponseProblem();
         assertEquals(SC_NOT_FOUND, gatewayResponse.getStatusCode());
-        assertThat(getProblemDetail(gatewayResponse), is(equalTo(expectedDetail)));
+        assertThat(getProblemDetail(gatewayResponse), is(equalTo(RESOURCE_NOT_FOUND_MESSAGE)));
     }
-    
+
+    private InputStream ownerUpdatesOwnPublication(SortableIdentifier publicationIdentifier,
+                                                   Publication publicationUpdate)
+        throws JsonProcessingException {
+        Map<String, String> pathParameters = Map.of(IDENTIFIER, publicationIdentifier.toString());
+
+        return new HandlerRequestBuilder<Publication>(JsonUtils.objectMapperNoEmpty)
+                   .withFeideId(publicationUpdate.getOwner())
+                   .withCustomerId(publicationUpdate.getPublisher().getId().toString())
+                   .withBody(publicationUpdate)
+                   .withPathParameters(pathParameters)
+                   .build();
+    }
+
+    private Publication updateTitle(Publication savedPublication) {
+        Publication update = savedPublication.copy().build();
+        update.getEntityDescription().setMainTitle(randomString());
+        return update;
+    }
+
     private TestAppender createAppenderForLogMonitoring() {
         return LogUtils.getTestingAppenderForRootLogger();
     }
-    
-    private void publicationServiceThrowsException() throws ApiGatewayException {
-        serviceSucceedsOnGetRequest(publication);
-        when(publicationService.updatePublication(any(Publication.class)))
-            .then((Answer<Publication>) invocation -> {
-                throw new RuntimeException(UpdatePublicationHandlerTest.SOME_MESSAGE);
-            });
+
+    private void publicationServiceThrowsException() {
+        publicationService = new ResourceService(client, Clock.systemDefaultZone()) {
+            @Override
+            public Publication updatePublication(Publication publication) {
+                throw new RuntimeException(SOME_MESSAGE);
+            }
+        };
     }
-    
-    private void serviceFailsOnModifyRequestWithRuntimeError() throws ApiGatewayException {
-        serviceSucceedsOnGetRequest(publication);
-        when(publicationService.updatePublication(any(Publication.class)))
-            .thenThrow(RuntimeException.class);
+
+    private ResourceService serviceFailsOnModifyRequestWithRuntimeError() throws ApiGatewayException {
+        return new ResourceService(client, Clock.systemDefaultZone()) {
+            @Override
+            public Publication updatePublication(Publication publicationUpdate) {
+                throw new RuntimeException(SOME_MESSAGE);
+            }
+        };
     }
-    
-    private String serviceFailsOnGetRequestWithNotFoundError(SortableIdentifier identifier) throws ApiGatewayException {
-        String expectedDetail = String.format(RESOURCE_NOT_FOUND_ERROR_TEMPLATE, identifier.toString());
-        when(publicationService.getPublication(any(UserInstance.class), any(SortableIdentifier.class)))
-            .thenThrow(new NotFoundException(expectedDetail));
-        return expectedDetail;
-    }
-    
-    private void serviceSucceedsOnGetRequest(Publication publication) throws ApiGatewayException {
-        when(publicationService.getPublication(any(UserInstance.class), any(SortableIdentifier.class)))
-            .thenReturn(publication);
-    }
-    
-    private void serviceSucceedsAndReturnsModifiedPublication(Publication modifiedPublication)
-        throws ApiGatewayException {
-        serviceSucceedsOnGetRequest(publication);
-        when(publicationService.updatePublication(any(Publication.class)))
-            .thenReturn(modifiedPublication);
-    }
-    
-    private HandlerRequestBuilder<Publication> generateInputStreamWithValidBodyAndHeadersAndPathParameters(
-        SortableIdentifier identifier)
-        throws IOException {
-        return new HandlerRequestBuilder<Publication>(objectMapper)
-                   .withBody(createPublication(identifier))
-                   .withHeaders(generateHeaders())
-                   .withPathParameters(singletonMap(IDENTIFIER, identifier.toString()));
-    }
-    
+
     private HandlerRequestBuilder<Publication> generateInputStreamMissingPathParameters() throws IOException {
         return new HandlerRequestBuilder<Publication>(objectMapper)
                    .withBody(createPublication())
                    .withHeaders(generateHeaders());
     }
-    
+
     private Map<String, String> generateHeaders() {
         Map<String, String> headers = new ConcurrentHashMap<>();
         headers.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
         return headers;
     }
-    
+
     private Publication createPublication() {
-        return createPublication(SortableIdentifier.next());
+        return PublicationGenerator.publicationWithIdentifier();
     }
-    
-    private Publication createPublication(SortableIdentifier identifier) {
-        return new Publication.Builder()
-                   .withIdentifier(identifier)
-                   .withModifiedDate(Instant.now())
-                   .withOwner(OWNER)
-                   .withPublisher(new Organization.Builder()
-                                      .withId(ANY_URI)
-                                      .build()
-                   )
-                   .build();
-    }
-    
-    private Publication clonePublicationAndUpdateStatus(PublicationStatus status) throws
-                                                                                  JsonProcessingException {
-        Publication modifiedPublication = clonePublication(publication);
-        modifiedPublication.setStatus(status);
-        return modifiedPublication;
-    }
-    
-    private Publication clonePublication(Publication publication) throws JsonProcessingException {
-        String that = objectMapper.writeValueAsString(publication);
-        return objectMapper.readValue(that, Publication.class);
-    }
-    
-    private GatewayResponse<PublicationResponse> toGatewayResponse() throws JsonProcessingException {
-        return objectMapper.readValue(output.toString(),
-            PARAMETERIZED_GATEWAY_RESPONSE_PUBLICATION_RESPONSE_TYPE);
-    }
-    
+
     private GatewayResponse<Problem> toGatewayResponseProblem() throws JsonProcessingException {
         return objectMapper.readValue(output.toString(),
-            PARAMETERIZED_GATEWAY_RESPONSE_PROBLEM_TYPE);
+                                      PARAMETERIZED_GATEWAY_RESPONSE_PROBLEM_TYPE);
     }
-    
+
     private String getProblemDetail(GatewayResponse<Problem> gatewayResponse) throws JsonProcessingException {
         return gatewayResponse.getBodyObject(Problem.class).getDetail();
-    }
-    
-    private PublicationStatus getGatewayResponseBodyStatus(GatewayResponse<PublicationResponse> gatewayResponse)
-        throws JsonProcessingException {
-        return gatewayResponse.getBodyObject(PublicationResponse.class).getStatus();
     }
 }


### PR DESCRIPTION
Rewrote all the tests by using a "real" service connected to a local database instead of mocking it. In this way we can test more complicated scenarios all the way down to writing to the database without extensive mocking and replicating logic