### PR TITLE
Bump limit on query, adding status tests

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
@@ -149,7 +149,8 @@ public class ReadResourceService {
         return new QueryRequest()
                    .withTableName(tableName)
                    .withIndexName(BY_CUSTOMER_RESOURCE_INDEX_NAME)
-                   .withKeyConditions(keyConditions);
+                   .withKeyConditions(keyConditions)
+                   .withLimit(100);
     }
     
     private List<Dao> parseResultSetToDaos(QueryResult queryResult) {


### PR DESCRIPTION
- byOwner results:
  - Bumps limit from DDB default (50) to 100
  - Test that statuses are observed