### PR TITLE
Use context uri in expanded resources

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -129,12 +129,15 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     }
 
     private ObjectNode replaceInlineContextWithUriContext(String resourceWithNviValues) {
-        var objectNode =  attempt(() -> (ObjectNode) objectMapper.readTree(resourceWithNviValues)).orElseThrow();
-        if (!objectNode.at(CONTEXT_NODE_SELECTOR).isMissingNode()) {
-            objectNode.remove(CONTEXT_FIELD_PROPERTY_NAME);
+        var objectNode = attempt(() -> (ObjectNode) objectMapper.readTree(resourceWithNviValues)).orElseThrow();
+        if (hasContextNode(objectNode)) {
             objectNode.put(CONTEXT_FIELD_PROPERTY_NAME, CONTEXT_URI);
         }
         return objectNode;
+    }
+
+    private static boolean hasContextNode(ObjectNode objectNode) {
+        return !objectNode.at(CONTEXT_NODE_SELECTOR).isMissingNode();
     }
 
     @Override

--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -1,6 +1,7 @@
 package no.unit.nva.expansion;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.expansion.model.ExpandedDataEntry;
@@ -35,6 +36,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import static java.util.Objects.isNull;
+import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.ioutils.IoUtils.stringToStream;
 
@@ -45,7 +47,10 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public static final String UNSUPPORTED_TYPE = "Expansion is not supported for type:";
     public static final String CRISTIN = "cristin";
     public static final String PERSON = "person";
-    public static final String API_HOST = "API_HOST";
+    public static final String API_HOST = new Environment().readEnv("API_HOST");
+    public static final String CONTEXT_URI = new UriWrapper(UriWrapper.HTTPS, API_HOST)
+                                                 .addChild("publication", "context")
+                                                 .toString();
     public static final String CRISTIN_ID_DELIMITER = "@";
     private static final String EXPAND_PERSON_DEFAULT_INFO = "Could not retrieve Cristin Person. Creating default "
                                                              + "expanded person for owner";
@@ -54,6 +59,8 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public static final String LAST_NAME_CRISTIN_TYPE = "LastName";
     public static final String PREFERRED_LAST_NAME_CRISTIN_TYPE = "PreferredLastName";
     private static final String PART_OF_PROPERTY = "https://nva.sikt.no/ontology/publication#partOf";
+    public static final String CONTEXT_NODE_SELECTOR = "/@context";
+    public static final String CONTEXT_FIELD_PROPERTY_NAME = "@context";
     private final ResourceService resourceService;
     private final TicketService ticketService;
     private final UriRetriever personRetriever;
@@ -105,7 +112,10 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
             logger.info("Expanding Resource: {}", resource.getIdentifier());
             var expandedResource = ExpandedResource.fromPublication(personRetriever,
                                                                     resource.toPublication(resourceService));
-            return NviCalculator.calculateNviType(expandedResource);
+            var resourceWithNviType = NviCalculator.calculateNviType(expandedResource);
+            var resourceWithContextUri = replaceInlineContextWithUriContext(resourceWithNviType);
+            return attempt(
+                () -> objectMapper.readValue(resourceWithContextUri.toString(), ExpandedResource.class)).orElseThrow();
         } else if (dataEntry instanceof TicketEntry ticketEntry) {
             logger.info("Expanding TicketEntry: {}", ticketEntry.getIdentifier());
             return ExpandedTicket.create((TicketEntry) dataEntry, resourceService, this, ticketService);
@@ -116,6 +126,15 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
         }
         // will throw exception if we want to index a new type that we are not handling yet
         throw new UnsupportedOperationException(UNSUPPORTED_TYPE + dataEntry.getClass().getSimpleName());
+    }
+
+    private ObjectNode replaceInlineContextWithUriContext(String resourceWithNviValues) {
+        var objectNode =  attempt(() -> (ObjectNode) objectMapper.readTree(resourceWithNviValues)).orElseThrow();
+        if (!objectNode.at(CONTEXT_NODE_SELECTOR).isMissingNode()) {
+            objectNode.remove(CONTEXT_FIELD_PROPERTY_NAME);
+            objectNode.put(CONTEXT_FIELD_PROPERTY_NAME, CONTEXT_URI);
+        }
+        return objectNode;
     }
 
     @Override
@@ -159,7 +178,7 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     }
 
     private URI constructUri(User owner) {
-        return UriWrapper.fromHost(new Environment().readEnv(API_HOST))
+        return UriWrapper.fromHost(API_HOST)
                 .addChild(CRISTIN)
                 .addChild(PERSON)
                 .addChild(extractCristinId(owner))

--- a/expansion/src/main/java/no/unit/nva/expansion/utils/NviCalculator.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/utils/NviCalculator.java
@@ -3,7 +3,6 @@ package no.unit.nva.expansion.utils;
 import static java.util.Objects.isNull;
 import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
 import static no.unit.nva.expansion.utils.JsonLdDefaults.frameJsonLd;
-import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.ioutils.IoUtils.stringToStream;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.InputStream;
@@ -37,11 +36,9 @@ public final class NviCalculator {
     private NviCalculator() {
     }
 
-    public static ExpandedResource calculateNviType(ExpandedResource expandedResource) throws JsonProcessingException {
+    public static String calculateNviType(ExpandedResource expandedResource) throws JsonProcessingException {
         var model = createModelWithNviType(expandedResource);
-        var expandedResourceJsonWithNviType = frameJsonLd(model, FRAME_SRC);
-        return attempt(
-            () -> objectMapper.readValue(expandedResourceJsonWithNviType, ExpandedResource.class)).orElseThrow();
+        return frameJsonLd(model, FRAME_SRC);
     }
 
     private static Model createModelWithNviType(ExpandedResource expandedResource) throws JsonProcessingException {

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -57,6 +57,7 @@ import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Username;
+import no.unit.nva.model.instancetypes.journal.AcademicArticle;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
 import no.unit.nva.model.testing.PublicationGenerator;
@@ -195,6 +196,21 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         Resource resourceUpdate = Resource.fromPublication(publication);
         ExpandedResource indexDoc = (ExpandedResource) expansionService.expandEntry(resourceUpdate);
         assertThat(indexDoc.fetchId(), is(not(nullValue())));
+    }
+
+    @Test
+    void shouldReturnIndexDocumentWithContextUri()
+        throws JsonProcessingException, NotFoundException {
+
+        Publication publication = randomPublication(AcademicArticle.class)
+                                      .copy()
+                                      .withEntityDescription(new EntityDescription())
+                                      .build();
+
+        Resource resourceUpdate = Resource.fromPublication(publication);
+        ExpandedResource indexDoc = (ExpandedResource) expansionService.expandEntry(resourceUpdate);
+        assertThat(indexDoc.getAllFields().get("@context"),
+                   is(equalTo("https://api.dev.nva.aws.unit.no/publication/context")));
     }
 
     @Test

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -202,13 +202,13 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
     void shouldReturnIndexDocumentWithContextUri()
         throws JsonProcessingException, NotFoundException {
 
-        Publication publication = randomPublication(AcademicArticle.class)
+        var publication = randomPublication(AcademicArticle.class)
                                       .copy()
                                       .withEntityDescription(new EntityDescription())
                                       .build();
 
-        Resource resourceUpdate = Resource.fromPublication(publication);
-        ExpandedResource indexDoc = (ExpandedResource) expansionService.expandEntry(resourceUpdate);
+        var resourceUpdate = Resource.fromPublication(publication);
+        var indexDoc = (ExpandedResource) expansionService.expandEntry(resourceUpdate);
         assertThat(indexDoc.getAllFields().get("@context"),
                    is(equalTo("https://api.dev.nva.aws.unit.no/publication/context")));
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 
 nva = { strictly = '1.34.0' }
-nvaDatamodel = { strictly = '0.20.48' }
+nvaDatamodel = { strictly = '0.20.54' }
 nvaDoiPartnerData = { strictly = '0.5.8' }
 jackson = { strictly = '2.15.2' }
 awsSdk = { strictly = '1.12.544' }

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/persistence/AnalyticsIntegrationHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/persistence/AnalyticsIntegrationHandlerTest.java
@@ -2,7 +2,6 @@ package no.unit.nva.publication.events.handlers.persistence;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
@@ -59,10 +58,8 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -170,7 +167,7 @@ class AnalyticsIntegrationHandlerTest extends ResourcesLocalTest {
         return new EventReference(EXPANDED_ENTRY_UPDATED_EVENT_TOPIC, fileUri);
     }
 
-    private ExpandedDoiRequest createSampleExpandedDoiRequest() throws ApiGatewayException, JsonProcessingException {
+    private ExpandedDoiRequest createSampleExpandedDoiRequest() throws ApiGatewayException {
         Publication samplePublication = insertSamplePublication();
         var doiRequest = DoiRequest.newDoiRequestForResource(Resource.fromPublication(samplePublication));
         var messages = doiRequest.fetchMessages(ticketService);
@@ -214,7 +211,7 @@ class AnalyticsIntegrationHandlerTest extends ResourcesLocalTest {
               "id" : "%s",
               "name" : "Test (Madrid)",
               "scientificValue" : "LevelOne",
-              "sameAs" : "https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=D4781C26-15BD-4CD2-BC2D-03C19B112134",
+              "sameAs" : "https://example.org/KanalTidsskriftInfo?pid=D4781C26-15BD-4CD2-BC2D-03C19B112134",
               "type" : "Publisher",
               "@context" : "https://bibsysdev.github.io/src/publication-channel/channel-context.json"
             }
@@ -230,7 +227,7 @@ class AnalyticsIntegrationHandlerTest extends ResourcesLocalTest {
               "onlineIssn" : "1863-8260",
               "printIssn" : "1133-0686",
               "scientificValue" : "LevelOne",
-              "sameAs" : "https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=D4781C26-15BD-4CD2-BC2D-03C19B112134",
+              "sameAs" : "https://example.org/KanalTidsskriftInfo?pid=D4781C26-15BD-4CD2-BC2D-03C19B112134",
               "type" : "Journal",
               "@context" : "https://bibsysdev.github.io/src/publication-channel/channel-context.json"
             }


### PR DESCRIPTION
- Removes the @context at the latest possible moment to avoid disrupting anything in any other process
- Does this in a rather ignorant way, but this is unavoidable at this point, alas.