### PR TITLE
Np 44674 expanded ticket publication summary

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -5,10 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.pages.Pages;
 import no.unit.nva.publication.PublicationServiceConfig;
 import no.unit.nva.publication.model.business.PublicationDetails;
 import no.unit.nva.publication.model.business.User;
@@ -17,9 +23,9 @@ import nva.commons.core.paths.UriWrapper;
 
 @JsonTypeName(PublicationSummary.TYPE)
 public class PublicationSummary {
-    
+
     public static final String TYPE = "Publication";
-    
+
     @JsonProperty("id")
     private URI publicationId;
     @JsonProperty("identifier")
@@ -34,21 +40,39 @@ public class PublicationSummary {
     private Instant modifiedDate;
     @JsonProperty
     private PublicationStatus status;
-    
+    @JsonProperty
+    private PublicationInstance<? extends Pages> publicationInstance;
+    @JsonProperty
+    private Instant publishedDate;
+    @JsonProperty
+    private List<Contributor> contributors;
+
     public static PublicationSummary create(Publication publication) {
         var publicationSummary = new PublicationSummary();
         publicationSummary.setIdentifier(publication.getIdentifier());
         publicationSummary.setPublicationId(toPublicationId(publication.getIdentifier()));
         publicationSummary.setCreatedDate(publication.getCreatedDate());
         publicationSummary.setModifiedDate(publication.getModifiedDate());
+        publicationSummary.setPublishedDate(publication.getPublishedDate());
         publicationSummary.setOwner(new User(publication.getResourceOwner().getOwner().getValue()));
         publicationSummary.setStatus(publication.getStatus());
-        if (nonNull(publication.getEntityDescription())) {
-            publicationSummary.setTitle(publication.getEntityDescription().getMainTitle());
+        var entityDescription = publication.getEntityDescription();
+        if (nonNull(entityDescription)) {
+            publicationSummary.setTitle(entityDescription.getMainTitle());
+            if (nonNull(entityDescription.getReference())) {
+                publicationSummary.setPublicationInstance(entityDescription.getReference().getPublicationInstance());
+            }
+            if (nonNull(entityDescription.getContributors())) {
+                publicationSummary.setContributors(entityDescription.getContributors()
+                                                       .stream()
+                                                       .sorted(Comparator.comparing(Contributor::getSequence))
+                                                       .limit(5)
+                                                       .collect(Collectors.toList()));
+            }
         }
         return publicationSummary;
     }
-    
+
     public static PublicationSummary create(PublicationDetails publicationDetails) {
         var publicationSummary = new PublicationSummary();
         publicationSummary.setIdentifier(publicationDetails.getIdentifier());
@@ -60,7 +84,7 @@ public class PublicationSummary {
         publicationSummary.setTitle(publicationDetails.getTitle());
         return publicationSummary;
     }
-    
+
     public static PublicationSummary create(URI publicationId, String publicationTitle) {
         var publicationSummary = new PublicationSummary();
         publicationSummary.setIdentifier(extractPublicationIdentifier(publicationId));
@@ -68,70 +92,99 @@ public class PublicationSummary {
         publicationSummary.setTitle(publicationTitle);
         return publicationSummary;
     }
-    
+
+    public Instant getPublishedDate() {
+        return publishedDate;
+    }
+
+    public void setPublishedDate(Instant publishedDate) {
+        this.publishedDate = publishedDate;
+    }
+
+    public List<Contributor> getContributors() {
+        return contributors;
+    }
+
+    public void setContributors(List<Contributor> contributors) {
+        this.contributors = contributors;
+    }
+
     public SortableIdentifier getIdentifier() {
         return identifier;
     }
-    
+
     public void setIdentifier(SortableIdentifier identifier) {
         this.identifier = identifier;
     }
-    
+
     public PublicationStatus getStatus() {
         return status;
     }
-    
+
     public void setStatus(PublicationStatus status) {
         this.status = status;
     }
-    
+
     public URI getPublicationId() {
         return publicationId;
     }
-    
+
     public void setPublicationId(URI publicationId) {
         this.publicationId = publicationId;
     }
-    
+
     public String getTitle() {
         return title;
     }
-    
+
     public void setTitle(String title) {
         this.title = title;
     }
-    
+
     public Instant getModifiedDate() {
         return modifiedDate;
     }
-    
+
     public void setModifiedDate(Instant modifiedDate) {
         this.modifiedDate = modifiedDate;
     }
-    
+
     public Instant getCreatedDate() {
         return createdDate;
     }
-    
+
     public void setCreatedDate(Instant createdDate) {
         this.createdDate = createdDate;
     }
-    
+
     public User getOwner() {
         return owner;
     }
-    
+
     public void setOwner(User owner) {
         this.owner = owner;
     }
-    
+
+    public PublicationInstance<? extends Pages> getPublicationInstance() {
+        return publicationInstance;
+    }
+
+    public void setPublicationInstance(PublicationInstance<? extends Pages> publicationInstance) {
+        this.publicationInstance = publicationInstance;
+    }
+
+    public SortableIdentifier extractPublicationIdentifier() {
+        return extractPublicationIdentifier(publicationId);
+    }
+
     @Override
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getCreatedDate(),
-            getModifiedDate(), getStatus());
+                            getModifiedDate(), getStatus(), getPublicationInstance(), getPublishedDate(),
+                            getContributors());
     }
-    
+
     @Override
     @JacocoGenerated
     public boolean equals(Object o) {
@@ -148,19 +201,19 @@ public class PublicationSummary {
                && Objects.equals(getOwner(), that.getOwner())
                && Objects.equals(getCreatedDate(), that.getCreatedDate())
                && Objects.equals(getModifiedDate(), that.getModifiedDate())
-               && getStatus() == that.getStatus();
+               && getStatus() == that.getStatus()
+               && Objects.equals(getPublicationInstance(), that.getPublicationInstance())
+               && Objects.equals(getPublishedDate(), that.getPublishedDate())
+               && Objects.equals(getContributors(), that.getContributors());
     }
-    
-    public SortableIdentifier extractPublicationIdentifier() {
-        return extractPublicationIdentifier(publicationId);
-    }
-    
+
     private static SortableIdentifier extractPublicationIdentifier(URI publicationId) {
         return new SortableIdentifier(UriWrapper.fromUri(publicationId).getLastPathElement());
     }
-    
+
     private static URI toPublicationId(SortableIdentifier identifier) {
         return UriWrapper.fromUri(PublicationServiceConfig.PUBLICATION_HOST_URI)
-                   .addChild(identifier.toString()).getUri();
+            .addChild(identifier.toString())
+            .getUri();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -25,6 +25,7 @@ import nva.commons.core.paths.UriWrapper;
 public class PublicationSummary {
 
     public static final String TYPE = "Publication";
+    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 5;
 
     @JsonProperty("id")
     private URI publicationId;
@@ -66,7 +67,7 @@ public class PublicationSummary {
                 publicationSummary.setContributors(entityDescription.getContributors()
                                                        .stream()
                                                        .sorted(Comparator.comparing(Contributor::getSequence))
-                                                       .limit(5)
+                                                       .limit(MAX_SIZE_CONTRIBUTOR_LIST)
                                                        .collect(Collectors.toList()));
             }
         }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -1,16 +1,19 @@
 package no.unit.nva.publication.model;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.publication.PublicationServiceConfig.dtoObjectMapper;
 import static no.unit.nva.publication.testing.http.RandomPersonServiceResponse.randomUri;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
+import java.util.Set;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.testing.PublicationGenerator;
@@ -23,7 +26,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PublicationSummaryTest extends ResourcesLocalTest {
-    
+
+    private static final String PUBLICATION_INSTANCE_FIELD = "publicationInstance";
+    private static final String PUBLISHED_DATE_FIELD = "publishedDate";
+    private static final String CONTRIBUTORS_FIELD = "contributors";
+
     @BeforeEach
     public void setup() {
         super.init();
@@ -50,13 +57,19 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         assertThat(summary.getOwner(), is(equalTo(new User(publication.getResourceOwner().getOwner().getValue()))));
         assertThat(summary.getCreatedDate(), is(equalTo(publication.getCreatedDate())));
         assertThat(summary.getModifiedDate(), is(equalTo(publication.getModifiedDate())));
+        assertThat(summary.getPublicationInstance(), is(equalTo(publication.getEntityDescription().getReference().getPublicationInstance())));
+        assertThat(summary.getPublishedDate(), is(equalTo(publication.getPublishedDate())));
+        assertThat(summary.getContributors(),
+                   containsInAnyOrder(publication.getEntityDescription().getContributors().toArray()));
     }
     
     @Test
     void shouldReturnPublicationSummaryWithoutEmptyFieldsfromPublicationDetails() {
         var publication = PublicationGenerator.publicationWithIdentifier();
         var summary = PublicationSummary.create(PublicationDetails.create(publication));
-        assertThat(summary, doesNotHaveEmptyValues());
+        assertThat(summary, doesNotHaveEmptyValuesIgnoringFields(Set.of(PUBLICATION_INSTANCE_FIELD,
+                                                                        PUBLISHED_DATE_FIELD,
+                                                                        CONTRIBUTORS_FIELD)));
         assertThat(summary.extractPublicationIdentifier(), is(equalTo(publication.getIdentifier())));
         assertThat(summary.getTitle(), is(equalTo(publication.getEntityDescription().getMainTitle())));
         assertThat(summary.getOwner(), is(equalTo(new User(publication.getResourceOwner().getOwner().getValue()))));

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -5,6 +5,7 @@ import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.publication.PublicationServiceConfig.dtoObjectMapper;
 import static no.unit.nva.publication.testing.http.RandomPersonServiceResponse.randomUri;
+import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -13,9 +14,19 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Publication;
+import no.unit.nva.model.Contributor;
+import no.unit.nva.model.Identity;
+import no.unit.nva.model.Organization;
+import no.unit.nva.model.role.Role;
+import no.unit.nva.model.role.RoleType;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.publication.model.business.PublicationDetails;
 import no.unit.nva.publication.model.business.User;
@@ -30,39 +41,65 @@ class PublicationSummaryTest extends ResourcesLocalTest {
     private static final String PUBLICATION_INSTANCE_FIELD = "publicationInstance";
     private static final String PUBLISHED_DATE_FIELD = "publishedDate";
     private static final String CONTRIBUTORS_FIELD = "contributors";
+    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 5;
 
     @BeforeEach
     public void setup() {
         super.init();
     }
-    
+
     @Test
     @DisplayName("objectMapper Can Write And Read PublicationSummary")
     void objectMapperCanWriteAndReadPublicationSummary() throws JsonProcessingException {
-        PublicationSummary publicationSummary = publicationSummary();
-        String content = dtoObjectMapper.writeValueAsString(publicationSummary);
-        PublicationSummary processedPublicationSummary =
+        var publicationSummary = publicationSummary();
+        var content = dtoObjectMapper.writeValueAsString(publicationSummary);
+        var processedPublicationSummary =
             dtoObjectMapper.readValue(content, PublicationSummary.class);
-        
+
         assertEquals(publicationSummary, processedPublicationSummary);
     }
-    
+
     @Test
     void fromPublicationReturnsPublicationSummaryWithoutEmptyFields() {
-        Publication publication = PublicationGenerator.publicationWithIdentifier();
-        PublicationSummary summary = PublicationSummary.create(publication);
+        var publication = PublicationGenerator.publicationWithIdentifier();
+        var summary = PublicationSummary.create(publication);
         assertThat(summary, doesNotHaveEmptyValues());
         assertThat(summary.extractPublicationIdentifier(), is(equalTo(publication.getIdentifier())));
         assertThat(summary.getTitle(), is(equalTo(publication.getEntityDescription().getMainTitle())));
         assertThat(summary.getOwner(), is(equalTo(new User(publication.getResourceOwner().getOwner().getValue()))));
         assertThat(summary.getCreatedDate(), is(equalTo(publication.getCreatedDate())));
         assertThat(summary.getModifiedDate(), is(equalTo(publication.getModifiedDate())));
-        assertThat(summary.getPublicationInstance(), is(equalTo(publication.getEntityDescription().getReference().getPublicationInstance())));
+        assertThat(summary.getPublicationInstance(),
+                   is(equalTo(publication.getEntityDescription().getReference().getPublicationInstance())));
         assertThat(summary.getPublishedDate(), is(equalTo(publication.getPublishedDate())));
         assertThat(summary.getContributors(),
                    containsInAnyOrder(publication.getEntityDescription().getContributors().toArray()));
     }
-    
+
+    @Test
+    void shouldReturnsPublicationSummaryWithMaxSizeOfContributors() {
+        var publication = PublicationGenerator.publicationWithIdentifier();
+        var entityDescription = publication.getEntityDescription();
+        entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
+        PublicationSummary summary = PublicationSummary.create(publication);
+        assertThat(summary.getContributors().size(), is(equalTo(MAX_SIZE_CONTRIBUTOR_LIST)));
+    }
+
+    @Test
+    void shouldReturnsPublicationSummaryWithMaxSizeOfContributorsWithLowestSequenceNumbers() {
+        var publication = PublicationGenerator.publicationWithIdentifier();
+        var entityDescription = publication.getEntityDescription();
+        entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
+        PublicationSummary summary = PublicationSummary.create(publication);
+        assertThat(summary.getContributors(),
+                   containsInAnyOrder(entityDescription.getContributors()
+                                          .stream()
+                                          .sorted(Comparator.comparing(Contributor::getSequence))
+                                          .limit(MAX_SIZE_CONTRIBUTOR_LIST)
+                                          .toArray())
+        );
+    }
+
     @Test
     void shouldReturnPublicationSummaryWithoutEmptyFieldsfromPublicationDetails() {
         var publication = PublicationGenerator.publicationWithIdentifier();
@@ -76,7 +113,7 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         assertThat(summary.getCreatedDate(), is(equalTo(publication.getCreatedDate())));
         assertThat(summary.getModifiedDate(), is(equalTo(publication.getModifiedDate())));
     }
-    
+
     @Test
     void shouldAllowCreationOfMinimumPossibleInformation() {
         var publicationId = randomPublicationId();
@@ -85,11 +122,41 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         assertThat(summary.getPublicationId(), is(equalTo(publicationId)));
         assertThat(summary.getTitle(), is(equalTo(publicationTitle)));
     }
-    
+
+    private int getRandomNumberOfContributorsLargerThanMaxSize() {
+        return MAX_SIZE_CONTRIBUTOR_LIST
+               + new Random().nextInt(10 - MAX_SIZE_CONTRIBUTOR_LIST + 1)
+               + MAX_SIZE_CONTRIBUTOR_LIST;
+    }
+
+    private List<Contributor> getNumberOfContributors(int number) {
+        var contributors = new ArrayList<Contributor>(Collections.emptyList());
+        for (int i = 0; i < number; i++) {
+            contributors.add(getRandomContributor(i));
+        }
+        return contributors;
+    }
+
+    private Contributor getRandomContributor(int sequenceNumber) {
+        return new Contributor(getRandomIdentity(),
+                               getListOfRandomOrganizations(),
+                               new RoleType(Role.OTHER),
+                               sequenceNumber,
+                               randomBoolean());
+    }
+
+    private List<Organization> getListOfRandomOrganizations() {
+        return List.of(new Organization.Builder().withId(randomUri()).build());
+    }
+
+    private Identity getRandomIdentity() {
+        return new Identity.Builder().withName(randomString()).withOrcId(randomString()).withId(randomUri()).build();
+    }
+
     private URI randomPublicationId() {
         return UriWrapper.fromUri(randomUri()).addChild(SortableIdentifier.next().toString()).getUri();
     }
-    
+
     private PublicationSummary publicationSummary() {
         return PublicationSummary.create(randomPublication());
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -20,7 +20,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoTest.java
@@ -1,47 +1,51 @@
 package no.unit.nva.publication.ticket;
 
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Set;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
-import no.unit.nva.publication.service.impl.TicketService;
+import no.unit.nva.publication.ticket.test.TicketTestUtils;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import no.unit.nva.publication.ticket.test.TicketTestUtils;
 
 class TicketDtoTest extends ResourcesLocalTest {
 
+    private static final String PUBLICATION_INSTANCE_FIELD = "publicationInstance";
+    private static final String PUBLISHED_DATE_FIELD = "publishedDate";
+    private static final String CONTRIBUTORS_FIELD = "contributors";
     private ResourceService resourceService;
-    private TicketService ticketService;
 
     @BeforeEach
     public void setup() {
         super.init();
         this.resourceService = new ResourceService(client, Clock.systemDefaultZone());
-        this.ticketService = new TicketService(client);
     }
 
     @ParameterizedTest
     @DisplayName("should include all publication summary fields")
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldIncludeAllPublicationSummaryFields(Class<? extends TicketEntry> ticketType, PublicationStatus status) throws ApiGatewayException {
+    void shouldIncludeAllPublicationSummaryFields(Class<? extends TicketEntry> ticketType, PublicationStatus status)
+        throws ApiGatewayException {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createNonPersistedTicket(publication, ticketType);
         var dto = TicketDto.fromTicket(ticket);
         var publicationSummary = dto.getPublicationSummary();
-        assertThat(publicationSummary, doesNotHaveEmptyValues());
+        assertThat(publicationSummary, doesNotHaveEmptyValuesIgnoringFields(Set.of(PUBLICATION_INSTANCE_FIELD,
+                                                                                   PUBLISHED_DATE_FIELD,
+                                                                                   CONTRIBUTORS_FIELD)));
     }
 
     @ParameterizedTest(name = "should accept both date (legacy) and createdDate: {0}")
@@ -49,11 +53,11 @@ class TicketDtoTest extends ResourcesLocalTest {
     void shouldAcceptBothLegacyDateAndCreatedDate(String field) {
         var isoDateTime = "2022-12-01T11:07:32.039628Z";
         var input = JsonUtils.dtoObjectMapper.createObjectNode()
-                        .put("type", MessageDto.TYPE)
-                        .put(field, isoDateTime);
+            .put("type", MessageDto.TYPE)
+            .put(field, isoDateTime);
 
         var result = attempt(() -> JsonUtils.dtoObjectMapper.readValue(input.toString(), MessageDto.class))
-                         .orElseThrow();
+            .orElseThrow();
 
         assertThat(result.getCreatedDate(), is(equalTo(Instant.parse(isoDateTime))));
     }


### PR DESCRIPTION
Added the following fields to PublicationSummary:

- publicationInstance
- publishedDate
- contributors. (List of contributers: max 5. Sort on contributer.sequenceand pick the first 5)

Wanted to remove createdDate and modifiedDate from PublicationSummary as discussed, but these are used in TicketDto in ticket endpoints and cannot be removed before [NP-42662: Improved tickets search for registrators and curators](https://unit.atlassian.net/browse/NP-42662) is finished and frontend uses search-api for listing tickets on “My Page” instead of publication api.

(No, i do not know how to spell summary correctly (ref branch name))