### PR TITLE
Migrate testing to OOP-paradigm

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -69,7 +69,6 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
         
         var identifier = RequestUtil.getIdentifier(requestInfo);
         var publication = resourceService.getPublicationByIdentifier(identifier);
-        
         return createResponse(requestInfo, publication);
     }
     

--- a/schema-org-metadata/build.gradle
+++ b/schema-org-metadata/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     testImplementation libs.bundles.testing
     testImplementation libs.nva.identifiers
     testImplementation project(':publication-testing')
-
+    testImplementation 'uk.co.datumedge:hamcrest-json:0.2'
 }

--- a/schema-org-metadata/src/main/resources/schema_org_conversion.sparql
+++ b/schema-org-metadata/src/main/resources/schema_org_conversion.sparql
@@ -1,28 +1,27 @@
 PREFIX nva: <https://nva.sikt.no/ontology/publication#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 
 CONSTRUCT {
-  ?id a ?schemaOrgType ;
+  ?id a ?type ;
     schema:provider <https://sikt.no> ;
     schema:name ?name ;
-    schema:creator [ a schema:Person ;
-      schema:name ?contributorName ] .
+    schema:creator [
+      a schema:Person ;
+      schema:name ?contributor
+    ] .
 
   <https://sikt.no> a schema:Organization ;
       schema:name "Sikt" .
 } WHERE {
-  ?id a nva:Publication .
-  ?id nva:entityDescription ?entityDescription .
-  ?entityDescription nva:mainTitle ?name .
 
-  ?entityDescription nva:reference/nva:publicationInstance ?publicationInstance .
-  ?publicationInstance a ?nvaType .
-  ?nvaType rdfs:subClassOf ?schemaOrgType .
+    ?id a nva:Publication .
+    ?id nva:entityDescription ?entityDescription .
+    ?entityDescription nva:mainTitle ?name .
+    ?entityDescription nva:reference/nva:publicationInstance/rdf:type/rdfs:subClassOf ?type .
 
-  OPTIONAL {
-      ?entityDescription nva:contributor ?contributors .
-      ?contributors nva:identity ?identity .
-      ?identity nva:name ?contributorName .
-  }
+    OPTIONAL {
+        ?id nva:entityDescription/nva:contributor/nva:identity/nva:name ?contributor .
+    }
 }

--- a/schema-org-metadata/src/main/resources/subtype_mappings.ttl
+++ b/schema-org-metadata/src/main/resources/subtype_mappings.ttl
@@ -22,7 +22,7 @@ nva:DegreeBachelor rdfs:subClassOf schema:Thesis .
 nva:JournalLeader rdfs:subClassOf schema:ScholarlyArticle .
 nva:MediaInterview rdfs:subClassOf schema:NewsArticle .
 nva:ConferencePoster rdfs:subClassOf schema:PresentationDigitalDocument .
-nva:ChapterArticle rdfs:subClassOf schema:Chapter, schema:ScholarlyArticle .
+nva:ChapterArticle rdfs:subClassOf schema:Chapter .
 nva:Lecture rdfs:subClassOf schema:PresentationDigitalDocument .
 nva:VisualArts rdfs:subClassOf schema:VisualArtwork .
 nva:ReportResearch rdfs:subClassOf schema:Report .

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/SchemaOrgDocumentTest.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/SchemaOrgDocumentTest.java
@@ -1,35 +1,40 @@
 package no.unit.nva.schemaorg;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.publication.testing.TypeProvider;
+import no.unit.nva.schemaorg.document.FramedSchemaOrgDocumentBuilder;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.ioutils.IoUtils.linesfromResource;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 
 class SchemaOrgDocumentTest {
 
     public static final ObjectMapper MAPPER = JsonUtils.dtoObjectMapper;
+    public static final String PREFIXED_TURTLE_TOKEN_TEMPLATE = ":%s ";
+    public static final String COMMA = ",";
+    public static final String JSON_ARRAY_DELIMITER = COMMA;
+    public static final String ID_NAMESPACE = "ID_NAMESPACE";
+    public static final String SCHEMA_ORG_NS_PREFIX = "schema:";
+    public static final String EMPTY_STRING = "";
+    public static final char TURTLE_STATEMENT_END = '.';
+    public static final Path RDF_SUBTYPE_MAPPINGS = Path.of("subtype_mappings.ttl");
 
     public static Stream<Class<?>> instanceTypeProvider() {
         return TypeProvider.listSubTypes(PublicationInstance.class);
@@ -37,63 +42,56 @@ class SchemaOrgDocumentTest {
 
     @ParameterizedTest(name = "Should generate schema.org for type: {0}")
     @MethodSource("instanceTypeProvider")
-    void shouldReturnSchemaOrgDocumentWithTypeWhenInputIsPublication(Class<? extends PublicationInstance<?>> instance) {
+    void shouldReturnSchemaOrgDocumentWithTypeMappingWhenInputIsPublication(
+            Class<? extends PublicationInstance<?>> instance) {
         var publication = randomPublication(instance);
         var actual = SchemaOrgDocument.fromPublication(publication);
-        var jsonNode = attempt(() -> MAPPER.readTree(actual)).orElseThrow();
-        var expectedType = calculateType(instance);
-        assertThatBasicDataIsInPlace(publication, jsonNode, expectedType);
+        var expected = generateExpected(publication, instance);
+        assertThat(actual, sameJSONAs(expected).allowingAnyArrayOrdering());
     }
 
-    private List<String> calculateType(Class<? extends PublicationInstance<?>> instance) {
+    private String generateExpected(Publication publication,
+                                                     Class<? extends PublicationInstance<?>> instance) {
+        return attempt(() -> MAPPER.writeValueAsString(FramedSchemaOrgDocumentBuilder.newInstance()
+                .withCreator(publication.getEntityDescription().getContributors())
+                .withName(publication.getEntityDescription().getMainTitle())
+                .withId(constructExpectedId(publication))
+                .withProvider(URI.create("https://sikt.no"), "Sikt")
+                .withContext(URI.create("https://schema.org/"))
+                .withType(calculateExpectedTypes(instance))
+                .build())).orElseThrow();
+    }
+
+    private List<String> calculateExpectedTypes(Class<? extends PublicationInstance<?>> instance) {
         var name = instance.getSimpleName();
-        return linesfromResource(Path.of("subtype_mappings.ttl"))
+        return linesfromResource(RDF_SUBTYPE_MAPPINGS)
                 .stream()
                 .filter(item -> matchRdfPrefixedTerm(name, item))
-                .map(this::getSchemaTypeFromString)
-                .map(SchemaOrgDocumentTest::splitOnComma)
+                .map(this::getSchemaTypeFromTurtleString)
+                .map(SchemaOrgDocumentTest::splitJsonArray)
                 .flatMap(Arrays::stream)
                 .map(String::trim)
                 .collect(Collectors.toList());
     }
 
     private static boolean matchRdfPrefixedTerm(String name, String item) {
-        return item.contains(":" + name + " ");
+        return item.contains(String.format(PREFIXED_TURTLE_TOKEN_TEMPLATE, name));
     }
 
-    private static String[] splitOnComma(String item) {
-        return item.split(",");
+    private static String[] splitJsonArray(String item) {
+        return item.split(JSON_ARRAY_DELIMITER);
     }
 
-    private String getSchemaTypeFromString(String input) {
-        var startIndex = input.indexOf("schema:");
-        var endIndex = input.indexOf('.');
+    private String getSchemaTypeFromTurtleString(String input) {
+        var startIndex = input.indexOf(SCHEMA_ORG_NS_PREFIX);
+        var endIndex = input.indexOf(TURTLE_STATEMENT_END);
         var schemaType = input.substring(startIndex, endIndex).trim();
-        return schemaType.replace("schema:", "");
+        return schemaType.replace(SCHEMA_ORG_NS_PREFIX, EMPTY_STRING);
     }
 
-    private static void assertThatBasicDataIsInPlace(Publication publication,
-                                                     JsonNode jsonNode,
-                                                     List<String> expectedType) {
-        var id = System.getenv("ID_NAMESPACE") + "/" + publication.getIdentifier().toString();
-        assertThat(jsonNode.get("@id").textValue(), is(equalTo(id)));
-        compareTypes(jsonNode, expectedType);
-        assertThat(jsonNode.get("name").textValue(), is(not(nullValue())));
-        assertThat(jsonNode.get("provider"), is(not(nullValue())));
-    }
-
-    private static void compareTypes(JsonNode jsonNode, List<String> expectedType) {
-        var actual = jsonNode.get("@type");
-        if (expectedType.size() == 1) {
-            assertThat(actual.textValue(), is(equalTo(expectedType.get(0))));
-        } else {
-            assertThat(toListOfStrings(actual), containsInAnyOrder(expectedType.toArray()));
-        }
-    }
-
-    private static List<String> toListOfStrings(JsonNode jsonNode) {
-        return StreamSupport.stream(jsonNode.spliterator(), false)
-                .map(JsonNode::textValue)
-                .collect(Collectors.toList());
+    private static URI constructExpectedId(Publication publication) {
+        return UriWrapper.fromUri(System.getenv(ID_NAMESPACE))
+                .addChild(publication.getIdentifier().toString())
+                .getUri();
     }
 }

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Context.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Context.java
@@ -1,0 +1,36 @@
+package no.unit.nva.schemaorg.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nva.commons.core.JacocoGenerated;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class Context {
+    public static final String VOCAB_FIELD = "@vocab";
+    @JsonProperty(VOCAB_FIELD)
+    private final URI vocab;
+
+    public Context(@JsonProperty(VOCAB_FIELD) URI vocab) {
+        this.vocab = vocab;
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Context)) {
+            return false;
+        }
+        Context context = (Context) o;
+        return Objects.equals(vocab, context.vocab);
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(vocab);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/FramedSchemaOrgDocument.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/FramedSchemaOrgDocument.java
@@ -1,0 +1,57 @@
+package no.unit.nva.schemaorg.document;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nva.commons.core.JacocoGenerated;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class FramedSchemaOrgDocument extends JsonLdBase {
+    public static final String NAME_FIELD = "name";
+    public static final String CREATOR_FIELD = "creator";
+    public static final String PROVIDER_FIELD = "provider";
+    @JsonProperty(CREATOR_FIELD)
+    private final PersonI creator;
+    @JsonProperty(PROVIDER_FIELD)
+    private final Organization provider;
+    @JsonProperty(NAME_FIELD)
+    private final String name;
+
+    @JsonCreator
+    public FramedSchemaOrgDocument(@JsonProperty(CONTEXT_FIELD) URI context,
+                                   @JsonProperty(ID_FIELD) URI id,
+                                   @JsonProperty(TYPE_FIELD) Object type,
+                                   @JsonProperty(NAME_FIELD) String name,
+                                   @JsonProperty(CREATOR_FIELD) PersonI creator,
+                                   @JsonProperty(PROVIDER_FIELD) Organization provider) {
+        super(context, id, type);
+        this.creator = creator;
+        this.name = name;
+        this.provider = provider;
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FramedSchemaOrgDocument)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        FramedSchemaOrgDocument that = (FramedSchemaOrgDocument) o;
+        return Objects.equals(creator, that.creator)
+                && Objects.equals(provider, that.provider)
+                && Objects.equals(name, that.name);
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), creator, provider, name);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/FramedSchemaOrgDocumentBuilder.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/FramedSchemaOrgDocumentBuilder.java
@@ -1,0 +1,69 @@
+package no.unit.nva.schemaorg.document;
+
+import no.unit.nva.model.Contributor;
+import no.unit.nva.model.Identity;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class FramedSchemaOrgDocumentBuilder {
+    private PersonI creator;
+    private Organization provider;
+    private URI context;
+    private URI id;
+    private Object type;
+
+    private String name;
+
+    private FramedSchemaOrgDocumentBuilder() {
+    }
+
+    public static FramedSchemaOrgDocumentBuilder newInstance() {
+        return new FramedSchemaOrgDocumentBuilder();
+    }
+
+    public FramedSchemaOrgDocumentBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public FramedSchemaOrgDocumentBuilder withCreator(List<Contributor> creators) {
+        var persons = generatorCreatorList(creators);
+        this.creator = creators.size() == 1 ? persons.get(0) : persons;
+        return this;
+    }
+
+    private PersonList generatorCreatorList(List<Contributor> creators) {
+        var persons = creators.stream()
+                .map(Contributor::getIdentity)
+                .map(Identity::getName)
+                .map(Person::new)
+                .collect(Collectors.toList());
+        return new PersonList(persons);
+    }
+
+    public FramedSchemaOrgDocumentBuilder withProvider(URI uri, String name) {
+        this.provider = new Organization(uri, name);
+        return this;
+    }
+
+    public FramedSchemaOrgDocumentBuilder withContext(URI context) {
+        this.context = context;
+        return this;
+    }
+
+    public FramedSchemaOrgDocumentBuilder withId(URI id) {
+        this.id = id;
+        return this;
+    }
+
+    public FramedSchemaOrgDocumentBuilder withType(List<String> type) {
+        this.type = type.size() == 1 ? type.get(0) : type;
+        return this;
+    }
+
+    public FramedSchemaOrgDocument build() {
+        return new FramedSchemaOrgDocument(context, id, type, name, creator, provider);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/JsonLdBase.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/JsonLdBase.java
@@ -1,0 +1,48 @@
+package no.unit.nva.schemaorg.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nva.commons.core.JacocoGenerated;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class JsonLdBase {
+    public static final String CONTEXT_FIELD = "@context";
+    public static final String ID_FIELD = "@id";
+    public static final String TYPE_FIELD = "@type";
+    @JsonProperty(CONTEXT_FIELD)
+    private final Context context;
+    @JsonProperty(ID_FIELD)
+    private final URI id;
+    @JsonProperty(TYPE_FIELD)
+    private final Object type;
+
+    public JsonLdBase(@JsonProperty(CONTEXT_FIELD) URI context,
+                      @JsonProperty(ID_FIELD) URI id,
+                      @JsonProperty(TYPE_FIELD) Object type) {
+        this.context = new Context(context);
+        this.id = id;
+        this.type = type;
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof JsonLdBase)) {
+            return false;
+        }
+        JsonLdBase that = (JsonLdBase) o;
+        return Objects.equals(context, that.context)
+                && Objects.equals(id, that.id)
+                && Objects.equals(type, that.type);
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(context, id, type);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Organization.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Organization.java
@@ -1,0 +1,44 @@
+package no.unit.nva.schemaorg.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import nva.commons.core.JacocoGenerated;
+
+import java.net.URI;
+import java.util.Objects;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+public class Organization {
+    public static final String ID_FIELD = "@id";
+    public static final String NAME_FIELD = "name";
+    @JsonProperty(ID_FIELD)
+    private final URI id;
+    @JsonProperty(NAME_FIELD)
+    private final String name;
+
+    public Organization(@JsonProperty(ID_FIELD) URI id,
+                        @JsonProperty(NAME_FIELD) String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Organization)) {
+            return false;
+        }
+        Organization that = (Organization) o;
+        return Objects.equals(id, that.id)
+                && Objects.equals(name, that.name);
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Person.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/Person.java
@@ -1,0 +1,37 @@
+package no.unit.nva.schemaorg.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import nva.commons.core.JacocoGenerated;
+
+import java.util.Objects;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+public class Person implements PersonI {
+    public static final String NAME_FIELD = "name";
+    @JsonProperty(NAME_FIELD)
+    private final String name;
+
+    public Person(@JsonProperty(NAME_FIELD) String name) {
+        this.name = name;
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Person)) {
+            return false;
+        }
+        Person person = (Person) o;
+        return Objects.equals(name, person.name);
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/PersonI.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/PersonI.java
@@ -1,0 +1,4 @@
+package no.unit.nva.schemaorg.document;
+
+public interface PersonI {
+}

--- a/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/PersonList.java
+++ b/schema-org-metadata/src/test/java/no/unit/nva/schemaorg/document/PersonList.java
@@ -1,0 +1,130 @@
+package no.unit.nva.schemaorg.document;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+public class PersonList implements List<Person>, PersonI {
+
+    private final List<Person> persons;
+
+    public PersonList(List<Person> persons) {
+        this.persons = persons;
+    }
+
+    @Override
+    public int size() {
+        return persons.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return persons.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return persons.contains(o);
+    }
+
+    @Override
+    public Iterator<Person> iterator() {
+        return persons.iterator();
+    }
+
+    @Override
+    public Person[] toArray() {
+        return persons.toArray(Person[]::new);
+    }
+
+    @Override
+    public Object[] toArray(Object[] objects) {
+        return persons.toArray(objects);
+    }
+
+    @Override
+    public boolean add(Person o) {
+        return persons.add(o);
+    }
+
+    @Override
+    public void add(int i, Person o) {
+        persons.add(i, o);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return persons.remove(o);
+    }
+
+    @Override
+    public Person remove(int i) {
+        return persons.remove(i);
+    }
+
+    @Override
+    public boolean addAll(Collection collection) {
+        return persons.addAll(collection);
+    }
+
+    @Override
+    public boolean addAll(int i, Collection collection) {
+        return persons.addAll(i, collection);
+    }
+
+    @Override
+    public void clear() {
+        persons.clear();
+    }
+
+    @Override
+    public Person get(int i) {
+        return persons.get(i);
+    }
+
+    @Override
+    public Person set(int i, Person o) {
+        return persons.set(i, o);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return persons.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return persons.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<Person> listIterator() {
+        return persons.listIterator();
+    }
+
+    @Override
+    public ListIterator<Person> listIterator(int i) {
+        return persons.listIterator(i);
+    }
+
+    @Override
+    public List<Person> subList(int i, int i1) {
+        return persons.subList(i, i1);
+    }
+
+    @Override
+    public boolean retainAll(Collection collection) {
+        return persons.retainAll(collection);
+    }
+
+    @Override
+    public boolean removeAll(Collection collection) {
+        return persons.removeAll(collection);
+    }
+
+    @Override
+    public boolean containsAll(Collection collection) {
+        return persons.containsAll(collection);
+    }
+}


### PR DESCRIPTION
- Adding the objects to test the result
- Remove multi-type mapping since this is not understood by consumers (i.e. Google, others simply ignore it)
- Minor fixes to SPARQL query: use property paths