### PR TITLE
TicketDto logical status New

### DIFF
--- a/tickets/src/main/java/no/unit/nva/publication/ticket/DoiRequestDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/DoiRequestDto.java
@@ -14,7 +14,6 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.User;
 import nva.commons.core.JacocoGenerated;
 
@@ -39,7 +38,7 @@ public class DoiRequestDto extends TicketDto {
     private final URI id;
 
     @JsonCreator
-    public DoiRequestDto(@JsonProperty(STATUS_FIELD) TicketStatus status,
+    public DoiRequestDto(@JsonProperty(STATUS_FIELD) TicketDtoStatus status,
                          @JsonProperty(CREATED_DATE_FIELD) Instant createdDate,
                          @JsonProperty(MODIFIED_DATE_FIELD) Instant modifiedDate,
                          @JsonProperty(IDENTIFIER_FIELD) SortableIdentifier identifier,
@@ -74,19 +73,6 @@ public class DoiRequestDto extends TicketDto {
     @Override
     public Class<? extends TicketEntry> ticketType() {
         return DoiRequest.class;
-    }
-
-    @Override
-    public TicketEntry toTicket() {
-        var ticket = new DoiRequest();
-        ticket.setCreatedDate(getCreatedDate());
-        ticket.setStatus(getStatus());
-        ticket.setModifiedDate(getModifiedDate());
-        ticket.setIdentifier(getIdentifier());
-        ticket.setResourceIdentifier(getPublicationIdentifier());
-        ticket.setViewedBy(getViewedBy());
-        ticket.setAssignee(getAssignee());
-        return ticket;
     }
 
     @Override

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/GeneralSupportRequestDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/GeneralSupportRequestDto.java
@@ -13,7 +13,6 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.User;
 import nva.commons.core.JacocoGenerated;
 
@@ -36,7 +35,7 @@ public class GeneralSupportRequestDto extends TicketDto {
     @JsonProperty(IDENTIFIER_FIELD)
     private final SortableIdentifier identifier;
 
-    public GeneralSupportRequestDto(@JsonProperty(STATUS_FIELD) TicketStatus status,
+    public GeneralSupportRequestDto(@JsonProperty(STATUS_FIELD) TicketDtoStatus status,
                                     @JsonProperty(CREATED_DATE_FIELD) Instant createdDate,
                                     @JsonProperty(MODIFIED_DATE_FIELD) Instant modifiedDate,
                                     @JsonProperty(IDENTIFIER_FIELD) SortableIdentifier identifier,
@@ -76,19 +75,6 @@ public class GeneralSupportRequestDto extends TicketDto {
     @Override
     public Class<? extends TicketEntry> ticketType() {
         return GeneralSupportRequest.class;
-    }
-
-    @Override
-    public TicketEntry toTicket() {
-        var request = new GeneralSupportRequest();
-        request.setIdentifier(this.getIdentifier());
-        request.setStatus(this.getStatus());
-        request.setResourceIdentifier(this.getPublicationIdentifier());
-        request.setCreatedDate(this.getCreatedDate());
-        request.setModifiedDate(this.getModifiedDate());
-        request.setViewedBy(this.getViewedBy());
-        request.setAssignee(this.getAssignee());
-        return request;
     }
 
     @Override

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/PublishingRequestDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/PublishingRequestDto.java
@@ -15,7 +15,6 @@ import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.PublishingWorkflow;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.User;
 import nva.commons.core.JacocoGenerated;
 
@@ -46,7 +45,7 @@ public class PublishingRequestDto extends TicketDto {
     private final PublishingWorkflow workflow;
 
     @JsonCreator
-    public PublishingRequestDto(@JsonProperty(STATUS_FIELD) TicketStatus status,
+    public PublishingRequestDto(@JsonProperty(STATUS_FIELD) TicketDtoStatus status,
                                 @JsonProperty(CREATED_DATE_FIELD) Instant createdDate,
                                 @JsonProperty(MODIFIED_DATE_FIELD) Instant modifiedDate,
                                 @JsonProperty(IDENTIFIER_FIELD) SortableIdentifier identifier,
@@ -87,19 +86,6 @@ public class PublishingRequestDto extends TicketDto {
     @Override
     public Class<? extends TicketEntry> ticketType() {
         return PublishingRequestCase.class;
-    }
-
-    @Override
-    public TicketEntry toTicket() {
-        var ticket = new PublishingRequestCase();
-        ticket.setCreatedDate(getCreatedDate());
-        ticket.setStatus(getStatus());
-        ticket.setModifiedDate(getModifiedDate());
-        ticket.setIdentifier(getIdentifier());
-        ticket.setResourceIdentifier(getPublicationIdentifier());
-        ticket.setViewedBy(getViewedBy());
-        ticket.setAssignee(getAssignee());
-        return ticket;
     }
 
     @Override

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDto.java
@@ -2,6 +2,7 @@ package no.unit.nva.publication.ticket;
 
 import static java.util.Objects.nonNull;
 import static no.unit.nva.publication.PublicationServiceConfig.API_HOST;
+import static no.unit.nva.publication.ticket.utils.TicketDtoStatusMapper.getTicketDtoStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -23,7 +24,6 @@ import no.unit.nva.publication.model.business.Message;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.PublishingWorkflow;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.ViewedBy;
 import nva.commons.core.paths.UriWrapper;
@@ -42,7 +42,7 @@ public abstract class TicketDto implements JsonSerializable {
     public static final String ASSIGNEE_FIELD = "assignee";
     public static final String PUBLICATION_IDENTIFIER_FIELD = "publicationIdentifier";
     @JsonProperty(STATUS_FIELD)
-    private final TicketStatus status;
+    private final TicketDtoStatus status;
     @JsonProperty(VIEWED_BY)
     private final Set<User> viewedBy;
     @JsonProperty(MESSAGES_FIELD)
@@ -52,7 +52,7 @@ public abstract class TicketDto implements JsonSerializable {
     @JsonProperty(PUBLICATION_IDENTIFIER_FIELD)
     private final SortableIdentifier publicationIdentifier;
 
-    protected TicketDto(TicketStatus status,
+    protected TicketDto(TicketDtoStatus status,
                         List<MessageDto> messages,
                         Set<User> viewedBy,
                         Username assignee,
@@ -78,7 +78,7 @@ public abstract class TicketDto implements JsonSerializable {
                               .collect(Collectors.toList());
         return TicketDto.builder()
                    .withCreatedDate(ticket.getCreatedDate())
-                   .withStatus(ticket.getStatus())
+                   .withStatus(getTicketDtoStatus(ticket))
                    .withModifiedDate(ticket.getModifiedDate())
                    .withIdentifier(ticket.getIdentifier())
                    .withId(createTicketId(ticket))
@@ -110,9 +110,7 @@ public abstract class TicketDto implements JsonSerializable {
 
     public abstract Class<? extends TicketEntry> ticketType();
 
-    public abstract TicketEntry toTicket();
-
-    public final TicketStatus getStatus() {
+    public final TicketDtoStatus getStatus() {
         return status;
     }
 
@@ -133,7 +131,7 @@ public abstract class TicketDto implements JsonSerializable {
 
     public static final class Builder {
 
-        private TicketStatus status;
+        private TicketDtoStatus status;
         private Instant createdDate;
         private Instant modifiedDate;
         private SortableIdentifier identifier;
@@ -146,7 +144,7 @@ public abstract class TicketDto implements JsonSerializable {
         private Builder() {
         }
 
-        public Builder withStatus(TicketStatus status) {
+        public Builder withStatus(TicketDtoStatus status) {
             this.status = status;
             return this;
         }

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
@@ -1,0 +1,50 @@
+package no.unit.nva.publication.ticket;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import no.unit.nva.publication.model.business.TicketStatus;
+import nva.commons.core.SingletonCollector;
+
+public enum TicketDtoStatus {
+    NEW("New"),
+    PENDING("Pending"),
+    COMPLETED("Completed"),
+    CLOSED("Closed");
+
+    private static final String INVALID_TICKET_STATUS_ERROR = "Invalid ticketDto status. Valid values:  ";
+    private static final String SEPARATOR = ",";
+    private final String value;
+
+    TicketDtoStatus(String value) {
+        this.value = value;
+    }
+
+    public static TicketDtoStatus parse(String candidate) {
+        return Arrays.stream(TicketDtoStatus.values())
+            .filter(enumValue -> enumValue.filterByNameOrValue(candidate))
+            .collect(SingletonCollector.tryCollect())
+            .orElseThrow(fail -> handleParsingError());
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    private static IllegalArgumentException handleParsingError() {
+        return new IllegalArgumentException(INVALID_TICKET_STATUS_ERROR + validValues());
+    }
+
+    private static String validValues() {
+        return Arrays.stream(TicketStatus.values())
+            .map(TicketStatus::toString)
+            .collect(Collectors.joining(SEPARATOR));
+    }
+
+    private boolean filterByNameOrValue(String candidate) {
+        return toString().equalsIgnoreCase(candidate)
+               || name().equalsIgnoreCase(candidate);
+    }
+}

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/utils/TicketDtoStatusMapper.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/utils/TicketDtoStatusMapper.java
@@ -1,0 +1,27 @@
+package no.unit.nva.publication.ticket.utils;
+
+import static java.util.Objects.isNull;
+import no.unit.nva.publication.model.business.TicketEntry;
+import no.unit.nva.publication.model.business.TicketStatus;
+import no.unit.nva.publication.ticket.TicketDtoStatus;
+
+public final class TicketDtoStatusMapper {
+
+    private TicketDtoStatusMapper() {
+    }
+
+    public static TicketDtoStatus getTicketDtoStatus(TicketEntry ticketEntry) {
+        if (isPending(ticketEntry)) {
+            return getStatusNewIfTicketIsUnassigned(ticketEntry);
+        }
+        return TicketDtoStatus.parse(ticketEntry.getStatusString());
+    }
+
+    static TicketDtoStatus getStatusNewIfTicketIsUnassigned(TicketEntry ticketEntry) {
+        return isNull(ticketEntry.getAssignee()) ? TicketDtoStatus.NEW : TicketDtoStatus.PENDING;
+    }
+
+    private static boolean isPending(TicketEntry ticketEntry) {
+        return TicketStatus.PENDING.equals(ticketEntry.getStatus());
+    }
+}

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoParser.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoParser.java
@@ -1,0 +1,70 @@
+package no.unit.nva.publication.ticket;
+
+import no.unit.nva.publication.model.business.DoiRequest;
+import no.unit.nva.publication.model.business.GeneralSupportRequest;
+import no.unit.nva.publication.model.business.PublishingRequestCase;
+import no.unit.nva.publication.model.business.TicketEntry;
+import no.unit.nva.publication.model.business.TicketStatus;
+
+public final class TicketDtoParser {
+
+    private TicketDtoParser() {
+
+    }
+
+    public static TicketEntry toTicket(TicketDto ticketDto) {
+        if (ticketDto instanceof DoiRequestDto) {
+            return toTicket((DoiRequestDto) ticketDto);
+        }
+        if (ticketDto instanceof PublishingRequestDto) {
+            return toTicket((PublishingRequestDto) ticketDto);
+        }
+        if (ticketDto instanceof GeneralSupportRequestDto) {
+            return toTicket((GeneralSupportRequestDto) ticketDto);
+        }
+        return null;
+    }
+
+    public static TicketEntry toTicket(GeneralSupportRequestDto generalSupportRequest) {
+        var request = new GeneralSupportRequest();
+        request.setIdentifier(generalSupportRequest.getIdentifier());
+        request.setStatus(getTicketStatus(generalSupportRequest.getStatus()));
+        request.setResourceIdentifier(generalSupportRequest.getPublicationIdentifier());
+        request.setCreatedDate(generalSupportRequest.getCreatedDate());
+        request.setModifiedDate(generalSupportRequest.getModifiedDate());
+        request.setViewedBy(generalSupportRequest.getViewedBy());
+        request.setAssignee(generalSupportRequest.getAssignee());
+        return request;
+    }
+
+    public static TicketEntry toTicket(PublishingRequestDto publishingRequestDto) {
+        var ticket = new PublishingRequestCase();
+        ticket.setCreatedDate(publishingRequestDto.getCreatedDate());
+        ticket.setStatus(getTicketStatus(publishingRequestDto.getStatus()));
+        ticket.setModifiedDate(publishingRequestDto.getModifiedDate());
+        ticket.setIdentifier(publishingRequestDto.getIdentifier());
+        ticket.setResourceIdentifier(publishingRequestDto.getPublicationIdentifier());
+        ticket.setViewedBy(publishingRequestDto.getViewedBy());
+        ticket.setAssignee(publishingRequestDto.getAssignee());
+        return ticket;
+    }
+
+    public static TicketEntry toTicket(DoiRequestDto doiRequestDto) {
+        var ticket = new DoiRequest();
+        ticket.setCreatedDate(doiRequestDto.getCreatedDate());
+        ticket.setStatus(getTicketStatus(doiRequestDto.getStatus()));
+        ticket.setModifiedDate(doiRequestDto.getModifiedDate());
+        ticket.setIdentifier(doiRequestDto.getIdentifier());
+        ticket.setResourceIdentifier(doiRequestDto.getPublicationIdentifier());
+        ticket.setViewedBy(doiRequestDto.getViewedBy());
+        ticket.setAssignee(doiRequestDto.getAssignee());
+        return ticket;
+    }
+
+    private static TicketStatus getTicketStatus(TicketDtoStatus ticketDtoStatus) {
+        if (TicketDtoStatus.NEW.equals(ticketDtoStatus)) {
+            return TicketStatus.PENDING;
+        }
+        return TicketStatus.parse(ticketDtoStatus.toString());
+    }
+}

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoStatusTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoStatusTest.java
@@ -1,0 +1,16 @@
+package no.unit.nva.publication.ticket;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+class TicketDtoStatusTest {
+
+    public static final String UNKNOWN_VALUE = "ObviouslyUnknownValue";
+
+    @Test
+    void shouldThrowExceptionWhenInputIsUnknownValue() {
+        Executable executable = () -> TicketDtoStatus.parse(UNKNOWN_VALUE);
+        assertThrows(IllegalArgumentException.class, executable);
+    }
+}

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
@@ -605,9 +605,9 @@ public class UpdateTicketHandlerTest extends TicketTestLocal {
 
     private InputStream authorizedUserAssigneesTicket(Publication publication, TicketEntry ticket, UserInstance user)
         throws JsonProcessingException {
-        return new HandlerRequestBuilder<TicketDto>(JsonUtils.dtoObjectMapper).withPathParameters(
+        return new HandlerRequestBuilder<UpdateTicketRequest>(JsonUtils.dtoObjectMapper).withPathParameters(
                 pathParameters(publication, ticket))
-                   .withBody(TicketDto.fromTicket(ticket))
+                   .withBody(new UpdateTicketRequest(ticket.getStatus(), ticket.getAssignee(), null))
                    .withUserName(user.getUsername())
                    .withCurrentCustomer(user.getOrganizationUri())
                    .withAccessRights(user.getOrganizationUri(), AccessRight.APPROVE_DOI_REQUEST.toString())


### PR DESCRIPTION
https://unit.atlassian.net/browse/NP-41622: 

- Replaced TicketStatus with TicketDtoStatus in TicketDto and logic for ticket status New.
- Moved TicketDto methods used only for testing to TicketDtoParser in test-directory.

Feel free to suggest a better name for _"TicketDtoStatus"_ :D