### PR TITLE
Np-3096 Test and Implement the mapping of ISBNs for reports

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -175,14 +175,17 @@ public class CristinMapper {
     }
 
     private PublicationContext buildPublicationContextWhenMainCategoryIsReport()
-            throws MalformedURLException, InvalidIsbnException, InvalidIssnException {
+            throws InvalidIsbnException, InvalidIssnException {
+        List<String> isbnList = extractIsbn().stream().collect(Collectors.toList());
         if (isDegreePhd(cristinObject) || isDegreeMaster(cristinObject)) {
             return new Degree.Builder()
                     .withPublisher(extractPublisherName())
+                    .withIsbnList(isbnList)
                     .build();
         }
         return new Report.Builder()
                 .withPublisher(extractPublisherName())
+                .withIsbnList(isbnList)
                 .build();
     }
 

--- a/cristin-import/src/main/resources/possiblyEmptyFields.txt
+++ b/cristin-import/src/main/resources/possiblyEmptyFields.txt
@@ -12,6 +12,7 @@ entityDescription.reference.publicationInstance.pages.begin
 entityDescription.reference.publicationContext.printIssn
 entityDescription.reference.publicationContext.level
 entityDescription.reference.publicationContext.url
+entityDescription.reference.publicationContext.linkedContext
 entityDescription.abstract
 entityDescription.tags
 entityDescription.npiSubjectHeading

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -11,6 +11,7 @@ import cucumber.utils.ContributorFlattenedDetails;
 import cucumber.utils.exceptions.MisformattedScenarioException;
 import cucumber.utils.transformers.CristinContributorTransformer;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -384,5 +385,10 @@ public class GeneralMappingRules {
     @Then("no error is reported.")
     public void noErrorIsReported() {
         assertThat(this.scenarioContext.mappingIsSuccessful(), is(true));
+    }
+
+    @And("the Cristin Result has an valid ISBN with the value {string}")
+    public void theCristinResultHasAnValidIsbnWithTheValue(String isbn) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setIsbn(isbn);
     }
 }

--- a/cristin-import/src/test/resources/features/ReportMainCategoryRules.feature
+++ b/cristin-import/src/test/resources/features/ReportMainCategoryRules.feature
@@ -1,0 +1,25 @@
+Feature:
+  Mapping rules for Cristin entries with main category RAPPORT.
+
+  Scenario Outline: Cristin Result's isbn value is copied to the isbn in the NVA's PublicationContext
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result has an valid ISBN with the value "9788247151464"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a PublicationContext with an ISBN list containing the value "9788247151464"
+    Examples:
+      | secondaryCategory  |
+      | RAPPORT            |
+      | DRGRADAVH          |
+      | MASTERGRADSOPPG    |
+
+  Scenario Outline: Mapping does not fail when a Cristin Result that is a "Book" has a null value for isbn.
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result does not have an ISBN
+    When the Cristin Result is converted to an NVA Resource
+    Then no error is reported.
+    Examples:
+      | secondaryCategory  |
+      | RAPPORT            |
+      | DRGRADAVH          |
+      | MASTERGRADSOPPG    |
+


### PR DESCRIPTION
The addition to the possiblyEmptyFields file is because we have no mapping for linkedContext. Not sure why this addition has not been added before as it old test stopped running without it.