### PR TITLE
converting to string bug fixed

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -56,6 +56,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private static final Logger logger = LoggerFactory.getLogger(BrageEntryEventConsumer.class);
     public static final String CRISTIN_RECORD_EXCEPTION =
         "Cristin record has not been merged with existing publication: ";
+    public static final String LINE_BREAK = "\n";
     private final S3Client s3Client;
     private final ResourceService resourceService;
     private String brageRecordFile;
@@ -289,7 +290,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     }
 
     private Record getBrageRecordFromS3(S3Event event) throws JsonProcessingException {
-        brageRecordFile = readFileFromS3(event);
+        brageRecordFile = readFileFromS3(event).replaceAll(LINE_BREAK, StringUtils.EMPTY_STRING);
         return parseBrageRecordJson(brageRecordFile);
     }
 

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 import java.net.URI;
 import java.util.List;
@@ -253,7 +252,8 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
                                 S3Event event) {
         var errorFileUri = constructErrorFileUri(event, fail.getException());
         var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_ERROR_BUCKET_NAME));
-        var content = attempt(() -> JsonUtils.dtoObjectMapper.readTree(determineBestEventReference(event))).orElseThrow();
+        var content = attempt(() -> JsonUtils.dtoObjectMapper.readTree(determineBestEventReference(event)))
+                          .orElseThrow();
         var reportContent = ImportResult.reportFailure(content, fail.getException());
         attempt(() -> s3Driver.insertFile(errorFileUri.toS3bucketPath(), reportContent.toJsonString())).orElseThrow();
     }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -56,7 +56,6 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private static final Logger logger = LoggerFactory.getLogger(BrageEntryEventConsumer.class);
     public static final String CRISTIN_RECORD_EXCEPTION =
         "Cristin record has not been merged with existing publication: ";
-    public static final String LINE_BREAK = "\n";
     private final S3Client s3Client;
     private final ResourceService resourceService;
     private String brageRecordFile;

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -856,8 +856,9 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
         Executable action = () -> handler.handleRequest(s3Event, CONTEXT);
         var exception = assertThrows(RuntimeException.class, action);
         var actualReport = extractActualReportFromS3Client(s3Event, exception);
-        var input = actualReport.get("input").asText();
+        var input = actualReport.get("input").toPrettyString();
         var actualErrorReportBrageRecord = JsonUtils.dtoObjectMapper.readValue(input, Record.class);
+
         assertThat(actualErrorReportBrageRecord,
                    is(equalTo(nvaBrageMigrationDataGenerator.getBrageRecord())));
     }


### PR DESCRIPTION
It seems like it is the only way to fix it, since all toString(), toJsonString(), objectMapper.writeValueAsString() return string with a lot of line breaks. 
I also could not assert that expected report does not contain line breaks, because it does even when those are removed. line breaks after coma in json structure.
But, when debugging, we see that report input is like:

`
{
    "customer": {
        "name": "someCustomer",
        "id": "https://dev.nva.sikt.no/registration/0184ebf2c2ad-0b4cd833-2f8c-4bd6-b11b-7b9cb15e9c05/edit"
    },
    "resourceOwner": {
        "owner": "institution@someOwner",
        "ownerAffiliation": "https://api.nva.unit.no/customer/test"
    },
    "brageLocation": "1986726885/11",
    "id": "http://hdl.handle.net/11250/1394738389",
    "doi": "https://doi.org/10.1000/7340",
    "publishedDate": {
        "brage": [
            "2003-02-19"
        ],
        "nva": "2003-02-19"
    },
    "publisherAuthority": null,
    "rightsholder": "eUBNtjfhZ8c6ks",
    "type": {
        "brage": [
            "Book"
        ],
        "nva": "Book"
    },
    "publication": {
        "issnList": [
            "7251-8324",
            "2555-2163"
        ],
        "isbnList": [
            "0088123588"
        ],
        "publicationContext": {
            "publisher": {
                "type": "Publisher"
            },
            "journal": {
                "type": "Journal"
            },
            "series": {
                "type": "Series"
            }
        }
    },
    "entityDescription": {
        "descriptions": [
            "q4Ia9DFISK4bL4UH59"
        ],
        "abstracts": [
            "RXZwPm90fkOAb7s2CA"
        ],
        "publicationDate": {
            "brage": "2020",
            "nva": {
                "type": "PublicationDateNva",
                "year": "2020"
            }
        },
        "mainTitle": "pftBfwFjjvswXcD7t",
        "alternativeTitles": [
            "Noe på norsk språk",
            "Something in English",
            "One more title in English",
            "Une chose en Francais",
            "Labdien, mans nezināmais draugs",
            "Ein ding aus Deutsch",
            "Mér likar þessir hestar"
        ],
        "contributors": [
            {
                "type": "Contributor",
                "brageRole": "author",
                "role": "Creator",
                "identity": {
                    "type": "Identity",
                    "name": "Ola",
                    "identifier": "123"
                },
                "affiliations": [
                    {
                        "type": "Affiliation",
                        "identifier": "12345",
                        "name": "someAffiliation",
                        "handle": "handle"
                    }
                ]
            }
        ],
        "publicationInstance": {
            "pages": {
                "bragePages": "46 s.",
                "range": {
                    "begin": "5",
                    "end": "10"
                },
                "pages": "5"
            }
        },
        "language": {
            "brage": [
                "norsk",
                "svensk"
            ],
            "nva": "http://lexvo.org/id/iso639-3/und"
        }
    }
}
`