### PR TITLE
Move top-level affiliations to index document root

### DIFF
--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -1,6 +1,7 @@
 {
   "@context": {
     "@vocab": "https://nva.sikt.no/ontology/publication#",
+    "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
     "id": "@id",
     "type": "@type",
     "contributors": {
@@ -68,6 +69,9 @@
       "@container": "@set"
     },
     "messages": {
+      "@container": "@set"
+    },
+    "topLevelOrganization": {
       "@container": "@set"
     }
   },

--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -76,14 +76,13 @@
     "contributors": {
       "affiliations": {
         "@explicit": true,
+        "@embed": "@always",
         "type": "Organization",
-        "labels": {},
-        "name": {},
-        "topLevelOrganization": {
-          "@explicit": true,
-          "type": "Organization",
-          "labels": {},
-          "name": {}
+        "labels": {
+          "@embed": "@always"
+        },
+        "name": {
+          "@embed": "@always"
         }
       }
     }

--- a/expansion/src/main/resources/topLevelAffiliationQuery.sparql
+++ b/expansion/src/main/resources/topLevelAffiliationQuery.sparql
@@ -4,8 +4,9 @@
 PREFIX  nva: <https://nva.sikt.no/ontology/publication#>
 
 CONSTRUCT {
-  ?org nva:topLevelOrganization ?top_org .
+  ?publication nva:topLevelOrganization ?top_org .
   } WHERE {
+  ?publication a nva:Publication .
   ?affiliation nva:affiliations ?org .
   ?org nva:partOf* ?top_org .
     FILTER NOT EXISTS { ?top_org nva:partOf ?e } .

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -64,6 +64,7 @@ class ExpandedResourceTest {
         "/entityDescription/reference/publicationContext/publisher/name";
     public static final String SERIES_NAME_JSON_PTR =
         "/entityDescription/reference/publicationContext/series/name";
+    public static final Set<String> ACCEPTABLE_FIELD_NAMES = Set.of("id", "name", "labels", "type", "hasPart");
 
     private UriRetriever uriRetriever;
 
@@ -257,21 +258,17 @@ class ExpandedResourceTest {
     private void assertExplicitFieldsFromFraming(ObjectNode framedResultNode) {
         var node = framedResultNode.at("/topLevelOrganization");
         StreamSupport.stream(node.spliterator(), false)
-            .flatMap(ExpandedResourceTest::getaVoid)
-            .forEach(ExpandedResourceTest::assertAllFieldsAreValid);
+            .flatMap(ExpandedResourceTest::getFieldNameStream)
+            .forEach(ExpandedResourceTest::assertFieldNameIsMemberOfAcceptableFieldNames);
     }
 
-    private static Stream<String> getaVoid(JsonNode topOrg) {
+    private static Stream<String> getFieldNameStream(JsonNode topOrg) {
         var spliterator = Spliterators.spliteratorUnknownSize(topOrg.fieldNames(), Spliterator.ORDERED);
         return StreamSupport.stream(spliterator, false);
     }
 
-    private static void assertAllFieldsAreValid(String fieldName) {
-        assert (Objects.equals(fieldName, "id")
-                || Objects.equals(fieldName, "name")
-                || Objects.equals(fieldName, "labels")
-                || Objects.equals(fieldName, "type")
-                || Objects.equals(fieldName, "hasPart"));
+    private static void assertFieldNameIsMemberOfAcceptableFieldNames(String fieldName) {
+        assert ACCEPTABLE_FIELD_NAMES.contains(fieldName);
     }
 
     private URI getTopLevelUri(int depth, URI affiliationToBeExpandedId, UriRetriever mockUriRetriever) {

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URI;
@@ -35,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import no.unit.nva.expansion.model.ExpandedResource;
 import no.unit.nva.expansion.utils.PublicationJsonPointers;
 import no.unit.nva.publication.external.services.UriRetriever;
@@ -134,7 +136,6 @@ class ExpandedResourceTest {
         final Publication publication = randomBookWithConfirmedPublisher();
         final URI seriesUri = extractSeriesUri(publication);
         final URI publisherUri = extractPublisherUri(publication);
-        final URI affiliationToBeExpandedId = extractAffiliationsUris(publication).get(0);
         final String publisherName = randomString();
         final String seriesName = randomString();
 
@@ -176,7 +177,9 @@ class ExpandedResourceTest {
     private List<URI> extractDistinctTopLevelIds(JsonNode framedResultNode) {
         var topLevelAffiliations = framedResultNode.findValues("topLevelOrganization");
         return topLevelAffiliations.stream()
-            .map(node -> URI.create(node.get("id").asText()))
+            .flatMap(arrayNode -> StreamSupport.stream(arrayNode.spliterator(), false))
+            .map(node -> node.get("id").asText())
+            .map(URI::create)
             .distinct()
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
- Moves the top-level affiliations to index document root
- Unfortunately includes blank-node ids on maps