### PR TITLE
Force pip3 to install latest sam-cli

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -5,7 +5,7 @@ phases:
     runtime-versions:
       java: openjdk11
     commands:
-      - pip3 install aws-sam-cli
+      - pip3 install aws-sam-cli -U
   build:
     commands:
       - sam build


### PR DESCRIPTION
- When building, we should use the latest sam-cli
- Arguments against this: repeatability, will break pipeline
- Arguments for: we should not be using outdated