### PR TITLE
Np 19713 use is publishable from model

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 
 nva = { strictly = '1.25.17' }
-nvaDatamodel = { strictly = '0.19.17' }
+nvaDatamodel = { strictly = '0.19.18' }
 nvaDoiPartnerData = { strictly = '0.4.0' }
 jackson = { strictly = '2.13.3' }
 awsSdk = { strictly = '1.12.220' }

--- a/publication-commons/src/main/java/no/unit/nva/publication/exception/InvalidPublicationException.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/exception/InvalidPublicationException.java
@@ -1,20 +1,12 @@
 package no.unit.nva.publication.exception;
 
-import java.util.List;
 import nva.commons.apigateway.exceptions.ConflictException;
 import org.apache.http.HttpStatus;
 
 public class InvalidPublicationException extends ConflictException {
-    
-    public static final String ERROR_MESSAGE_TEMPLATE =
-        "The Publication cannot be published because the following fields are not populated: ";
-    
+
     public InvalidPublicationException(String message) {
         super(message);
-    }
-    
-    public InvalidPublicationException(List<String> missingFields) {
-        super(ERROR_MESSAGE_TEMPLATE + String.join(", ", missingFields));
     }
     
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -44,7 +44,6 @@ public class UpdateResourceService extends ServiceWithTransactions {
 
     public static final String PUBLISH_METADATA_COMPLETED = "Publication metadata is published.";
     public static final String PUBLISH_IN_PROGRESS = "Publication is being published. This may take a while.";
-    public static final String RESOURCE_WITHOUT_MAIN_TITLE_ERROR = "Resource is missing main title: ";
     public static final String RESOURCE_LINK_FIELD = "link";
     
     //TODO: fix affiliation update when updating owner

--- a/publication-commons/src/test/java/no/unit/nva/publication/exception/InvalidPublicationExceptionTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/exception/InvalidPublicationExceptionTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 class InvalidPublicationExceptionTest {
     
     @Test
-    public void getStatusCodeReturnsConflict() {
-        InvalidPublicationException exception = new InvalidPublicationException("someMessage");
+    void getStatusCodeReturnsConflict() {
+        var exception = new InvalidPublicationException("someMessage");
         assertThat(exception.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
     }
 }

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -1,7 +1,6 @@
 package no.unit.nva.publication.events.handlers.tickets;
 
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.publication.service.impl.UpdateResourceService.RESOURCE_WITHOUT_MAIN_TITLE_ERROR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,6 +35,8 @@ import org.junit.jupiter.api.Test;
 class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     
     private static final Context CONTEXT = new FakeContext();
+    public static final String RESOURCE_LACKS_REQUIRED_DATA = "Resource does not have required data to be "
+                                                              + "published: ";
     private ResourceService resourceService;
     private AcceptedPublishingRequestEventHandler handler;
     private ByteArrayOutputStream outputStream;
@@ -86,7 +87,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var updatedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
         
         assertThat(updatedPublication.getStatus(), is(equalTo(PublicationStatus.DRAFT)));
-        assertThat(logger.getMessages(), containsString(RESOURCE_WITHOUT_MAIN_TITLE_ERROR));
+        assertThat(logger.getMessages(), containsString(RESOURCE_LACKS_REQUIRED_DATA));
     }
     
     private InputStream createEvent(TicketEntry pendingPublishingRequest,

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/PendingPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/PendingPublishingRequestEventHandlerTest.java
@@ -3,7 +3,6 @@ package no.unit.nva.publication.events.handlers.tickets;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.publication.service.impl.UpdateResourceService.RESOURCE_WITHOUT_MAIN_TITLE_ERROR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +52,8 @@ class PendingPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     
     public static final Entity EMPTY = null;
     private static final URI CUSTOMER_ID = randomUri();
+    public static final String RESOURCE_LACKS_REQUIRED_DATA = "Resource does not have required data to be "
+                                                              + "published: ";
     private S3Driver s3Driver;
     private FakeS3Client s3Client;
     private PendingPublishingRequestEventHandler handler;
@@ -163,7 +164,7 @@ class PendingPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var updatedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
 
         assertThat(updatedPublication.getStatus(), is(equalTo(PublicationStatus.DRAFT)));
-        assertThat(logger.getMessages(), containsString(RESOURCE_WITHOUT_MAIN_TITLE_ERROR));
+        assertThat(logger.getMessages(), containsString(RESOURCE_LACKS_REQUIRED_DATA));
     }
 
     @Test

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -16,6 +16,7 @@ import no.unit.nva.PublicationMapper;
 import no.unit.nva.api.PublicationResponse;
 import no.unit.nva.doi.DataCiteMetadataDtoMapper;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.RequestUtil;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.schemaorg.SchemaOrgDocument;
@@ -69,9 +70,18 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
         
         var identifier = RequestUtil.getIdentifier(requestInfo);
         var publication = resourceService.getPublicationByIdentifier(identifier);
+        temporaryHackWhileWeWaitForUnauthenticatedUserAccess(publication);
         return createResponse(requestInfo, publication);
     }
-    
+
+    // TODO: implement unauthenticated users to allow us to remove unpublished files from returned data when the user
+    //  is unauthenticated.
+    private static void temporaryHackWhileWeWaitForUnauthenticatedUserAccess(Publication publication) {
+        if (PublicationStatus.PUBLISHED_METADATA.equals(publication.getStatus())) {
+            publication.setStatus(PublicationStatus.PUBLISHED);
+        }
+    }
+
     @Override
     protected Integer getSuccessStatusCode(Void input, String output) {
         return HttpURLConnection.HTTP_OK;


### PR DESCRIPTION
- Removes Publication validation code from service, delegating it to a method on the model
- Removes fine-grained exception since this is difficult to achieve, once the full validation is in place, we can return to a more fine-grained report