### PR TITLE
ResourceService scans and refreshes entries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ mockito = { strictly = '3.12.4' }
 configTypesafe = { strictly = '1.4.1' }
 jsonld = { strictly = '0.13.3' }
 nva-language ={strictly = '1.0'}
+guava = {strictly= '31.0.1-jre'}
 
 [libraries]
 nva-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }
@@ -76,7 +77,7 @@ slf4j-api = { group = 'org.slf4j', name = 'slf4j-api', version.ref = 'slf4j' }
 
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commonsValidator' }
 jsonld = { group = 'com.github.jsonld-java', name = 'jsonld-java', version.ref = 'jsonld' }
-
+guava = { group= 'com.google.guava', name= 'guava', version.ref = 'guava'}
 
 hamcrest-base = { group = 'org.hamcrest', name = 'hamcrest', version.ref = 'hamcrest' }
 hamcrest-core = { group = 'org.hamcrest', name = 'hamcrest-core', version.ref = 'hamcrest' }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/ListingResult.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/ListingResult.java
@@ -1,0 +1,46 @@
+package no.unit.nva.publication.model;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import no.unit.nva.publication.storage.model.ResourceUpdate;
+import nva.commons.core.JacocoGenerated;
+
+public class ListingResult<T> {
+
+    private final List<T> databaseEntries;
+    private final Map<String, AttributeValue> startMarker;
+    private final boolean truncated;
+
+    public ListingResult(List<T> databaseEntries, Map<String, AttributeValue> startMarker, boolean truncated) {
+        this.databaseEntries = databaseEntries;
+        this.startMarker = startMarker;
+        this.truncated = truncated;
+    }
+
+    public static ListingResult<ResourceUpdate> empty() {
+        return new ListingResult<>(Collections.emptyList(), null, true);
+    }
+
+    @JacocoGenerated
+    public boolean isTruncated() {
+        return truncated;
+    }
+
+    @JacocoGenerated
+    public List<T> getDatabaseEntries() {
+        return databaseEntries;
+    }
+
+    @JacocoGenerated
+    public Map<String, AttributeValue> getStartMarker() {
+        return startMarker;
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return databaseEntries.isEmpty();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/ListingResult.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/ListingResult.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.model;
 
+import static java.util.Objects.nonNull;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Collections;
@@ -31,7 +32,7 @@ public class ListingResult<T> {
 
     @JacocoGenerated
     public List<T> getDatabaseEntries() {
-        return databaseEntries;
+        return nonNull(databaseEntries) ? databaseEntries : Collections.emptyList();
     }
 
     @JacocoGenerated

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.service.impl;
 
+import static java.util.Objects.isNull;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.RESOURCES_TABLE_NAME;
 import static no.unit.nva.publication.storage.model.Resource.resourceQueryObject;
 import static no.unit.nva.publication.storage.model.daos.DynamoEntry.parseAttributeValuesMap;
@@ -7,12 +8,18 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.PutRequest;
 import com.amazonaws.services.dynamodbv2.model.ReturnValue;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.google.common.collect.Lists;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -28,8 +35,10 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.exception.BadRequestException;
 import no.unit.nva.publication.exception.TransactionFailedException;
+import no.unit.nva.publication.model.ListingResult;
 import no.unit.nva.publication.model.PublishPublicationStatusResponse;
 import no.unit.nva.publication.storage.model.Resource;
+import no.unit.nva.publication.storage.model.ResourceUpdate;
 import no.unit.nva.publication.storage.model.UserInstance;
 import no.unit.nva.publication.storage.model.daos.Dao;
 import no.unit.nva.publication.storage.model.daos.DoiRequestDao;
@@ -59,13 +68,13 @@ public class ResourceService extends ServiceWithTransactions {
     public static final String RESOURCE_CANNOT_BE_DELETED_ERROR_MESSAGE = "Resource cannot be deleted: ";
 
     private static final Logger logger = LoggerFactory.getLogger(ResourceService.class);
+    public static final int MAX_SIZE_OF_BATCH_REQUEST = 20;
     private final String tableName;
     private final AmazonDynamoDB client;
     private final Clock clockForTimestamps;
     private final Supplier<SortableIdentifier> identifierSupplier;
     private final ReadResourceService readResourceService;
     private final UpdateResourceService updateResourceService;
-
 
     public ResourceService(AmazonDynamoDB client, Clock clock, Supplier<SortableIdentifier> identifierSupplier) {
         super();
@@ -100,7 +109,7 @@ public class ResourceService extends ServiceWithTransactions {
     }
 
     public Publication createPublicationWhilePersistingEntryFromLegacySystems(Publication inputData)
-            throws TransactionFailedException {
+        throws TransactionFailedException {
         Resource newResource = Resource.fromPublication(inputData);
         newResource.setIdentifier(identifierSupplier.get());
         newResource.setPublishedDate(inputData.getPublishedDate());
@@ -121,7 +130,7 @@ public class ResourceService extends ServiceWithTransactions {
         throws ApiGatewayException {
 
         return markResourceForDeletion(resourceQueryObject(userInstance, resourceIdentifier))
-                   .toPublication();
+            .toPublication();
     }
 
     public PublishPublicationStatusResponse publishPublication(UserInstance userInstance,
@@ -134,19 +143,49 @@ public class ResourceService extends ServiceWithTransactions {
     public void deleteDraftPublication(UserInstance userInstance, SortableIdentifier resourceIdentifier)
         throws BadRequestException, TransactionFailedException {
         List<Dao> daos = readResourceService
-                             .fetchResourceAndDoiRequestFromTheByResourceIndex(userInstance, resourceIdentifier);
+            .fetchResourceAndDoiRequestFromTheByResourceIndex(userInstance, resourceIdentifier);
 
         List<TransactWriteItem> transactionItems = transactionItemsForDraftPublicationDeletion(daos);
         TransactWriteItemsRequest transactWriteItemsRequest = newTransactWriteItemsRequest(transactionItems);
         sendTransactionWriteRequest(transactWriteItemsRequest);
     }
 
-    private Publication insertResource(Resource newResource) throws TransactionFailedException {
-        TransactWriteItem[] transactionItems = transactionItemsForNewResourceInsertion(newResource);
-        TransactWriteItemsRequest putRequest = newTransactWriteItemsRequest(transactionItems);
-        sendTransactionWriteRequest(putRequest);
+    public ListingResult<ResourceUpdate> scanResources(int pageSize, Map<String, AttributeValue> startMarker) {
+        var scanRequest = createScanRequestThatFiltersOutIdentityEntries(pageSize, startMarker);
+        var scanResult = client.scan(scanRequest);
 
-        return fetchSavedResource(newResource);
+        List<ResourceUpdate> values = extractDatabaseEntries(scanResult);
+        var isTruncated = isNull(scanResult.getLastEvaluatedKey()) || scanResult.getLastEvaluatedKey().isEmpty();
+
+        return new ListingResult<>(values, scanResult.getLastEvaluatedKey(), isTruncated);
+    }
+
+    public List<ResourceUpdate> refreshResources(List<ResourceUpdate> resourceUpdates) {
+        final List<ResourceUpdate> refreshedEntries = resourceUpdates
+            .stream()
+            .map(ResourceUpdate::refreshRowVersion)
+            .collect(Collectors.toList());
+
+        List<WriteRequest> writeRequests = createWriteRequestsForBatchJob(refreshedEntries);
+        writetoS3InBatches(writeRequests);
+
+        return refreshedEntries;
+    }
+
+    private void writetoS3InBatches(List<WriteRequest> writeRequests) {
+        Lists.partition(writeRequests, MAX_SIZE_OF_BATCH_REQUEST)
+            .stream()
+            .map(items -> new BatchWriteItemRequest().withRequestItems(Map.of(tableName, items)))
+            .forEach(client::batchWriteItem);
+    }
+
+    private List<WriteRequest> createWriteRequestsForBatchJob(List<ResourceUpdate> refreshedEntries) {
+        return refreshedEntries.stream()
+            .map(ResourceUpdate::toDao)
+            .map(Dao::toDynamoFormat)
+            .map(item -> new PutRequest().withItem(item))
+            .map(WriteRequest::new)
+            .collect(Collectors.toList());
     }
 
     public Publication getPublication(UserInstance userInstance, SortableIdentifier resourceIdentifier)
@@ -190,10 +229,38 @@ public class ResourceService extends ServiceWithTransactions {
         return clockForTimestamps;
     }
 
+    private ScanRequest createScanRequestThatFiltersOutIdentityEntries(int pageSize,
+                                                                       Map<String, AttributeValue> startMarker) {
+        return new ScanRequest()
+            .withTableName(tableName)
+            .withLimit(pageSize)
+            .withExclusiveStartKey(startMarker)
+            .withFilterExpression(Dao.scanFilterExpression())
+            .withExpressionAttributeNames(Dao.scanFilterExpressionAttributeNames())
+            .withExpressionAttributeValues(Dao.scanFilterExpressionAttributeValues());
+    }
+
+    private List<ResourceUpdate> extractDatabaseEntries(ScanResult response) {
+        return response.getItems()
+            .stream()
+            .map(value -> parseAttributeValuesMap(value, Dao.class))
+            .map(Dao::getData)
+            .map(d -> (ResourceUpdate) d)
+            .collect(Collectors.toList());
+    }
+
+    private Publication insertResource(Resource newResource) throws TransactionFailedException {
+        TransactWriteItem[] transactionItems = transactionItemsForNewResourceInsertion(newResource);
+        TransactWriteItemsRequest putRequest = newTransactWriteItemsRequest(transactionItems);
+        sendTransactionWriteRequest(putRequest);
+
+        return fetchSavedResource(newResource);
+    }
+
     private Publication fetchSavedResource(Resource newResource) {
         return fetchEventuallyConsistentResource(newResource)
-                   .map(Resource::toPublication)
-                   .orElse(null);
+            .map(Resource::toPublication)
+            .orElse(null);
     }
 
     @SuppressWarnings(RAWTYPES)
@@ -264,7 +331,7 @@ public class ResourceService extends ServiceWithTransactions {
         ResourceDao dao = new ResourceDao(resource);
         UpdateItemRequest updateRequest = markForDeletionUpdateRequest(dao);
         return attempt(() -> sendUpdateRequest(updateRequest))
-                   .orElseThrow(failure -> markForDeletionError(failure, resource));
+            .orElseThrow(failure -> markForDeletionError(failure, resource));
     }
 
     private Optional<Resource> fetchEventuallyConsistentResource(Resource newResource) {
@@ -320,13 +387,13 @@ public class ResourceService extends ServiceWithTransactions {
             "#data", RESOURCE_FIELD_IN_RESOURCE_DAO);
 
         UpdateItemRequest request = new UpdateItemRequest()
-                                        .withTableName(tableName)
-                                        .withKey(dao.primaryKey())
-                                        .withUpdateExpression(updateExpression)
-                                        .withConditionExpression(conditionExpression)
-                                        .withExpressionAttributeNames(expressionAttributeNames)
-                                        .withExpressionAttributeValues(expressionValuesMap)
-                                        .withReturnValues(ReturnValue.ALL_NEW);
+            .withTableName(tableName)
+            .withKey(dao.primaryKey())
+            .withUpdateExpression(updateExpression)
+            .withConditionExpression(conditionExpression)
+            .withExpressionAttributeNames(expressionAttributeNames)
+            .withExpressionAttributeValues(expressionValuesMap)
+            .withReturnValues(ReturnValue.ALL_NEW);
         logger.info("DeleteRequest:" + request.toString());
         return request;
     }
@@ -334,10 +401,10 @@ public class ResourceService extends ServiceWithTransactions {
     private Resource sendUpdateRequest(UpdateItemRequest updateRequest) {
         UpdateItemResult requestResult = client.updateItem(updateRequest);
         return Try.of(requestResult)
-                   .map(UpdateItemResult::getAttributes)
-                   .map(valuesMap -> parseAttributeValuesMap(valuesMap, ResourceDao.class))
-                   .map(ResourceDao::getData)
-                   .orElseThrow();
+            .map(UpdateItemResult::getAttributes)
+            .map(valuesMap -> parseAttributeValuesMap(valuesMap, ResourceDao.class))
+            .map(ResourceDao::getData)
+            .orElseThrow();
     }
 
     private TransactWriteItem createNewTransactionPutEntryForEnsuringUniqueIdentifier(Resource resource) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -813,12 +813,11 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
     }
 
     @Test
-    void shouldScanNEntriesInDatabaseAfterMarkerX() throws TransactionFailedException {
-        var publication = PublicationGenerator.randomPublication();
-        var createdPublication = resourceService.createPublication(publication);
-        var doiRequestIdentifier = doiRequestService.createDoiRequest(createdPublication);
-        var userInstance = new UserInstance(publication.getOwner(), publication.getPublisher().getId());
-        var messageIdentifier = messageService.createSimpleMessage(userInstance, publication, randomString());
+    void shouldScanEntriesInDatabaseAfterSpecifiedMarker() throws TransactionFailedException {
+        var samplePublication = resourceService.createPublication( PublicationGenerator.randomPublication());
+        var sampleDoiRequestIdentifier = doiRequestService.createDoiRequest(samplePublication);
+        var userInstance = new UserInstance(samplePublication.getOwner(), samplePublication.getPublisher().getId());
+        var sampleMessageIdentifier = messageService.createSimpleMessage(userInstance, samplePublication, randomString());
 
         var listingResult = fetchFirstDataEntry();
         var databaseEntryInFirstScan = extractIdentifierFromFirstScanResult(listingResult);
@@ -826,7 +825,7 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         var secondListingResult = fetchRestOfDatabaseEntries(listingResult);
 
         var expectedIdentifiers =
-            new ArrayList<>(List.of(createdPublication.getIdentifier(), doiRequestIdentifier, messageIdentifier));
+            new ArrayList<>(List.of(samplePublication.getIdentifier(), sampleDoiRequestIdentifier, sampleMessageIdentifier));
         expectedIdentifiers.remove(databaseEntryInFirstScan);
 
         var actualIdentifiers = secondListingResult
@@ -838,9 +837,9 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
 
     @Test
     void shouldUpdateResourceRowVersionWhenRefreshesEntry() {
-        int numberOfResources = 40;
-        int numberOfTotalExpectedDatabaseEntries = 2 * numberOfResources; //due to identity entries
-        var sampleResources = createManySampleResources(numberOfResources);
+        int arbitraryNumberOfResources = 40;
+        int numberOfTotalExpectedDatabaseEntries = 2 * arbitraryNumberOfResources; //due to identity entries
+        var sampleResources = createManySampleResources(arbitraryNumberOfResources);
 
         resourceService.refreshResources(sampleResources);
         var firstUpdates =

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -10,8 +10,10 @@ import static no.unit.nva.publication.service.impl.ResourceServiceUtils.userOrga
 import static no.unit.nva.publication.service.impl.UpdateResourceService.RESOURCE_LINK_FIELD;
 import static no.unit.nva.publication.service.impl.UpdateResourceService.RESOURCE_WITHOUT_MAIN_TITLE_ERROR;
 import static no.unit.nva.publication.storage.model.daos.DynamoEntry.parseAttributeValuesMap;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -42,6 +44,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -49,6 +52,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.DoiRequestStatus;
@@ -61,15 +65,18 @@ import no.unit.nva.publication.PublicationGenerator;
 import no.unit.nva.publication.exception.BadRequestException;
 import no.unit.nva.publication.exception.InvalidPublicationException;
 import no.unit.nva.publication.exception.TransactionFailedException;
+import no.unit.nva.publication.model.ListingResult;
 import no.unit.nva.publication.model.PublishPublicationStatusResponse;
 import no.unit.nva.publication.service.ResourcesDynamoDbLocalTest;
 import no.unit.nva.publication.storage.model.DatabaseConstants;
 import no.unit.nva.publication.storage.model.DoiRequest;
 import no.unit.nva.publication.storage.model.Resource;
+import no.unit.nva.publication.storage.model.ResourceUpdate;
 import no.unit.nva.publication.storage.model.UserInstance;
 import no.unit.nva.publication.storage.model.daos.ResourceDao;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
+import nva.commons.core.SingletonCollector;
 import nva.commons.core.attempt.Try;
 import nva.commons.logutils.LogUtils;
 import nva.commons.logutils.TestAppender;
@@ -96,6 +103,8 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
                                                                               + MAIN_TITLE_FIELD;
     public static final String ANOTHER_TITLE = "anotherTitle";
     public static final URI SOME_DOI = URI.create("https://some-doi.example.org");
+    public static final Javers JAVERS = JaversBuilder.javers().build();
+    public static final int BIG_PAGE = 10;
     private static final URI SOME_ORG = URI.create(PublicationGenerator.PUBLISHER_ID);
     public static final UserInstance SAMPLE_USER = new UserInstance(PublicationGenerator.OWNER, SOME_ORG);
     private static final URI SOME_OTHER_ORG = URI.create("https://example.org/789-ABC");
@@ -104,11 +113,10 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
     private static final Instant RESOURCE_SECOND_MODIFICATION_TIME = Instant.parse("2010-01-03T02:00:25.00Z");
     private static final Instant RESOURCE_THIRD_MODIFICATION_TIME = Instant.parse("2020-01-03T06:00:32.00Z");
     private static final URI SOME_LINK = URI.create("http://www.example.com/someLink");
-    public static final Javers JAVERS = JaversBuilder.javers().build();
-
     private ResourceService resourceService;
     private Clock clock;
     private DoiRequestService doiRequestService;
+    private MessageService messageService;
 
     @BeforeEach
     public void init() {
@@ -116,11 +124,17 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         Clock clock = setupClock();
         resourceService = new ResourceService(client, clock);
         doiRequestService = new DoiRequestService(client, clock);
+        messageService = new MessageService(client, clock, SortableIdentifier::next);
+    }
+
+    public Optional<ResourceDao> searchForResource(ResourceDao resourceDaoWithStatusDraft) {
+        QueryResult queryResult = queryForDraftResource(resourceDaoWithStatusDraft);
+        return parseResult(queryResult);
     }
 
     @Test
     void createResourceWithPredefinedCreationDateStoresResourceWithCreationDateEqualToInputsCreationDate()
-        throws TransactionFailedException, NotFoundException, JsonProcessingException {
+        throws TransactionFailedException, NotFoundException {
         Publication inputPublication = PublicationGenerator.publicationWithoutIdentifier();
         assertThat(inputPublication.getSubjects(), is(not(nullValue())));
         verifyThatResourceClockWillReturnPredefinedCreationTime();
@@ -506,15 +520,6 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         verifyThatTheResourceIsInThePublishedResources(resourceWithStatusDraft);
     }
 
-    private void verifyThatTheSampleHasStillStatusDraft(Publication resourceWithStatusDraft) {
-        assertThat(resourceWithStatusDraft.getStatus(), is(equalTo(PublicationStatus.DRAFT)));
-    }
-
-    public Optional<ResourceDao> searchForResource(ResourceDao resourceDaoWithStatusDraft) {
-        QueryResult queryResult = queryForDraftResource(resourceDaoWithStatusDraft);
-        return parseResult(queryResult);
-    }
-
     @Test
     void publishPublicationSetsPublishedDate() throws ApiGatewayException {
         Publication updatedResource = createPublishedResource();
@@ -567,11 +572,6 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         Publication updatedResource =
             publishResource(savedResource);
         assertThat(updatedResource.getStatus().toString(), is(equalTo(PublicationStatus.PUBLISHED.toString())));
-    }
-
-    private Publication publishResource(Publication resource) throws ApiGatewayException {
-        resourceService.publishPublication(extractUserInstance(resource), resource.getIdentifier());
-        return resourceService.getPublication(resource);
     }
 
     @Test
@@ -810,6 +810,92 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         assertThat(exception.getMessage(), containsString(someIdentifier.toString()));
         assertThat(testAppender.getMessages(), containsString(RESOURCE_BY_IDENTIFIER_NOT_FOUND_ERROR_PREFIX));
         assertThat(testAppender.getMessages(), containsString(someIdentifier.toString()));
+    }
+
+    @Test
+    void shouldScanNEntriesInDatabaseAfterMarkerX() throws TransactionFailedException {
+        var publication = PublicationGenerator.randomPublication();
+        var createdPublication = resourceService.createPublication(publication);
+        var doiRequestIdentifier = doiRequestService.createDoiRequest(createdPublication);
+        var userInstance = new UserInstance(publication.getOwner(), publication.getPublisher().getId());
+        var messageIdentifier = messageService.createSimpleMessage(userInstance, publication, randomString());
+
+        var listingResult = fetchFirstDataEntry();
+        var databaseEntryInFirstScan = extractIdentifierFromFirstScanResult(listingResult);
+
+        var secondListingResult = fetchRestOfDatabaseEntries(listingResult);
+
+        var expectedIdentifiers =
+            new ArrayList<>(List.of(createdPublication.getIdentifier(), doiRequestIdentifier, messageIdentifier));
+        expectedIdentifiers.remove(databaseEntryInFirstScan);
+
+        var actualIdentifiers = secondListingResult
+            .getDatabaseEntries().stream()
+            .map(ResourceUpdate::getIdentifier)
+            .collect(Collectors.toList());
+        assertThat(actualIdentifiers, containsInAnyOrder(expectedIdentifiers.toArray(SortableIdentifier[]::new)));
+    }
+
+    @Test
+    void shouldUpdateResourceRowVersionWhenRefreshesEntry() {
+        int numberOfResources = 40;
+        int numberOfTotalExpectedDatabaseEntries = 2 * numberOfResources; //due to identity entries
+        var sampleResources = createManySampleResources(numberOfResources);
+
+        resourceService.refreshResources(sampleResources);
+        var firstUpdates =
+            resourceService.scanResources(numberOfTotalExpectedDatabaseEntries, null).getDatabaseEntries();
+
+        resourceService.refreshResources(sampleResources);
+        var secondUpdates =
+            resourceService.scanResources(numberOfTotalExpectedDatabaseEntries, null).getDatabaseEntries();
+
+        for (var firstUpdate : firstUpdates) {
+            ResourceUpdate secondUpdate = secondUpdates.stream()
+                .filter(resource -> resource.getIdentifier().equals(firstUpdate.getIdentifier()))
+                .collect(SingletonCollector.collect());
+
+            assertThat(secondUpdate.getRowVersion(), is(not(equalTo(firstUpdate.getRowVersion()))));
+        }
+    }
+
+    private List<ResourceUpdate> createManySampleResources(int numberOfResources) {
+        return IntStream.range(0, numberOfResources)
+            .boxed()
+            .map(ignored -> PublicationGenerator.randomPublication())
+            .map(attempt(p -> resourceService.createPublication(p)))
+            .map(Try::orElseThrow)
+            .map(Resource::fromPublication)
+            .map(resource -> (ResourceUpdate) resource)
+            .collect(Collectors.toList());
+    }
+
+    private ListingResult<ResourceUpdate> fetchRestOfDatabaseEntries(ListingResult<ResourceUpdate> listingResult) {
+        return resourceService.scanResources(BIG_PAGE, listingResult.getStartMarker());
+    }
+
+    private SortableIdentifier extractIdentifierFromFirstScanResult(ListingResult<ResourceUpdate> listingResult) {
+        return listingResult.getDatabaseEntries()
+            .stream()
+            .collect(SingletonCollector.collect())
+            .getIdentifier();
+    }
+
+    private ListingResult<ResourceUpdate> fetchFirstDataEntry() {
+        ListingResult<ResourceUpdate> listingResult = ListingResult.empty();
+        while (listingResult.isEmpty()) {
+            listingResult = resourceService.scanResources(1, listingResult.getStartMarker());
+        }
+        return listingResult;
+    }
+
+    private void verifyThatTheSampleHasStillStatusDraft(Publication resourceWithStatusDraft) {
+        assertThat(resourceWithStatusDraft.getStatus(), is(equalTo(PublicationStatus.DRAFT)));
+    }
+
+    private Publication publishResource(Publication resource) throws ApiGatewayException {
+        resourceService.publishPublication(extractUserInstance(resource), resource.getIdentifier());
+        return resourceService.getPublication(resource);
     }
 
     private Clock setupClock() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -513,7 +513,6 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
         resourceService.publishPublication(extractUserInstance(resourceWithStatusDraft),
                                            resourceWithStatusDraft.getIdentifier());
 
-        verifyThatTheSampleHasStillStatusDraft(resourceWithStatusDraft);
 
         verifyThatTheResourceWasMovedFromtheDrafts(resourceDaoWithStatusDraft);
 
@@ -839,7 +838,7 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
     }
 
     @Test
-    void shouldUpdateResourceRowVersionWhenRefreshesEntry() {
+    void shouldUpdateResourceRowVersionWhenEntityIsRefreshed() {
         int arbitraryNumberOfResources = 40;
         int numberOfTotalExpectedDatabaseEntries = 2 * arbitraryNumberOfResources; //due to identity entries
         var sampleResources = createManySampleResources(arbitraryNumberOfResources);
@@ -892,10 +891,6 @@ public class ResourceServiceTest extends ResourcesDynamoDbLocalTest {
             listingResult = resourceService.scanResources(1, listingResult.getStartMarker());
         }
         return listingResult;
-    }
-
-    private void verifyThatTheSampleHasStillStatusDraft(Publication resourceWithStatusDraft) {
-        assertThat(resourceWithStatusDraft.getStatus(), is(equalTo(PublicationStatus.DRAFT)));
     }
 
     private Publication publishResource(Publication resource) throws ApiGatewayException {

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/DoiRequest.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/DoiRequest.java
@@ -26,6 +26,8 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
+import no.unit.nva.publication.storage.model.daos.Dao;
+import no.unit.nva.publication.storage.model.daos.DoiRequestDao;
 import no.unit.nva.publication.storage.model.exceptions.IllegalDoiRequestUpdate;
 import nva.commons.core.JacocoGenerated;
 
@@ -41,7 +43,7 @@ public class DoiRequest
     public static final String RESOURCE_STATUS_FIELD = "resourceStatus";
     public static final String STATUS_FIELD = "status";
     public static final String MODIFIED_DATE_FIELD = "modifiedDate";
-    public static final String TYPE = DoiRequest.class.getSimpleName();
+    public static final String TYPE = "DoiRequest";
 
     public static final String MISSING_RESOURCE_REFERENCE_ERROR = "Resource identifier cannot be null or empty";
 
@@ -348,8 +350,14 @@ public class DoiRequest
         return rowVersion;
     }
 
+    @Override
     public void setRowVersion(String rowVersion) {
         this.rowVersion = rowVersion;
+    }
+
+    @Override
+    public Dao<?> toDao() {
+        return new DoiRequestDao(this);
     }
 
     @Override

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/Message.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/Message.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
+import no.unit.nva.publication.storage.model.daos.Dao;
+import no.unit.nva.publication.storage.model.daos.MessageDao;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonSerializable;
 
@@ -24,6 +26,7 @@ public class Message implements WithIdentifier,
                                 JsonSerializable {
 
     public static final MessageType DEFAULT_MESSAGE_TYPE = MessageType.SUPPORT;
+    public static final String TYPE = "Message";
     private SortableIdentifier identifier;
     private String owner;
     private URI customerId;
@@ -200,9 +203,15 @@ public class Message implements WithIdentifier,
         return this.rowVersion;
     }
 
+    @Override
     @JacocoGenerated
     public void setRowVersion(String rowVersion) {
         this.rowVersion = rowVersion;
+    }
+
+    @Override
+    public Dao<?> toDao() {
+        return new MessageDao(this);
     }
 
     @Override

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/Resource.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/Resource.java
@@ -20,13 +20,15 @@ import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResearchProject;
+import no.unit.nva.publication.storage.model.daos.Dao;
+import no.unit.nva.publication.storage.model.daos.ResourceDao;
 import nva.commons.core.JacocoGenerated;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.TooManyFields","PMD.ExcessivePublicCount"})
 @JsonTypeInfo(use = Id.NAME, property = "type")
 public class Resource implements WithIdentifier, RowLevelSecurity, WithStatus, ResourceUpdate {
 
-    public static final String TYPE = Resource.class.getSimpleName();
+    public static final String TYPE = "Resource";
 
     @JsonProperty
     private SortableIdentifier identifier;
@@ -118,6 +120,11 @@ public class Resource implements WithIdentifier, RowLevelSecurity, WithStatus, R
 
     public static String nextRowVersion() {
         return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public Dao<?> toDao() {
+        return new ResourceDao(this);
     }
 
     @JacocoGenerated
@@ -327,6 +334,7 @@ public class Resource implements WithIdentifier, RowLevelSecurity, WithStatus, R
         return rowVersion;
     }
 
+    @Override
     @JacocoGenerated
     public void setRowVersion(String rowVersion) {
         this.rowVersion = rowVersion;

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/ResourceUpdate.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/ResourceUpdate.java
@@ -6,12 +6,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.UUID;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.publication.storage.model.daos.Dao;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-    @JsonSubTypes.Type(name = "Resource", value = Resource.class),
-    @JsonSubTypes.Type(name = "DoiRequest", value = DoiRequest.class),
-    @JsonSubTypes.Type(name = "Message", value = Message.class),
+    @JsonSubTypes.Type(name = Resource.TYPE, value = Resource.class),
+    @JsonSubTypes.Type(name = DoiRequest.TYPE, value = DoiRequest.class),
+    @JsonSubTypes.Type(name = Message.TYPE, value = Message.class),
 })
 public interface ResourceUpdate {
 
@@ -24,8 +25,16 @@ public interface ResourceUpdate {
     @JsonProperty(ROW_VERSION)
     String getRowVersion();
 
+    void setRowVersion(String rowVersion);
 
-    static String nextRowVersion(){
+    static String nextRowVersion() {
         return UUID.randomUUID().toString();
     }
+
+    default ResourceUpdate refreshRowVersion() {
+        setRowVersion(nextRowVersion());
+        return this;
+    }
+
+    Dao<?> toDao();
 }

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/Dao.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/Dao.java
@@ -56,12 +56,12 @@ public abstract class Dao<R extends WithIdentifier & RowLevelSecurity & Resource
                +"begins_with(#PK, :Message)";
     }
 
-    // replace the hash values in the filter expression with the actual key name
+    // replaces the hash values in the filter expression with the actual key name
     public static Map<String, String> scanFilterExpressionAttributeNames() {
         return Map.of("#PK", DatabaseConstants.PRIMARY_KEY_PARTITION_KEY_NAME);
     }
 
-    // replace the colon values in the filter expression with the actual value
+    // replaces the colon values in the filter expression with the actual value
     public  static Map<String, AttributeValue> scanFilterExpressionAttributeValues() {
         return Map.of(":Resource", new AttributeValue(ResourceDao.TYPE + KEY_FIELDS_DELIMITER),
                       ":DoiRequest", new AttributeValue(DoiRequestDao.TYPE+KEY_FIELDS_DELIMITER),

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/DoiRequestDao.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/DoiRequestDao.java
@@ -12,7 +12,7 @@ import no.unit.nva.publication.storage.model.UserInstance;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonSerializable;
 
-@JsonTypeName("DoiRequest")
+@JsonTypeName(DoiRequestDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class DoiRequestDao extends Dao<DoiRequest>
     implements
@@ -20,7 +20,7 @@ public class DoiRequestDao extends Dao<DoiRequest>
     JsonSerializable {
 
     public static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "a";
-
+    public static final String TYPE = "DoiRequest";
     private DoiRequest data;
 
     @JacocoGenerated
@@ -35,10 +35,10 @@ public class DoiRequestDao extends Dao<DoiRequest>
 
     public static DoiRequestDao queryObject(URI publisherId, String owner, SortableIdentifier doiRequestIdentifier) {
         DoiRequest doi = DoiRequest.builder()
-                             .withIdentifier(doiRequestIdentifier)
-                             .withOwner(owner)
-                             .withCustomerId(publisherId)
-                             .build();
+            .withIdentifier(doiRequestIdentifier)
+            .withOwner(owner)
+            .withCustomerId(publisherId)
+            .build();
 
         return new DoiRequestDao(doi);
     }
@@ -50,10 +50,10 @@ public class DoiRequestDao extends Dao<DoiRequest>
     public static DoiRequestDao queryByCustomerAndResourceIdentifier(UserInstance resourceOwner,
                                                                      SortableIdentifier resourceIdentifier) {
         DoiRequest doi = DoiRequest.builder()
-                             .withResourceIdentifier(resourceIdentifier)
-                             .withOwner(resourceOwner.getUserIdentifier())
-                             .withCustomerId(resourceOwner.getOrganizationUri())
-                             .build();
+            .withResourceIdentifier(resourceIdentifier)
+            .withOwner(resourceOwner.getUserIdentifier())
+            .withCustomerId(resourceOwner.getOrganizationUri())
+            .build();
         return new DoiRequestDao(doi);
     }
 

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/MessageDao.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/MessageDao.java
@@ -15,15 +15,15 @@ import nva.commons.core.JacocoGenerated;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class MessageDao extends Dao<Message>
     implements JoinWithResource {
-    
+
     public static final String TYPE = "Message";
     private static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX = "c";
     private Message data;
-    
+
     public MessageDao() {
         super();
     }
-    
+
     public MessageDao(Message message) {
         super();
         this.data = message;
@@ -31,27 +31,27 @@ public class MessageDao extends Dao<Message>
 
     public static MessageDao queryObject(UserInstance owner, SortableIdentifier identifier) {
         Message message = Message.builder()
-                              .withOwner(owner.getUserIdentifier())
-                              .withCustomerId(owner.getOrganizationUri())
-                              .withIdentifier(identifier)
-                              .build();
+            .withOwner(owner.getUserIdentifier())
+            .withCustomerId(owner.getOrganizationUri())
+            .withIdentifier(identifier)
+            .build();
         return new MessageDao(message);
     }
 
     public static MessageDao listMessagesForCustomerAndStatus(URI customerId, MessageStatus messageStatus) {
 
         Message message = Message.builder()
-                              .withCustomerId(customerId)
-                              .withStatus(messageStatus)
-                              .build();
+            .withCustomerId(customerId)
+            .withStatus(messageStatus)
+            .build();
         return new MessageDao(message);
     }
 
     public static MessageDao listMessagesAndResourcesForUser(UserInstance owner) {
         Message message = Message.builder()
-                              .withCustomerId(owner.getOrganizationUri())
-                              .withOwner(owner.getUserIdentifier())
-                              .build();
+            .withCustomerId(owner.getOrganizationUri())
+            .withOwner(owner.getUserIdentifier())
+            .build();
         return new MessageDao(message);
     }
 
@@ -64,33 +64,33 @@ public class MessageDao extends Dao<Message>
     public void setData(Message data) {
         this.data = data;
     }
-    
+
     @Override
     public String getType() {
         return TYPE;
     }
-    
+
     @Override
     public URI getCustomerId() {
         return data.getCustomerId();
     }
-    
+
     @Override
     public SortableIdentifier getIdentifier() {
         return data.getIdentifier();
     }
-    
+
     @Override
     protected String getOwner() {
         return data.getOwner();
     }
-    
+
     @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hash(getData());
     }
-    
+
     @JacocoGenerated
     @Override
     public boolean equals(Object o) {
@@ -103,16 +103,16 @@ public class MessageDao extends Dao<Message>
         MessageDao that = (MessageDao) o;
         return Objects.equals(getData(), that.getData());
     }
-    
+
     public static String joinByResourceOrderedContainedType() {
         return JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX + KEY_FIELDS_DELIMITER + TYPE;
     }
-    
+
     @Override
     public String joinByResourceOrderedType() {
         return joinByResourceOrderedContainedType();
     }
-    
+
     @Override
     public SortableIdentifier getResourceIdentifier() {
         return data.getResourceIdentifier();

--- a/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/ResourceDao.java
+++ b/storage-model/src/main/java/no/unit/nva/publication/storage/model/daos/ResourceDao.java
@@ -16,7 +16,7 @@ import no.unit.nva.publication.storage.model.ResourceByIdentifier;
 import no.unit.nva.publication.storage.model.UserInstance;
 import nva.commons.core.SingletonCollector;
 
-@JsonTypeName("Resource")
+@JsonTypeName(ResourceDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ResourceDao extends Dao<Resource>
     implements JoinWithResource,
@@ -24,6 +24,7 @@ public class ResourceDao extends Dao<Resource>
                WithCristinIdentifier {
 
     public static final String CRISTIN_SOURCE = "Cristin";
+    public static final String TYPE = "Resource";
     private static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "b";
     private Resource data;
 

--- a/storage-model/src/test/java/no/unit/nva/publication/storage/model/MessageTest.java
+++ b/storage-model/src/test/java/no/unit/nva/publication/storage/model/MessageTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import com.amazonaws.services.kms.model.CustomKeyStoreInvalidStateException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.time.Clock;
@@ -49,9 +48,9 @@ public class MessageTest {
     @Test
     public void toStringReturnsAJsonString() throws JsonProcessingException {
         Message message = Message.builder()
-                              .withStatus(MessageStatus.UNREAD)
-                              .withIdentifier(SortableIdentifier.next())
-                              .build();
+            .withStatus(MessageStatus.UNREAD)
+            .withIdentifier(SortableIdentifier.next())
+            .build();
         String json = message.toString();
         Message recreatedMessage = dynamoDbObjectMapper.readValue(json, Message.class);
         assertThat(recreatedMessage, is(equalTo(message)));
@@ -89,7 +88,7 @@ public class MessageTest {
     }
 
     @Test
-    void shouldReturnCopyWithoutLossOfInformation(){
+    void shouldReturnCopyWithoutLossOfInformation() {
         Clock clock = Clock.systemDefaultZone();
         Publication publication = PublicationGenerator.randomPublication();
         Message message = Message.supportMessage(SAMPLE_SENDER, publication,
@@ -98,7 +97,7 @@ public class MessageTest {
                                                  clock);
         var copy = message.copy().build();
         assertThat(copy, doesNotHaveEmptyValues());
-        assertThat(copy,is(equalTo(message)));
+        assertThat(copy, is(equalTo(message)));
     }
 
     private static UserInstance sampleSender() {
@@ -109,10 +108,10 @@ public class MessageTest {
         Organization publisher = new Builder().withId(SAMPLE_OWNER.getOrganizationUri()).build();
         EntityDescription entityDescription = new EntityDescription.Builder().withMainTitle(randomString()).build();
         return new Publication.Builder()
-                   .withPublisher(publisher)
-                   .withOwner(SAMPLE_OWNER.getUserIdentifier())
-                   .withIdentifier(resourceIdentifier)
-                   .withEntityDescription(entityDescription)
-                   .build();
+            .withPublisher(publisher)
+            .withOwner(SAMPLE_OWNER.getUserIdentifier())
+            .withIdentifier(resourceIdentifier)
+            .withEntityDescription(entityDescription)
+            .build();
     }
 }

--- a/storage-model/src/test/java/no/unit/nva/publication/storage/model/ResourceUpdateTest.java
+++ b/storage-model/src/test/java/no/unit/nva/publication/storage/model/ResourceUpdateTest.java
@@ -7,6 +7,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import java.time.Clock;
 import java.time.Instant;
@@ -14,6 +15,8 @@ import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.PublicationGenerator;
+import no.unit.nva.publication.storage.model.daos.Dao;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -32,7 +35,6 @@ class ResourceUpdateTest {
                          new Tuple(leftMessage, rightMessage));
     }
 
-
     //This test guarantees backwards compatibility and the requirements can change when optimistic concurrency control
     // is implemented.
     @ParameterizedTest(name = "should return equals true when two resources differ only in their row version")
@@ -41,6 +43,22 @@ class ResourceUpdateTest {
         assertThat(tuple.left, doesNotHaveEmptyValues());
         assertThat(tuple.right.getRowVersion(), is(not(equalTo(tuple.left.getRowVersion()))));
         assertThat(tuple.right, is(equalTo(tuple.left)));
+    }
+
+    @Test
+    void shouldCreateNewRowVersionWhenRefreshed() {
+        var publication = PublicationGenerator.randomPublication();
+        var resource = Resource.fromPublication(publication);
+        var oldRowVersion = resource.getRowVersion();
+        var newRowVersion = resource.refreshRowVersion().getRowVersion();
+        assertThat(newRowVersion, is(not(equalTo(oldRowVersion))));
+    }
+
+    @ParameterizedTest(name= "should return Dao object:{0}")
+    @MethodSource("resourceProvider")
+    void shouldReturnDaoObject(Tuple resourceUpdate){
+        assertThat(resourceUpdate.left.toDao(),is(instanceOf(Dao.class)));
+
     }
 
     private static Message randomMessage(Publication publication) {

--- a/storage-model/src/test/java/no/unit/nva/publication/storage/model/daos/DaoTest.java
+++ b/storage-model/src/test/java/no/unit/nva/publication/storage/model/daos/DaoTest.java
@@ -24,6 +24,8 @@ import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.MalformedURLException;
@@ -80,9 +82,9 @@ public class DaoTest extends ResourcesDynamoDbLocalTest {
         String primaryKeyPartitionKey = jsonNode.get(PRIMARY_KEY_PARTITION_KEY_NAME).textValue();
 
         String expectedFormat = String.join(KEY_FIELDS_DELIMITER,
-            daoInstance.getType(),
-            daoInstance.getCustomerIdentifier(),
-            daoInstance.getOwner()
+                                            daoInstance.getType(),
+                                            daoInstance.getCustomerIdentifier(),
+                                            daoInstance.getOwner()
         );
 
         assertThat(primaryKeyPartitionKey, is(equalTo(expectedFormat)));
@@ -97,8 +99,8 @@ public class DaoTest extends ResourcesDynamoDbLocalTest {
         String primaryKeySortKey = jsonNode.get(PRIMARY_KEY_SORT_KEY_NAME).textValue();
 
         String expectedFormat = String.join(KEY_FIELDS_DELIMITER,
-            daoInstance.getType(),
-            daoInstance.getIdentifier().toString());
+                                            daoInstance.getType(),
+                                            daoInstance.getIdentifier().toString());
         assertThat(primaryKeySortKey, is(equalTo(expectedFormat)));
     }
 
@@ -114,11 +116,11 @@ public class DaoTest extends ResourcesDynamoDbLocalTest {
         String byTypeCustomerStatusIndexPartitionKey = dao.getByTypeCustomerStatusPartitionKey();
 
         String expectedFormat = String.join(KEY_FIELDS_DELIMITER,
-            dao.getType(),
-            CUSTOMER_INDEX_FIELD_PREFIX,
-            dao.getCustomerIdentifier(),
-            STATUS_INDEX_FIELD_PREFIX,
-            dao.getData().getStatusString());
+                                            dao.getType(),
+                                            CUSTOMER_INDEX_FIELD_PREFIX,
+                                            dao.getCustomerIdentifier(),
+                                            STATUS_INDEX_FIELD_PREFIX,
+                                            dao.getData().getStatusString());
 
         assertThat(byTypeCustomerStatusIndexPartitionKey, is(equalTo(expectedFormat)));
     }
@@ -132,8 +134,8 @@ public class DaoTest extends ResourcesDynamoDbLocalTest {
         String byTypeCustomerStatusIndexPartitionKey = dao.getByTypeCustomerStatusSortKey();
 
         String expectedFormat = String.join(KEY_FIELDS_DELIMITER,
-            dao.getType(),
-            dao.getIdentifier().toString());
+                                            dao.getType(),
+                                            dao.getIdentifier().toString());
 
         assertThat(byTypeCustomerStatusIndexPartitionKey, is(equalTo(expectedFormat)));
     }
@@ -151,54 +153,74 @@ public class DaoTest extends ResourcesDynamoDbLocalTest {
         assertThat(originalResource, doesNotHaveEmptyValues());
         assertThat(originalResource, is(equalTo(retrievedResource)));
     }
-    
+
     @ParameterizedTest(name = "dao can be retrieved by the ByTypePublisherStatus index: {0}")
     @MethodSource("instanceProvider")
     public void daoCanBeRetrievedByTypePublisherStatusIndex(Dao<?> originalDao) {
         client.putItem(toPutItemRequest(originalDao));
         QueryResult queryResult = client.query(queryByTypeCustomerStatusIndex(originalDao));
         Dao<?> retrievedDao = queryResult.getItems()
-                                  .stream()
-                                  .map(map -> parseAttributeValuesMap(map, originalDao.getClass()))
-                                  .collect(SingletonCollector.collect());
+            .stream()
+            .map(map -> parseAttributeValuesMap(map, originalDao.getClass()))
+            .collect(SingletonCollector.collect());
         assertThat(retrievedDao, is(equalTo(originalDao)));
     }
-    
+
     @ParameterizedTest(name = "toDynamoFormat creates a Dynamo object preserving all information")
     @MethodSource("instanceProvider")
     public void toDynamoFormatCreatesADynamoJsonFormatObjectPreservingAllInformation(Dao<?> originalDao) {
-        
+
         Map<String, AttributeValue> dynamoMap = originalDao.toDynamoFormat();
         client.putItem(RESOURCES_TABLE_NAME, dynamoMap);
         Map<String, AttributeValue> savedMap = client
-                                                   .getItem(RESOURCES_TABLE_NAME, originalDao.primaryKey())
-                                                   .getItem();
+            .getItem(RESOURCES_TABLE_NAME, originalDao.primaryKey())
+            .getItem();
         assertThat(dynamoMap, is(equalTo(savedMap)));
-    
+
         Dao<?> retrievedDao = parseAttributeValuesMap(savedMap, originalDao.getClass());
         assertThat(retrievedDao, doesNotHaveEmptyValues());
         assertThat(retrievedDao, is(equalTo(originalDao)));
     }
-    
+
     @ParameterizedTest
     @MethodSource("instanceProvider")
     public void parseAttributeValuesMapCreatesDaoWithoutLossOfInformation(Dao<?> originalDao) {
-        
+
         assertThat(originalDao, doesNotHaveEmptyValues());
         Map<String, AttributeValue> dynamoMap = originalDao.toDynamoFormat();
         Dao<?> parsedDao = parseAttributeValuesMap(dynamoMap, originalDao.getClass());
         assertThat(parsedDao, is(equalTo(originalDao)));
     }
-    
+
+    @ParameterizedTest(name= "should return filter expression that filters out non data entries:{0}")
+    @MethodSource("instanceProvider")
+    void shouldReturnFilteringExpressionThatFiltersOutNonDataEntries(Dao<?> sampleDao) {
+        IdentifierEntry identifier = IdentifierEntry.create(sampleDao);
+        client.putItem(RESOURCES_TABLE_NAME, identifier.toDynamoFormat());
+        client.putItem(RESOURCES_TABLE_NAME, sampleDao.toDynamoFormat());
+
+        ScanRequest scanRequest = new ScanRequest()
+            .withTableName(RESOURCES_TABLE_NAME)
+            .withFilterExpression(Dao.scanFilterExpression())
+            .withExpressionAttributeNames(Dao.scanFilterExpressionAttributeNames())
+            .withExpressionAttributeValues(Dao.scanFilterExpressionAttributeValues());
+        ScanResult result = client.scan(scanRequest);
+
+        Dao<?> actualItem = result.getItems().stream().map(value -> parseAttributeValuesMap(value, Dao.class))
+            .collect(SingletonCollector.collect());
+
+        assertThat(actualItem, is(equalTo(sampleDao)));
+    }
+
     private static Stream<Dao<?>> instanceProvider() throws InvalidIssnException, MalformedURLException {
         return DaoUtils.instanceProvider();
     }
-    
+
     private QueryRequest queryByTypeCustomerStatusIndex(Dao<?> originalResource) {
         return new QueryRequest()
-                   .withTableName(RESOURCES_TABLE_NAME)
-                   .withIndexName(BY_TYPE_CUSTOMER_STATUS_INDEX_NAME)
-                   .withKeyConditions(originalResource.fetchEntryByTypeCustomerStatusKey());
+            .withTableName(RESOURCES_TABLE_NAME)
+            .withIndexName(BY_TYPE_CUSTOMER_STATUS_INDEX_NAME)
+            .withKeyConditions(originalResource.fetchEntryByTypeCustomerStatusKey());
     }
 
     private JsonNode serializeInstance(Dao<?> daoInstance) throws JsonProcessingException {


### PR DESCRIPTION
Two methods for Resource Service that will be used by an event handler. One method scans the database for data entries (i.e. it filters out IdentityEntries). The other method, re-writes a set of entries by updating the row version of the data entry.