### PR TITLE
Use .jsonld in context path

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -608,7 +608,7 @@ Resources:
         GetEvent:
           Type: Api
           Properties:
-            Path: /context
+            Path: /context.jsonld
             Method: get
             RestApiId: !Ref NvaPublicationApi
 


### PR DESCRIPTION
Looking at the JSON-LD docs, it seems that the standard usage is to include ".jsonld" for contexts (FWIW, the current context doesn't work in playground, which is why I am attempting this, though the problem may lie deeper)
