### PR TITLE
NP-2878: add fields to "ignored lists" when they are not used

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -2,13 +2,14 @@ package no.unit.nva.cristin.lambda;
 
 import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_PUBLICATIONS_OWNER;
 import static no.unit.nva.publication.s3imports.ApplicationConstants.MAX_SLEEP_TIME;
-import static nva.commons.core.JsonUtils.objectMapperNoEmpty;
+import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Clock;
 import java.util.Objects;
@@ -50,9 +51,10 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Js
     public static final String UNKNOWN_CRISTIN_ID_ERROR_REPORT_PREFIX = "unknownCristinId_";
     public static final String DO_NOT_WRITE_ID_IN_EXCEPTION_MESSAGE = null;
     public static final String ERRORS_FOLDER = "errors";
-    private static final Logger logger = LoggerFactory.getLogger(CristinEntryEventConsumer.class);
     public static final ObjectMapper OBJECT_MAPPER_FAIL_ON_UNKNOWN =
-        objectMapperNoEmpty.copy().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        objectMapperWithEmpty.copy().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    private static final Logger logger = LoggerFactory.getLogger(CristinEntryEventConsumer.class);
     private final ResourceService resourceService;
     private final S3Client s3Client;
 
@@ -108,7 +110,7 @@ public class CristinEntryEventConsumer extends EventHandler<FileContentsEvent<Js
 
         return attempt(() -> event.getDetail().getContents())
                    .map(jsonNode ->
-                            objectMapperNoEmpty.convertValue(jsonNode, Identifiable.class))
+                            objectMapperWithEmpty.convertValue(jsonNode, Identifiable.class))
                    .orElseThrow();
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorsAffiliation.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.mapper;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Collections;
@@ -21,6 +22,8 @@ import no.unit.nva.publication.s3imports.UriWrapper;
     setterPrefix = "with"
 )
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"stednavn_opprinnelig", "avdelingsnavn_opprinnelig", "institusjonsnavn_opprinnelig",
+    "stedkode_opprinnelig"})
 public class CristinContributorsAffiliation {
 
     public static final String CRISTIN_UNITS_DELIMITER = ".";
@@ -32,14 +35,6 @@ public class CristinContributorsAffiliation {
     private Integer subdepartmentIdentifier;
     @JsonProperty("gruppenr")
     private Integer groupNumber;
-    @JsonProperty("stedkode_opprinnelig")
-    private String originalInsitutionCode;
-    @JsonProperty("institusjonsnavn_opprinnelig")
-    private String originalInstitutionName;
-    @JsonProperty("avdelingsnavn_opprinnelig")
-    private String originalDepartmentName;
-    @JsonProperty("stednavn_opprinnelig")
-    private String originalPlaceName; //TODO:  what is a place?
     @JsonProperty("VARBEID_PERSON_STED_ROLLE")
     private List<CristinContributorRole> roles;
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.mapper;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.List;
@@ -19,12 +20,20 @@ import nva.commons.core.JsonSerializable;
     setterPrefix = "with"
 )
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"TYPE_MEDIEBIDRAG", "brukernavn_opprettet", "TYPE_TIDSSKRIFTPUBLIKASJON",
+    "brukernavn_siste_endring", "kildekode", "publiseringstatuskode", "merknadtekst_godkjenning",
+    "PRESENTASJON_VARBEID", "dato_utgitt", "FINANSIERING_VARBEID", "VARBEID_EMNEORD", "TYPE_PRODUKT",
+    "TYPE_FOREDRAG_POSTER", "kildepostid", "TYPE_BOK_RAPPORT_DEL", "eierkode_opprettet", "ARKIVPOST",
+    "TYPE_KUNSTNERISKPRODUKSJON", "TYPE_UTSTILLING", "pubidnr", "VARBEID_KILDE", "eierkode_siste_endring",
+    "arstall_rapportert", "VARBEID_VDISIPLIN", "ARKIVFIL", "VITENSKAPELIGARBEID_LOKAL", "VARBEID_HRCS_KLASSIFISERING",
+    "merknadtekst", "dato_siste_endring", "TYPE_BOK_RAPPORT"})
 public class CristinObject implements JsonSerializable {
 
     public static final String PUBLICATION_OWNER_FIELD = "publicationOwner";
     public static final String MAIN_CATEGORY_FIELD = "varbeidhovedkatkode";
     public static final String SECONDARY_CATEGORY_FIELD = "varbeidunderkatkode";
     public static String IDENTIFIER_ORIGIN = "Cristin";
+
     @JsonProperty("id")
     private Integer id;
     @JsonProperty("arstall")
@@ -39,7 +48,6 @@ public class CristinObject implements JsonSerializable {
     private CristinSecondaryCategory secondaryCategory;
     @JsonProperty("VARBEID_PERSON")
     private List<CristinContributor> contributors;
-    @JsonProperty
     private String publicationOwner;
 
     public CristinObject() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinTitle.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinTitle.java
@@ -1,6 +1,7 @@
 package no.unit.nva.cristin.mapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,11 +11,12 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"sammendragtekst"})
 public class CristinTitle {
 
     public static final String MAIN_TITLE = "titteltekst";
     public static final String LANGUAGE_CODE = "sprakkode";
-    public static final String ABSTRACT = "abstract";
+    public static final String ABSTRACT = "sammendragtekst";
     public static final String ORIGINAL_TITLE = "J"; //probably means "Ja"
     public static final String NOT_ORIGINAL_TITLE = "N"; //probably means "Nei"
 
@@ -22,8 +24,6 @@ public class CristinTitle {
     private String languagecode;
     @JsonProperty(MAIN_TITLE)
     private String title;
-    @JsonProperty(ABSTRACT)
-    private String abstractText;
     @JsonProperty("status_original")
     private String statusOriginal;
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -262,7 +262,6 @@ public class CristinDataGenerator {
         CristinTitle title = new CristinTitle();
         title.setTitle(randomString());
         title.setLanguagecode(randomLanguageCode());
-//        title.setAbstractText(randomString());
         if (index == FIRST_TITLE) {
             title.setStatusOriginal(CristinTitle.ORIGINAL_TITLE);
         } else {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -159,10 +159,6 @@ public class CristinDataGenerator {
                 .withDepartmentIdentifier(threeDigitPositiveNumber())
                 .withGroupNumber(threeDigitPositiveNumber())
                 .withSubdepartmentIdentifier(threeDigitPositiveNumber())
-                .withOriginalInsitutionCode(randomString())
-                .withOriginalInstitutionName(randomString())
-                .withOriginalPlaceName(randomString())
-                .withOriginalDepartmentName(randomString())
                 .withDepartmentIdentifier(largeRandomNumber())
                 .withRoles(List.of(createRole(roleCode)))
                 .build();
@@ -266,7 +262,7 @@ public class CristinDataGenerator {
         CristinTitle title = new CristinTitle();
         title.setTitle(randomString());
         title.setLanguagecode(randomLanguageCode());
-        title.setAbstractText(randomString());
+//        title.setAbstractText(randomString());
         if (index == FIRST_TITLE) {
             title.setStatusOriginal(CristinTitle.ORIGINAL_TITLE);
         } else {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -56,7 +56,6 @@ import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -325,12 +324,9 @@ public class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         assertThat(file, containsString(UNKNOWN_PROPERTY_NAME_IN_RESOURCE_FILE_WITH_UNKNOWN_PROPERTY));
     }
 
-    // This test will fail until we have mapped all properties in the resource file or we
-    // have removed (from the resource and the import) the ones that we do not want to keep.
-    @Disabled
     @Test
     public void handleRequestDoesNotThrowExceptionWhenInputDoesNotHaveUnknownProperties() {
-        String input = IoUtils.stringFromResources(Path.of("valid_cristin_entry_event.json"));
+        String input = IoUtils.stringFromResources(Path.of("cristin_entry_of_known_type_with_all_fields.json"));
         Executable action = () -> handler.handleRequest(stringToStream(input), outputStream, CONTEXT);
         assertDoesNotThrow(action);
     }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -1,8 +1,36 @@
 package no.unit.nva.cristin.mapper;
 
+import static no.unit.nva.cristin.CristinDataGenerator.largeRandomNumber;
+import static no.unit.nva.cristin.CristinDataGenerator.randomAffiliation;
+import static no.unit.nva.cristin.CristinDataGenerator.randomString;
+import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_SAMPLE_DOI;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.CRISTIN_ORG_URI;
+import static no.unit.nva.cristin.mapper.CristinContributor.MISSING_ROLE_ERROR;
+import static no.unit.nva.cristin.mapper.CristinObject.IDENTIFIER_ORIGIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import no.unit.nva.cristin.AbstractCristinImportTest;
 import no.unit.nva.cristin.CristinDataGenerator;
-
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
@@ -24,38 +52,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.net.URI;
-import java.nio.file.Path;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-
-import static no.unit.nva.cristin.CristinDataGenerator.largeRandomNumber;
-import static no.unit.nva.cristin.CristinDataGenerator.randomAffiliation;
-import static no.unit.nva.cristin.CristinDataGenerator.randomString;
-import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_SAMPLE_DOI;
-import static no.unit.nva.cristin.lambda.constants.MappingConstants.CRISTIN_ORG_URI;
-import static no.unit.nva.cristin.mapper.CristinContributor.MISSING_ROLE_ERROR;
-import static no.unit.nva.cristin.mapper.CristinObject.IDENTIFIER_ORIGIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CristinMapperTest extends AbstractCristinImportTest {
 

--- a/cristin-import/src/test/resources/cristin_entry_of_known_type_with_all_fields.json
+++ b/cristin-import/src/test/resources/cristin_entry_of_known_type_with_all_fields.json
@@ -14,8 +14,8 @@
     "fileUri": "s3://bucket/parent/child/filename.json",
     "contents": {
       "id": 417536,
-      "varbeidhovedkatkode": "TIDSSKRIFTPUBL",
-      "varbeidunderkatkode": "ARTIKKEL",
+      "varbeidhovedkatkode": "BOK",
+      "varbeidunderkatkode": "MONOGRAFI",
       "brukernavn_opprettet": null,
       "eierkode_opprettet": "NTNU",
       "dato_opprettet": "2000-01-21T00:00:00",


### PR DESCRIPTION
Exported Cristin data, contain many fields that we currently do not use. To keep track on the fields that we are not using we require that the mapping fails when there is at least one field that we do not parse explicitly or we do not ignore explicitly. 
By "ignoring explicitly" we mean to add the field in the `@JsonIgnoreProperties` annotation in each object that we need to ignore a field. 
The ultimate target is to require that the export data do not have any fields that are not participating in the mapping to NVA entries and we do not have any fields in the `@JsonIgnoreProperties` field.