### PR TITLE
topLevelOrganizations to List

### DIFF
--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -178,6 +178,10 @@
       "@container": "@set",
       "@id": "venue"
     },
+    "topLevelOrganizations": {
+      "@container": "@set",
+      "@id": "topLevelOrganization"
+    },
     "nviType": {
       "@type": "@vocab",
       "@context": {
@@ -233,10 +237,6 @@
   "link": {
     "@embed": "@never",
     "@default": "@null"
-  },
-  "topLevelOrganization": {
-    "@container": "@set",
-    "@embed": "@always"
   },
   "resourceOwner": {
     "ownerAffiliation": {

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -84,10 +84,8 @@ import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -654,7 +654,7 @@ class ExpandedResourceTest {
     }
 
     private Collection<URI> extractDistinctTopLevelIds(JsonNode framedResultNode) {
-        var topLevelAffiliations = framedResultNode.at("/topLevelOrganization");
+        var topLevelAffiliations = framedResultNode.at("/topLevelOrganizations");
         return StreamSupport.stream(topLevelAffiliations.spliterator(), false)
                    .map(node -> node.get("id").asText())
                    .map(URI::create)


### PR DESCRIPTION
Problem:

"topLevelOrganization" in expanded resource serializes as List or Object, based on number of entries in topLevelOrgs.

This will probably make topLevelOrganization to deserialize to List only. 
Renaming of topLevelOrganization to topLevelOrganizations will most likely affect search-api and nvi, but it is the way it should be named. 