### PR TITLE
fix:arstall is number

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -218,7 +218,7 @@ public class CristinMapper extends CristinMappingModule {
     }
 
     private PublicationDate extractPublicationDate() {
-        return new PublicationDate.Builder().withYear(cristinObject.getPublicationYear()).build();
+        return new PublicationDate.Builder().withYear(cristinObject.getPublicationYear().toString()).build();
     }
 
     private String extractMainTitle() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -46,7 +46,7 @@ public class CristinObject implements JsonSerializable {
     @JsonProperty("id")
     private Integer id;
     @JsonProperty("arstall")
-    private String publicationYear;
+    private Integer publicationYear;
     @JsonProperty("dato_opprettet")
     private LocalDate entryCreationDate;
     @JsonProperty("varbeid_sprak")

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
@@ -37,7 +37,7 @@ public class PeriodicalBuilder extends CristinMappingModule {
         URI journalUri = new UriWrapper(NVA_API_DOMAIN).addChild(MappingConstants.NSD_PROXY_PATH)
             .addChild(MappingConstants.NSD_PROXY_PATH_JOURNAL)
             .addChild(cristinObject.getJournalPublication().getJournal().getNsdCode().toString())
-            .addChild(cristinObject.getPublicationYear())
+            .addChild(cristinObject.getPublicationYear().toString())
             .getUri();
         return new Journal(journalUri.toString());
     }

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -84,8 +84,8 @@ public class GeneralMappingRules {
         scenarioContext.getLatestCristinTitle().setStatusOriginal(statusOriginal);
     }
 
-    @Given("the Cristin Result has publication year {string}")
-    public void theCristinEntryHasPublicationYear(String publicationYear) {
+    @Given("the Cristin Result has publication year {int}")
+    public void theCristinEntryHasPublicationYear(int publicationYear) {
         scenarioContext.getCristinEntry().setPublicationYear(publicationYear);
     }
 
@@ -117,11 +117,11 @@ public class GeneralMappingRules {
         assertThat(actualTitle, is(equalTo(expectedTitle)));
     }
 
-    @Then("the NVA Resource has a Publication Date with year equal to {string}, month equal to null and "
+    @Then("the NVA Resource has a Publication Date with year equal to {int}, month equal to null and "
           + "day equal to null")
-    public void theNvaResourceHasPublicationDateWithTheCristinYear(String expectedPublicationYear) {
+    public void theNvaResourceHasPublicationDateWithTheCristinYear(Integer expectedPublicationYear) {
         PublicationDate actualDate = scenarioContext.getNvaEntry().getEntityDescription().getDate();
-        assertThat(actualDate.getYear(), is(equalTo(expectedPublicationYear)));
+        assertThat(actualDate.getYear(), is(equalTo(expectedPublicationYear.toString())));
         assertThat(actualDate.getMonth(), is(nullValue()));
         assertThat(actualDate.getDay(), is(nullValue()));
     }

--- a/cristin-import/src/test/java/cucumber/JournalFeatures.java
+++ b/cristin-import/src/test/java/cucumber/JournalFeatures.java
@@ -183,12 +183,12 @@ public class JournalFeatures {
 
     @Given("the Journal Publication has publishing year equal to {int}")
     public void theJournalPublicationHasPublishingYearEqualTo(int yearPublishedInJournal) {
-        scenarioContext.getCristinEntry().setPublicationYear(Integer.toString(yearPublishedInJournal));
+        scenarioContext.getCristinEntry().setPublicationYear(yearPublishedInJournal);
     }
 
     @Given("the year the Cristin Result was published is equal to {int}")
     public void theYearTheCristinResultWasPublishedIsEqualTo(int publicationYear) {
-        scenarioContext.getCristinEntry().setPublicationYear(Integer.toString(publicationYear));
+        scenarioContext.getCristinEntry().setPublicationYear(publicationYear);
     }
 
     @Then("the NVA Resource has a Reference object with a journal URI that points to NVAs NSD proxy")

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -481,12 +481,11 @@ public final class CristinDataGenerator {
         return randomArrayElement(CristinSecondaryCategory.values(), NUMBER_OF_KNOWN_SECONDARY_CATEGORIES);
     }
 
-    private static String randomYear() {
+    private static int randomYear() {
         Date date = FAKER.date().birthday();
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
-        int year = calendar.get(Calendar.YEAR);
-        return Integer.toString(year);
+        return calendar.get(Calendar.YEAR);
     }
 
     private static JsonNode cristinObjectWithUnexpectedValue(CristinObject cristinObject,

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -111,17 +111,18 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     @Test
     @DisplayName("map returns resource with date equal to \"arstall\"")
     public void mapReturnsResourceWithDateEqualToArstall() {
-        List<String> expectedPublicationYear = cristinObjects()
+        List<Integer> expectedPublicationYear = cristinObjects()
             .map(CristinObject::getPublicationYear)
             .collect(Collectors.toList());
 
-        List<String> actualPublicationDates = cristinObjects().map(CristinObject::toPublication)
+        List<Integer> actualPublicationDates = cristinObjects().map(CristinObject::toPublication)
             .map(Publication::getEntityDescription)
             .map(EntityDescription::getDate)
             .map(PublicationDate::getYear)
+            .map(Integer::parseInt)
             .collect(Collectors.toList());
         assertThat(expectedPublicationYear, is(not(empty())));
-        assertThat(actualPublicationDates, containsInAnyOrder(expectedPublicationYear.toArray(String[]::new)));
+        assertThat(actualPublicationDates, containsInAnyOrder(expectedPublicationYear.toArray(Integer[]::new)));
     }
 
     @Test
@@ -252,7 +253,7 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     public void mapReturnsPublicationWithPublicationDateEqualToCristinPublicationYear() {
         List<PublicationDate> expectedPublicationDates = cristinObjects()
             .map(CristinObject::getPublicationYear)
-            .map(this::yearStringToPublicationDate)
+            .map(this::yearToPublicationDate)
             .collect(Collectors.toList());
         List<PublicationDate> actualPublicationDates = cristinObjects()
             .map(CristinObject::toPublication)
@@ -455,8 +456,8 @@ public class CristinMapperTest extends AbstractCristinImportTest {
             .build();
     }
 
-    private PublicationDate yearStringToPublicationDate(String yearString) {
-        return new PublicationDate.Builder().withYear(yearString).build();
+    private PublicationDate yearToPublicationDate(Integer year) {
+        return new PublicationDate.Builder().withYear(year.toString()).build();
     }
 
     //We do not use any more complex logic to make the tests fail if anything changes

--- a/cristin-import/src/test/resources/features/GeneralMappingRules.feature
+++ b/cristin-import/src/test/resources/features/GeneralMappingRules.feature
@@ -56,13 +56,10 @@ Feature: Mappings that hold for all types of Cristin Results
 
 
   Scenario Outline: The Resources Publication Date is set  the Cristin Result's Publication Year
-    Given the Cristin Result has publication year <publicationYear>
+    Given the Cristin Result has publication year 1996
     When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource has a Publication Date with year equal to <publicationYear>, month equal to null and day equal to null
-    Examples:
-      | publicationYear |
-      | "1996"          |
-      | "c.a 1996"      |
+    Then the NVA Resource has a Publication Date with year equal to 1996, month equal to null and day equal to null
+
 
   Scenario:The NVA Resource Creation Date is set to be the Cristin entry's creation date
     Given that Cristin Result has created date equal to the local date "2011-12-03"


### PR DESCRIPTION
The field arstall in Cristin data is a number and it should be treated like one. That is, in the input files its type is number and not string and there is no need to treat it as a string.