### PR TITLE
NP-3092-use-doi-converter-from-commons

### DIFF
--- a/cristin-import/build.gradle
+++ b/cristin-import/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 
     implementation libs.nva.s3
     implementation libs.nva.core
-
     implementation libs.nva.eventhandlers
+    implementation libs.nva.doi
+
 
     implementation libs.jackson.annotations
 implementation libs.jackson.databind
@@ -31,6 +32,7 @@ implementation libs.jackson.databind
     implementation libs.aws.sdk2.urlconnectionclient
     implementation libs.aws.sdk2.regions
 
+    implementation libs.typesafe.config
 
     testImplementation project(":storage-model")
     testImplementation project(":publication-testing")

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -1,5 +1,30 @@
 package no.unit.nva.cristin.mapper;
 
+import static java.util.Objects.isNull;
+import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_NVA_CUSTOMER;
+import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_SAMPLE_DOI;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.IGNORED_AND_POSSIBLY_EMPTY_PUBLICATION_FIELDS;
+import static no.unit.nva.cristin.mapper.CristinMainCategory.isBook;
+import static no.unit.nva.cristin.mapper.CristinMainCategory.isChapter;
+import static no.unit.nva.cristin.mapper.CristinMainCategory.isJournal;
+import static no.unit.nva.cristin.mapper.CristinMainCategory.isReport;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isDegreeMaster;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isDegreePhd;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import no.unit.nva.model.AdditionalIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
@@ -25,31 +50,8 @@ import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
 import nva.commons.core.attempt.Try;
 import nva.commons.core.language.LanguageMapper;
-
-import java.net.URI;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Objects.isNull;
-import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_NVA_CUSTOMER;
-import static no.unit.nva.cristin.lambda.constants.HardcodedValues.HARDCODED_SAMPLE_DOI;
-import static no.unit.nva.cristin.lambda.constants.MappingConstants.IGNORED_AND_POSSIBLY_EMPTY_PUBLICATION_FIELDS;
-import static no.unit.nva.cristin.mapper.CristinMainCategory.isBook;
-import static no.unit.nva.cristin.mapper.CristinMainCategory.isChapter;
-import static no.unit.nva.cristin.mapper.CristinMainCategory.isJournal;
-import static no.unit.nva.cristin.mapper.CristinMainCategory.isReport;
-import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isDegreeMaster;
-import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isDegreePhd;
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
+import nva.commons.doi.DoiConverter;
+import nva.commons.doi.DoiValidator;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
 public class CristinMapper {
@@ -57,27 +59,50 @@ public class CristinMapper {
     public static final String EMPTY_STRING = "";
     public static final BookSeries EMPTY_SERIES = null;
     public static final String EMPTY_SERIES_NUMBER = null;
-
+    private static final Config config = loadConfiguration();
+    private static final boolean VALIDATE_DOI_ONLINE = parseValidateDoiOnline();
     private final CristinObject cristinObject;
+    private final DoiConverter doiConverter;
 
     public CristinMapper(CristinObject cristinObject) {
         this.cristinObject = cristinObject;
+        DoiValidator doiValidator = new DoiValidator();
+        doiConverter = new DoiConverter(doiUri -> validateDoi(doiValidator, doiUri));
+    }
+
+    private static boolean validateDoi(DoiValidator doiValidator, URI doiUri) {
+        return VALIDATE_DOI_ONLINE ? doiValidator.validateOnline(doiUri) : DoiValidator.validateOffline(doiUri);
     }
 
     public Publication generatePublication() {
         Publication publication = new Builder()
-                                      .withAdditionalIdentifiers(Set.of(extractIdentifier()))
-                                      .withEntityDescription(generateEntityDescription())
-                                      .withCreatedDate(extractEntryCreationDate())
-                                      .withPublisher(extractOrganization())
-                                      .withOwner(cristinObject.getPublicationOwner())
-                                      .withStatus(PublicationStatus.DRAFT)
-                                      .withLink(HARDCODED_SAMPLE_DOI)
-                                      .withProjects(extractProjects())
-                                      .build();
+            .withAdditionalIdentifiers(Set.of(extractIdentifier()))
+            .withEntityDescription(generateEntityDescription())
+            .withCreatedDate(extractEntryCreationDate())
+            .withPublisher(extractOrganization())
+            .withOwner(cristinObject.getPublicationOwner())
+            .withStatus(PublicationStatus.DRAFT)
+            .withLink(HARDCODED_SAMPLE_DOI)
+            .withProjects(extractProjects())
+            .build();
         assertPublicationDoesNotHaveEmptyFields(publication);
         return publication;
     }
+
+    public CristinBookOrReportMetadata extractCristinBookReport() {
+        return Optional.ofNullable(cristinObject)
+            .map(CristinObject::getBookOrReportMetadata)
+            .orElse(null);
+    }
+
+    private static boolean parseValidateDoiOnline() {
+        return config.getBoolean("doi.validation.online");
+    }
+
+    private static Config loadConfiguration() {
+        return ConfigFactory.load(ConfigFactory.defaultApplication());
+    }
+
 
 
     private void assertPublicationDoesNotHaveEmptyFields(Publication publication) {
@@ -95,10 +120,10 @@ public class CristinMapper {
             return null;
         }
         return cristinObject.getPresentationalWork()
-                .stream()
-                .filter(CristinPresentationalWork::isProject)
-                .map(CristinPresentationalWork::toNvaResearchProject)
-                .collect(Collectors.toList());
+            .stream()
+            .filter(CristinPresentationalWork::isProject)
+            .map(CristinPresentationalWork::toNvaResearchProject)
+            .collect(Collectors.toList());
     }
 
     private Organization extractOrganization() {
@@ -107,8 +132,8 @@ public class CristinMapper {
 
     private Instant extractEntryCreationDate() {
         return Optional.ofNullable(cristinObject.getEntryCreationDate())
-                   .map(ld -> ld.atStartOfDay().toInstant(zoneOffset()))
-                   .orElse(null);
+            .map(ld -> ld.atStartOfDay().toInstant(zoneOffset()))
+            .orElse(null);
     }
 
     private ZoneOffset zoneOffset() {
@@ -117,41 +142,40 @@ public class CristinMapper {
 
     private EntityDescription generateEntityDescription() {
         return new EntityDescription.Builder()
-                   .withLanguage(extractLanguage())
-                   .withMainTitle(extractMainTitle())
-                   .withDate(extractPublicationDate())
-                   .withReference(buildReference())
-                   .withContributors(extractContributors())
-                   .withNpiSubjectHeading(extractNpiSubjectHeading())
-                   .withAbstract(extractAbstract())
-                   .withTags(extractTags())
-                   .build();
+            .withLanguage(extractLanguage())
+            .withMainTitle(extractMainTitle())
+            .withDate(extractPublicationDate())
+            .withReference(buildReference())
+            .withContributors(extractContributors())
+            .withNpiSubjectHeading(extractNpiSubjectHeading())
+            .withAbstract(extractAbstract())
+            .withTags(extractTags())
+            .build();
     }
-
 
     private List<Contributor> extractContributors() {
         return cristinObject.getContributors()
-                   .stream()
-                   .map(attempt(CristinContributor::toNvaContributor))
-                   .map(Try::orElseThrow)
-                   .collect(Collectors.toList());
+            .stream()
+            .map(attempt(CristinContributor::toNvaContributor))
+            .map(Try::orElseThrow)
+            .collect(Collectors.toList());
     }
 
     private Reference buildReference() {
         PublicationInstanceBuilderImpl publicationInstanceBuilderImpl
-                = new PublicationInstanceBuilderImpl(cristinObject);
+            = new PublicationInstanceBuilderImpl(cristinObject);
         PublicationInstance<? extends Pages> publicationInstance
-                = publicationInstanceBuilderImpl.build();
+            = publicationInstanceBuilderImpl.build();
         PublicationContext publicationContext = attempt(this::buildPublicationContext).orElseThrow();
         return new Reference.Builder()
-                   .withPublicationInstance(publicationInstance)
-                   .withPublishingContext(publicationContext)
-                   .withDoi(extractDoi())
-                   .build();
+            .withPublicationInstance(publicationInstance)
+            .withPublishingContext(publicationContext)
+            .withDoi(extractDoi())
+            .build();
     }
 
     private PublicationContext buildPublicationContext()
-            throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
+        throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
         if (isBook(cristinObject)) {
             return buildBookForPublicationContext();
         }
@@ -167,7 +191,7 @@ public class CristinMapper {
         return null;
     }
 
-    private Book buildBookForPublicationContext() throws InvalidIsbnException, InvalidUnconfirmedSeriesException {
+    private Book buildBookForPublicationContext() throws InvalidIsbnException {
         List<String> isbnList = extractIsbn().stream().collect(Collectors.toList());
         return new Book(EMPTY_SERIES, EMPTY_SERIES_NUMBER, buildUnconfirmedPublisher(), isbnList);
     }
@@ -181,26 +205,24 @@ public class CristinMapper {
     }
 
     private PublicationContext buildPublicationContextWhenMainCategoryIsReport()
-            throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
+        throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
         List<String> isbnList = extractIsbn().stream().collect(Collectors.toList());
         if (isDegreePhd(cristinObject) || isDegreeMaster(cristinObject)) {
             return new Degree.Builder()
-                    .withPublisher(buildUnconfirmedPublisher())
-                    .withIsbnList(isbnList)
-                    .build();
-        }
-        return new Report.Builder()
                 .withPublisher(buildUnconfirmedPublisher())
                 .withIsbnList(isbnList)
                 .build();
+        }
+        return new Report.Builder()
+            .withPublisher(buildUnconfirmedPublisher())
+            .withIsbnList(isbnList)
+            .build();
     }
 
     private Chapter buildChapterForPublicationContext() {
         return new Chapter.Builder()
-                .build();
+            .build();
     }
-
-
 
     private PublicationDate extractPublicationDate() {
         return new PublicationDate.Builder().withYear(cristinObject.getPublicationYear()).build();
@@ -208,23 +230,17 @@ public class CristinMapper {
 
     private String extractMainTitle() {
         return extractCristinTitles()
-                   .filter(CristinTitle::isMainTitle)
-                   .findFirst()
-                   .map(CristinTitle::getTitle)
-                   .orElseThrow();
+            .filter(CristinTitle::isMainTitle)
+            .findFirst()
+            .map(CristinTitle::getTitle)
+            .orElseThrow();
     }
 
     private Stream<CristinTitle> extractCristinTitles() {
         return Optional.ofNullable(cristinObject)
-                   .map(CristinObject::getCristinTitles)
-                   .stream()
-                   .flatMap(Collection::stream);
-    }
-
-    public CristinBookOrReportMetadata extractCristinBookReport() {
-        return Optional.ofNullable(cristinObject)
-            .map(CristinObject::getBookOrReportMetadata)
-            .orElse(null);
+            .map(CristinObject::getCristinTitles)
+            .stream()
+            .flatMap(Collection::stream);
     }
 
     private String extractPublisherName() {
@@ -237,11 +253,11 @@ public class CristinMapper {
 
     private URI extractLanguage() {
         return extractCristinTitles()
-                   .filter(CristinTitle::isMainTitle)
-                   .findFirst()
-                   .map(CristinTitle::getLanguagecode)
-                   .map(LanguageMapper::toUri)
-                   .orElse(LanguageMapper.LEXVO_URI_UNDEFINED);
+            .filter(CristinTitle::isMainTitle)
+            .findFirst()
+            .map(CristinTitle::getLanguagecode)
+            .map(LanguageMapper::toUri)
+            .orElse(LanguageMapper.LEXVO_URI_UNDEFINED);
     }
 
     private AdditionalIdentifier extractIdentifier() {
@@ -259,8 +275,8 @@ public class CristinMapper {
 
     private String extractSubjectFieldCode(CristinSubjectField subjectField) {
         return Optional.ofNullable(subjectField.getSubjectFieldCode())
-                .map(String::valueOf)
-                .orElseThrow(() -> new MissingFieldsException(CristinSubjectField.MISSING_SUBJECT_FIELD_CODE));
+            .map(String::valueOf)
+            .orElseThrow(() -> new MissingFieldsException(CristinSubjectField.MISSING_SUBJECT_FIELD_CODE));
     }
 
     private boolean resourceShouldAlwaysHaveAnNpiSubjectHeading() {
@@ -284,8 +300,8 @@ public class CristinMapper {
 
     private CristinJournalPublication extractCristinJournalPublication() {
         return Optional.ofNullable(cristinObject)
-                .map(CristinObject::getJournalPublication)
-                .orElse(null);
+            .map(CristinObject::getJournalPublication)
+            .orElse(null);
     }
 
     private String extractIssn() {
@@ -301,24 +317,28 @@ public class CristinMapper {
     }
 
     private URI extractDoi() {
-        if (isJournal(cristinObject) && extractCristinJournalPublication().getDoi() != null) {
-            return URI.create(extractCristinJournalPublication().getDoi());
+        System.out.println("*****************************************************");
+        if (isJournal(cristinObject)) {
+            return Optional.of(extractCristinJournalPublication())
+                .map(CristinJournalPublication::getDoi)
+                .map(doiConverter::toUri)
+                .orElse(null);
         }
         return null;
     }
 
     private List<CristinTags> extractCristinTags() {
         return Optional.ofNullable(cristinObject)
-                .map(CristinObject::getTags)
-                .orElse(null);
+            .map(CristinObject::getTags)
+            .orElse(null);
     }
 
     private String extractAbstract() {
         return extractCristinTitles()
-                .filter(CristinTitle::isMainTitle)
-                .findFirst()
-                .map(CristinTitle::getAbstractText)
-                .orElse(null);
+            .filter(CristinTitle::isMainTitle)
+            .findFirst()
+            .map(CristinTitle::getAbstractText)
+            .orElse(null);
     }
 
     private List<String> extractTags() {
@@ -339,5 +359,4 @@ public class CristinMapper {
         }
         return listOfTags;
     }
-
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -317,7 +317,6 @@ public class CristinMapper {
     }
 
     private URI extractDoi() {
-        System.out.println("*****************************************************");
         if (isJournal(cristinObject)) {
             return Optional.of(extractCristinJournalPublication())
                 .map(CristinJournalPublication::getDoi)

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -38,7 +38,7 @@ public class CristinObject implements JsonSerializable {
     public static final String PUBLICATION_OWNER_FIELD = "publicationOwner";
     public static final String MAIN_CATEGORY_FIELD = "varbeidhovedkatkode";
     public static final String SECONDARY_CATEGORY_FIELD = "varbeidunderkatkode";
-    public static String IDENTIFIER_ORIGIN = "Cristin";
+    public static final String IDENTIFIER_ORIGIN = "Cristin";
     private static final ObjectMapper OBJECT_MAPPER_FAIL_ON_UNKNOWN =
         objectMapperWithEmpty.copy().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPresentationalWork.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPresentationalWork.java
@@ -44,7 +44,7 @@ public class CristinPresentationalWork {
     }
 
     public boolean isProject() {
-        return presentationType.equals(PROSJEKT);
+        return PROSJEKT.equals(presentationType);
     }
 
     public ResearchProject toNvaResearchProject() {

--- a/cristin-import/src/main/resources/reference.conf
+++ b/cristin-import/src/main/resources/reference.conf
@@ -1,0 +1,5 @@
+doi {
+ validation{
+  online = true
+ }
+}

--- a/cristin-import/src/test/java/cucumber/BookFeatures.java
+++ b/cristin-import/src/test/java/cucumber/BookFeatures.java
@@ -1,13 +1,9 @@
 package cucumber;
 
-import static no.unit.nva.cristin.CristinDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-
-import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import no.unit.nva.cristin.CristinDataGenerator;
@@ -16,20 +12,10 @@ import no.unit.nva.cristin.mapper.CristinSubjectField;
 import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.PublishingHouse;
-import no.unit.nva.model.contexttypes.Report;
 import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
 import no.unit.nva.model.instancetypes.PeerReviewedMonograph;
 import no.unit.nva.model.instancetypes.PublicationInstance;
-import no.unit.nva.model.instancetypes.book.BookMonograph;
-import no.unit.nva.model.instancetypes.journal.JournalArticle;
-import no.unit.nva.model.instancetypes.journal.JournalArticleContentType;
-import no.unit.nva.model.pages.MonographPages;
-import no.unit.nva.model.pages.Pages;
 import nva.commons.core.SingletonCollector;
-import org.hamcrest.Matchers;
-
-import java.net.URI;
-
 
 public class BookFeatures {
 
@@ -53,9 +39,9 @@ public class BookFeatures {
     @Then("the NVA Resource has a PublicationContext with an ISBN list containing the value {string}")
     public void theNvaResourceHasAPublicationContextWithAnIsbnListContainingTheValues(String expectedIsbn) {
         PublicationContext publicationContext = scenarioContext.getNvaEntry()
-                                                    .getEntityDescription()
-                                                    .getReference()
-                                                    .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
         Book bookContext = (Book) publicationContext;
         String singleIsbn = bookContext.getIsbnList().stream().collect(SingletonCollector.collect());
         assertThat(singleIsbn, is(equalTo(expectedIsbn)));
@@ -85,9 +71,9 @@ public class BookFeatures {
     @Then("the NVA Resource has a PublicationContext with publisher with name equal to {string}")
     public void theNvaResourceHasAPublicationContextWithPublisherWithNameEqualTo(String expectedPublisherName) {
         PublicationContext context = scenarioContext.getNvaEntry()
-                                         .getEntityDescription()
-                                         .getReference()
-                                         .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
         Book book = (Book) context;
         PublishingHouse expectedPublisher = new UnconfirmedPublisher(expectedPublisherName);
         assertThat(book.getPublisher(), is(equalTo(expectedPublisher)));
@@ -104,10 +90,10 @@ public class BookFeatures {
     public void thatTheBookReportHasASubjectFieldWithTheSubjectFieldCodeEqualTo(int subjectFieldCode) {
         scenarioContext.getCristinEntry()
             .getBookOrReportMetadata()
-                        .setSubjectField(CristinSubjectField
-                                        .builder()
-                                        .withSubjectFieldCode(subjectFieldCode)
-                                        .build()
+            .setSubjectField(CristinSubjectField
+                                 .builder()
+                                 .withSubjectFieldCode(subjectFieldCode)
+                                 .build()
             );
     }
 
@@ -139,11 +125,11 @@ public class BookFeatures {
     }
 
     @Then("NVA Resource has a Publisher that cannot be verified through a URI")
-    public void nvaResourceHasAPublisherThatCannotBeVerifiedThroughAURI() {
+    public void nvaResourceHasAPublisherThatCannotBeVerifiedThroughAUri() {
         PublicationContext context = scenarioContext.getNvaEntry()
-                .getEntityDescription()
-                .getReference()
-                .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
         Book bookContext = (Book) context;
         PublishingHouse publisher = bookContext.getPublisher();
         assertThat(publisher, is(instanceOf(UnconfirmedPublisher.class)));

--- a/cristin-import/src/test/java/cucumber/JournalFeatures.java
+++ b/cristin-import/src/test/java/cucumber/JournalFeatures.java
@@ -6,6 +6,8 @@ import static no.unit.nva.cristin.CristinDataGenerator.smallRandomNumber;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
 
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -38,15 +40,7 @@ public class JournalFeatures {
 
     @Given("that the Cristin Result has a non empty Journal Publication")
     public void thatTheCristinResultHasANonEmptyJournalPublication() {
-        CristinJournalPublication journalPublication = CristinJournalPublication.builder()
-            .withJournal(createCristinJournalPublicationJournal())
-            .withPagesBegin("1")
-            .withPagesEnd(String.valueOf(smallRandomNumber()))
-            .withVolume(String.valueOf(smallRandomNumber()))
-            .withDoi(String.valueOf(smallRandomNumber()))
-            .withIssue(String.valueOf(smallRandomNumber()))
-            .build();
-        scenarioContext.getCristinEntry().setJournalPublication(journalPublication);
+        assertThat(scenarioContext.getCristinEntry().getJournalPublication(),is(not(nullValue())));
     }
 
     @Given("the Journal Publication has a \"journalName\" entry equal to {string}")

--- a/cristin-import/src/test/java/cucumber/ReportFeatures.java
+++ b/cristin-import/src/test/java/cucumber/ReportFeatures.java
@@ -37,7 +37,7 @@ public class ReportFeatures {
     }
 
     @Then("the NVA Resource Report has a Publisher that cannot be verified through a URI")
-    public void theNVAResourceReportHasAPublisherThatCannotBeVerifiedThroughAURI() {
+    public void theNVAResourceReportHasAPublisherThatCannotBeVerifiedThroughAUri() {
         PublicationContext context = scenarioContext.getNvaEntry()
                 .getEntityDescription()
                 .getReference()

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -40,6 +40,7 @@ import no.unit.nva.cristin.mapper.CristinTitle;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.publication.s3imports.FileContentsEvent;
 import nva.commons.core.JsonUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public final class CristinDataGenerator {
 
@@ -60,6 +61,12 @@ public final class CristinDataGenerator {
     private static final String CRISTIN_TAGS = "tags";
     private static final String CRISTIN_PRESENTATIONAL_WORK = "presentationalWork";
     private static final String CRISTIN_SUBJECT_FIELD = "bookReport.subjectField";
+    public static final int MIN_DOI_PREFIX_SUBPART_LENGTH = 3;
+    public static final int MAX_DOI_PREFIX_SUBPART_LENGTH = 10;
+    public static final String DOI_SUBPART_DELIMITER = ".";
+    public static final String DOI_PREFIX_SUFFIX_SEPARATOR = "/";
+    public static final String DOI_PREFIX_FIRST_SUBPART = "10";
+    public static final int MIN_SUFFIX_PARTS_NUMBER = 2;
 
     private CristinDataGenerator() {
 
@@ -437,7 +444,7 @@ public final class CristinDataGenerator {
                 .withPagesBegin("1")
                 .withPagesEnd(String.valueOf(smallRandomNumber()))
                 .withVolume(String.valueOf(smallRandomNumber()))
-                .withDoi(String.valueOf(smallRandomNumber()))
+                .withDoi(randomDoiString())
                 .build();
     }
 
@@ -552,6 +559,25 @@ public final class CristinDataGenerator {
                 + "-"
                 + issnWithChecksum.substring(MIDDLE_INDEX_OF_ISSN_STRING);
     }
+
+    private static String randomDoiString() {
+        String prefixSecondPart = RandomStringUtils.randomAlphanumeric(MIN_DOI_PREFIX_SUBPART_LENGTH,
+                                                                       MAX_DOI_PREFIX_SUBPART_LENGTH);
+        String suffix = randomDoiSuffix();
+        return DOI_PREFIX_FIRST_SUBPART
+               + DOI_SUBPART_DELIMITER
+               + prefixSecondPart
+               + DOI_PREFIX_SUFFIX_SEPARATOR
+               + suffix;
+    }
+
+    private static String randomDoiSuffix() {
+        return IntStream.range(1, MIN_SUFFIX_PARTS_NUMBER + RANDOM.nextInt(4)).boxed()
+            .map(ignored -> RandomStringUtils.randomAlphanumeric(MIN_DOI_PREFIX_SUBPART_LENGTH,
+                                                                 MAX_DOI_PREFIX_SUBPART_LENGTH))
+            .collect(Collectors.joining(DOI_SUBPART_DELIMITER));
+    }
+
 
 
 }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -1,6 +1,5 @@
 package no.unit.nva.cristin.mapper;
 
-import static no.unit.nva.cristin.CristinDataGenerator.NULL_KEY;
 import static no.unit.nva.cristin.CristinDataGenerator.largeRandomNumber;
 import static no.unit.nva.cristin.CristinDataGenerator.randomAffiliation;
 import static no.unit.nva.cristin.CristinDataGenerator.randomString;
@@ -12,6 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -44,7 +44,6 @@ import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.PublishingHouse;
 import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
-import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.book.BookAnthology;
 import no.unit.nva.model.instancetypes.book.BookMonograph;
@@ -78,12 +77,12 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         Set<Integer> expectedIds = cristinObjects().map(CristinObject::getId).collect(Collectors.toSet());
 
         Set<Integer> actualIds = cristinObjects()
-                                     .map(CristinObject::toPublication)
-                                     .map(Publication::getAdditionalIdentifiers)
-                                     .flatMap(Collection::stream)
-                                     .map(AdditionalIdentifier::getValue)
-                                     .map(Integer::parseInt)
-                                     .collect(Collectors.toSet());
+            .map(CristinObject::toPublication)
+            .map(Publication::getAdditionalIdentifiers)
+            .flatMap(Collection::stream)
+            .map(AdditionalIdentifier::getValue)
+            .map(Integer::parseInt)
+            .collect(Collectors.toSet());
 
         assertThat(expectedIds.size(), is(equalTo(NUMBER_OF_LINES_IN_RESOURCES_FILE)));
         assertThat(actualIds, is(equalTo(expectedIds)));
@@ -94,16 +93,16 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
         List<CristinObject> cristinObjects = cristinObjects().collect(Collectors.toList());
         List<String> expectedTitles = cristinObjects.stream()
-                                          .map(CristinObject::getCristinTitles)
-                                          .map(this::mainTitle)
-                                          .map(CristinTitle::getTitle)
-                                          .collect(Collectors.toList());
+            .map(CristinObject::getCristinTitles)
+            .map(this::mainTitle)
+            .map(CristinTitle::getTitle)
+            .collect(Collectors.toList());
 
         List<String> actualTitles = cristinObjects.stream()
-                                        .map(CristinObject::toPublication)
-                                        .map(Publication::getEntityDescription)
-                                        .map(EntityDescription::getMainTitle)
-                                        .collect(Collectors.toList());
+            .map(CristinObject::toPublication)
+            .map(Publication::getEntityDescription)
+            .map(EntityDescription::getMainTitle)
+            .collect(Collectors.toList());
         assertThat(expectedTitles, is(not(empty())));
         assertThat(actualTitles, containsInAnyOrder(expectedTitles.toArray(String[]::new)));
         assertThat(actualTitles.size(), is(equalTo(cristinObjects.size())));
@@ -113,14 +112,14 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @DisplayName("map returns resource with date equal to \"arstall\"")
     public void mapReturnsResourceWithDateEqualToArstall() {
         List<String> expectedPublicationYear = cristinObjects()
-                                                   .map(CristinObject::getPublicationYear)
-                                                   .collect(Collectors.toList());
+            .map(CristinObject::getPublicationYear)
+            .collect(Collectors.toList());
 
         List<String> actualPublicationDates = cristinObjects().map(CristinObject::toPublication)
-                                                  .map(Publication::getEntityDescription)
-                                                  .map(EntityDescription::getDate)
-                                                  .map(PublicationDate::getYear)
-                                                  .collect(Collectors.toList());
+            .map(Publication::getEntityDescription)
+            .map(EntityDescription::getDate)
+            .map(PublicationDate::getYear)
+            .collect(Collectors.toList());
         assertThat(expectedPublicationYear, is(not(empty())));
         assertThat(actualPublicationDates, containsInAnyOrder(expectedPublicationYear.toArray(String[]::new)));
     }
@@ -130,14 +129,14 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     public void mapReturnsResourceWithCreatedDateEqualToCristinDateAssumedToBeUtcDate() {
         ZoneOffset utc = ZoneId.of("UTC").getRules().getOffset(Instant.now());
         List<Instant> expectedCreatedDates = cristinObjects()
-                                                 .map(CristinObject::getEntryCreationDate)
-                                                 .map(LocalDate::atStartOfDay)
-                                                 .map(time -> time.toInstant(utc))
-                                                 .collect(Collectors.toList());
+            .map(CristinObject::getEntryCreationDate)
+            .map(LocalDate::atStartOfDay)
+            .map(time -> time.toInstant(utc))
+            .collect(Collectors.toList());
 
         List<Instant> actualCreatedDates = cristinObjects().map(CristinObject::toPublication)
-                                               .map(Publication::getCreatedDate)
-                                               .collect(Collectors.toList());
+            .map(Publication::getCreatedDate)
+            .collect(Collectors.toList());
 
         assertThat(actualCreatedDates, containsInAnyOrder(expectedCreatedDates.toArray(Instant[]::new)));
     }
@@ -145,21 +144,21 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapReturnsBookAnthologyWhenInputHasMainTypeBookAndSecondaryTypeAnthology() {
         testingData = Stream.of(CristinDataGenerator.randomBookAnthology())
-                          .map(JsonSerializable::toJsonString)
-                          .collect(SingletonCollector.collect());
+            .map(JsonSerializable::toJsonString)
+            .collect(SingletonCollector.collect());
 
         Publication actualPublication = cristinObjects()
-                                            .map(CristinObject::toPublication)
-                                            .collect(SingletonCollector.collect());
+            .map(CristinObject::toPublication)
+            .collect(SingletonCollector.collect());
 
         PublicationInstance<?> actualPublicationInstance = actualPublication
-                                                               .getEntityDescription()
-                                                               .getReference()
-                                                               .getPublicationInstance();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationInstance();
         PublicationContext actualPublicationContext = actualPublication
-                                                          .getEntityDescription()
-                                                          .getReference()
-                                                          .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
 
         assertThat(actualPublicationInstance, is(instanceOf(BookAnthology.class)));
         assertThat(actualPublicationContext, is(instanceOf(Book.class)));
@@ -168,21 +167,21 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapReturnsBookMonographWhenInputHasMainTypeBookAndSecondaryTypeMonograph() {
         testingData = Stream.of(CristinDataGenerator.randomBookMonograph(CristinSecondaryCategory.MONOGRAPH))
-                          .map(JsonSerializable::toJsonString)
-                          .collect(SingletonCollector.collect());
+            .map(JsonSerializable::toJsonString)
+            .collect(SingletonCollector.collect());
 
         Publication actualPublication = cristinObjects()
-                                            .map(CristinObject::toPublication)
-                                            .collect(SingletonCollector.collect());
+            .map(CristinObject::toPublication)
+            .collect(SingletonCollector.collect());
 
         PublicationInstance<?> actualPublicationInstance = actualPublication
-                                                               .getEntityDescription()
-                                                               .getReference()
-                                                               .getPublicationInstance();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationInstance();
         PublicationContext actualPublicationContext = actualPublication
-                                                          .getEntityDescription()
-                                                          .getReference()
-                                                          .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
 
         assertThat(actualPublicationInstance, is(instanceOf(BookMonograph.class)));
         assertThat(actualPublicationContext, is(instanceOf(Book.class)));
@@ -192,19 +191,19 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     public void mapReturnsResourceWhereNvaContributorsNamesAreConcatenationsOfCristinFirstAndFamilyNames() {
 
         List<String> expectedContributorNames = cristinObjects()
-                                                    .map(CristinObject::getContributors)
-                                                    .flatMap(Collection::stream)
-                                                    .map(this::formatNameAccordingToNvaPattern)
-                                                    .collect(Collectors.toList());
+            .map(CristinObject::getContributors)
+            .flatMap(Collection::stream)
+            .map(this::formatNameAccordingToNvaPattern)
+            .collect(Collectors.toList());
 
         List<String> actualContributorNames = cristinObjects()
-                                                  .map(CristinObject::toPublication)
-                                                  .map(Publication::getEntityDescription)
-                                                  .map(EntityDescription::getContributors)
-                                                  .flatMap(Collection::stream)
-                                                  .map(Contributor::getIdentity)
-                                                  .map(Identity::getName)
-                                                  .collect(Collectors.toList());
+            .map(CristinObject::toPublication)
+            .map(Publication::getEntityDescription)
+            .map(EntityDescription::getContributors)
+            .flatMap(Collection::stream)
+            .map(Contributor::getIdentity)
+            .map(Identity::getName)
+            .collect(Collectors.toList());
 
         assertThat(actualContributorNames, containsInAnyOrder(expectedContributorNames.toArray(String[]::new)));
     }
@@ -213,15 +212,15 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     public void mapReturnsResourceWhereNvaContributorSequenceIsEqualToCristinContributorSequence() {
 
         Set<ContributionReference> expectedContributions = cristinObjects()
-                                                               .map(this::extractContributions)
-                                                               .flatMap(Collection::stream)
-                                                               .collect(Collectors.toSet());
+            .map(this::extractContributions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
 
         Set<ContributionReference> actualContributions = cristinObjects()
-                                                             .map(CristinObject::toPublication)
-                                                             .map(this::extractContributions)
-                                                             .flatMap(Collection::stream)
-                                                             .collect(Collectors.toSet());
+            .map(CristinObject::toPublication)
+            .map(this::extractContributions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
 
         assertThat(expectedContributions, is(equalTo(actualContributions)));
     }
@@ -230,21 +229,21 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     public void mapReturnsResourceWhereNvaContributorHasAffiliationsWithUriCreatedBasedOnReferenceUriAndUnitNumbers() {
 
         List<URI> expectedAffiliations = cristinObjects()
-                                             .flatMap(cristinEntries -> cristinEntries.getContributors().stream())
-                                             .flatMap(contributor -> contributor.getAffiliations().stream())
-                                             .map(this::explicitFormattingOfCristinAffiliationCode)
-                                             .map(this::addCristinOrgHostPrefix)
-                                             .map(URI::create)
-                                             .collect(Collectors.toList());
+            .flatMap(cristinEntries -> cristinEntries.getContributors().stream())
+            .flatMap(contributor -> contributor.getAffiliations().stream())
+            .map(this::explicitFormattingOfCristinAffiliationCode)
+            .map(this::addCristinOrgHostPrefix)
+            .map(URI::create)
+            .collect(Collectors.toList());
 
         List<URI> actualAffiliations = cristinObjects().map(CristinObject::toPublication)
-                                           .map(Publication::getEntityDescription)
-                                           .map(EntityDescription::getContributors)
-                                           .flatMap(Collection::stream)
-                                           .map(Contributor::getAffiliations)
-                                           .flatMap(Collection::stream)
-                                           .map(Organization::getId)
-                                           .collect(Collectors.toList());
+            .map(Publication::getEntityDescription)
+            .map(EntityDescription::getContributors)
+            .flatMap(Collection::stream)
+            .map(Contributor::getAffiliations)
+            .flatMap(Collection::stream)
+            .map(Organization::getId)
+            .collect(Collectors.toList());
 
         assertThat(actualAffiliations, containsInAnyOrder(expectedAffiliations.toArray(URI[]::new)));
     }
@@ -252,14 +251,14 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapReturnsPublicationWithPublicationDateEqualToCristinPublicationYear() {
         List<PublicationDate> expectedPublicationDates = cristinObjects()
-                                                             .map(CristinObject::getPublicationYear)
-                                                             .map(this::yearStringToPublicationDate)
-                                                             .collect(Collectors.toList());
+            .map(CristinObject::getPublicationYear)
+            .map(this::yearStringToPublicationDate)
+            .collect(Collectors.toList());
         List<PublicationDate> actualPublicationDates = cristinObjects()
-                                                           .map(CristinObject::toPublication)
-                                                           .map(Publication::getEntityDescription)
-                                                           .map(EntityDescription::getDate)
-                                                           .collect(Collectors.toList());
+            .map(CristinObject::toPublication)
+            .map(Publication::getEntityDescription)
+            .map(EntityDescription::getDate)
+            .collect(Collectors.toList());
 
         assertThat(actualPublicationDates,
                    containsInAnyOrder(expectedPublicationDates.toArray(PublicationDate[]::new)));
@@ -268,9 +267,9 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapReturnsPublicationWithHardcodedLink() {
         Set<URI> actualLicenseIdentifiers = cristinObjects()
-                                                .map(CristinObject::toPublication)
-                                                .map(Publication::getLink)
-                                                .collect(Collectors.toSet());
+            .map(CristinObject::toPublication)
+            .map(Publication::getLink)
+            .collect(Collectors.toSet());
 
         Set<URI> expectedLinks = Set.of(HARDCODED_SAMPLE_DOI);
 
@@ -286,11 +285,11 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         CristinObject objectWithEditor = createObjectWithRoleCode(actualCristinRole);
 
         Optional<Contributor> contributor = objectWithEditor.toPublication()
-                                                .getEntityDescription()
-                                                .getContributors()
-                                                .stream()
-                                                .filter(c -> c.getRole().equals(expectedNvaRole))
-                                                .findAny();
+            .getEntityDescription()
+            .getContributors()
+            .stream()
+            .filter(c -> c.getRole().equals(expectedNvaRole))
+            .findAny();
         assertThat(contributor.isPresent(), is(true));
         assertThat(contributor.orElseThrow().getRole(), is(equalTo(expectedNvaRole)));
     }
@@ -304,9 +303,9 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         Publication actualPublication = cristinImport.toPublication();
 
         PublicationInstance<?> actualPublicationInstance = actualPublication
-                                                               .getEntityDescription()
-                                                               .getReference()
-                                                               .getPublicationInstance();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationInstance();
 
         MonographPages monographPages = (MonographPages) actualPublicationInstance.getPages();
         String actualNumberOfPages = monographPages.getPages();
@@ -319,14 +318,14 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         CristinObject cristinImport = CristinDataGenerator.objectWithRandomBookReport();
 
         UnconfirmedPublisher expectedPublisher =
-                new UnconfirmedPublisher(cristinImport.getBookOrReportMetadata().getPublisherName());
+            new UnconfirmedPublisher(cristinImport.getBookOrReportMetadata().getPublisherName());
 
         Publication actualPublication = cristinImport.toPublication();
 
         PublicationContext actualPublicationContext = actualPublication
-                                                          .getEntityDescription()
-                                                          .getReference()
-                                                          .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
 
         Book bookSubType = (Book) actualPublicationContext;
         PublishingHouse actualPublisher = bookSubType.getPublisher();
@@ -343,9 +342,9 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         Publication actualPublication = cristinImport.toPublication();
 
         PublicationContext actualPublicationContext = actualPublication
-                                                          .getEntityDescription()
-                                                          .getReference()
-                                                          .getPublicationContext();
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
 
         Book bookSubType = (Book) actualPublicationContext;
         List<String> actualIsbnList = bookSubType.getIsbnList();
@@ -370,10 +369,10 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     public void mapSetsNameToNullWhenBothFamilyNameAndGivenNameAreMissing() {
         CristinContributor contributorWithMissingName = CristinContributor.builder()
-                                                            .withIdentifier(largeRandomNumber())
-                                                            .withContributorOrder(1)
-                                                            .withAffiliations(List.of(randomAffiliation()))
-                                                            .build();
+            .withIdentifier(largeRandomNumber())
+            .withContributorOrder(1)
+            .withAffiliations(List.of(randomAffiliation()))
+            .build();
         CristinObject cristinObjectWithContributorsWithoutRole =
             CristinDataGenerator.randomObject().copy()
                 .withPublicationOwner(randomString())
@@ -401,23 +400,59 @@ public class CristinMapperTest extends AbstractCristinImportTest {
         mapSetsNameToNullWhenBothFamilyNameAndGivenNameAreMissing();
     }
 
+    @ParameterizedTest(name = "map returns journal with DOI URI when input is Journal with DOI:{0}")
+    @CsvSource({
+        "http://dx.doi.org/10.5750/ejpch.v5i1.1209, https://doi.org/10.5750/ejpch.v5i1.1209",
+        "https://doi.org/10.1016/j.toxlet.2020.09.006, https://doi.org/10.1016/j.toxlet.2020.09.006",
+        "DOI:10.1080/02699052.2017.1312145, https://doi.org/10.1080/02699052.2017.1312145",
+        "doi:10.1080/02699052.2017.1312145, https://doi.org/10.1080/02699052.2017.1312145",
+        "10.1016/j.toxlet.2020.09.006, https://doi.org/10.1016/j.toxlet.2020.09.006"
+    })
+    public void mapReturnsJournalWithDoiWhenInputIsJournalResultWithDoi(String inputDoi, String expectedDoiUri) {
+        CristinObject cristinObject =
+            CristinDataGenerator.randomObject(CristinSecondaryCategory.JOURNAL_ARTICLE.toString());
+        cristinObject.getJournalPublication().setDoi(inputDoi);
+        Publication publication = cristinObject.toPublication();
+        assertThat(publication.getEntityDescription().getReference().getDoi(), is(equalTo(URI.create(expectedDoiUri))));
+    }
+
+    @Test
+    public void mapReturnsJournalWithDoiUriWhenInputIsANonExistingDoiAndOnlineValidationIsDisabled() {
+        String inputDoi = "10.1234/non.existin.doi";
+        URI expectedDoiUri = URI.create("https://doi.org/" + inputDoi);
+        CristinObject cristinObject =
+            CristinDataGenerator.randomObject(CristinSecondaryCategory.JOURNAL_ARTICLE.toString());
+        cristinObject.getJournalPublication().setDoi(inputDoi);
+        Publication publication = cristinObject.toPublication();
+        assertThat(publication.getEntityDescription().getReference().getDoi(), is(equalTo(expectedDoiUri)));
+    }
+
+    @Test
+    public void mapReturnsJournalWithoutDoiUriWhenInputIsAJournalArticleWihoutDoi() {
+        CristinObject cristinObject =
+            CristinDataGenerator.randomObject(CristinSecondaryCategory.JOURNAL_ARTICLE.toString());
+        cristinObject.getJournalPublication().setDoi(null);
+        Publication publication = cristinObject.toPublication();
+        assertThat(publication.getEntityDescription().getReference().getDoi(), is(nullValue()));
+    }
+
     private CristinObject createObjectWithRoleCode(CristinContributorRoleCode actualCristinRoleCode) {
         return CristinDataGenerator.newCristinObjectWithRoleCode(actualCristinRoleCode);
     }
 
     private CristinContributor contributorWithoutRoles() {
         CristinContributorsAffiliation affiliation = randomAffiliation()
-                                                         .copy()
-                                                         .withRoles(Collections.emptyList())
-                                                         .build();
+            .copy()
+            .withRoles(Collections.emptyList())
+            .build();
 
         return CristinContributor.builder()
-                   .withFamilyName(randomString())
-                   .withIdentifier(largeRandomNumber())
-                   .withContributorOrder(1)
-                   .withGivenName(randomString())
-                   .withAffiliations(List.of((affiliation)))
-                   .build();
+            .withFamilyName(randomString())
+            .withIdentifier(largeRandomNumber())
+            .withContributorOrder(1)
+            .withGivenName(randomString())
+            .withAffiliations(List.of((affiliation)))
+            .build();
     }
 
     private PublicationDate yearStringToPublicationDate(String yearString) {
@@ -439,22 +474,22 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     private List<ContributionReference> extractContributions(Publication publication) {
 
         AdditionalIdentifier cristinIdentifier = publication.getAdditionalIdentifiers().stream()
-                                                     .filter(this::isCristinIdentifier)
-                                                     .collect(SingletonCollector.collect());
+            .filter(this::isCristinIdentifier)
+            .collect(SingletonCollector.collect());
         Integer cristinIdentifierValue = Integer.parseInt(cristinIdentifier.getValue());
 
         return publication.getEntityDescription()
-                   .getContributors().stream()
-                   .map(contributor -> extractContributionReference(cristinIdentifierValue, contributor))
-                   .collect(Collectors.toList());
+            .getContributors().stream()
+            .map(contributor -> extractContributionReference(cristinIdentifierValue, contributor))
+            .collect(Collectors.toList());
     }
 
     private List<ContributionReference> extractContributions(CristinObject cristinObject) {
         final Integer cristinResourceIdentifier = cristinObject.getId();
         return cristinObject.getContributors().stream()
-                   .map(c -> new ContributionReference(cristinResourceIdentifier, c.getIdentifier(),
-                                                       c.getContributorOrder()))
-                   .collect(Collectors.toList());
+            .map(c -> new ContributionReference(cristinResourceIdentifier, c.getIdentifier(),
+                                                c.getContributorOrder()))
+            .collect(Collectors.toList());
     }
 
     private boolean isCristinIdentifier(AdditionalIdentifier identifier) {

--- a/cristin-import/src/test/resources/application.conf
+++ b/cristin-import/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+doi {
+ validation{
+  online = false
+ }
+}

--- a/cristin-import/src/test/resources/features/JournalArticleRules.feature
+++ b/cristin-import/src/test/resources/features/JournalArticleRules.feature
@@ -79,7 +79,7 @@ Feature: Mapping of "Article in business/trade/industry journal", "Academic arti
     Given that the Cristin Result has a non empty Journal Publication
     And the Journal Publication has a "doi" entry equal to "10.1093/ajae/aaq063"
     When the Cristin Result is converted to an NVA Resource
-    Then the Nva Resource has a Reference object with doi equal to "10.1093/ajae/aaq063"
+    Then the Nva Resource has a Reference object with doi equal to "https://doi.org/10.1093/ajae/aaq063"
 
   Scenario: Mapping fails when a Cristin Result of type JournalArticle has no information about the Journal title.
     Given that the Journal Article entry has an empty "publisherName" field

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-nva = { strictly = "1.7.7" }
+nva = { strictly = "1.8.1" }
 nvaDatamodelVersion = { strictly = "0.13.1" }
 jacksonVersion = { strictly = "2.12.4" }
-awsSdkVersion = { strictly = "1.12.42" }
+awsSdkVersion = { strictly = "1.12.52" }
 awsSdk2Version = { strictly = "2.17.14" }
 log4jApiVersion = { require = "2.14.1" }
 zalandoProblemVersion = { strictly = "0.26.0" }
@@ -17,6 +17,7 @@ apacheCommons = { strictly = "4.4" }
 testUtils = { strictly = "0.1.24" }
 hamcrest = { strictly = '2.2' }
 cucumber = { strictly = '6.11.0' }
+config-typesafe-version = { strictly = '1.4.1' }
 
 [libraries]
 nva-core = { group = "com.github.bibsysdev", name = "core", version.ref = "nva" }
@@ -28,7 +29,7 @@ nva-eventhandlers = { group = "com.github.bibsysdev", name = "eventhandlers", ve
 nva-testutils = { group = "com.github.bibsysdev", name = "nva-testutils", version.ref = "testUtils" }
 nva-user-access-rights = { group = "com.github.bibsysdev.nva-user-access-service", name = "user-access-rights", version.ref = "nvaUserAccessService" }
 nva-datamodel = { group = "com.github.bibsysdev", name = "nva-datamodel-java", version.ref = "nvaDatamodelVersion" }
-
+nva-doi = { group = "com.github.bibsysdev", name = "doi", version.ref = "nva" }
 
 
 jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jacksonVersion" }
@@ -70,6 +71,9 @@ dynamodDbLocal = { group = "com.amazonaws", name = "DynamoDBLocal", version.ref 
 javafaker = { group = "com.github.javafaker", name = "javafaker", version = { strictly = "1.0.2" } }
 javers = { group = "org.javers", name = "javers-core", version = { strictly = "6.0.1" } }
 zalando = { group = "org.zalando", name = "problem", version.ref = "zalandoProblemVersion" }
+typesafe-config = { group = 'com.typesafe', name = 'config', version.ref = "config-typesafe-version" }
+
+
 
 commons-validator = { group = "commons-validator", name = "commons-validator", version.ref = "commonsValidator" }
 

--- a/publication-fanout-handler/src/main/java/no/unit/nva/publication/events/DynamodbStreamRecordPublicationMapper.java
+++ b/publication-fanout-handler/src/main/java/no/unit/nva/publication/events/DynamodbStreamRecordPublicationMapper.java
@@ -88,7 +88,7 @@ public final class DynamodbStreamRecordPublicationMapper {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","PMD.CognitiveComplexity"})
     private  static <T> T toSimpleValue(com.amazonaws.services.dynamodbv2.model.AttributeValue value) {
         if (value == null) {
             return null;

--- a/publication-testing/src/main/java/no/unit/nva/publication/testing/TestHeaders.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/testing/TestHeaders.java
@@ -10,8 +10,8 @@ import nva.commons.core.JacocoGenerated;
 @JacocoGenerated
 public class TestHeaders {
 
-    public static String APPLICATION_PROBLEM_JSON = "application/problem+json";
-    public static String WILDCARD = "*";
+    public static final String APPLICATION_PROBLEM_JSON = "application/problem+json";
+    public static final String WILDCARD = "*";
 
     /**
      * Request headers for testing.

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/ResourceDao.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/ResourceDao.java
@@ -19,12 +19,12 @@ import nva.commons.core.SingletonCollector;
 @JsonTypeName("Resource")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ResourceDao extends Dao<Resource>
-        implements JoinWithResource,
-        ResourceByIdentifier,
-        WithCristinIdentifier {
+    implements JoinWithResource,
+               ResourceByIdentifier,
+               WithCristinIdentifier {
 
-    private static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "b";
     public static final String CRISTIN_SOURCE = "Cristin";
+    private static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "b";
     private Resource data;
 
     public ResourceDao() {
@@ -38,15 +38,15 @@ public class ResourceDao extends Dao<Resource>
 
     public static ResourceDao queryObject(UserInstance userInstance, SortableIdentifier resourceIdentifier) {
         Resource resource = Resource.emptyResource(
-                userInstance.getUserIdentifier(),
-                userInstance.getOrganizationUri(),
-                resourceIdentifier);
+            userInstance.getUserIdentifier(),
+            userInstance.getOrganizationUri(),
+            resourceIdentifier);
         return new ResourceDao(resource);
     }
 
     public static String constructPrimaryPartitionKey(URI customerId, String owner) {
         return String.format(PRIMARY_KEY_PARTITION_KEY_FORMAT, Resource.TYPE,
-                orgUriToOrgIdentifier(customerId), owner);
+                             orgUriToOrgIdentifier(customerId), owner);
     }
 
     @JsonIgnore
@@ -84,26 +84,20 @@ public class ResourceDao extends Dao<Resource>
         return data.getIdentifier();
     }
 
+    @Override
+    protected String getOwner() {
+        return data.getOwner();
+    }
 
     @Override
     public Optional<String> getCristinIdentifier() {
         String cristinIdentifierValue = Optional.ofNullable(data.getAdditionalIdentifiers())
-                .stream()
-                .flatMap(Collection::stream)
-                .filter(this::keyEqualsCristin)
-                .map(AdditionalIdentifier::getValue)
-                .collect(SingletonCollector.collectOrElse(null));
+            .stream()
+            .flatMap(Collection::stream)
+            .filter(this::keyEqualsCristin)
+            .map(AdditionalIdentifier::getValue)
+            .collect(SingletonCollector.collectOrElse(null));
         return Optional.ofNullable(cristinIdentifierValue);
-
-    }
-
-    private boolean keyEqualsCristin(AdditionalIdentifier identifier) {
-        return identifier.getSource().equals(CRISTIN_SOURCE);
-    }
-
-    @Override
-    protected String getOwner() {
-        return data.getOwner();
     }
 
     @Override
@@ -132,5 +126,12 @@ public class ResourceDao extends Dao<Resource>
         }
         ResourceDao that = (ResourceDao) o;
         return Objects.equals(getData(), that.getData());
+    }
+
+    private boolean keyEqualsCristin(AdditionalIdentifier identifier) {
+        return Optional.ofNullable(identifier)
+            .map(AdditionalIdentifier::getSource)
+            .map(CRISTIN_SOURCE::equals)
+            .orElse(false);
     }
 }

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/exceptions/EmptyValueMapException.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/exceptions/EmptyValueMapException.java
@@ -2,7 +2,7 @@ package no.unit.nva.publication.storage.model.exceptions;
 
 public class EmptyValueMapException extends RuntimeException {
     
-    public static String DEFAULT_MESSAGE = "Trying to parse empty item";
+    public static final  String DEFAULT_MESSAGE = "Trying to parse empty item";
     
     public EmptyValueMapException() {
         super(DEFAULT_MESSAGE);


### PR DESCRIPTION
Convert DOI string to URLs by using the DoiConverter from 
The DoiConverter validates the DOIs online, but we want to disable this in unit tests. To achieve this I used [lightbend](https://github.com/lightbend/config/). In this way we have a default configuration that enables the online validation and a test configuration that disables it.

I received a lot of PMD complaints for code that I did not touch, which was weird but probably is related to some plugin update.