### PR TITLE
expand ticket.org on ticket.ownerAffiliation.

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -104,9 +104,11 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     @Override
     public ExpandedOrganization getOrganization(Entity dataEntry) throws NotFoundException {
         if (dataEntry instanceof TicketEntry ticketEntry) {
-            var resourceIdentifier = ticketEntry.getResourceIdentifier();
-            var resource = resourceService.getResourceByIdentifier(resourceIdentifier);
-            var organizationIds = resource.getResourceOwner().getOwnerAffiliation();
+
+            var organizationIds = ticketEntry.getOwnerAffiliation() != null
+                                      ? ticketEntry.getOwnerAffiliation()
+                                      : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
+                                          .getResourceOwner().getOwnerAffiliation();
 
             var partOf = attempt(() -> this.organizationRetriever.getRawContent(organizationIds, CONTENT_TYPE)).map(
                     Optional::orElseThrow)

--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Objects;
 import java.util.Optional;
 import no.unit.nva.expansion.model.ExpandedDataEntry;
 import no.unit.nva.expansion.model.ExpandedMessage;
@@ -105,7 +106,7 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public ExpandedOrganization getOrganization(Entity dataEntry) throws NotFoundException {
         if (dataEntry instanceof TicketEntry ticketEntry) {
 
-            var organizationIds = ticketEntry.getOwnerAffiliation() != null
+            var organizationIds = Objects.nonNull(ticketEntry.getOwnerAffiliation())
                                       ? ticketEntry.getOwnerAffiliation()
                                       : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                           .getResourceOwner().getOwnerAffiliation();

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -270,31 +270,15 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldGetOrganizationIdsForAffiliations(Class<? extends TicketEntry> ticketType, PublicationStatus status)
-        throws ApiGatewayException {
-        var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
-        var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
-        assertThat(ticket.getOwnerAffiliation(), is(nullValue()));
-        ticket.setOwnerAffiliation(randomUri());
-        var orgIds = expansionService.getOrganization(ticket).id();
-        assertThat(orgIds, is(equalTo(ticket.getOwnerAffiliation())));
-    }
-
-    @ParameterizedTest
-    @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldUseOwnerAffiliationWhenTicketHasOwnerAffiliation(Class<? extends TicketEntry> ticketType,
                                                                 PublicationStatus status)
         throws Exception {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         ticket.setOwnerAffiliation(randomUri());
-
-        var organizationIds = Objects.nonNull(ticket.getOwnerAffiliation())
-                                  ? ticket.getOwnerAffiliation()
-                                  : resourceService.getResourceByIdentifier(ticket.getResourceIdentifier())
-                                      .getResourceOwner().getOwnerAffiliation();
-
-        assertThat(organizationIds, is(equalTo(ticket.getOwnerAffiliation())));
+        var expectedOrgId = ticket.getOwnerAffiliation();
+        var organizationIds = expansionService.getOrganization(ticket).id();
+        assertThat(organizationIds, is(equalTo(expectedOrgId)));
     }
 
     @ParameterizedTest
@@ -304,14 +288,8 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         throws Exception {
         var publication = TicketTestUtils.createPersistedPublicationWithOwner(status, USER, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
-
         var expectedOrgId = publication.getResourceOwner().getOwnerAffiliation();
-
-        var organizationIds = Objects.nonNull(ticket.getOwnerAffiliation())
-                                  ? ticket.getOwnerAffiliation()
-                                  : resourceService.getResourceByIdentifier(ticket.getResourceIdentifier())
-                                      .getResourceOwner().getOwnerAffiliation();
-
+        var organizationIds = expansionService.getOrganization(ticket).id();
         assertThat(organizationIds, is(equalTo(expectedOrgId)));
     }
 

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -282,6 +282,37 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
+    void shouldUseOwnerAffiliationWhenTicketHasOwnerAffiliation(Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
+        var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
+        var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+        ticket.setOwnerAffiliation(randomUri());
+
+        var organizationIds = Objects.nonNull(ticket.getOwnerAffiliation())
+                                  ? ticket.getOwnerAffiliation()
+                                  : resourceService.getResourceByIdentifier(ticket.getResourceIdentifier())
+                                      .getResourceOwner().getOwnerAffiliation();
+
+        assertThat(organizationIds, is(equalTo(ticket.getOwnerAffiliation())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
+    void shouldUseResourceOwnerAffiliationWhenTicketHasNoOwnerAffiliation(Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
+        var publication = TicketTestUtils.createPersistedPublicationWithOwner(status, USER, resourceService);
+        var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+
+        var expectedOrgId = publication.getResourceOwner().getOwnerAffiliation();
+
+        var organizationIds = Objects.nonNull(ticket.getOwnerAffiliation())
+                                  ? ticket.getOwnerAffiliation()
+                                  : resourceService.getResourceByIdentifier(ticket.getResourceIdentifier())
+                                      .getResourceOwner().getOwnerAffiliation();
+
+        assertThat(organizationIds, is(equalTo(expectedOrgId)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldGetOrganizationPartOfsForAffiliations(Class<? extends TicketEntry> ticketType,
                                                        PublicationStatus status)
         throws ApiGatewayException {

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -128,9 +128,9 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
-        var userAffiliation = publication.getResourceOwner().getOwnerAffiliation();
+        ticket.setOwnerAffiliation(randomUri());
         var expandedTicket = (ExpandedTicket) expansionService.expandEntry(ticket);
-        assertThat(userAffiliation, is(equalTo(expandedTicket.getOrganization().id())));
+        assertThat(ticket.getOwnerAffiliation(), is(equalTo(expandedTicket.getOrganization().id())));
     }
 
     @ParameterizedTest
@@ -273,11 +273,11 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         throws ApiGatewayException {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+        ticket.setOwnerAffiliation(randomUri());
 
-        var expectedOrgId = publication.getResourceOwner().getOwnerAffiliation();
         var orgIds = expansionService.getOrganization(ticket).id();
 
-        assertThat(orgIds, is(equalTo(expectedOrgId)));
+        assertThat(orgIds, is(equalTo(ticket.getOwnerAffiliation())));
     }
 
     @ParameterizedTest

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -36,6 +36,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -130,7 +131,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         ticket.setOwnerAffiliation(randomUri());
         var expandedTicket = (ExpandedTicket) expansionService.expandEntry(ticket);
-        assertThat(ticket.getOwnerAffiliation(), is(equalTo(expandedTicket.getOrganization().id())));
+        assertThat(expandedTicket.getOrganization().id(), is(equalTo(ticket.getOwnerAffiliation())));
     }
 
     @ParameterizedTest
@@ -273,6 +274,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         throws ApiGatewayException {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+        assertThat(ticket.getOwnerAffiliation(), is(nullValue()));
         ticket.setOwnerAffiliation(randomUri());
 
         var orgIds = expansionService.getOrganization(ticket).id();

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -278,7 +278,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         ticket.setOwnerAffiliation(randomUri());
         var expectedOrgId = ticket.getOwnerAffiliation();
         var actualAffiliation  = expansionService.getOrganization(ticket).id();
-        assertThat(actualAffiliation , is(equalTo(expectedOrgId)));
+        assertThat(actualAffiliation, is(equalTo(expectedOrgId)));
     }
 
     @ParameterizedTest
@@ -290,7 +290,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         var expectedOrgId = publication.getResourceOwner().getOwnerAffiliation();
         var actualAffiliation  = expansionService.getOrganization(ticket).id();
-        assertThat(actualAffiliation , is(equalTo(expectedOrgId)));
+        assertThat(actualAffiliation, is(equalTo(expectedOrgId)));
     }
 
     @ParameterizedTest

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -277,8 +277,8 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         ticket.setOwnerAffiliation(randomUri());
         var expectedOrgId = ticket.getOwnerAffiliation();
-        var organizationIds = expansionService.getOrganization(ticket).id();
-        assertThat(organizationIds, is(equalTo(expectedOrgId)));
+        var actualAffiliation  = expansionService.getOrganization(ticket).id();
+        assertThat(actualAffiliation , is(equalTo(expectedOrgId)));
     }
 
     @ParameterizedTest
@@ -289,8 +289,8 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublicationWithOwner(status, USER, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         var expectedOrgId = publication.getResourceOwner().getOwnerAffiliation();
-        var organizationIds = expansionService.getOrganization(ticket).id();
-        assertThat(organizationIds, is(equalTo(expectedOrgId)));
+        var actualAffiliation  = expansionService.getOrganization(ticket).id();
+        assertThat(actualAffiliation , is(equalTo(expectedOrgId)));
     }
 
     @ParameterizedTest

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -276,9 +276,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         assertThat(ticket.getOwnerAffiliation(), is(nullValue()));
         ticket.setOwnerAffiliation(randomUri());
-
         var orgIds = expansionService.getOrganization(ticket).id();
-
         assertThat(orgIds, is(equalTo(ticket.getOwnerAffiliation())));
     }
 

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -282,7 +282,9 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldUseOwnerAffiliationWhenTicketHasOwnerAffiliation(Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
+    void shouldUseOwnerAffiliationWhenTicketHasOwnerAffiliation(Class<? extends TicketEntry> ticketType,
+                                                                PublicationStatus status)
+        throws Exception {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         ticket.setOwnerAffiliation(randomUri());
@@ -297,7 +299,9 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldUseResourceOwnerAffiliationWhenTicketHasNoOwnerAffiliation(Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
+    void shouldUseResourceOwnerAffiliationWhenTicketHasNoOwnerAffiliation(Class<? extends TicketEntry> ticketType,
+                                                                          PublicationStatus status)
+        throws Exception {
         var publication = TicketTestUtils.createPersistedPublicationWithOwner(status, USER, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
 

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
@@ -62,8 +62,8 @@ public class CreateTicketHandler extends ApiGatewayHandler<TicketDto, Void> {
         var publicationIdentifier = new SortableIdentifier(requestInfo.getPathParameter(PUBLICATION_IDENTIFIER));
         var publication = fetchPublication(publicationIdentifier, getUser(requestInfo), requestInfo);
         var newTicket = TicketEntry.requestNewTicket(publication, input.ticketType());
-        var ownerAffiliation = requestInfo.getPersonAffiliation();
-        newTicket.setOwnerAffiliation(ownerAffiliation);
+        logger.info("ownerAffiliation {}", requestInfo.getPersonAffiliation());
+        newTicket.setOwnerAffiliation(requestInfo.getPersonAffiliation());
         var customer = requestInfo.getCurrentCustomer();
         var username = new Username(requestInfo.getUserName());
         var isCurator = requestInfo.userIsAuthorized(AccessRight.APPROVE_DOI_REQUEST.name());


### PR DESCRIPTION
Used the existing expansion for `ticket.organization` on `ticket.ownerAffiliation` instead of` resourceOwner.ownerAffiliation` if `ticket.ownerAffiliation` is not null.