### PR TITLE
Bump data model 0.18.6 -> 0.18.7

### DIFF
--- a/cristin-import/src/main/resources/ignoredFields.txt
+++ b/cristin-import/src/main/resources/ignoredFields.txt
@@ -1,5 +1,6 @@
 doi
 fileSet
+associatedArtifacts
 handle
 identifier
 indexedDate

--- a/docs/hard-coded-and-ignored-fields.txt
+++ b/docs/hard-coded-and-ignored-fields.txt
@@ -1,6 +1,7 @@
 # Ignored fields:
 doi
 fileSet
+associatedArtifacts
 handle
 identifier
 indexedDate

--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -30,6 +30,9 @@
     "files": {
       "@container": "@set"
     },
+    "associatedArtifacts": {
+      "@container": "@set"
+    },
     "grants": {
       "@container": "@set"
     },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 nva = { strictly = '1.24.18' }
-nvaDatamodel = { strictly = '0.18.6' }
+nvaDatamodel = { strictly = '0.18.7' }
 nvaDoiPartnerData = { strictly = '0.4.0' }
 jackson = { strictly = '2.13.3' }
 awsSdk = { strictly = '1.12.220' }


### PR DESCRIPTION
This PR:
 - bumps data model 0.18.6 -> 0.18.7
 - adds associatedArtifact to excluded fields in Cristin mappings etc. 
 - adds set-coercion to JSON-LD frame