### PR TITLE
adding test to verify functionality

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -43,7 +43,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     public static final Random RANDOM = new Random(System.currentTimeMillis());
     public static final int MAX_EFFORTS = 10;
     public static final String SOURCE_CRISTIN = "Cristin";
-    public static final String BRAGE_MIGRATION_ERROR_BUCKET_NAME = "BRAGE_MIGRATION_ERROR_BUCKET_NAME";
+    public static final String BRAGE_MIGRATION_REPORTS_BUCKET_NAME = "BRAGE_MIGRATION_ERROR_BUCKET_NAME";
     public static final String YYYY_MM_DD_HH_FORMAT = "yyyy-MM-dd:HH";
     public static final String ERROR_BUCKET_PATH = "ERROR";
     public static final String HANDLE_REPORTS_PATH = "HANDLE_REPORTS";
@@ -131,7 +131,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
 
     private void storePublicationBeforeUpdate(Publication publication, S3Event s3Event) {
         var fileUri = updateResourceFilePath(publication, s3Event);
-        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_ERROR_BUCKET_NAME));
+        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_REPORTS_BUCKET_NAME));
         attempt(() -> s3Driver.insertFile(fileUri.toS3bucketPath(), publication.toString())).orElseThrow();
     }
 
@@ -179,7 +179,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private Publication storeHandleAndPublicationIdentifier(Publication publication, S3Event s3Event) {
         var handle = publication.getHandle();
         var fileUri = constructResourcehandleFileUri(s3Event, publication);
-        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_ERROR_BUCKET_NAME));
+        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_REPORTS_BUCKET_NAME));
         attempt(() -> s3Driver.insertFile(fileUri.toS3bucketPath(), handle.toString())).orElseThrow();
         return publication;
     }
@@ -247,7 +247,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private void saveReportToS3(Failure<Publication> fail,
                                 S3Event event) {
         var errorFileUri = constructErrorFileUri(event, fail.getException());
-        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_ERROR_BUCKET_NAME));
+        var s3Driver = new S3Driver(s3Client, new Environment().readEnv(BRAGE_MIGRATION_REPORTS_BUCKET_NAME));
         var content = attempt(() -> JsonUtils.dtoObjectMapper.readTree(determineBestEventReference(event)))
                           .orElseThrow();
         var reportContent = ImportResult.reportFailure(content, fail.getException());

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -890,6 +890,26 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     }
 
     @Test
+    void shouldSaveSuccessReportContainingIncomingHandleWhenUpdatingExistingPublication()
+        throws BadRequestException, IOException {
+        var cristinIdentifier = randomString();
+        var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder().withPublishedDate(null)
+                                                 .withType(TYPE_BOOK)
+                                                 .withCristinIdentifier(cristinIdentifier)
+                                                 .build();
+        var existingPublication =
+            persistPublicationWithCristinIdAndHandle(cristinIdentifier,
+                                                     nvaBrageMigrationDataGenerator.getNvaPublication().getHandle());
+        var s3Event = createNewBrageRecordEvent(nvaBrageMigrationDataGenerator.getBrageRecord());
+        var actualPublication = handler.handleRequest(s3Event, CONTEXT);
+
+        var actualStoredHandleString = extractActualHandleReportFromS3Client(s3Event, actualPublication);
+        assertThat(actualPublication.getIdentifier(), is(equalTo(existingPublication.getIdentifier())));
+        assertThat(actualStoredHandleString,
+                   is(equalTo(nvaBrageMigrationDataGenerator.getBrageRecord().getId().toString())));
+    }
+
+    @Test
     void shouldSavePublicationBeforeUpdateInS3() throws IOException, BadRequestException {
         var cristinIdentifier = randomString();
         var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder().withPublishedDate(null)
@@ -1108,9 +1128,9 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     private UriWrapper constructHandleReportFileUri(S3Event s3Event, Publication actualPublication) {
         var timestamp = s3Event.getRecords().get(0).getEventTime().toString(YYYY_MM_DD_HH_FORMAT);
         return UriWrapper.fromUri(HANDLE_REPORTS_PATH)
-                   .addChild(actualPublication.getResourceOwner().getOwner().getValue().split("@")[0])
-                   .addChild(timestamp)
-                   .addChild(actualPublication.getIdentifier().toString());
+                                    .addChild("institution")
+                                    .addChild(timestamp)
+                                    .addChild(actualPublication.getIdentifier().toString());
     }
 
     private JsonNode extractActualReportFromS3Client(S3Event s3Event, Exception exception, Record brageRecord)


### PR DESCRIPTION
We already create HANDLE_REPORT for brage record which is merged with existing nva publication:
Merged record is reported in both UPDATE_REPORT (publication json before merging as file content) and handle report (handle of incoming brage record as file content)

It is not the problem that some publications will have multiple reports, because brage catalogs do not have duplicates (we remove duplicates when creating brage records), and HANDLE_REPORTS have institution name in s3 path.

Multiple brage records (from different institution) merged with nva publication will have following handle reports:

ntnu/timestamp/publicationId
nmbu/timestamp/publicationId
uio/timestamp/publicationId