### PR TITLE
Specify global use of arm64 architecture

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -17,6 +17,8 @@ Metadata:
 Globals:
   Function:
     Timeout: 20
+    Architectures:
+      - arm64
   Api:
     Cors:
       AllowMethods: "'PUT, GET,OPTIONS,DELETE,POST'"


### PR DESCRIPTION
- This should be tested in dev before merging
  - sam build works, but is there something missing?
- Using ARM64-based Graviton v2 apparently saves money and performs better than the traditional x86_64 architecture
  - Not sure if this is the case for us, but I suggest we give it a try
  - I'm particularly interested to see if cold-start times remain the same (I suspect they will, but certainly shouldn't be slower)
- See: https://aws.amazon.com/about-aws/whats-new/2021/09/better-price-performance-aws-lambda-functions-aws-graviton2-processor/