### PR TITLE
updating access right validation when updating ticket

### DIFF
--- a/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
@@ -59,7 +59,7 @@ public class ListTicketsForPublicationHandler extends TicketHandler<Void, Ticket
                                          UserInstance userInstance) throws ApiGatewayException {
         var ticketEntries = requestUtils.hasOneOfAccessRights(MANAGE_DOI, MANAGE_PUBLISHING_REQUESTS, SUPPORT)
                                 ? fetchTicketsForElevatedUser(userInstance, publicationIdentifier)
-                                      .filter(requestUtils::isAuthorizedToView)
+                                      .filter(requestUtils::isAuthorizedToManage)
                                 : fetchTicketsForPublicationOwner(publicationIdentifier, userInstance);
 
         return ticketEntries.map(this::createDto).collect(Collectors.toList());

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/utils/RequestUtils.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/utils/RequestUtils.java
@@ -3,34 +3,53 @@ package no.unit.nva.publication.ticket.utils;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.SUPPORT;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.TicketEntry;
+import no.unit.nva.publication.model.business.UnpublishRequest;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 
-public record RequestUtils(List<AccessRight> accessRights) {
+public record RequestUtils(List<AccessRight> accessRights,
+                           URI customer,
+                           String username,
+                           Map<String, String> pathParameters) {
 
-    public static RequestUtils fromRequestInfo(RequestInfo requestInfo) {
-        return new RequestUtils(requestInfo.getAccessRights());
+    public static RequestUtils fromRequestInfo(RequestInfo requestInfo) throws UnauthorizedException {
+        return new RequestUtils(requestInfo.getAccessRights(),
+                                requestInfo.getCurrentCustomer(),
+                                requestInfo.getUserName(),
+                                requestInfo.getPathParameters());
     }
 
     public boolean hasOneOfAccessRights(AccessRight... rights) {
         return Arrays.stream(rights).anyMatch(accessRights::contains);
     }
 
+    public SortableIdentifier pathParameterAsIdentifier(String parameter) {
+        return Optional.ofNullable(pathParameters().get(parameter))
+                   .map(SortableIdentifier::new)
+                   .orElseThrow(() -> new IllegalArgumentException("Missing from pathParameters: " + parameter));
+    }
+
     public boolean hasAccessRight(AccessRight accessRight) {
         return accessRights.contains(accessRight);
     }
 
-    public boolean isAuthorizedToView(TicketEntry ticket) {
+    public boolean isAuthorizedToManage(TicketEntry ticket) {
         return switch (ticket) {
             case DoiRequest doi -> hasAccessRight(MANAGE_DOI);
             case PublishingRequestCase publishing -> hasAccessRight(MANAGE_PUBLISHING_REQUESTS);
             case GeneralSupportRequest support -> hasAccessRight(SUPPORT);
+            case UnpublishRequest unpublish -> true;
             case null, default -> false;
         };
     }

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/utils/RequestUtilsTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/utils/RequestUtilsTest.java
@@ -1,0 +1,36 @@
+package no.unit.nva.publication.ticket.utils;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Map;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RequestUtilsTest {
+
+    @Test
+    void shouldReturnFalseWhenCheckingAuthorizationForNullTicket() throws UnauthorizedException {
+        Assertions.assertFalse(RequestUtils.fromRequestInfo(mockedRequestInfo()).isAuthorizedToManage(null));
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentWhenExtractingMissingPathParamAsIdentifier() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> RequestUtils.fromRequestInfo(mockedRequestInfo()).pathParameterAsIdentifier(randomString()));
+    }
+
+    private static RequestInfo mockedRequestInfo() throws UnauthorizedException {
+        var requestInfo = mock(RequestInfo.class);
+        when(requestInfo.getCurrentCustomer()).thenReturn(randomUri());
+        when(requestInfo.getUserName()).thenReturn(randomString());
+        when(requestInfo.getPathParameters()).thenReturn(Map.of());
+        when(requestInfo.getAccessRights()).thenReturn(List.of());
+        return requestInfo;
+    }
+}


### PR DESCRIPTION
Innfører RequestUtils med følgende funksjon som gjør validering av accessRights knyttet til tickets flyten ganske lettvint:

```
public boolean isAuthorizedToManage(TicketEntry ticket) {
        return switch (ticket) {
            case DoiRequest doi -> hasAccessRight(MANAGE_DOI);
            case PublishingRequestCase publishing -> hasAccessRight(MANAGE_PUBLISHING_REQUESTS);
            case GeneralSupportRequest support -> hasAccessRight(SUPPORT);
            case UnpublishRequest unpublish -> true;
            case null, default -> false;
        };
    }
```