### PR TITLE
Post Deployment Initialization function

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/initialization/InitializationHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/initialization/InitializationHandler.java
@@ -1,0 +1,22 @@
+package no.unit.nva.publication.events.handlers.initialization;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InitializationHandler extends EventHandler<PipelineEvent, Void> {
+
+    private static final Logger logger = LoggerFactory.getLogger(InitializationHandler.class);
+
+    protected InitializationHandler() {
+        super(PipelineEvent.class);
+    }
+
+    @Override
+    protected Void processInput(PipelineEvent input, AwsEventBridgeEvent<PipelineEvent> event, Context context) {
+        logger.info(event.toJsonString());
+        return null;
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/initialization/PipelineEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/initialization/PipelineEvent.java
@@ -1,0 +1,23 @@
+package no.unit.nva.publication.events.handlers.initialization;
+
+public class PipelineEvent {
+
+    private String pipeline;
+    private String state;
+
+    public String getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(String pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/initialization/InitializationHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/initialization/InitializationHandlerTest.java
@@ -1,0 +1,40 @@
+package no.unit.nva.publication.events.handlers.initialization;
+
+import static nva.commons.core.ioutils.IoUtils.stringFromResources;
+import static nva.commons.core.ioutils.IoUtils.stringToStream;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+import nva.commons.logutils.LogUtils;
+import nva.commons.logutils.TestAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class InitializationHandlerTest {
+
+    public static final Context CONTEXT = mock(Context.class);
+    public static final String SAMPLE_PIPELINE_EVENT_FROM_AWS_DOCUMENTATION =
+        "initialization/pipeline_succeeded_event.json";
+    private InitializationHandler handler;
+    private ByteArrayOutputStream outputStream;
+    public static final String PIPELINE_NAME_IN_RESOURCES_FILE= "myPipeline";
+
+    @BeforeEach
+    public void init(){
+        this.handler = new InitializationHandler();
+        this.outputStream = new ByteArrayOutputStream();
+    }
+
+    @Test
+    void shouldLogReceivedEventWhenHandlerIsActivated(){
+        TestAppender logger = LogUtils.getTestingAppenderForRootLogger();
+        var sampleEvent = stringFromResources(Path.of(SAMPLE_PIPELINE_EVENT_FROM_AWS_DOCUMENTATION));
+        handler.handleRequest(stringToStream(sampleEvent), outputStream, CONTEXT);
+        assertThat(logger.getMessages(),containsString(PIPELINE_NAME_IN_RESOURCES_FILE));
+
+    }
+
+}

--- a/publication-event-handlers/src/test/resources/initialization/pipeline_succeeded_event.json
+++ b/publication-event-handlers/src/test/resources/initialization/pipeline_succeeded_event.json
@@ -1,0 +1,18 @@
+{
+  "version": "0",
+  "id": "01234567-EXAMPLE",
+  "detail-type": "CodePipeline Pipeline Execution State Change",
+  "source": "aws.codepipeline",
+  "account": "123456789012",
+  "time": "2020-01-24T22:03:44Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:codepipeline:us-east-1:123456789012:myPipeline"
+  ],
+  "detail": {
+    "pipeline": "myPipeline",
+    "execution-id": "12345678-1234-5678-abcd-12345678abcd",
+    "state": "SUCCEEDED",
+    "version": 3
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -399,11 +399,11 @@ Resources:
       Handler: no.unit.nva.publication.fetch.FetchPublicationHandler::handleRequest
       Runtime: java11
       MemorySize: 1408
-#      AutoPublishAlias: live
-#      DeploymentPreference:
-#        Type: AllAtOnce
-#      ProvisionedConcurrencyConfig:
-#        ProvisionedConcurrentExecutions: 1
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: AllAtOnce
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
       Environment:
         Variables:
           ALLOWED_ORIGIN: '*'
@@ -420,28 +420,27 @@ Resources:
             Method: get
             RestApiId: !Ref NvaPublicationApi
 
-#  NvaFecthPublicationFunctionScalableTarget:
-#    Type: AWS::ApplicationAutoScaling::ScalableTarget
-#    Properties:
-#      MaxCapacity: !Ref MaxConcurrency
-#      MinCapacity: !Ref MinConcurrency
-#      ResourceId: !Sub function:${NvaFetchPublicationFunction}:live # You need to specify an alias or version here
-#      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/lambda.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_LambdaConcurrency
-#      ScalableDimension: lambda:function:ProvisionedConcurrency
-#      ServiceNamespace: lambda
-#    DependsOn: NvaFetchPublicationFunctionAliaslive # This is your function logical ID + "Alias" + what you use for AutoPublishAlias
-#
-#  NvaFetchPublicationFucntionScalingPolicy:
-#    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-#    Properties:
-#      PolicyName: NvaFetchPublicationFucntionScalingPolicy
-#      PolicyType: TargetTrackingScaling
-#      ScalingTargetId: !Ref NvaFecthPublicationFunctionScalableTarget
-#      TargetTrackingScalingPolicyConfiguration:
-#        TargetValue: 0.70 # Any value between 0.1 and 0.9 can be used here
-#        PredefinedMetricSpecification:
-#          PredefinedMetricType: LambdaProvisionedConcurrencyUtilization
+  NvaFetchPublicationFunctionScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: !Ref MaxConcurrency
+      MinCapacity: !Ref MinConcurrency
+      ResourceId: !Sub function:${NvaFetchPublicationFunction}:live # You need to specify an alias or version here
+      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/lambda.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_LambdaConcurrency
+      ScalableDimension: lambda:function:ProvisionedConcurrency
+      ServiceNamespace: lambda
+    DependsOn: NvaFetchPublicationFunctionAliaslive # This is your function logical ID + "Alias" + what you use for AutoPublishAlias
 
+  NvaFetchPublicationFunctionScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: NvaFetchPublicationFunctionScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref NvaFetchPublicationFunctionScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 0.70 # Any value between 0.1 and 0.9 can be used here
+        PredefinedMetricSpecification:
+          PredefinedMetricType: LambdaProvisionedConcurrencyUtilization
 
   NvaUpdatePublicationFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
This is the very first version of a stack initialization function. The function belongs to the stack because it will be easier to use the stack resources. 

### Background:
In order for the initialization function to be executed after a successful pipeline, there are two alternatives:
1. The pipeline calls the function directly
     This method requires that we know from before the name (and therefore the ARN) of both the stack and the init function before the stack is created. In other words, each stack should have deterministic name and each init function should have a deterministic name as well.  
2. The function listens to pipeline events and is activated when a pipeline execution is successful.
   This approach requires that the pipeline name is passed as a parameter to the stack. Probably this is an easier way to go. 

To achieve the second approach we use CodePipeline EventBridge events as they are described here: https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html

### This PR.

This PR contains only the logic of a very simple handler, that logs the event. The connection to the pipeline is not yet implemented but it will follow. 

