### PR TITLE
NP-3061: Cristin publisher

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinBookOrReportMetadata.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinBookOrReportMetadata.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.StringUtils;
 
 
 @Data
@@ -23,11 +22,11 @@ import nva.commons.core.StringUtils;
     "status_utgitt_av_forlag", "stedangivelse_utgiver", "landkode_utgiver", "institusjonsnr_utgiver",
     "avdnr_utgiver", "undavdnr_utgiver", "gruppenr_utgiver", "tidsskriftnr_serie",
     "sprakkode_oversatt_fra", "sprakkode_oversatt_til", "originalforfatter", "originaltittel",
-    "forlag",  "arkivpost"})
+    "arkivpost"})
 public class CristinBookOrReportMetadata {
 
     public static final String ISBN_LIST = "isbn";
-    public static final String PUBLISHER = "utgivernavn";
+    public static final String PUBLISHER_NAME = "utgivernavn";
     public static final String NUMBER_OF_PAGES = "antall_sider_totalt";
     public static final String SUBJECT_FIELD = "fagfelt";
     public static final String SUBJECT_FIELD_IS_A_REQUIRED_FIELD =
@@ -35,10 +34,11 @@ public class CristinBookOrReportMetadata {
     public static final String BOOK_SERIES = "tidsskrift_serie";
     public static final String ISSUE = "hefte";
     public static final String VOLUME = "volum_serie";
+    public static final String PUBLISHER = "forlag";
 
     @JsonProperty(ISBN_LIST)
     private String isbn;
-    @JsonProperty(PUBLISHER)
+    @JsonProperty(PUBLISHER_NAME)
     private String publisherName;
     @JsonProperty(NUMBER_OF_PAGES)
     private String numberOfPages;
@@ -51,6 +51,9 @@ public class CristinBookOrReportMetadata {
     private String issue;
     @JsonProperty(VOLUME)
     private String volume;
+    @JsonProperty(PUBLISHER)
+    private CristinPublisher cristinPublisher;
+
 
     public CristinBookOrReportMetadata() {
 
@@ -61,9 +64,6 @@ public class CristinBookOrReportMetadata {
     }
 
     public String getPublisherName() {
-        if (StringUtils.isBlank(publisherName)) {
-            throw new InvalidCristinBookReportEntryException(PUBLISHER, publisherName);
-        }
         return publisherName;
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPublisher.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPublisher.java
@@ -1,0 +1,32 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(
+    builderClassName = "CristinPublisherBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"forlagsnr"})
+public class CristinPublisher {
+
+    public static final String PUBLISHER_NAME = "forlagsnavn";
+    public static final String NSD_CODE = "nsdkode";
+    @JsonProperty(PUBLISHER_NAME)
+    private String publisherName;
+    @JsonProperty(NSD_CODE)
+    private Integer nsdCode;
+
+    public CristinPublisher() {
+
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/Nsd.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/Nsd.java
@@ -2,6 +2,7 @@ package no.unit.nva.cristin.mapper;
 
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.NSD_PROXY_PATH;
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.NSD_PROXY_PATH_JOURNAL;
+import static no.unit.nva.cristin.lambda.constants.MappingConstants.NSD_PROXY_PATH_PUBLISHER;
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.NVA_API_DOMAIN;
 import java.net.URI;
 import no.unit.nva.publication.s3imports.UriWrapper;
@@ -17,13 +18,20 @@ public class Nsd {
     }
 
     public URI createJournalOrSeriesUri() {
+        return getNsdProxyUri(NSD_PROXY_PATH_JOURNAL);
+    }
+
+    public URI getPublisherUri() {
+        return getNsdProxyUri(NSD_PROXY_PATH_PUBLISHER);
+    }
+
+    private URI getNsdProxyUri(String nsdProxyPathPublisher) {
         return nvaProxyUri()
-            .addChild(NSD_PROXY_PATH_JOURNAL)
+            .addChild(nsdProxyPathPublisher)
             .addChild(Integer.toString(nsdCode))
             .addChild(Integer.toString(year))
             .getUri();
     }
-
 
     private UriWrapper nvaProxyUri() {
         return new UriWrapper(NVA_API_DOMAIN).addChild(NSD_PROXY_PATH);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
@@ -33,15 +33,12 @@ public class PeriodicalBuilder extends CristinMappingModule {
 
     private Periodical createJournal() {
         Integer nsdCode = cristinObject.getJournalPublication().getJournal().getNsdCode();
-        int publicationYear = getYearReportedInNvi();
+        int publicationYear = extractYearReportedInNvi();
         URI journalUri = new Nsd(nsdCode, publicationYear).createJournalOrSeriesUri();
         return new Journal(journalUri.toString());
     }
 
-    private Integer getYearReportedInNvi() {
-        return Optional.ofNullable(cristinObject.getYearReported())
-            .orElseGet(cristinObject::getPublicationYear);
-    }
+
 
     private String extractIssn() {
         return extractCristinJournalPublication().getJournal().getIssn();

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
@@ -23,7 +23,6 @@ public class PublicationInstanceBuilderImpl  {
         this.cristinObject = cristinObject;
     }
 
-
     public PublicationInstance<? extends Pages> build() {
         if (isBook(cristinObject)) {
             return new BookBuilder(cristinObject).build();

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/CristinMappingModule.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/CristinMappingModule.java
@@ -4,8 +4,6 @@ import java.util.Optional;
 import no.unit.nva.cristin.mapper.CristinBookOrReportMetadata;
 import no.unit.nva.cristin.mapper.CristinJournalPublication;
 import no.unit.nva.cristin.mapper.CristinObject;
-import no.unit.nva.model.contexttypes.PublishingHouse;
-import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
 
 /**
  * Class containing common functionality for the different modules implementing the mapping logic of Cristin entries to
@@ -35,11 +33,7 @@ public class CristinMappingModule {
             .orElse(null);
     }
 
-    protected PublishingHouse buildUnconfirmedPublisher() {
-        return new UnconfirmedPublisher(extractPublisherName());
-    }
-
-    private String extractPublisherName() {
-        return extractCristinBookReport().getPublisherName();
+    protected Integer extractYearReportedInNvi() {
+        return Optional.ofNullable(cristinObject.getYearReported()).orElseGet(cristinObject::getPublicationYear);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookBuilder.java
@@ -11,7 +11,7 @@ public class NvaBookBuilder extends NvaBookLikeBuilder {
     }
 
     public Book buildBookForPublicationContext() throws InvalidIsbnException {
-        return new Book(buildSeries(), constructSeriesNumber(), buildUnconfirmedPublisher(), createIsbnList());
+        return new Book(buildSeries(), constructSeriesNumber(), buildPublisher(), createIsbnList());
     }
 
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
@@ -1,28 +1,45 @@
 package no.unit.nva.cristin.mapper.nva;
 
+import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import no.unit.nva.cristin.mapper.CristinBookOrReportMetadata;
 import no.unit.nva.cristin.mapper.CristinObject;
+import no.unit.nva.cristin.mapper.CristinPublisher;
+import no.unit.nva.cristin.mapper.Nsd;
+import no.unit.nva.cristin.mapper.nva.exceptions.NoPublisherException;
 import no.unit.nva.model.contexttypes.BookSeries;
+import no.unit.nva.model.contexttypes.Publisher;
+import no.unit.nva.model.contexttypes.PublishingHouse;
+import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
+import nva.commons.core.StringUtils;
 
 public class NvaBookLikeBuilder extends CristinMappingModule {
+
+    public static final String CUSTOM_VOLUME_SERIES_DELIMITER = ";";
+    private static final String EMPTY_STRING = null;
 
     public NvaBookLikeBuilder(CristinObject cristinObject) {
         super(cristinObject);
     }
 
     protected String constructSeriesNumber() {
-        String volume = Optional.of(cristinObject)
-            .map(CristinObject::getBookOrReportMetadata)
+        String volume = extractBookOrReportMetadata()
             .map(CristinBookOrReportMetadata::getVolume)
-            .orElse(null);
-        String issue = Optional.of(cristinObject)
-            .map(CristinObject::getBookOrReportMetadata)
+            .filter(StringUtils::isNotBlank)
+            .map(volumeNumber -> String.format("Volume:%s", volumeNumber))
+            .orElse(EMPTY_STRING);
+        String issue = extractBookOrReportMetadata()
             .map(CristinBookOrReportMetadata::getIssue)
+            .filter(StringUtils::isNotBlank)
+            .map(issueNumber -> String.format("Issue:%s", issueNumber))
             .orElse(null);
-        return String.format("Volume:%s;Issue:%s", volume, issue);
+
+        return Stream.of(volume, issue).filter(Objects::nonNull)
+            .collect(Collectors.joining(CUSTOM_VOLUME_SERIES_DELIMITER));
     }
 
     protected BookSeries buildSeries() {
@@ -31,5 +48,59 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
 
     protected List<String> createIsbnList() {
         return extractIsbn().stream().collect(Collectors.toList());
+    }
+
+    protected PublishingHouse buildPublisher() {
+        return createConfirmedPublisherIfPublisherReferenceHasNsdCode()
+            .orElseGet(this::createUnconfirmedPublisher);
+    }
+
+    private Optional<CristinBookOrReportMetadata> extractBookOrReportMetadata() {
+        return Optional.of(cristinObject)
+            .map(CristinObject::getBookOrReportMetadata);
+    }
+
+    private Optional<PublishingHouse> createConfirmedPublisherIfPublisherReferenceHasNsdCode() {
+        return extractPublishersNsdCode()
+            .map(n -> new Nsd(n, extractYearReportedInNvi()))
+            .map(Nsd::getPublisherUri)
+            .map(this::createConfirmedPublisher);
+    }
+
+    private Optional<Integer> extractPublishersNsdCode() {
+        return extractBookOrReportMetadata()
+            .map(CristinBookOrReportMetadata::getCristinPublisher)
+            .map(CristinPublisher::getNsdCode);
+    }
+
+    private PublishingHouse createUnconfirmedPublisher() {
+        return new UnconfirmedPublisher(extractUnconfirmedPublisherName());
+    }
+
+    private PublishingHouse createConfirmedPublisher(URI uri) {
+        return new Publisher(uri);
+    }
+
+    private String extractUnconfirmedPublisherName() {
+        String publisherName = extractPublisherNameFromPrimaryField()
+            .orElseGet(this::lookForPublisherNameInAlternativeField);
+        return Optional.ofNullable(publisherName)
+            .orElseThrow(this::publicationWithoutPublisherIsNotAllowed);
+    }
+
+    private NoPublisherException publicationWithoutPublisherIsNotAllowed() {
+        return new NoPublisherException(cristinObject.getId());
+    }
+
+    private Optional<String> extractPublisherNameFromPrimaryField() {
+        return extractBookOrReportMetadata()
+            .map(CristinBookOrReportMetadata::getCristinPublisher)
+            .map(CristinPublisher::getPublisherName);
+    }
+
+    private String lookForPublisherNameInAlternativeField() {
+        return extractBookOrReportMetadata()
+            .map(CristinBookOrReportMetadata::getPublisherName)
+            .orElse(null);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
@@ -62,7 +62,7 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
 
     private Optional<PublishingHouse> createConfirmedPublisherIfPublisherReferenceHasNsdCode() {
         return extractPublishersNsdCode()
-            .map(n -> new Nsd(n, extractYearReportedInNvi()))
+            .map(nsdCode -> new Nsd(nsdCode, extractYearReportedInNvi()))
             .map(Nsd::getPublisherUri)
             .map(this::createConfirmedPublisher);
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaDegreeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaDegreeBuilder.java
@@ -13,7 +13,7 @@ public class NvaDegreeBuilder extends NvaBookLikeBuilder {
 
     public Degree buildDegree() throws InvalidIsbnException, InvalidUnconfirmedSeriesException {
         return new Degree.Builder()
-            .withPublisher(buildUnconfirmedPublisher())
+            .withPublisher(buildPublisher())
             .withIsbnList(createIsbnList())
             .withSeries(buildSeries())
             .withSeriesNumber(constructSeriesNumber())

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaReportBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaReportBuilder.java
@@ -15,7 +15,7 @@ public class NvaReportBuilder extends NvaBookLikeBuilder {
     public Report buildNvaReport()
         throws InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
         return new Report.Builder()
-            .withPublisher(buildUnconfirmedPublisher())
+            .withPublisher(buildPublisher())
             .withIsbnList(createIsbnList())
             .withSeries(buildSeries())
             .withSeriesNumber(constructSeriesNumber())

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/NoPublisherException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/NoPublisherException.java
@@ -1,0 +1,11 @@
+package no.unit.nva.cristin.mapper.nva.exceptions;
+
+public class NoPublisherException extends RuntimeException {
+
+    public static final String ERROR_MESSAGE = "Cristin entry without publisher. Id:";
+
+    public NoPublisherException(Integer id) {
+        super(ERROR_MESSAGE + id);
+
+    }
+}

--- a/cristin-import/src/test/java/cucumber/BookFeatures.java
+++ b/cristin-import/src/test/java/cucumber/BookFeatures.java
@@ -46,12 +46,7 @@ public class BookFeatures {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().setIsbn(cristinIsbn);
     }
 
-    @Then("the NVA Resource has a PublicationContext with an ISBN list containing the value {string}")
-    public void theNvaResourceHasAPublicationContextWithAnIsbnListContainingTheValues(String expectedIsbn) {
-        Book bookContext = extractNvaBook();
-        String singleIsbn = bookContext.getIsbnList().stream().collect(SingletonCollector.collect());
-        assertThat(singleIsbn, is(equalTo(expectedIsbn)));
-    }
+
 
     @Given("the Book Report has a \"total number of pages\" entry equal to {string}")
     public void theBookReportHasAEqualTo(String numberOfPages) {
@@ -59,15 +54,6 @@ public class BookFeatures {
             .setNumberOfPages(numberOfPages);
     }
 
-    @Then("the NVA Resource has a PublicationContext with number of pages equal to {string}")
-    public void theNvaResourceHasAPublicationContextWithNumberOfPagesEqualTo(String expectedNumberOfPages) {
-        PublicationInstance<?> context = scenarioContext.getNvaEntry()
-            .getEntityDescription()
-            .getReference()
-            .getPublicationInstance();
-        PeerReviewedMonograph book = (PeerReviewedMonograph) context;
-        assertThat(book.getPages().getPages(), is(equalTo(expectedNumberOfPages)));
-    }
 
     @Given("the Book Report has a \"publisher name\" entry equal to {string}")
     public void theBookReportHasAPublisherNameEntryEqualTo(String publisherName) {
@@ -104,6 +90,99 @@ public class BookFeatures {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setNsdCode(nsdCode);
     }
 
+
+    @Given("that the Book Report has no subjectField")
+    public void thatTheBookReportHasNoSubjectField() {
+        scenarioContext.getCristinEntry().getBookOrReportMetadata().setSubjectField(null);
+    }
+
+
+    @Given("the Cristin Result belongs to a Series")
+    public void theCristinResultBelongsToASeries() {
+        assertThat(this.scenarioContext.getCristinEntry().getBookOrReportMetadata(), is(notNullValue()));
+    }
+
+    @Given("the Series mentions a title {string}")
+    public void theSeriesMentionsATitle(String seriesTitle) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setJournalTitle(seriesTitle);
+    }
+
+    @Given("the Series mentions an issn {string}")
+    public void theSeriesMentionsAnIssn(String issn) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setIssn(issn);
+    }
+
+    @Given("the Series mentions online issn {string}")
+    public void theSeriesMentionsOnlineIssn(String issn) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setIssnOnline(issn);
+    }
+
+    @Given("the Series mentions a volume {string}")
+    public void theSeriesMentionsAVolume(String volume) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setVolume(volume);
+    }
+
+    @Given("the Series mentions an issue {string}")
+    public void theSeriesMentionsAnIssue(String issue) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setIssue(issue);
+    }
+
+
+
+    @Given("the Series does not include an NSD code")
+    public void theSeriesDoesNotIncludeAnNsdCode() {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setNsdCode(null);
+    }
+
+    @Given("the Cristin Result mentions a Publisher with NSD code {int}")
+    public void theCristinResultMentionsAPublisherWithNsdCode(Integer publisherNsdCode) {
+        this.scenarioContext.getCristinEntry()
+            .getBookOrReportMetadata()
+            .getCristinPublisher()
+            .setNsdCode(publisherNsdCode);
+    }
+
+    @Given("the Cristin Result was reported in NVI the year {int}")
+    public void theCristinResultWasReportedInNVITheYear(Integer yearReported) {
+        this.scenarioContext.getCristinEntry().setYearReported(yearReported);
+    }
+
+    @Given("the Cristin Result mentions a Publisher with name {string} and without an NSD code")
+    public void theCristinResultMentionsAPublisherWithNameAndWithoutAnNsdCode(String publisherName) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getCristinPublisher()
+            .setPublisherName(publisherName);
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getCristinPublisher().setNsdCode(null);
+    }
+
+
+    @Given("the Cristin Result does not a primary Publisher entry")
+    public void theCristinResultDoesNotAPrimaryPublisherEntry() {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setCristinPublisher(null);
+    }
+
+    @Given("the Cristin Results has an alternative mention to a Publisher Name with value {string}")
+    public void theCristinResultsHasAnAlternativeMentionToAPublisherNameWithValue(String publisherName) {
+        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setPublisherName(publisherName);
+    }
+
+
+    @Then("the NVA Resource has a PublicationContext with an ISBN list containing the value {string}")
+    public void theNvaResourceHasAPublicationContextWithAnIsbnListContainingTheValues(String expectedIsbn) {
+        Book bookContext = extractNvaBook();
+        String singleIsbn = bookContext.getIsbnList().stream().collect(SingletonCollector.collect());
+        assertThat(singleIsbn, is(equalTo(expectedIsbn)));
+    }
+
+    @Then("the NVA Resource has a PublicationContext with number of pages equal to {string}")
+    public void theNvaResourceHasAPublicationContextWithNumberOfPagesEqualTo(String expectedNumberOfPages) {
+        PublicationInstance<?> context = scenarioContext.getNvaEntry()
+            .getEntityDescription()
+            .getReference()
+            .getPublicationInstance();
+        PeerReviewedMonograph book = (PeerReviewedMonograph) context;
+        assertThat(book.getPages().getPages(), is(equalTo(expectedNumberOfPages)));
+    }
+
     @Then("the NVA Resource has a npiSubjectHeading with value equal to {int}")
     public void theNvaResourceHasANpiSubjectHeadingWithValueEqualTo(int expectedSubjectFieldCode) {
         String actualSubjectFieldCode = scenarioContext.getNvaEntry()
@@ -112,9 +191,41 @@ public class BookFeatures {
         assertThat(actualSubjectFieldCode, is(equalTo(String.valueOf(expectedSubjectFieldCode))));
     }
 
-    @Given("that the Book Report has no subjectField")
-    public void thatTheBookReportHasNoSubjectField() {
-        scenarioContext.getCristinEntry().getBookOrReportMetadata().setSubjectField(null);
+    @Then("the NVA Resource contains a Publisher reference that is a URI pointing to the NVA NSD proxy")
+    public void theNbaResourceContainsAPublisherReferenceThatIsAURIPointingToTheNvaNsdProxy() {
+        Publisher publisher = extractConfirmedPublisher();
+        assertThat(publisher.getId().toString(), containsString(MappingConstants.NVA_API_DOMAIN));
+    }
+
+
+    @Then("the NVA Resource contains an Unconfirmed Series with title {string}, issn {string}, online issn {string} "
+          + "and seriesNumber {string}")
+    public void theNvaResourceContainsAnUnconfirmedSeriesWithTitleIssnOnlineIssnAndSeriesNumber(String title,
+                                                                                                String issn,
+                                                                                                String onlineIssn,
+                                                                                                String seriesNumber) {
+        Book book = extractNvaBook();
+        assertThat(book.getSeries().isConfirmed(), is(equalTo(false)));
+        UnconfirmedSeries unconfirmedSeries = (UnconfirmedSeries) book.getSeries();
+        assertThat(unconfirmedSeries.getIssn(), is(equalTo(issn)));
+        assertThat(unconfirmedSeries.getOnlineIssn(), is(equalTo(onlineIssn)));
+        assertThat(unconfirmedSeries.getTitle(), is(equalTo(title)));
+        assertThat(book.getSeriesNumber(), is(equalTo(seriesNumber)));
+    }
+
+    @Then("the NVA Resource mentions an Unconfirmed Publisher with name {string}")
+    public void theNvaResourceMentionsAnUnconfirmedPublisherWithName(String publisherName) {
+        Book book = extractNvaBook();
+        assertThat(book.getPublisher(), is(instanceOf(UnconfirmedPublisher.class)));
+        UnconfirmedPublisher publisher = (UnconfirmedPublisher) book.getPublisher();
+        assertThat(publisher.getName(), is(equalTo(publisherName)));
+    }
+
+    @Then("the Publisher URI contains the NSD code {int} and the publication year {int}")
+    public void thePublisherUriContainsTheNsdCodeAndThePublicationYear(Integer nsdCode, Integer publicationYear) {
+        URI publisherId = extractConfirmedPublisher().getId();
+        assertThat(publisherId.getPath(), containsString(nsdCode.toString()));
+        assertThat(publisherId.getPath(), containsString(publicationYear.toString()));
     }
 
     @Then("the NVA Resource has a PublicationContext of type {string}")
@@ -162,112 +273,6 @@ public class BookFeatures {
             .getPublicationInstance();
         PeerReviewedMonograph book = (PeerReviewedMonograph) context;
         assertThat(book.isPeerReviewed(), is(true));
-    }
-
-    @Given("the Cristin Result belongs to a Series")
-    public void theCristinResultBelongsToASeries() {
-        assertThat(this.scenarioContext.getCristinEntry().getBookOrReportMetadata(), is(notNullValue()));
-    }
-
-    @Given("the Series mentions a title {string}")
-    public void theSeriesMentionsATitle(String seriesTitle) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setJournalTitle(seriesTitle);
-    }
-
-    @Given("the Series mentions an issn {string}")
-    public void theSeriesMentionsAnIssn(String issn) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setIssn(issn);
-    }
-
-    @Given("the Series mentions online issn {string}")
-    public void theSeriesMentionsOnlineIssn(String issn) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setIssnOnline(issn);
-    }
-
-    @Given("the Series mentions a volume {string}")
-    public void theSeriesMentionsAVolume(String volume) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setVolume(volume);
-    }
-
-    @Given("the Series mentions an issue {string}")
-    public void theSeriesMentionsAnIssue(String issue) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setIssue(issue);
-    }
-
-    @Then("the NVA Resource contains an Unconfirmed Series with title {string}, issn {string}, online issn {string} "
-          + "and seriesNumber {string}")
-    public void theNvaResourceContainsAnUnconfirmedSeriesWithTitleIssnOnlineIssnAndSeriesNumber(String title,
-                                                                                                String issn,
-                                                                                                String onlineIssn,
-                                                                                                String seriesNumber) {
-        Book book = extractNvaBook();
-        assertThat(book.getSeries().isConfirmed(), is(equalTo(false)));
-        UnconfirmedSeries unconfirmedSeries = (UnconfirmedSeries) book.getSeries();
-        assertThat(unconfirmedSeries.getIssn(), is(equalTo(issn)));
-        assertThat(unconfirmedSeries.getOnlineIssn(), is(equalTo(onlineIssn)));
-        assertThat(unconfirmedSeries.getTitle(), is(equalTo(title)));
-        assertThat(book.getSeriesNumber(), is(equalTo(seriesNumber)));
-    }
-
-    @Given("the Series does not include an NSD code")
-    public void theSeriesDoesNotIncludeAnNsdCode() {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setNsdCode(null);
-    }
-
-    @Given("the Cristin Result mentions a Publisher with NSD code {int}")
-    public void theCristinResultMentionsAPublisherWithNsdCode(Integer publisherNsdCode) {
-        this.scenarioContext.getCristinEntry()
-            .getBookOrReportMetadata()
-            .getCristinPublisher()
-            .setNsdCode(publisherNsdCode);
-    }
-
-    @Given("the Cristin Result was reported in NVI the year {int}")
-    public void theCristinResultWasReportedInNVITheYear(Integer yearReported) {
-        this.scenarioContext.getCristinEntry().setYearReported(yearReported);
-    }
-
-    @Then("the NVA Resource contains a Publisher reference that is a URI pointing to the NVA NSD proxy")
-    public void theNbaResourceContainsAPublisherReferenceThatIsAURIPointingToTheNvaNsdProxy() {
-        Publisher publisher = extractConfirmedPublisher();
-        assertThat(publisher.getId().toString(), containsString(MappingConstants.NVA_API_DOMAIN));
-    }
-
-    @Given("the Cristin Result mentions a Publisher with name {string} and without an NSD code")
-    public void theCristinResultMentionsAPublisherWithNameAndWithoutAnNsdCode(String publisherName) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getCristinPublisher()
-            .setPublisherName(publisherName);
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getCristinPublisher().setNsdCode(null);
-    }
-
-    @Then("the NVA Resource mentions an Unconfirmed Publisher with name {string}")
-    public void theNvaResourceMentionsAnUnconfirmedPublisherWithName(String publisherName) {
-        Book book = extractNvaBook();
-        assertThat(book.getPublisher(), is(instanceOf(UnconfirmedPublisher.class)));
-        UnconfirmedPublisher publisher = (UnconfirmedPublisher) book.getPublisher();
-        assertThat(publisher.getName(), is(equalTo(publisherName)));
-    }
-
-    @Then("the Publisher URI contains the NSD code {int} and the publication year {int}")
-    public void thePublisherUriContainsTheNsdCodeAndThePublicationYear(Integer nsdCode, Integer publicationYear) {
-        URI publisherId = extractConfirmedPublisher().getId();
-        assertThat(publisherId.getPath(), containsString(nsdCode.toString()));
-        assertThat(publisherId.getPath(), containsString(publicationYear.toString()));
-    }
-
-    @Given("the Cristin Result does not a primary Publisher entry")
-    public void theCristinResultDoesNotAPrimaryPublisherEntry() {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setCristinPublisher(null);
-    }
-
-    @Given("the Cristin Results has an alternative mention to a Publisher Name with value {string}")
-    public void theCristinResultsHasAnAlternativeMentionToAPublisherNameWithValue(String publisherName) {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setPublisherName(publisherName);
-    }
-
-    @And("the Series mentions no issue number")
-    public void theSeriesMentionsNoIssueNumber() {
-        this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setIssue(null);
     }
 
     private Book extractNvaBook() {

--- a/cristin-import/src/test/java/cucumber/BookFeatures.java
+++ b/cristin-import/src/test/java/cucumber/BookFeatures.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.net.URI;
@@ -46,14 +45,11 @@ public class BookFeatures {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().setIsbn(cristinIsbn);
     }
 
-
-
     @Given("the Book Report has a \"total number of pages\" entry equal to {string}")
     public void theBookReportHasAEqualTo(String numberOfPages) {
         scenarioContext.getCristinEntry().getBookOrReportMetadata()
             .setNumberOfPages(numberOfPages);
     }
-
 
     @Given("the Book Report has a \"publisher name\" entry equal to {string}")
     public void theBookReportHasAPublisherNameEntryEqualTo(String publisherName) {
@@ -90,12 +86,10 @@ public class BookFeatures {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setNsdCode(nsdCode);
     }
 
-
     @Given("that the Book Report has no subjectField")
     public void thatTheBookReportHasNoSubjectField() {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().setSubjectField(null);
     }
-
 
     @Given("the Cristin Result belongs to a Series")
     public void theCristinResultBelongsToASeries() {
@@ -127,8 +121,6 @@ public class BookFeatures {
         this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setIssue(issue);
     }
 
-
-
     @Given("the Series does not include an NSD code")
     public void theSeriesDoesNotIncludeAnNsdCode() {
         this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getBookSeries().setNsdCode(null);
@@ -154,7 +146,6 @@ public class BookFeatures {
         this.scenarioContext.getCristinEntry().getBookOrReportMetadata().getCristinPublisher().setNsdCode(null);
     }
 
-
     @Given("the Cristin Result does not a primary Publisher entry")
     public void theCristinResultDoesNotAPrimaryPublisherEntry() {
         this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setCristinPublisher(null);
@@ -164,7 +155,6 @@ public class BookFeatures {
     public void theCristinResultsHasAnAlternativeMentionToAPublisherNameWithValue(String publisherName) {
         this.scenarioContext.getCristinEntry().getBookOrReportMetadata().setPublisherName(publisherName);
     }
-
 
     @Then("the NVA Resource has a PublicationContext with an ISBN list containing the value {string}")
     public void theNvaResourceHasAPublicationContextWithAnIsbnListContainingTheValues(String expectedIsbn) {
@@ -196,7 +186,6 @@ public class BookFeatures {
         Publisher publisher = extractConfirmedPublisher();
         assertThat(publisher.getId().toString(), containsString(MappingConstants.NVA_API_DOMAIN));
     }
-
 
     @Then("the NVA Resource contains an Unconfirmed Series with title {string}, issn {string}, online issn {string} "
           + "and seriesNumber {string}")

--- a/cristin-import/src/test/java/cucumber/CucumberRunner.java
+++ b/cristin-import/src/test/java/cucumber/CucumberRunner.java
@@ -6,7 +6,7 @@ import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"junit", "summary"}, snippets = CAMELCASE,
+@CucumberOptions(plugin = {"pretty", "summary"}, snippets = CAMELCASE,
     features = {"src/test/resources/features"}
 )
 public class CucumberRunner {

--- a/cristin-import/src/test/java/cucumber/CucumberRunner.java
+++ b/cristin-import/src/test/java/cucumber/CucumberRunner.java
@@ -6,7 +6,7 @@ import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"pretty", "summary"}, snippets = CAMELCASE,
+@CucumberOptions(plugin = {"junit", "summary"}, snippets = CAMELCASE,
     features = {"src/test/resources/features"}
 )
 public class CucumberRunner {

--- a/cristin-import/src/test/java/cucumber/ReportFeatures.java
+++ b/cristin-import/src/test/java/cucumber/ReportFeatures.java
@@ -31,7 +31,7 @@ public class ReportFeatures {
         assertThat(actualPublisher, is(equalTo(expectedPublisher)));
     }
 
-    @Given("that the Cristin Result has an empty publisherName field")
+    @Given("the Cristin Result does not mention a publisher in the alternative field")
     public void thatTheCristinResultHasAnEmptyPublisherNameField() {
         scenarioContext.getCristinEntry().getBookOrReportMetadata().setPublisherName(null);
     }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -3,6 +3,12 @@ package no.unit.nva.cristin;
 import static no.unit.nva.cristin.mapper.CristinObject.MAIN_CATEGORY_FIELD;
 import static no.unit.nva.cristin.mapper.CristinObject.PUBLICATION_OWNER_FIELD;
 import static no.unit.nva.cristin.mapper.CristinObject.SECONDARY_CATEGORY_FIELD;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.ENCYCLOPEDIA;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.MONOGRAPH;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.NON_FICTION_BOOK;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.POPULAR_BOOK;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.REFERENCE_MATERIAL;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.TEXTBOOK;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +40,7 @@ import no.unit.nva.cristin.mapper.CristinJournalPublicationJournal;
 import no.unit.nva.cristin.mapper.CristinMainCategory;
 import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.cristin.mapper.CristinPresentationalWork;
+import no.unit.nva.cristin.mapper.CristinPublisher;
 import no.unit.nva.cristin.mapper.CristinSecondaryCategory;
 import no.unit.nva.cristin.mapper.CristinSubjectField;
 import no.unit.nva.cristin.mapper.CristinTitle;
@@ -69,6 +76,14 @@ public final class CristinDataGenerator {
     private static final String CRISTIN_SUBJECT_FIELD = "bookReport.subjectField";
     private static final String BOOK_OR_REPORT_PART_METADATA = "bookOrReportPartMetadata";
     private static final String BOOK_OR_REPORT_METADATA_FIELD = "bookOrReportMetadata";
+
+    private static final CristinSecondaryCategory[] BOOK_SECONDARY_CATEGORIES = new CristinSecondaryCategory[]{
+        MONOGRAPH,
+        TEXTBOOK,
+        NON_FICTION_BOOK,
+        ENCYCLOPEDIA,
+        POPULAR_BOOK,
+        REFERENCE_MATERIAL};
 
     private CristinDataGenerator() {
 
@@ -133,7 +148,7 @@ public final class CristinDataGenerator {
             case ENCYCLOPEDIA:
             case POPULAR_BOOK:
             case REFERENCE_MATERIAL:
-                return randomBookMonograph(category);
+                return randomBook(category);
             case ANTHOLOGY:
                 return randomBookAnthology();
             case FEATURE_ARTICLE:
@@ -185,12 +200,13 @@ public final class CristinDataGenerator {
         return createRandomBookWithSpecifiedSecondaryCategory(CristinSecondaryCategory.ANTHOLOGY);
     }
 
-    public static CristinObject randomBookMonograph(CristinSecondaryCategory secondaryCategory) {
-        return createRandomBookWithSpecifiedSecondaryCategory(secondaryCategory);
+    public static CristinObject randomBook() {
+        CristinSecondaryCategory category = randomArrayElement(BOOK_SECONDARY_CATEGORIES, USE_WHOLE_ARRAY);
+        return randomBook(category);
     }
 
-    public static CristinObject objectWithRandomBookReport() {
-        return createRandomBookWithBookReportValues();
+    public static CristinObject randomBook(CristinSecondaryCategory secondaryCategory) {
+        return createRandomBookWithSpecifiedSecondaryCategory(secondaryCategory);
     }
 
     public static String singleRandomObjectAsString() {
@@ -252,6 +268,14 @@ public final class CristinDataGenerator {
             .withBookSeries(randomBookSeries())
             .withIssue(randomString())
             .withVolume(randomString())
+            .withCristinPublisher(randomPublisher())
+            .build();
+    }
+
+    private static CristinPublisher randomPublisher() {
+        return CristinPublisher.builder()
+            .withPublisherName(randomString())
+            .withNsdCode(largeRandomNumber())
             .build();
     }
 
@@ -412,7 +436,7 @@ public final class CristinDataGenerator {
             .withCristinTitles(List.of(randomCristinTitle(FIRST_TITLE)))
             .withEntryCreationDate(LocalDate.now())
             .withMainCategory(CristinMainCategory.BOOK)
-            .withSecondaryCategory(CristinSecondaryCategory.MONOGRAPH)
+            .withSecondaryCategory(MONOGRAPH)
             .withId(largeRandomNumber())
             .withPublicationYear(randomYear())
             .withPublicationOwner(randomString())

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -42,8 +42,6 @@ import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.Role;
 import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.PublicationContext;
-import no.unit.nva.model.contexttypes.PublishingHouse;
-import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.book.BookAnthology;
 import no.unit.nva.model.instancetypes.book.BookMonograph;
@@ -60,11 +58,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class CristinMapperTest extends AbstractCristinImportTest {
 
     public static final String NAME_DELIMITER = ", ";
-    public static final String MISSING_FIELD_ERROR_TEMPLATE = "\nExpected: All fields of all included "
-                                                              + "objects need to be non empty\n     "
-                                                              + "but: Empty field found: %s";
-    public static final String PUBLISHER_NVA_LOCATION = ".entityDescription.reference.publicationContext.publisher";
-    public static final String PAGES_NVA_LOCATION = ".entityDescription.reference.publicationInstance.pages.pages";
 
     @BeforeEach
     public void init() {
@@ -167,7 +160,7 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
     @Test
     public void mapReturnsBookMonographWhenInputHasMainTypeBookAndSecondaryTypeMonograph() {
-        testingData = Stream.of(CristinDataGenerator.randomBookMonograph(CristinSecondaryCategory.MONOGRAPH))
+        testingData = Stream.of(CristinDataGenerator.randomBook(CristinSecondaryCategory.MONOGRAPH))
             .map(JsonSerializable::toJsonString)
             .collect(SingletonCollector.collect());
 
@@ -297,7 +290,7 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
     @Test
     public void mapReturnsPublicationWhereCristinTotalNumberOfPagesIsMappedToNvaPages() {
-        CristinObject cristinImport = CristinDataGenerator.objectWithRandomBookReport();
+        CristinObject cristinImport = CristinDataGenerator.randomBook();
 
         String numberOfPages = cristinImport.getBookOrReportMetadata().getNumberOfPages();
 
@@ -315,28 +308,8 @@ public class CristinMapperTest extends AbstractCristinImportTest {
     }
 
     @Test
-    public void mapReturnsPublicationWhereCristinPublisherNameIsMappedToNvaPublisher() {
-        CristinObject cristinImport = CristinDataGenerator.objectWithRandomBookReport();
-
-        UnconfirmedPublisher expectedPublisher =
-            new UnconfirmedPublisher(cristinImport.getBookOrReportMetadata().getPublisherName());
-
-        Publication actualPublication = cristinImport.toPublication();
-
-        PublicationContext actualPublicationContext = actualPublication
-            .getEntityDescription()
-            .getReference()
-            .getPublicationContext();
-
-        Book bookSubType = (Book) actualPublicationContext;
-        PublishingHouse actualPublisher = bookSubType.getPublisher();
-
-        assertThat(actualPublisher, is(equalTo(expectedPublisher)));
-    }
-
-    @Test
     public void mapReturnsPublicationWhereCristinIsbnIsMappedToNvaIsbnList() {
-        CristinObject cristinImport = CristinDataGenerator.objectWithRandomBookReport();
+        CristinObject cristinImport = CristinDataGenerator.randomBook();
 
         String isbn = cristinImport.getBookOrReportMetadata().getIsbn();
 
@@ -386,7 +359,7 @@ public class CristinMapperTest extends AbstractCristinImportTest {
 
     @Test
     public void constructorThrowsExceptionWhenABookReportHasASubjectFieldButSubjectFieldCodeIsNull() {
-        CristinObject cristinObject = CristinDataGenerator.objectWithRandomBookReport();
+        CristinObject cristinObject = CristinDataGenerator.randomBook();
         cristinObject.getBookOrReportMetadata().getSubjectField().setSubjectFieldCode(null);
 
         System.out.println(cristinObject);

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
@@ -1,0 +1,46 @@
+package no.unit.nva.cristin.mapper.nva;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import no.unit.nva.cristin.CristinDataGenerator;
+import no.unit.nva.cristin.mapper.CristinObject;
+import no.unit.nva.model.contexttypes.Book;
+import no.unit.nva.model.contexttypes.PublicationContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class NvaBookLikeBuilderTest {
+
+    public static final String ONLY_VOLUME_EXPECTED = "^Volume:[^;]*$";
+    public static final String ONLY_ISSUE_EXPECTED = "^Issue:[^;]*$";
+
+    @ParameterizedTest(name = "nvaBookLikeBuilder returns Series that does contain blank String represetations"
+                              + "when issue is blank")
+    @NullAndEmptySource
+    public void nvaBookLikeBuilderReturnsSeriesThatDoesNotContainBlankStringRepresentationsWhenIssueIsNull(
+        String issueNumber) {
+        CristinObject randomBook = CristinDataGenerator.randomBook();
+        randomBook.getBookOrReportMetadata().setIssue(issueNumber);
+        PublicationContext context = randomBook.toPublication()
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
+        Book book = (Book) context;
+        assertThat(book.getSeriesNumber(), matchesPattern(ONLY_VOLUME_EXPECTED));
+    }
+
+    @ParameterizedTest(name = "nvaBookLikeBuilder returns Series that does contain blank String represetations"
+                              + "when volume is blank")
+    @NullAndEmptySource
+    public void nvaBookLikeBuilderReturnsSeriesThatDoesNotContainBlankStringRepresentationsWhenVolumeIsNull(
+        String volumeNumber) {
+        CristinObject randomBook = CristinDataGenerator.randomBook();
+        randomBook.getBookOrReportMetadata().setVolume(volumeNumber);
+        PublicationContext context = randomBook.toPublication()
+            .getEntityDescription()
+            .getReference()
+            .getPublicationContext();
+        Book book = (Book) context;
+        assertThat(book.getSeriesNumber(), matchesPattern(ONLY_ISSUE_EXPECTED));
+    }
+}

--- a/cristin-import/src/test/resources/features/BookAndReportRules.feature
+++ b/cristin-import/src/test/resources/features/BookAndReportRules.feature
@@ -4,59 +4,6 @@ Feature: Rules that apply for both Books and Reports
   #TODO: replace the examples with a List of Cristin Results and the Scenario Outlines with
   # simple Scenarios.
 
-  Scenario Outline: Mapping creates a reference to an NSD Series when the Cristin entry contains
-  an NSD code for the series
-    Given a valid Cristin Result with secondary category "<secondaryCategory>"
-    And the Cristin Result refers to a Series with NSD code 12345
-    And the Cristin Result has publication year 2002
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource has a Reference to a Series that is a URI pointing to the NVA NSD proxy
-    And the Series URI contains the NSD code 12345 and the publication year 2002
-    Examples:
-      | secondaryCategory |
-      | MONOGRAFI         |
-      | ANTOLOGI          |
-      | FAGBOK            |
-      | LÆREBOK           |
-      | LEKSIKON          |
-      | POPVIT_BOK        |
-      | OPPSLAGSVERK      |
-      | ANTOLOGI          |
-      | RAPPORT           |
-      | DRGRADAVH         |
-      | MASTERGRADSOPPG   |
-      | HOVEDFAGSOPPGAVE  |
-      | FORSKERLINJEOPPG  |
-
-
-  Scenario Outline: Mapping creates an Unconfirmed series when a Cristin Book has a references to
-  Book series but there is no NSD code.
-    Given a valid Cristin Result with secondary category "<secondaryCategory>"
-    And the Cristin Result belongs to a Series
-    And the Series does not include an NSD code
-    And the Series mentions a title "SomeSeries"
-    And the Series mentions an issn "0028-0836"
-    And  the Series mentions online issn "0028-0836"
-    And the Series mentions a volume "Vol 1"
-    And the Series mentions an issue "Issue 2"
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
-
-    Examples:
-      | secondaryCategory |
-      | MONOGRAFI         |
-      | ANTOLOGI          |
-      | FAGBOK            |
-      | LÆREBOK           |
-      | LEKSIKON          |
-      | POPVIT_BOK        |
-      | OPPSLAGSVERK      |
-      | ANTOLOGI          |
-      | RAPPORT           |
-      | DRGRADAVH         |
-      | MASTERGRADSOPPG   |
-      | HOVEDFAGSOPPGAVE  |
-      | FORSKERLINJEOPPG  |
 
   Scenario Outline: Mapping creates a reference to an NSD publisher when a Cristin Result mentions
   a Publisher with an NSD code.

--- a/cristin-import/src/test/resources/features/BookAndReportRules.feature
+++ b/cristin-import/src/test/resources/features/BookAndReportRules.feature
@@ -1,0 +1,151 @@
+Feature: Rules that apply for both Books and Reports
+
+
+  #TODO: replace the examples with a List of Cristin Results and the Scenario Outlines with
+  # simple Scenarios.
+
+  Scenario Outline: Mapping creates a reference to an NSD Series when the Cristin entry contains
+  an NSD code for the series
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result refers to a Series with NSD code 12345
+    And the Cristin Result has publication year 2002
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a Reference to a Series that is a URI pointing to the NVA NSD proxy
+    And the Series URI contains the NSD code 12345 and the publication year 2002
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+
+  Scenario Outline: Mapping creates an Unconfirmed series when a Cristin Book has a references to
+  Book series but there is no NSD code.
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result belongs to a Series
+    And the Series does not include an NSD code
+    And the Series mentions a title "SomeSeries"
+    And the Series mentions an issn "0028-0836"
+    And  the Series mentions online issn "0028-0836"
+    And the Series mentions a volume "Vol 1"
+    And the Series mentions an issue "Issue 2"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
+
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+  Scenario Outline: Mapping creates a reference to an NSD publisher when a Cristin Result mentions
+  a Publisher with an NSD code.
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result mentions a Publisher with NSD code 12345
+    And the Cristin Result was reported in NVI the year 2005
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource contains a Publisher reference that is a URI pointing to the NVA NSD proxy
+    And the Publisher URI contains the NSD code 12345 and the publication year 2005
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+  Scenario Outline: Mapping creates a mention to an Unconfirmed Publisher when a Cristin Result mentions
+  a Publisher only by name
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result mentions a Publisher with name "SomePublishingHouse" and without an NSD code
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource mentions an Unconfirmed Publisher with name "SomePublishingHouse"
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+
+  Scenario Outline: Mapping creates a mention to an Unconfirmed Publisher when a Cristin Result does
+  not have a Publisher in the default field but has a Publisher name in the alternative field.
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result does not a primary Publisher entry
+    But the Cristin Results has an alternative mention to a Publisher Name with value "SomeUnconfirmedPublishingHouse"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource mentions an Unconfirmed Publisher with name "SomeUnconfirmedPublishingHouse"
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+  Scenario Outline: Mapping fails when a Cristin Entry does not have a Publisher mention at all
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result does not a primary Publisher entry
+    And the Cristin Result does not mention a publisher in the alternative field
+    When the Cristin Result is converted to an NVA Resource
+    Then an error is reported.
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -119,7 +119,6 @@ Feature: Book conversion rules
     When the Cristin Result is converted to an NVA Resource
     Then no error is reported.
 
-
   Scenario Outline: Mapping creates a reference to an NSD Series when the Cristin entry contains
   an NSD code for the series
     Given a valid Cristin Result with secondary category "<secondaryCategory>"
@@ -132,12 +131,6 @@ Feature: Book conversion rules
       | secondaryCategory |
       | MONOGRAFI         |
       | ANTOLOGI          |
-      | FAGBOK            |
-      | LÆREBOK           |
-      | LEKSIKON          |
-      | POPVIT_BOK        |
-      | OPPSLAGSVERK      |
-      | ANTOLOGI          |
       | RAPPORT           |
       | DRGRADAVH         |
       | MASTERGRADSOPPG   |
@@ -145,33 +138,27 @@ Feature: Book conversion rules
       | FORSKERLINJEOPPG  |
 
 
-  Scenario Outline: Mapping creates an Unconfirmed series when a Cristin Book has a references to
-  Book series but there is no NSD code.
-    Given a valid Cristin Result with secondary category "<secondaryCategory>"
-    And the Cristin Result belongs to a Series
-    And the Series does not include an NSD code
-    And the Series mentions a title "SomeSeries"
-    And the Series mentions an issn "0028-0836"
-    And  the Series mentions online issn "0028-0836"
-    And the Series mentions a volume "Vol 1"
-    And the Series mentions an issue "Issue 2"
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
-
-    Examples:
-      | secondaryCategory |
-      | MONOGRAFI         |
-      | ANTOLOGI          |
-      | FAGBOK            |
-      | LÆREBOK           |
-      | LEKSIKON          |
-      | POPVIT_BOK        |
-      | OPPSLAGSVERK      |
-      | ANTOLOGI          |
-      | RAPPORT           |
-      | DRGRADAVH         |
-      | MASTERGRADSOPPG   |
-      | HOVEDFAGSOPPGAVE  |
-      | FORSKERLINJEOPPG  |
 
 
+  Scenario Outline: Mapping crates an Unconfirmed series when a Cristin Book has a references to
+      Book series but there is no NSD code.
+      Given a valid Cristin Result with secondary category "<secondaryCategory>"
+      And the Cristin Result belongs to a Series
+      And the Series does not include an NSD code
+      And the Series mentions a title "SomeSeries"
+      And the Series mentions an issn "0028-0836"
+      And  the Series mentions online issn "0028-0836"
+      And the Series mentions a volume "Vol 1"
+      And the Series mentions an issue "Issue 2"
+      When the Cristin Result is converted to an NVA Resource
+      Then  the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
+
+      Examples:
+        | secondaryCategory |
+        | MONOGRAFI         |
+        | ANTOLOGI          |
+        | RAPPORT           |
+        | DRGRADAVH         |
+        | MASTERGRADSOPPG   |
+        | HOVEDFAGSOPPGAVE  |
+        | FORSKERLINJEOPPG  |

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -120,5 +120,58 @@ Feature: Book conversion rules
     Then no error is reported.
 
 
+  Scenario Outline: Mapping creates a reference to an NSD Series when the Cristin entry contains
+  an NSD code for the series
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result refers to a Series with NSD code 12345
+    And the Cristin Result has publication year 2002
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a Reference to a Series that is a URI pointing to the NVA NSD proxy
+    And the Series URI contains the NSD code 12345 and the publication year 2002
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
+
+
+  Scenario Outline: Mapping creates an Unconfirmed series when a Cristin Book has a references to
+  Book series but there is no NSD code.
+    Given a valid Cristin Result with secondary category "<secondaryCategory>"
+    And the Cristin Result belongs to a Series
+    And the Series does not include an NSD code
+    And the Series mentions a title "SomeSeries"
+    And the Series mentions an issn "0028-0836"
+    And  the Series mentions online issn "0028-0836"
+    And the Series mentions a volume "Vol 1"
+    And the Series mentions an issue "Issue 2"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
+
+    Examples:
+      | secondaryCategory |
+      | MONOGRAFI         |
+      | ANTOLOGI          |
+      | FAGBOK            |
+      | LÆREBOK           |
+      | LEKSIKON          |
+      | POPVIT_BOK        |
+      | OPPSLAGSVERK      |
+      | ANTOLOGI          |
+      | RAPPORT           |
+      | DRGRADAVH         |
+      | MASTERGRADSOPPG   |
+      | HOVEDFAGSOPPGAVE  |
+      | FORSKERLINJEOPPG  |
 
 

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -62,19 +62,6 @@ Feature: Book conversion rules
       | approx. 1000 | ANTOLOGI          |
 
 
-  Scenario Outline: Publisher's name is copied from the Cristin Entry's Book report entry as is.
-    Given a valid Cristin Result with secondary category "<secondaryCategory>"
-    Given that the Cristin Result has a non empty Book Report
-    And the Book Report has a "publisher name" entry equal to "House of Publishing"
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource has a PublicationContext with publisher with name equal to "House of Publishing"
-    Then NVA Resource has a Publisher that cannot be verified through a URI
-    Examples:
-      | secondaryCategory |
-      | MONOGRAFI         |
-      | ANTOLOGI          |
-
-
   Scenario Outline: NPI subject heading is copied from Cristin Result as is.
     Given a valid Cristin Result with secondary category "<secondaryCategory>"
     And that the Cristin Result has a non empty Book Report
@@ -132,46 +119,6 @@ Feature: Book conversion rules
     When the Cristin Result is converted to an NVA Resource
     Then no error is reported.
 
-  Scenario Outline: Mapping creates a reference to an NSD Series when the Cristin entry contains
-    an NSD code for the series
-    Given a valid Cristin Result with secondary category "<secondaryCategory>"
-    And the Cristin Result refers to a Series with NSD code 12345
-    And the Cristin Result has publication year 2002
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource has a Reference to a Series that is a URI pointing to the NVA NSD proxy
-    And the URI contains the NSD code 12345 and the publication year 2002
-    Examples:
-      | secondaryCategory |
-      | MONOGRAFI         |
-      | ANTOLOGI          |
-      | RAPPORT           |
-      | DRGRADAVH         |
-      | MASTERGRADSOPPG   |
-      | HOVEDFAGSOPPGAVE  |
-      | FORSKERLINJEOPPG  |
 
 
 
-
-  Scenario Outline: Mapping crates an Unconfirmed series when a Cristin Book has a references to
-      Book series but there is no NSD code.
-      Given a valid Cristin Result with secondary category "<secondaryCategory>"
-      And the Cristin Result belongs to a Series
-      And the Series does not include an NSD code
-      And the Series mentions a title "SomeSeries"
-      And the Series mentions an issn "0028-0836"
-      And  the Series mentions online issn "0028-0836"
-      And the Series mentions a volume "Vol 1"
-      And the Series mentions an issue "Issue 2"
-      When the Cristin Result is converted to an NVA Resource
-      Then  the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "0028-0836", online issn "0028-0836" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
-
-      Examples:
-        | secondaryCategory |
-        | MONOGRAFI         |
-        | ANTOLOGI          |
-        | RAPPORT           |
-        | DRGRADAVH         |
-        | MASTERGRADSOPPG   |
-        | HOVEDFAGSOPPGAVE  |
-        | FORSKERLINJEOPPG  |

--- a/cristin-import/src/test/resources/features/ReportRules.feature
+++ b/cristin-import/src/test/resources/features/ReportRules.feature
@@ -1,29 +1,12 @@
 Feature:
   Mapping rules for Reports
 
-  Background:
-    Given a valid Cristin Result with secondary category "RAPPORT"
-
   Scenario: Cristin Result with type "Report" is converted to an NVA entry with PublicationInstance of type "ReportResearch".
   ReportResearch when the Cristin Result's secondary category is "Rapport"
+    Given a valid Cristin Result with secondary category "RAPPORT"
     When the Cristin Result is converted to an NVA Resource
     Then the NVA Resource has a Publication Instance of type "ReportResearch"
 
-  Scenario: Cristin Result's "publisher name" ("utgivernavn") in the "BookOrReport" ("type_bok_report") entry
-  is copied as is in the "publisher" in the NVA's PublicationContext
-  the Cristin Result's BookReport's value of publisherName
-    Given that the Cristin Result has a non empty Book Report
-    And the Book Report has a "publisher name" entry equal to "some Publisher"
-    When the Cristin Result is converted to an NVA Resource
-    Then the NVA Resource Report has a PublicationContext with a publisher with name equal to "some Publisher"
-    Then the NVA Resource Report has a Publisher that cannot be verified through a URI
-
-
-
-  Scenario: Mapping fails when a Cristin Entry has no publisher name
-    Given that the Cristin Result has an empty publisherName field
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
 
   Scenario Outline: Map does not fail for a Cristin Result without subjectField when the secondary category does not require it.
     Given a valid Cristin Result with secondary category "<secondaryCategory>"


### PR DESCRIPTION
The PR is longer than it should be, but this is because of the Cucumber tests. Please read the cucumber tests first.


Fixes NP-3061.  Maps Cristin publishers to NVA publishers. In Cristin, publishers are stored in 2 places, in a field with the name "utgivernanv" and in a field with the name "forlag"  (Example below).  The implemented logic is the following:

Case 1: if the field `forlag` contains a non empty NSD code, then Cristing publisher is mapped to an NVA `Publisher` with ID that is the URI produced by the URL location of our NSD proxy, the NSD code and the publication year. 
Example: for the entry given below the NVA publisher would have the ID https://api.dev.nva.aws.unit.no/publication-channels/18424/<publicationYear>

Case 2: if the field "forlag" does not contain an NSD code, then the Cristin publisher is mapped to an NVA `UnconfirmedPublisher` and the publisher name will be equal to the value of the field `forlag.forlagsnavn`. 

Case 3: if the field `forlag.forlagsnavn` is empty and `utgivernanv` is not empty, then we create an `UnconfirmedPublisher` with name equal to the value of the field `utgivernavn`

Case 4: If there is no information about the Publication's publisher we throw an Exception to indicate that the mapping cannot continue.