### PR TITLE
Add duplicate doi check for brage migration

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -117,17 +117,16 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         var doi = publication.getEntityDescription().getReference().getDoi();
 
         if (nonNull(doi)) {
-            var publications = searchForPublicationsByDoi(doi);
-            if (publications.isEmpty()) {
+            var publicationsByDoi = searchForPublicationsByDoi(doi);
+            if (publicationsByDoi.isEmpty()) {
                 return false;
             }
 
-            // Fetch first publication regardless of how many hits
-            var publicationByDoi = publications.get(0);
+            var firstPublicationHitByDoi = publicationsByDoi.get(0);
 
-            // The Search Index is not reliable enough, therefore we fetch the publication from the source
-            var publicationFromResource = resourceService.getPublicationByIdentifier(publicationByDoi.getIdentifier());
-            publicationsToMerge = List.of(publicationFromResource);
+            var upToDateVersionOfPublication =
+                resourceService.getPublicationByIdentifier(firstPublicationHitByDoi.getIdentifier());
+            publicationsToMerge = List.of(upToDateVersionOfPublication);
 
             return true;
         }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Iterables;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,9 +26,12 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import no.unit.nva.publication.external.services.UriRetriever;
+import no.unit.nva.publication.model.SearchResourceApiResponse;
 import no.unit.nva.publication.s3imports.ImportResult;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
@@ -59,26 +63,33 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private static final String S3_URI_TEMPLATE = "s3://%s/%s";
     private static final String ERROR_SAVING_BRAGE_IMPORT = "Error saving brage import for record with object key: ";
     private static final Logger logger = LoggerFactory.getLogger(BrageEntryEventConsumer.class);
+    private static final String RESOURCES_2 = "resources2";
+    private static final String SEARCH = "search";
+    private static final String DOI = "doi";
+    private static final String APPLICATION_JSON = "application/json";
     private final S3Client s3Client;
     private final ResourceService resourceService;
     private String brageRecordFile;
-    private List<Publication> publicationsByCristinIdentifier;
+    private List<Publication> publicationsToMerge;
+    private final UriRetriever uriRetriever;
+    private final String apiHost = new Environment().readEnv("API_HOST");
 
-    public BrageEntryEventConsumer(S3Client s3Client, ResourceService resourceService) {
+    public BrageEntryEventConsumer(S3Client s3Client, ResourceService resourceService, UriRetriever uriRetriever) {
         this.s3Client = s3Client;
         this.resourceService = resourceService;
+        this.uriRetriever = uriRetriever;
     }
 
     @JacocoGenerated
     public BrageEntryEventConsumer() {
-        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService());
+        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService(), new UriRetriever());
     }
 
     @Override
     public Publication handleRequest(S3Event s3Event, Context context) {
         return attempt(() -> parseBrageRecord(s3Event))
                    .map(publication -> pushAssociatedFilesToPersistedStorage(publication, s3Event))
-                   .map(publication -> publicationWithCristinIdentifierAlreadyExists(publication)
+                   .map(publication -> shouldMergePublications(publication)
                                            ? attemptToUpdateExistingPublication(publication, s3Event)
                                            : createNewPublication(publication, s3Event))
                    .orElse(fail -> handleSavingError(fail, s3Event));
@@ -91,13 +102,61 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
                        fail.getException()));
     }
 
-    private boolean publicationWithCristinIdentifierAlreadyExists(Publication publication) {
+    private boolean shouldMergePublications(Publication publication) throws NotFoundException {
         var cristinIdentifier = getCristinIdentifier(publication);
         if (nonNull(cristinIdentifier)) {
-            publicationsByCristinIdentifier = getPublicationsByCristinIdentifier(cristinIdentifier);
-            return !publicationsByCristinIdentifier.isEmpty();
+            publicationsToMerge = getPublicationsByCristinIdentifier(cristinIdentifier);
+            return !publicationsToMerge.isEmpty();
+        }
+
+        return existingPublicationHasSameDoi(publication);
+    }
+
+    private boolean existingPublicationHasSameDoi(Publication publication)
+        throws NotFoundException {
+        var doi = publication.getEntityDescription().getReference().getDoi();
+
+        if (nonNull(doi)) {
+            var publications = searchForPublicationsByDoi(doi);
+            if (publications.isEmpty()) {
+                return false;
+            }
+
+            // Fetch first publication regardless of how many hits
+            var publicationByDoi = publications.get(0);
+
+            // The Search Index is not reliable enough, therefore we fetch the publication from the source
+            var publicationFromResource = resourceService.getPublicationByIdentifier(publicationByDoi.getIdentifier());
+            publicationsToMerge = List.of(publicationFromResource);
+
+            return true;
         }
         return false;
+    }
+
+    private List<Publication> searchForPublicationsByDoi(URI doi) {
+        var searchUri = constructSearchUri(doi);
+        return getResponseBody(searchUri)
+                .map(this::toResponse)
+                .map(SearchResourceApiResponse::hits)
+                .orElse(List.of());
+    }
+
+    private URI constructSearchUri(URI doi) {
+        return UriWrapper.fromHost(apiHost)
+                   .addChild(SEARCH)
+                   .addChild(RESOURCES_2)
+                   .addQueryParameter(DOI, doi.toString())
+                   .getUri();
+    }
+
+    private Optional<String> getResponseBody(URI uri) {
+        return uriRetriever.getRawContent(uri, APPLICATION_JSON);
+    }
+
+    private SearchResourceApiResponse toResponse(String response) {
+        return attempt(() -> JsonUtils.dtoObjectMapper.readValue(response, SearchResourceApiResponse.class))
+                   .orElseThrow();
     }
 
     private List<Publication> getPublicationsByCristinIdentifier(String cristinIdentifier) {
@@ -131,7 +190,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     }
 
     private Publication attemptToUpdateExistingPublication(Publication publication, S3Event s3Event) {
-        return attempt(() -> publicationsByCristinIdentifier)
+        return attempt(() -> publicationsToMerge)
                    .map(publications -> mergeTwoPublications(publication, getOnlyElement(publications), s3Event))
                    .orElseThrow();
     }

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -1024,7 +1024,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
                    .persistNew(resourceService, UserInstance.fromPublication(publication));
     }
 
-    private Publication persistPublicationWithDoi( URI doi)
+    private Publication persistPublicationWithDoi(URI doi)
         throws BadRequestException {
         var publication = randomPublication().copy()
                               .withDoi(doi)

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -22,6 +22,7 @@ import static no.sikt.nva.brage.migration.mapper.PublicationContextMapper.NOT_SU
 import static no.sikt.nva.brage.migration.merger.AssociatedArtifactMover.COULD_NOT_COPY_ASSOCIATED_ARTEFACT_EXCEPTION_MESSAGE;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.TEST_DESCRIPTION;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.testutils.RandomDataGenerator.randomDoi;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIsbn10;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomJson;
@@ -36,6 +37,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import com.amazonaws.services.kms.model.NotFoundException;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
@@ -55,6 +59,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -81,6 +86,8 @@ import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.File;
+import no.unit.nva.publication.external.services.UriRetriever;
+import no.unit.nva.publication.model.SearchResourceApiResponse;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.ResourcesLocalTest;
@@ -193,14 +200,16 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     private S3Driver s3Driver;
     private FakeS3Client s3Client;
     private ResourceService resourceService;
+    private UriRetriever uriRetriever;
 
     @BeforeEach
     public void init() {
         super.init();
         this.resourceService = new ResourceService(client, Clock.systemDefaultZone());
         this.s3Client = new FakeS3cClientWithCopyObjectSupport();
-        this.handler = new BrageEntryEventConsumer(s3Client, resourceService);
         this.s3Driver = new S3Driver(s3Client, INPUT_BUCKET_NAME);
+        this.uriRetriever = mock(UriRetriever.class);
+        this.handler = new BrageEntryEventConsumer(s3Client, resourceService, uriRetriever);
     }
 
     @Test
@@ -793,7 +802,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     void shouldTryToPersistPublicationInDatabaseSeveralTimesWhenResourceServiceIsThrowingException()
         throws IOException {
         var fakeResourceServiceThrowingException = new FakeResourceServiceThrowingException(client);
-        this.handler = new BrageEntryEventConsumer(s3Client, fakeResourceServiceThrowingException);
+        this.handler = new BrageEntryEventConsumer(s3Client, fakeResourceServiceThrowingException, uriRetriever);
         var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder().withPublishedDate(null)
                                                  .withType(TYPE_BOOK)
                                                  .build();
@@ -808,7 +817,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     void shouldStoreExceptionIfItCannotCopyAssociatedArtifacts() throws IOException {
         this.s3Client = new FakeS3ClientThrowingExceptionWhenCopying();
         this.s3Driver = new S3Driver(s3Client, INPUT_BUCKET_NAME);
-        this.handler = new BrageEntryEventConsumer(s3Client, resourceService);
+        this.handler = new BrageEntryEventConsumer(s3Client, resourceService, uriRetriever);
         var brageGenerator = new NvaBrageMigrationDataGenerator.Builder().withPublishedDate(null)
                                  .withType(TYPE_BOOK)
                                  .withResourceContent(createResourceContent())
@@ -866,7 +875,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     @Test
     void shouldSaveErrorReportInS3ContainingTheOriginalInputData() throws IOException {
         resourceService = new FakeResourceServiceThrowingException(client);
-        this.handler = new BrageEntryEventConsumer(s3Client, resourceService);
+        this.handler = new BrageEntryEventConsumer(s3Client, resourceService, uriRetriever);
         var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder().withPublishedDate(null)
                                                  .withType(TYPE_BOOK)
                                                  .build();
@@ -930,6 +939,88 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
         assertThat(storedPublication, is(equalTo(existingPublication.toString())));
     }
 
+    @Test
+    void shouldMergePublicationsIfDoiDuplicateExistsWithCristinIdentifier() throws BadRequestException, IOException {
+        var doi = randomDoi();
+        var existingPublication = persistPublicationWithCristinIdAndDoi(randomString(), doi);
+        assertThat(existingPublication.getHandle(), is(nullValue()));
+
+        var listOfExistingPublications = List.of(existingPublication);
+        var searchResourceApiResponseSingleHit = new SearchResourceApiResponse(listOfExistingPublications.size(),
+                                                                               listOfExistingPublications);
+        var singleHitOptional = Optional.of(searchResourceApiResponseSingleHit.toString());
+        when(uriRetriever.getRawContent(any(), any())).thenReturn(singleHitOptional);
+
+        var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder()
+                                                 .withPublishedDate(null)
+                                                 .withType(TYPE_BOOK)
+                                                 .withDoi(doi)
+                                                 .build();
+
+        var brageRecord = nvaBrageMigrationDataGenerator.getBrageRecord();
+        var s3Event = createNewBrageRecordEvent(brageRecord);
+        var publication = handler.handleRequest(s3Event, CONTEXT);
+        assertThat(publication.getHandle(), is(equalTo(brageRecord.getId())));
+        assertThat(publication.getIdentifier(), is(equalTo(existingPublication.getIdentifier())));
+
+        var actualStoredHandleString = extractActualHandleReportFromS3Client(s3Event, existingPublication);
+        assertThat(actualStoredHandleString,
+                   is(equalTo(nvaBrageMigrationDataGenerator.getBrageRecord().getId().toString())));
+    }
+
+    @Test
+    void shouldMergePublicationsIfDoiDuplicateExistsWithoutCristinIdentifier() throws BadRequestException, IOException {
+        var doi = randomDoi();
+        var existingPublicationWithoutCristinIdentifier = persistPublicationWithCristinIdAndDoi(null, doi);
+        assertThat(existingPublicationWithoutCristinIdentifier.getHandle(), is(nullValue()));
+
+        var listOfExistingPublications = List.of(existingPublicationWithoutCristinIdentifier);
+        var searchResourceApiResponseSingleHit = new SearchResourceApiResponse(listOfExistingPublications.size(),
+                                                                               listOfExistingPublications);
+        var singleHitOptional = Optional.of(searchResourceApiResponseSingleHit.toString());
+        when(uriRetriever.getRawContent(any(), any())).thenReturn(singleHitOptional);
+
+        var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder()
+                                                 .withPublishedDate(null)
+                                                 .withType(TYPE_BOOK)
+                                                 .withDoi(doi)
+                                                 .build();
+
+        var brageRecord = nvaBrageMigrationDataGenerator.getBrageRecord();
+        var s3Event = createNewBrageRecordEvent(brageRecord);
+        var publication = handler.handleRequest(s3Event, CONTEXT);
+        assertThat(publication.getHandle(), is(equalTo(brageRecord.getId())));
+        assertThat(publication.getIdentifier(),
+                   is(equalTo(existingPublicationWithoutCristinIdentifier.getIdentifier())));
+
+        var actualStoredHandleString =
+            extractActualHandleReportFromS3Client(s3Event, existingPublicationWithoutCristinIdentifier);
+        assertThat(actualStoredHandleString,
+                   is(equalTo(nvaBrageMigrationDataGenerator.getBrageRecord().getId().toString())));
+    }
+
+    @Test
+    void shouldNotMergePublicationsIfNoDoiDuplicateExists() throws IOException {
+        var searchResourceApiResponseNoHits = new SearchResourceApiResponse(0, null);
+        var noHitsOptional = Optional.of(searchResourceApiResponseNoHits.toString());
+        when(uriRetriever.getRawContent(any(), any())).thenReturn(noHitsOptional);
+
+        var nvaBrageMigrationDataGenerator = new NvaBrageMigrationDataGenerator.Builder()
+                                                 .withPublishedDate(null)
+                                                 .withType(TYPE_BOOK)
+                                                 .withDoi(randomDoi())
+                                                 .build();
+
+        var brageRecord = nvaBrageMigrationDataGenerator.getBrageRecord();
+        var s3Event = createNewBrageRecordEvent(brageRecord);
+        var publication = handler.handleRequest(s3Event, CONTEXT);
+        assertThat(publication.getHandle(), is(equalTo(brageRecord.getId())));
+
+        var actualStoredHandleString = extractActualHandleReportFromS3Client(s3Event, publication);
+        assertThat(actualStoredHandleString,
+                   is(equalTo(nvaBrageMigrationDataGenerator.getBrageRecord().getId().toString())));
+    }
+
     private static Publication copyPublication(NvaBrageMigrationDataGenerator brageGenerator)
         throws JsonProcessingException {
         return JsonUtils.dtoObjectMapper.readValue(
@@ -960,6 +1051,23 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
                                   Set.of(new AdditionalIdentifier("Cristin", cristinIdentifier)))
                               .withHandle(handle)
                               .build();
+        return Resource.fromPublication(publication)
+                   .persistNew(resourceService, UserInstance.fromPublication(publication));
+    }
+
+    private Publication persistPublicationWithCristinIdAndDoi(String cristinIdentifier, URI doi)
+        throws BadRequestException {
+        var publication = randomPublication().copy()
+                              .withDoi(doi)
+                              .withHandle(null)
+                              .build();
+
+        if (cristinIdentifier != null) {
+            publication.setAdditionalIdentifiers(
+                Set.of(new AdditionalIdentifier("Cristin", cristinIdentifier))
+            );
+        }
+
         return Resource.fromPublication(publication)
                    .persistNew(resourceService, UserInstance.fromPublication(publication));
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
@@ -3,9 +3,11 @@ package no.unit.nva.publication.model;
 import java.util.List;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.model.Publication;
+import nva.commons.core.JacocoGenerated;
 
 public record SearchResourceApiResponse(int totalHits, List<Publication> hits) implements JsonSerializable {
 
+    @JacocoGenerated
     @Override
     public String toString() {
         return toJsonString();

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
@@ -1,0 +1,13 @@
+package no.unit.nva.publication.model;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.util.List;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.model.Publication;
+
+public record SearchResourceApiResponse(int totalHits, List<Publication> hits) {
+    @Override
+    public String toString() {
+        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
@@ -1,13 +1,13 @@
 package no.unit.nva.publication.model;
 
-import static nva.commons.core.attempt.Try.attempt;
 import java.util.List;
-import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.model.Publication;
 
-public record SearchResourceApiResponse(int totalHits, List<Publication> hits) {
+public record SearchResourceApiResponse(int totalHits, List<Publication> hits) implements JsonSerializable {
+
     @Override
     public String toString() {
-        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+        return toJsonString();
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/SearchResourceApiResponseTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/SearchResourceApiResponseTest.java
@@ -1,0 +1,21 @@
+package no.unit.nva.publication.model;
+
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+public class SearchResourceApiResponseTest {
+
+    @Test
+    void shouldBeAbleToConvertSearchResourceApiRequestToJsonAndBackAgain() throws JsonProcessingException {
+        var searchResponse = new SearchResourceApiResponse(1, List.of(randomPublication()));
+        var json = searchResponse.toJsonString();
+        var parsedSearchResponse = JsonUtils.dtoObjectMapper.readValue(json, SearchResourceApiResponse.class);
+        assertThat(parsedSearchResponse, is(equalTo(searchResponse)));
+    }
+}


### PR DESCRIPTION
Will look for duplicate doi as well as existing cristin identifier when deciding if brage post should merge with existing or create a new publication.

First, the Search Index is used to look for an already existing publication with the same doi. If a hit is made, the resource service is used to fetch an up-to-date version of the publication, as the Search Index might be unstable.