### PR TITLE
fix: ExpandedResourceConversation does not have own identifier

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDataEntry.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDataEntry.java
@@ -27,5 +27,10 @@ public interface ExpandedDataEntry extends JsonSerializable {
         }
     }
 
-    SortableIdentifier retrieveIdentifier();
+    /**
+     * An identifier that identifies the specific entry uniquely. It is meant to be used only
+     * for persisting entries for usage from other services (such as the Search service or Analytics services)
+     * @return a unique identifier.
+     */
+    SortableIdentifier identifyExpandedEntry();
 }

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
@@ -165,7 +165,7 @@ public final class ExpandedDoiRequest implements WithOrganizationScope, Expanded
     }
 
     @Override
-    public SortableIdentifier retrieveIdentifier() {
+    public SortableIdentifier identifyExpandedEntry() {
         return getIdentifier();
     }
 

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedMessage.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedMessage.java
@@ -165,7 +165,7 @@ public final class ExpandedMessage implements WithOrganizationScope, ExpandedDat
 
 
     @Override
-    public SortableIdentifier retrieveIdentifier() {
+    public SortableIdentifier identifyExpandedEntry() {
         return getIdentifier();
     }
 

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
@@ -81,7 +81,7 @@ public final class ExpandedResource implements JsonSerializable, ExpandedDataEnt
     }
 
     @Override
-    public SortableIdentifier retrieveIdentifier() {
+    public SortableIdentifier identifyExpandedEntry() {
         return SortableIdentifier.fromUri(fetchId());
     }
 

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResourceConversation.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResourceConversation.java
@@ -16,7 +16,7 @@ import java.util.Set;
 public class ExpandedResourceConversation extends ResourceConversation
         implements WithOrganizationScope, ExpandedDataEntry {
 
-    @JsonProperty("identifier")
+    @JsonProperty("publicationIdentifier")
     private SortableIdentifier publicationIdentifier;
     private Set<URI> organizationIds;
 
@@ -55,8 +55,8 @@ public class ExpandedResourceConversation extends ResourceConversation
     }
 
     @Override
-    public SortableIdentifier retrieveIdentifier() {
-        return publicationIdentifier;
+    public SortableIdentifier identifyExpandedEntry() {
+        return getPublicationIdentifier();
     }
 
     public SortableIdentifier getPublicationIdentifier() {

--- a/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDatabaseEntryTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDatabaseEntryTest.java
@@ -11,12 +11,12 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.net.URI;
 import java.time.Clock;
 import java.util.stream.Stream;
 import no.unit.nva.expansion.FakeResourceExpansionService;
 import no.unit.nva.expansion.ResourceExpansionService;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.publication.model.PublicationSummary;
 import no.unit.nva.publication.storage.model.DoiRequest;
@@ -31,54 +31,101 @@ class ExpandedDatabaseEntryTest {
 
     private static final ResourceExpansionService resourceExpansionService = new FakeResourceExpansionService();
 
-    public static Stream<ExpandedDataEntry> entryProvider() throws JsonProcessingException, NotFoundException {
-        return Stream.of(randomResource(), randomDoiRequest(), randomMessage(), randomResourceConversation());
+    public static Stream<ExpandedDataEntryWithAssociatedPublication> entryProvider()
+        throws JsonProcessingException, NotFoundException {
+        return Stream.of(ExpandedDataEntryWithAssociatedPublication.create(ExpandedResource.class),
+                         ExpandedDataEntryWithAssociatedPublication.create(ExpandedDoiRequest.class),
+                         ExpandedDataEntryWithAssociatedPublication.create(ExpandedMessage.class),
+                         ExpandedDataEntryWithAssociatedPublication.create(ExpandedResourceConversation.class)
+        );
     }
 
     @ParameterizedTest(name = "should return identifier using a non serializable method")
     @MethodSource("entryProvider")
-    void shouldReturnIdentifierUsingNonSerializableMethod(ExpandedDataEntry entry) {
-        SortableIdentifier identifier = entry.retrieveIdentifier();
-        SortableIdentifier fromSerializedId = SortableIdentifier.fromUri(extractIdFromSerializedObject(entry));
-        assertThat(identifier, is(equalTo(fromSerializedId)));
+    void shouldReturnIdentifierUsingNonSerializableMethod(ExpandedDataEntryWithAssociatedPublication entry) {
+        SortableIdentifier identifier = entry.getExpandedDataEntry().identifyExpandedEntry();
+        SortableIdentifier expectedIdentifier = extractExpectedIdentifier(entry);
+        assertThat(identifier, is(equalTo(expectedIdentifier)));
     }
 
-    private URI extractIdFromSerializedObject(ExpandedDataEntry entry) {
+    private static ExpandedDoiRequest randomDoiRequest(Publication publication) throws NotFoundException {
+        DoiRequest doiRequest = DoiRequest.newDoiRequestForResource(Resource.fromPublication(publication));
+        return ExpandedDoiRequest.create(doiRequest, resourceExpansionService);
+    }
+
+    private static ExpandedMessage randomMessage(Publication publication) throws NotFoundException {
+        var randomUser = new UserInstance(randomString(), randomUri());
+        var clock = Clock.systemDefaultZone();
+        var message = supportMessage(randomUser, publication, randomString(), SortableIdentifier.next(), clock);
+        return ExpandedMessage.create(message, resourceExpansionService);
+    }
+
+    private static ExpandedResourceConversation randomResourceConversation(Publication publication) {
+        //TODO: create proper ExpandedResourceConversation
+        var expandedResourceConversation = new ExpandedResourceConversation();
+        expandedResourceConversation.setPublicationSummary(PublicationSummary.create(publication));
+        expandedResourceConversation.setPublicationIdentifier(publication.getIdentifier());
+        return expandedResourceConversation;
+    }
+
+    private SortableIdentifier extractExpectedIdentifier(ExpandedDataEntryWithAssociatedPublication generatedData) {
+        if (entryIsAnAggregationOfOtherEntriesAndDoesNotHaveOwnIdentifiers(generatedData)) {
+            return generatedData.getPublication().getIdentifier();
+        } else {
+            return new SortableIdentifier(extractIdFromSerializedObject(generatedData.getExpandedDataEntry()));
+        }
+    }
+
+    private boolean entryIsAnAggregationOfOtherEntriesAndDoesNotHaveOwnIdentifiers(
+        ExpandedDataEntryWithAssociatedPublication entry) {
+        return entry.getExpandedDataEntry() instanceof ExpandedResourceConversation;
+    }
+
+    private String extractIdFromSerializedObject(ExpandedDataEntry entry) {
         return Try.of(entry)
             .map(ExpandedDataEntry::toJsonString)
             .map(objectMapper::readTree)
             .map(json -> (ObjectNode) json)
             .map(json -> json.at(IDENTIFIER_JSON_PTR))
             .map(JsonNode::textValue)
-            .map(URI::create)
             .orElseThrow();
     }
 
-    private static ExpandedResource randomResource() throws JsonProcessingException {
-        var publication = PublicationGenerator.randomPublication();
-        return ExpandedResource.fromPublication(publication);
-    }
+    private static class ExpandedDataEntryWithAssociatedPublication {
 
-    private static ExpandedDoiRequest randomDoiRequest() throws NotFoundException {
-        DoiRequest doiRequest = DoiRequest.newDoiRequestForResource(
-            Resource.fromPublication(PublicationGenerator.randomPublication()));
-        return ExpandedDoiRequest.create(doiRequest, resourceExpansionService);
-    }
+        private final Publication publication;
+        private final ExpandedDataEntry expandedDataEntry;
 
-    private static ExpandedMessage randomMessage() throws NotFoundException {
-        var randomUser = new UserInstance(randomString(), randomUri());
-        var publication = PublicationGenerator.randomPublication();
-        var clock = Clock.systemDefaultZone();
-        var message = supportMessage(randomUser, publication, randomString(), SortableIdentifier.next(), clock);
-        return ExpandedMessage.create(message, resourceExpansionService);
-    }
+        public ExpandedDataEntryWithAssociatedPublication(Publication publication, ExpandedDataEntry data) {
+            this.publication = publication;
+            this.expandedDataEntry = data;
+        }
 
-    private static ExpandedResourceConversation randomResourceConversation() {
-        var publication = PublicationGenerator.randomPublication();
-        //TODO: create proper ExpandedResourceConversation
-        var expandedResourceConversation = new ExpandedResourceConversation();
-        expandedResourceConversation.setPublicationSummary(PublicationSummary.create(publication));
-        expandedResourceConversation.setPublicationIdentifier(publication.getIdentifier());
-        return expandedResourceConversation;
+        public static ExpandedDataEntryWithAssociatedPublication create(Class<?> expandedDataEntryClass)
+            throws JsonProcessingException, NotFoundException {
+            var publication = PublicationGenerator.randomPublication();
+            if (expandedDataEntryClass.equals(ExpandedResource.class)) {
+                return
+                    new ExpandedDataEntryWithAssociatedPublication(publication,
+                                                                   ExpandedResource.fromPublication(publication));
+            }
+
+            if (expandedDataEntryClass.equals(ExpandedMessage.class)) {
+                return new ExpandedDataEntryWithAssociatedPublication(publication, randomMessage(publication));
+            } else if (expandedDataEntryClass.equals(ExpandedDoiRequest.class)) {
+                return new ExpandedDataEntryWithAssociatedPublication(publication, randomDoiRequest(publication));
+            } else {
+                return new ExpandedDataEntryWithAssociatedPublication(publication,
+                                                                      randomResourceConversation(publication));
+            }
+        }
+
+        public Publication getPublication() {
+            return publication;
+        }
+
+        public ExpandedDataEntry getExpandedDataEntry() {
+            return expandedDataEntry;
+        }
     }
 }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/PersistedDocumentConsumptionAttributes.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/PersistedDocumentConsumptionAttributes.java
@@ -35,11 +35,11 @@ public class PersistedDocumentConsumptionAttributes {
 
     public static PersistedDocumentConsumptionAttributes createAttributes(ExpandedDataEntry expandedEntry) {
         if (expandedEntry instanceof ExpandedResource) {
-            return new PersistedDocumentConsumptionAttributes(RESOURCES_INDEX, expandedEntry.retrieveIdentifier());
+            return new PersistedDocumentConsumptionAttributes(RESOURCES_INDEX, expandedEntry.identifyExpandedEntry());
         } else if (expandedEntry instanceof ExpandedDoiRequest) {
-            return new PersistedDocumentConsumptionAttributes(DOI_REQUESTS_INDEX, expandedEntry.retrieveIdentifier());
+            return new PersistedDocumentConsumptionAttributes(DOI_REQUESTS_INDEX, expandedEntry.identifyExpandedEntry());
         } else if (expandedEntry instanceof ExpandedResourceConversation) {
-            return new PersistedDocumentConsumptionAttributes(MESSAGES_INDEX, expandedEntry.retrieveIdentifier());
+            return new PersistedDocumentConsumptionAttributes(MESSAGES_INDEX, expandedEntry.identifyExpandedEntry());
         }
         throw new UnsupportedOperationException(
             UNSUPPORTED_TYPE_ERROR_MESSAGE + expandedEntry.getClass().getSimpleName());

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/PersistedDocumentConsumptionAttributes.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/PersistedDocumentConsumptionAttributes.java
@@ -27,7 +27,7 @@ public class PersistedDocumentConsumptionAttributes {
     @JsonCreator
     public PersistedDocumentConsumptionAttributes(
         @JsonProperty(INDEX_FIELD) String index,
-         @JsonProperty(DOCUMENT_IDENTIFIER) SortableIdentifier documentIdentifier
+        @JsonProperty(DOCUMENT_IDENTIFIER) SortableIdentifier documentIdentifier
     ) {
         this.index = index;
         this.documentIdentifier = documentIdentifier;
@@ -35,11 +35,14 @@ public class PersistedDocumentConsumptionAttributes {
 
     public static PersistedDocumentConsumptionAttributes createAttributes(ExpandedDataEntry expandedEntry) {
         if (expandedEntry instanceof ExpandedResource) {
-            return new PersistedDocumentConsumptionAttributes(RESOURCES_INDEX, expandedEntry.identifyExpandedEntry());
+            return new PersistedDocumentConsumptionAttributes(RESOURCES_INDEX,
+                                                              expandedEntry.identifyExpandedEntry());
         } else if (expandedEntry instanceof ExpandedDoiRequest) {
-            return new PersistedDocumentConsumptionAttributes(DOI_REQUESTS_INDEX, expandedEntry.identifyExpandedEntry());
+            return new PersistedDocumentConsumptionAttributes(DOI_REQUESTS_INDEX,
+                                                              expandedEntry.identifyExpandedEntry());
         } else if (expandedEntry instanceof ExpandedResourceConversation) {
-            return new PersistedDocumentConsumptionAttributes(MESSAGES_INDEX, expandedEntry.identifyExpandedEntry());
+            return new PersistedDocumentConsumptionAttributes(MESSAGES_INDEX,
+                                                              expandedEntry.identifyExpandedEntry());
         }
         throw new UnsupportedOperationException(
             UNSUPPORTED_TYPE_ERROR_MESSAGE + expandedEntry.getClass().getSimpleName());


### PR DESCRIPTION
A ResourceConversation is an aggregation(collection) of messages associated with a specific Publication. It is not a resource on its own and therefore it cannot have a permanent identifier. It is connected though to a publicationIdentifier.

This fix renames the field and fixes the tests so that they do not have the expectation that  the ResourceConversation has a field called "identifier"