### PR TITLE
NP-41153-disallow-doi-request-when-non-published, work in progress

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
@@ -114,7 +114,8 @@ public final class ExpandedDoiRequest extends ExpandedTicket implements WithOrga
     public void setOrganizationIds(Set<URI> organizationIds) {
         this.organizationIds = organizationIds;
     }
-    
+
+    @JacocoGenerated
     @Override
     public DoiRequest toTicketEntry() {
         DoiRequest doiRequest = new DoiRequest();

--- a/expansion/src/main/java/no/unit/nva/expansion/utils/JsonLdUtils.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/utils/JsonLdUtils.java
@@ -5,6 +5,7 @@ import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import nva.commons.core.JacocoGenerated;
 
 public final class JsonLdUtils {
     
@@ -15,7 +16,8 @@ public final class JsonLdUtils {
     public static String toJsonString(JsonNode root) {
         return attempt(() -> objectMapper.writeValueAsString(addContext(root))).orElseThrow();
     }
-    
+
+    @JacocoGenerated
     private static JsonNode addContext(JsonNode root) {
         if (nonNull(root)) {
             ObjectNode context = objectMapper.createObjectNode();

--- a/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDataEntryTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDataEntryTest.java
@@ -1,14 +1,31 @@
 package no.unit.nva.expansion.model;
 
+import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
+import static no.unit.nva.expansion.model.ExpandedResource.fromPublication;
+import static no.unit.nva.expansion.utils.PublicationJsonPointers.ID_JSON_PTR;
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.stream.Stream;
 import no.unit.nva.expansion.ResourceExpansionService;
 import no.unit.nva.expansion.ResourceExpansionServiceImpl;
-import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.testing.PublicationInstanceBuilder;
+import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.PublicationDetails;
@@ -29,27 +46,11 @@ import nva.commons.core.attempt.Try;
 import nva.commons.core.paths.UriWrapper;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
-import static no.unit.nva.expansion.model.ExpandedResource.fromPublication;
-import static no.unit.nva.expansion.utils.PublicationJsonPointers.ID_JSON_PTR;
-import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ExpandedDataEntryTest extends ResourcesLocalTest {
 
@@ -117,12 +118,21 @@ class ExpandedDataEntryTest extends ResourcesLocalTest {
     @ParameterizedTest(name = "Expanded DOI request should have type DoiRequest for instance type {0}")
     @MethodSource("publicationInstanceProvider")
     void expandedDoiRequestShouldHaveTypeDoiRequest(Class<?> instanceType) throws ApiGatewayException {
-        var publication = createPublicationWithoutDoi(instanceType);
+        var publication = createPublishedPublicationWithoutDoi(instanceType);
         var doiRequest = createDoiRequest(publication);
         var expandedResource =
                 ExpandedDoiRequest.createEntry(doiRequest, resourceExpansionService, resourceService, ticketService);
         var json = objectMapper.convertValue(expandedResource, ObjectNode.class);
         assertThat(json.get(TYPE).textValue(), is(equalTo(ExpandedDoiRequest.TYPE)));
+    }
+
+    private Publication createPublishedPublicationWithoutDoi(Class<?> instanceType) throws ApiGatewayException {
+        var publication = randomPublicationWithoutDoi(instanceType);
+        var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService,
+                                                                UserInstance.fromPublication(publication));
+        resourceService.publishPublication(UserInstance.fromPublication(publication),
+                                           persistedPublication.getIdentifier());
+        return resourceService.getPublication(persistedPublication);
     }
 
     @ParameterizedTest(name = "should return identifier using a non serializable method:{0}")
@@ -139,6 +149,13 @@ class ExpandedDataEntryTest extends ResourcesLocalTest {
         assertThat(identifier, is(equalTo(expectedIdentifier)));
     }
 
+    @Test
+    void shouldReturnUnsupportedOperationExceptionWhenTicketIsOfUnsupportedType()  {
+        var publication = randomPublication();
+        Executable action = () -> TicketEntry.createNewTicket(publication, null, SortableIdentifier::next);
+        assertThrows(UnsupportedOperationException.class, action);
+    }
+
     private static ExpandedDoiRequest randomDoiRequest(Publication publication,
                                                        ResourceExpansionService resourceExpansionService,
                                                        ResourceService resourceService,
@@ -146,7 +163,9 @@ class ExpandedDataEntryTest extends ResourcesLocalTest {
                                                        TicketService ticketService)
             throws ApiGatewayException {
         var userInstance = UserInstance.fromPublication(publication);
-        var doiRequest = (DoiRequest) TicketEntry.requestNewTicket(publication, DoiRequest.class)
+        resourceService.publishPublication(userInstance, publication.getIdentifier());
+        var publishedPublication = resourceService.getPublication(publication);
+        var doiRequest = (DoiRequest) TicketEntry.requestNewTicket(publishedPublication, DoiRequest.class)
                 .persistNewTicket(ticketService);
         messageService.createMessage(doiRequest, userInstance, randomString());
         return attempt(() -> ExpandedDoiRequest.createEntry(doiRequest, resourceExpansionService,

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -93,10 +93,10 @@ public class PublishingRequestCase extends TicketEntry {
     @Override
     public void validateCreationRequirements(Publication publication)
         throws ConflictException {
-        if (PublicationStatus.PUBLISHED == publication.getStatus()) {
+        if (PublicationStatus.PUBLISHED.equals(publication.getStatus())) {
             throw new ConflictException(ALREADY_PUBLISHED_ERROR);
         }
-        if (PublicationStatus.DRAFT_FOR_DELETION == publication.getStatus()) {
+        if (PublicationStatus.DRAFT_FOR_DELETION.equals(publication.getStatus())) {
             throw new ConflictException(MARKED_FOR_DELETION_ERROR);
         }
         assertThatPublicationHasMinimumMandatoryFields(publication);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -31,6 +31,7 @@ import no.unit.nva.model.funding.FundingList;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.ResourceDao;
 import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.JacocoGenerated;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.TooManyFields", "PMD.ExcessivePublicCount"})
 @JsonTypeInfo(use = Id.NAME, property = "type")
@@ -377,6 +378,7 @@ public class Resource implements Entity {
      *
      * @return the hashcode.
      */
+    @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hash(getIdentifier(), getStatus(), getResourceOwner(), getPublisher(), getCreatedDate(),
@@ -391,6 +393,7 @@ public class Resource implements Entity {
      * @param o the other Resource.
      * @return true if the two Resources are equivalent without considering the row version, false otherwise.
      */
+    @JacocoGenerated
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.service.impl.TicketService;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -27,23 +28,25 @@ import nva.commons.apigateway.exceptions.NotFoundException;
     @JsonSubTypes.Type(name = PublishingRequestCase.TYPE, value = PublishingRequestCase.class),
     @JsonSubTypes.Type(name = GeneralSupportRequest.TYPE, value = GeneralSupportRequest.class)})
 public abstract class TicketEntry implements Entity {
-    
+
     public static final User SUPPORT_SERVICE_CORRESPONDENT = new User("SupportService");
-    
+
     public static final String VIEWED_BY_FIELD = "viewedBy";
     public static final String TICKET_WITHOUT_REFERENCE_TO_PUBLICATION_ERROR =
         "Ticket without reference to publication";
+    public static final String DOI_REQUEST_EXCEPTION_MESSAGE_WHEN_NON_PUBLISHED =
+        "Can not create DoiRequest ticket for unpublished publication, use draft doi flow instead.";
     @JsonProperty(VIEWED_BY_FIELD)
     private ViewedBy viewedBy;
     @JsonProperty(PUBLICATION_DETAILS_FIELD)
     private PublicationDetails publicationDetails;
     @JsonProperty("resourceIdentifier")
     private SortableIdentifier resourceIdentifier;
-    
+
     protected TicketEntry() {
         viewedBy = ViewedBy.empty();
     }
-    
+
     public static <T extends TicketEntry> TicketEntry createNewTicket(Publication publication, Class<T> ticketType,
                                                                       Supplier<SortableIdentifier> identifierProvider)
         throws ConflictException {
@@ -51,10 +54,11 @@ public abstract class TicketEntry implements Entity {
         newTicket.validateCreationRequirements(publication);
         return newTicket;
     }
-    
-    public static <T extends TicketEntry> TicketEntry requestNewTicket(Publication publication, Class<T> ticketType) {
+
+    public static <T extends TicketEntry> TicketEntry requestNewTicket(Publication publication, Class<T> ticketType)
+        throws BadRequestException {
         if (DoiRequest.class.equals(ticketType)) {
-            return DoiRequest.fromPublication(publication);
+            return requestDoiRequestTicket(publication);
         } else if (PublishingRequestCase.class.equals(ticketType)) {
             return createOpeningCaseObject(publication);
         } else if (GeneralSupportRequest.class.equals(ticketType)) {
@@ -62,7 +66,19 @@ public abstract class TicketEntry implements Entity {
         }
         throw new RuntimeException("Unrecognized ticket type");
     }
-    
+
+    private static DoiRequest requestDoiRequestTicket(Publication publication) throws BadRequestException {
+        if(isPublished(publication)) {
+            return DoiRequest.fromPublication(publication);
+        } else {
+            throw new BadRequestException(DOI_REQUEST_EXCEPTION_MESSAGE_WHEN_NON_PUBLISHED);
+        }
+    }
+
+    private static boolean isPublished(Publication publication) {
+        return PublicationStatus.PUBLISHED.equals(publication.getStatus());
+    }
+
     public static <T extends TicketEntry> T createQueryObject(URI customerId, SortableIdentifier resourceIdentifier,
                                                               Class<T> ticketType) {
         if (DoiRequest.class.equals(ticketType)) {
@@ -79,57 +95,57 @@ public abstract class TicketEntry implements Entity {
         }
         throw new UnsupportedOperationException();
     }
-    
+
     public static UntypedTicketQueryObject createQueryObject(UserInstance userInstance,
                                                              SortableIdentifier ticketIdentifier) {
         return UntypedTicketQueryObject.create(userInstance, ticketIdentifier);
     }
-    
+
     public static UntypedTicketQueryObject createQueryObject(SortableIdentifier ticketIdentifier) {
         return UntypedTicketQueryObject.create(ticketIdentifier);
     }
-    
+
     public static TicketEntry createNewGeneralSupportRequest(Publication publication,
                                                              Supplier<SortableIdentifier> identifierProvider) {
         var ticket = GeneralSupportRequest.fromPublication(publication);
         setServiceControlledFields(ticket, identifierProvider);
         return ticket;
     }
-    
+
     //TODO: Delete resourceIdentifier field ASAP.
     public SortableIdentifier getResourceIdentifier() {
         return Optional.ofNullable(resourceIdentifier)
                    .or(() -> Optional.ofNullable(getPublicationDetails()).map(PublicationDetails::getIdentifier))
                    .orElse(null);
     }
-    
+
     public void setResourceIdentifier(SortableIdentifier resourceIdentifier) {
         this.resourceIdentifier = resourceIdentifier;
     }
-    
+
     public Set<User> getViewedBy() {
         return nonNull(viewedBy) ? viewedBy : Collections.emptySet();
     }
-    
+
     public void setViewedBy(Set<User> viewedBy) {
         this.viewedBy = new ViewedBy(viewedBy);
     }
-    
+
     public void persistUpdate(TicketService ticketService) {
         ticketService.updateTicket(this);
     }
-    
+
     public final SortableIdentifier extractPublicationIdentifier() {
         return Optional.ofNullable(getPublicationDetails())
                    .map(PublicationDetails::getIdentifier)
                    .or(() -> Optional.ofNullable(getResourceIdentifier()))
                    .orElseThrow(() -> new IllegalStateException(TICKET_WITHOUT_REFERENCE_TO_PUBLICATION_ERROR));
     }
-    
+
     public abstract void validateCreationRequirements(Publication publication) throws ConflictException;
-    
+
     public abstract void validateCompletionRequirements(Publication publication);
-    
+
     public TicketEntry complete(Publication publication) {
         var updated = this.copy();
         updated.setStatus(TicketStatus.COMPLETED);
@@ -137,7 +153,7 @@ public abstract class TicketEntry implements Entity {
         updated.setModifiedDate(Instant.now());
         return updated;
     }
-    
+
     public final TicketEntry close() throws ApiGatewayException {
         validateClosingRequirements();
         var updated = this.copy();
@@ -145,7 +161,7 @@ public abstract class TicketEntry implements Entity {
         updated.setModifiedDate(Instant.now());
         return updated;
     }
-    
+
     public void validateClosingRequirements() throws ApiGatewayException {
         if (!getStatus().equals(TicketStatus.PENDING)) {
             var errorMessage = String.format("Cannot close a ticket that has any other status than %s",
@@ -153,76 +169,76 @@ public abstract class TicketEntry implements Entity {
             throw new BadRequestException(errorMessage);
         }
     }
-    
+
     public abstract TicketEntry copy();
-    
+
     public abstract TicketStatus getStatus();
-    
+
     public abstract void setStatus(TicketStatus ticketStatus);
-    
+
     public final List<Message> fetchMessages(TicketService ticketService) {
         return ticketService.fetchTicketMessages(this);
     }
-    
+
     public final TicketEntry refresh() {
         var refreshed = this.copy();
         refreshed.setModifiedDate(Instant.now());
         return refreshed;
     }
-    
+
     public final TicketEntry persistNewTicket(TicketService ticketService) throws ApiGatewayException {
         // this is the only place that deprecated should be called.
         return ticketService.createTicket(this, this.getClass());
     }
-    
+
     public final TicketEntry markUnreadByOwner() {
         viewedBy.remove(this.getOwner());
         return this;
     }
-    
+
     public TicketEntry fetch(TicketService ticketService) throws NotFoundException {
         return ticketService.fetchTicket(this);
     }
-    
+
     public TicketEntry markReadByOwner() {
         viewedBy.add(getOwner());
         return this;
     }
-    
+
     public TicketEntry markReadForCurators() {
         viewedBy.add(TicketEntry.SUPPORT_SERVICE_CORRESPONDENT);
         return this;
     }
-    
+
     public TicketEntry markUnreadForCurators() {
         viewedBy.remove(TicketEntry.SUPPORT_SERVICE_CORRESPONDENT);
         return this;
     }
-    
+
     public final String extractPublicationTitle() {
         return Optional.of(this.getPublicationDetails()).map(PublicationDetails::getTitle).orElse(null);
     }
-    
+
     public PublicationDetails getPublicationDetails() {
         return publicationDetails;
     }
-    
+
     public void setPublicationDetails(PublicationDetails publicationDetails) {
         this.publicationDetails = publicationDetails;
     }
-    
+
     public TicketEntry update(Resource resource) {
         this.getPublicationDetails().update(resource);
         this.setPublicationDetails(
             this.getPublicationDetails().update(resource));
         return this;
     }
-    
+
     private static <T extends TicketEntry> TicketEntry createNewTicketEntry(
         Publication publication,
         Class<T> ticketType,
         Supplier<SortableIdentifier> identifierProvider) {
-        
+
         if (DoiRequest.class.equals(ticketType)) {
             return createNewDoiRequest(publication, identifierProvider);
         }
@@ -234,14 +250,14 @@ public abstract class TicketEntry implements Entity {
         }
         throw new UnsupportedOperationException();
     }
-    
+
     private static TicketEntry createNewDoiRequest(Publication publication,
                                                    Supplier<SortableIdentifier> identifierProvider) {
         var doiRequest = DoiRequest.fromPublication(publication);
         setServiceControlledFields(doiRequest, identifierProvider);
         return doiRequest;
     }
-    
+
     private static void setServiceControlledFields(TicketEntry ticketEntry,
                                                    Supplier<SortableIdentifier> identifierProvider) {
         var now = Instant.now();
@@ -249,16 +265,16 @@ public abstract class TicketEntry implements Entity {
         ticketEntry.setModifiedDate(now);
         ticketEntry.setIdentifier(identifierProvider.get());
     }
-    
+
     private static TicketEntry createNewPublishingRequestEntry(Publication publication,
                                                                Supplier<SortableIdentifier> identifierProvider) {
         var entry = createOpeningCaseObject(publication);
         setServiceControlledFields(entry, identifierProvider);
         return entry;
     }
-    
+
     public static final class Constants {
-        
+
         public static final String STATUS_FIELD = "status";
         public static final String MODIFIED_DATE_FIELD = "modifiedDate";
         public static final String CREATED_DATE_FIELD = "createdDate";
@@ -266,9 +282,9 @@ public abstract class TicketEntry implements Entity {
         public static final String CUSTOMER_ID_FIELD = "customerId";
         public static final String PUBLICATION_DETAILS_FIELD = "publicationDetails";
         public static final String IDENTIFIER_FIELD = "identifier";
-        
+
         private Constants() {
-        
+
         }
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
@@ -4,6 +4,7 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
@@ -46,6 +47,7 @@ public final class TestingUtils extends TestDataSource {
     }
     
     public static GeneralSupportRequest createGeneralSupportRequest(Publication publication) {
-        return (GeneralSupportRequest) TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class);
+        return attempt(() -> (GeneralSupportRequest) TicketEntry.requestNewTicket(publication,
+                                                                                  GeneralSupportRequest.class)).orElseThrow();
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/DoiRequestTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/DoiRequestTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Clock;
 import java.time.Instant;
@@ -15,6 +16,7 @@ import java.time.ZoneId;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.testing.PublicationGenerator;
+import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.storage.model.exceptions.IllegalDoiRequestUpdate;
 import org.junit.jupiter.api.Test;
 
@@ -64,7 +66,14 @@ class DoiRequestTest {
         DoiRequest updatedDoiRequest = doiRequest.update(updatedResource);
         assertThat(updatedDoiRequest.getPublicationDetails().getTitle(), is(equalTo(newTitle)));
     }
-    
+
+    @Test
+    void doiRequestConvertsToPublication() {
+        var doiRequest = new DoiRequest();
+        var publication = doiRequest.toPublication(new ResourceService(AmazonDynamoDBClient.builder().build(),
+                                                      Clock.systemDefaultZone()));
+        assertThat(publication, is(nullValue()));
+    }
     @Test
     void updateThrowsExceptionWhenResourceIdentifierIsDifferent() {
         Resource resource = Resource.fromPublication(PublicationGenerator.publicationWithIdentifier());

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/EntityTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/EntityTest.java
@@ -11,20 +11,21 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.testing.TypeProvider;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class EntityTest extends ResourcesLocalTest {
     
     public static final ResourceService SHOULD_NOT_USE_RESOURCE_SERVICE = null;
     private ResourceService resourceService;
-    
-    public static Stream<Arguments> ticketTypeProvider() {
-        return TypeProvider.listSubTypes(TicketEntry.class).map(Arguments::of);
+
+    public static Stream<Class<?>> publishingAndGeneralSupportTicketTypeProvider() {
+        return TypeProvider.listSubTypes(TicketEntry.class)
+                   .filter(type -> type == PublishingRequestCase.class || type == GeneralSupportRequest.class);
     }
     
     @BeforeEach
@@ -35,9 +36,9 @@ class EntityTest extends ResourcesLocalTest {
     
     @ParameterizedTest(name = "entity type:{0}")
     @DisplayName("should return referenced stored publication when entity is referencing a publication ")
-    @MethodSource("ticketTypeProvider")
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
     void shouldReturnReferencedStoredPublicationWhenEntityIsReferencingAPublication(
-        Class<? extends TicketEntry> ticketType) {
+        Class<? extends TicketEntry> ticketType) throws BadRequestException {
         var publication = createDraftPublicationWithoutDoi();
         var ticket = TicketEntry.requestNewTicket(publication, ticketType);
         var storedPublication = ticket.toPublication(resourceService);

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
@@ -4,22 +4,29 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.stream.Stream;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.testing.TypeProvider;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class TicketEntryTest {
-    
-    public static Stream<Class<?>> ticketTypeProv() {
-        return TypeProvider.listSubTypes(TicketEntry.class);
+
+    public static Stream<Class<?>> publishingAndGeneralSupportTicketTypeProvider() {
+        return TypeProvider.listSubTypes(TicketEntry.class)
+                   .filter(type -> type == PublishingRequestCase.class || type == GeneralSupportRequest.class);
     }
+
     
     @ParameterizedTest(name = "ticket type:{0}")
     @DisplayName("should request a new ticket ")
-    @MethodSource("ticketTypeProv")
-    void shouldRequestNewTicket(Class<? extends TicketEntry> ticketType) {
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
+    void shouldRequestNewTicket(Class<? extends TicketEntry> ticketType) throws BadRequestException {
         var publication = randomPublication();
         var ticket = TicketEntry.requestNewTicket(publication, ticketType);
         var actualUserInstance = UserInstance.fromTicket(ticket);
@@ -29,5 +36,32 @@ class TicketEntryTest {
         assertThat(ticket.getClass(), is(equalTo(ticketType)));
         assertThat(ticket.extractPublicationIdentifier(), is(equalTo(publication.getIdentifier())));
         assertThat(actualUserInstance, is(equalTo(expectedUserInstance)));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRequestingDoiRequestTicketForUnpublishedPublication() {
+        var publication = randomPublication();
+        assertThrows(BadRequestException.class, () -> TicketEntry.requestNewTicket(publication, DoiRequest.class));
+    }
+
+    @Test
+    void shouldReturnRuntimeExceptionWhenUnrecognizedTicketType() {
+        var publication = randomPublication();
+        assertThrows(RuntimeException.class, () -> TicketEntry.requestNewTicket(publication, null));
+    }
+
+    @Test
+    void shouldReturnUnsupportedOperationCreatingQueryObjectForUnsupportedTicketType() {
+        var publication = randomPublication();
+        Executable action = () -> TicketEntry.createQueryObject(publication.getPublisher().getId(),
+                                                                    publication.getIdentifier(), null);
+        assertThrows(UnsupportedOperationException.class, action);
+    }
+
+    @Test
+    void shouldReturnUnsupportedOperationCreatingNewTicketEntryForUnsupportedTicketType() {
+        var publication = randomPublication();
+        Executable action = () -> TicketEntry.createNewTicket(publication, null, SortableIdentifier::next);
+        assertThrows(UnsupportedOperationException.class, action);
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
@@ -8,9 +8,11 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Test;
 
@@ -34,8 +36,9 @@ class UserInstanceTest {
     }
     
     @Test
-    void shouldReturnUserInstanceFromMessage() {
-        Publication publication = PublicationGenerator.randomPublication();
+    void shouldReturnUserInstanceFromMessage() throws BadRequestException {
+        Publication publication = PublicationGenerator.randomPublication().copy()
+                                      .withStatus(PublicationStatus.PUBLISHED).build();
         var ticket = TicketEntry.requestNewTicket(publication, DoiRequest.class);
         var message = Message.create(ticket, UserInstance.fromTicket(ticket), randomString());
         var userInstance = UserInstance.fromMessage(message);

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -856,7 +856,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
     @Test
     void shouldScanEntriesInDatabaseAfterSpecifiedMarker() throws ApiGatewayException {
-        var samplePublication = createPersistedPublicationWithoutDoi();
+        var samplePublication = createPublishedResource();
         var sampleTicket = TicketEntry.requestNewTicket(samplePublication, DoiRequest.class)
                                .persistNewTicket(ticketService);
 
@@ -974,6 +974,18 @@ class ResourceServiceTest extends ResourcesLocalTest {
         resourceService.updatePublishedStatusToDeleted(publicationIdentifier);
         var actualUpdateStatus = resourceService.updatePublishedStatusToDeleted(publicationIdentifier);
         assertThat(expectedUpdateStatus, is(equalTo(actualUpdateStatus)));
+    }
+
+    @Test
+    void shouldReturnUnsupportedOperationWhenUpdatingPublicationWithUnsupportedStatus() throws ApiGatewayException {
+        var publication = createPersistedPublicationWithDoi(resourceService, randomPublication().copy()
+                                                                      .withStatus(PublicationStatus.DELETED)
+                                                                      .build());
+        var userInstance = UserInstance.fromPublication(publication);
+        resourceService.updatePublishedStatusToDeleted(publication.getIdentifier());
+        Executable action = () -> resourceService.publishPublication(userInstance, publication.getIdentifier());
+        assertThrows(UnsupportedOperationException.class, action);
+
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoTest.java
@@ -7,12 +7,13 @@ import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.stream.Stream;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
+import no.unit.nva.publication.model.business.GeneralSupportRequest;
+import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -21,12 +22,9 @@ import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
 import no.unit.nva.publication.testing.TypeProvider;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.core.attempt.Try;
-import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,8 +33,9 @@ class TicketDtoTest extends ResourcesLocalTest {
     private ResourceService resourceService;
     private TicketService ticketService;
 
-    public static Stream<Arguments> ticketTypeProvider() {
-        return TypeProvider.listSubTypes(TicketEntry.class).map(Arguments::of);
+    public static Stream<Class<?>> publishingAndGeneralSupportTicketTypeProvider() {
+        return TypeProvider.listSubTypes(TicketEntry.class)
+                   .filter(type -> type == PublishingRequestCase.class || type == GeneralSupportRequest.class);
     }
 
     @BeforeEach
@@ -48,7 +47,7 @@ class TicketDtoTest extends ResourcesLocalTest {
 
     @ParameterizedTest(name = "ticketType:{0}")
     @DisplayName("should include all publication summary fields")
-    @MethodSource("ticketTypeProvider")
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
     void shouldIncludeAllPublicationSummaryFields(Class<? extends TicketEntry> ticketType) throws ApiGatewayException {
         var publication = draftPublicationWithoutDoi();
         var ticket = TicketEntry.requestNewTicket(publication, ticketType).persistNewTicket(ticketService);

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketTestLocal.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketTestLocal.java
@@ -9,6 +9,8 @@ import java.util.stream.Stream;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.model.business.DoiRequest;
+import no.unit.nva.publication.model.business.GeneralSupportRequest;
+import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -28,6 +30,11 @@ public abstract class TicketTestLocal extends ResourcesLocalTest {
     
     public static Stream<Class<?>> ticketTypeProvider() {
         return TypeProvider.listSubTypes(TicketEntry.class);
+    }
+
+    public static Stream<Class<?>> publishingAndGeneralSupportTicketTypeProvider() {
+        return TypeProvider.listSubTypes(TicketEntry.class)
+                   .filter(type -> type == PublishingRequestCase.class || type == GeneralSupportRequest.class);
     }
     
     public void init() {
@@ -62,7 +69,9 @@ public abstract class TicketTestLocal extends ResourcesLocalTest {
     }
     
     protected TicketEntry createPersistedTicket(Class<? extends TicketEntry> ticketType) throws ApiGatewayException {
-        return createPersistedTicket(createAndPersistDraftPublication(), ticketType);
+        return DoiRequest.class == ticketType
+            ? createPersistedTicket(createAndPersistPublication(PublicationStatus.PUBLISHED), ticketType)
+            : createPersistedTicket(createAndPersistDraftPublication(), ticketType);
     }
     
     protected TicketEntry createPersistedTicket(Publication publication, Class<? extends TicketEntry> ticketType)

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
@@ -62,6 +63,12 @@ class CreateTicketHandlerTest extends TicketTestLocal {
     public static Stream<Arguments> ticketEntryProvider() {
         return TypeProvider.listSubTypes(TicketEntry.class).map(Arguments::of);
     }
+
+    public static Stream<Arguments> publishingAndGeneralSupportTicketEntryProvider() {
+        return TypeProvider.listSubTypes(TicketEntry.class)
+                   .filter(type -> type == PublishingRequestCase.class || type == GeneralSupportRequest.class)
+                   .map(Arguments::of);
+    }
     
     @BeforeEach
     public void setup() {
@@ -72,7 +79,7 @@ class CreateTicketHandlerTest extends TicketTestLocal {
     @ParameterizedTest(name = "ticketType")
     @DisplayName("should persist ticket when publication exists, user is publication owner and "
                  + "publication meets ticket creation criteria")
-    @MethodSource("ticketEntryProvider")
+    @MethodSource("publishingAndGeneralSupportTicketEntryProvider")
     void shouldPersistTicketWhenPublicationExistsUserIsOwnerAndPublicationMeetsTicketCreationCriteria(
         Class<? extends TicketEntry> ticketType) throws IOException, ApiGatewayException {
         
@@ -178,7 +185,7 @@ class CreateTicketHandlerTest extends TicketTestLocal {
     
     @ParameterizedTest(name = "ticketType:{0}")
     @DisplayName("should mark ticket as read for the publication owner when publication owner creates new ticket")
-    @MethodSource("ticketEntryProvider")
+    @MethodSource("publishingAndGeneralSupportTicketEntryProvider")
     void shouldMarkTicketAsReadForThePublicationOwnerWhenPublicationOwnerCreatesNewTicket(
         Class<? extends TicketEntry> ticketType) throws ApiGatewayException, IOException {
         var publication = createPersistedDraftPublication();
@@ -193,7 +200,7 @@ class CreateTicketHandlerTest extends TicketTestLocal {
     
     @ParameterizedTest(name = "ticketType:{0}")
     @DisplayName("should mark ticket as Unread for the Curators when publication owner creates new ticket")
-    @MethodSource("ticketEntryProvider")
+    @MethodSource("publishingAndGeneralSupportTicketEntryProvider")
     void shouldMarkTicketAsUnReadForTheCuratorsWhenPublicationOwnerCreatesNewTicket(
         Class<? extends TicketEntry> ticketType) throws ApiGatewayException, IOException {
         var publication = createPersistedDraftPublication();
@@ -211,7 +218,7 @@ class CreateTicketHandlerTest extends TicketTestLocal {
     @Test
     void shouldUpdateExistingDoiRequestWhenNewDoiIsRequestedButUnfulfilledDoiRequestAlreadyExists()
         throws ApiGatewayException, IOException {
-        var publication = createPersistedDraftPublication();
+        var publication = createAndPersistPublication(PublicationStatus.PUBLISHED);
         var owner = UserInstance.fromPublication(publication);
         var requestBody = constructDto(DoiRequest.class);
         

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/read/GetTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/read/GetTicketHandlerTest.java
@@ -70,7 +70,7 @@ class GetTicketHandlerTest extends TicketTestLocal {
     @ParameterizedTest(name = " ticket type: {0}")
     @DisplayName("should  return not found when publication identifier exists, but ticket identifier does not "
                  + "correspond to a ticket of that publication")
-    @MethodSource("ticketTypeProvider")
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
     void shouldReturnNotFoundWhenPublicationIdentifierExistsButTicketIdentifierDoesCorrespondToPublication(
         Class<? extends TicketEntry> ticketType) throws ApiGatewayException, IOException {
         var publication = createAndPersistDraftPublication();
@@ -85,7 +85,7 @@ class GetTicketHandlerTest extends TicketTestLocal {
     
     @ParameterizedTest(name = " ticket type: {0}")
     @DisplayName("should  return not found when user is not the owner of the associated publication")
-    @MethodSource("ticketTypeProvider")
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
     void shouldReturnNotFoundWhenUserIsNotTheOwnerOfTheAssociatedPublication(
         Class<? extends TicketEntry> ticketType) throws ApiGatewayException, IOException {
         var publication = createAndPersistDraftPublication();
@@ -189,7 +189,7 @@ class GetTicketHandlerTest extends TicketTestLocal {
     
     @ParameterizedTest(name = "ticket type:{0}")
     @DisplayName("should return publication title with the ticket")
-    @MethodSource("ticketTypeProvider")
+    @MethodSource("publishingAndGeneralSupportTicketTypeProvider")
     void shouldReturnPublicationTitleWithTheTicket(Class<? extends TicketEntry> ticketType)
         throws ApiGatewayException, IOException {
         var publication = createAndPersistDraftPublication();

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketStatusHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketStatusHandlerTest.java
@@ -48,8 +48,6 @@ class UpdateTicketStatusHandlerTest extends TicketTestLocal {
     
     public static Stream<Arguments> ticketAndBadStatusProvider() {
         return Stream.of(
-            Arguments.of(DoiRequest.class, PublicationStatus.DRAFT),
-            Arguments.of(DoiRequest.class, PublicationStatus.DRAFT_FOR_DELETION),
             Arguments.of(PublishingRequestCase.class, PublicationStatus.DRAFT_FOR_DELETION));
     }
     


### PR DESCRIPTION
This disallows creation of DoiRequest when publication is published, in other case user should use draft doi flow. 
Since PublishingRequest and GeneralSupportRequest can be created for publications with different statuses, I had to change ticketTypeProvider to publishingAndGeneralSupportTicketTypeProvider for almost all the tests that have ticket logic involved.