### PR TITLE
Set project name to an empty string when generating publications with projects in Cristin import

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/HardcodedValues.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/constants/HardcodedValues.java
@@ -6,7 +6,7 @@ public final class HardcodedValues {
     public static final String UNIT_CUSTOMER_ID = "f54c8aa9-073a-46a1-8f7c-dde66c853934";
     public static final String HARDCODED_PUBLICATIONS_OWNER = "someone@unit.no";
     //RESEARCH_PROJECT
-    public static final String HARDCODED_RESEARCH_PROJECT_NAME = "Some project name";
+    public static final String HARDCODED_RESEARCH_PROJECT_NAME = "";
     public static final String SIKT_OWNER = "sikt@20754.0.0.0";
     public static final String SIKT_AFFILIATION_IDENTIFIER = "20754.0.0.0";
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPresentationalWork.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinPresentationalWork.java
@@ -28,7 +28,7 @@ import nva.commons.core.paths.UriWrapper;
 public class CristinPresentationalWork {
     
     private static final String PROJECT = "project";
-    private static final String PROSJEKT = "PROSJEKT";
+    public static final String PROSJEKT = "PROSJEKT";
 
     @JsonProperty("presentasjonslopenr")
     private Integer identifier;

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -139,6 +139,13 @@ public final class CristinDataGenerator {
                    .build();
     }
 
+    public static CristinPresentationalWork randomPresentationalWork(String presentationType) {
+        return CristinPresentationalWork.builder()
+                   .withPresentationType(presentationType)
+                   .withIdentifier(smallRandomNumber())
+                   .build();
+    }
+
     public static List<CristinContributorsAffiliation> randomAffiliations() {
         return smallSample().map(ignored -> randomAffiliation()).collect(Collectors.toList());
     }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -4,6 +4,7 @@ import static no.unit.nva.cristin.CristinDataGenerator.largeRandomNumber;
 import static no.unit.nva.cristin.CristinDataGenerator.randomAffiliation;
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.NVA_API_DOMAIN;
 import static no.unit.nva.cristin.mapper.CristinObject.IDENTIFIER_ORIGIN;
+import static no.unit.nva.cristin.mapper.CristinPresentationalWork.PROSJEKT;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -51,6 +52,7 @@ import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
 import nva.commons.core.SingletonCollector;
 import nva.commons.core.StringUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,6 +63,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 class CristinMapperTest extends AbstractCristinImportTest {
 
     public static final int NUMBER_OF_OBJECTS = 100;
+    public static final String EMPTY_STRING = "";
     private List<CristinObject> cristinObjects;
 
     @BeforeEach
@@ -465,6 +468,21 @@ class CristinMapperTest extends AbstractCristinImportTest {
     void mapThrowsMissingFieldsExceptionWhenNonIgnoredFieldIsMissing() {
         //re-use the test for the author's name
         mapSetsNameToNullWhenBothFamilyNameAndGivenNameAreMissing();
+    }
+
+    @Test
+    void shouldSetEmptyProjectNameWhenGeneratingPublication() {
+        var cristinObject = CristinDataGenerator.randomObject();
+        cristinObject.setPresentationalWork(
+            List.of(CristinDataGenerator.randomPresentationalWork(PROSJEKT))
+        );
+
+        var publication = cristinObject.toPublication();
+        var projects = publication.getProjects();
+        Assertions.assertFalse(projects.isEmpty());
+
+        var projectName = projects.get(0).getName();
+        assertThat(projectName, is(equalTo(EMPTY_STRING)));
     }
 
     private static List<Contributor> getContributors(CristinObject singleCristinObject) {


### PR DESCRIPTION
When projects are generated from Presentational Work when generating a Publication in Cristin import, the project name will now be an empty string.