### PR TITLE
Taking in use tike mime type detector

### DIFF
--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
@@ -246,7 +246,7 @@ public class ScopusFileConverter {
         var filename = getFilename(fetchFileResponse);
 
         return file.copy()
-                   .withMimeType(mediaType.getType())
+                   .withMimeType(mediaType.toString())
                    .withContent(inputStream)
                    .withName(filename).build();
     }

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
@@ -7,7 +7,6 @@ import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
-import static no.sikt.nva.scopus.conversion.files.model.ContentVersion.UNSPECIFIED;
 import static no.sikt.nva.scopus.conversion.files.model.ContentVersion.VOR;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.s3.Headers;
@@ -248,15 +247,15 @@ public class ScopusFileConverter {
 
         return file.copy()
                    .withMimeType(mediaType.getType())
-                   .withContent(inputStream.getInputStreamFactory().getInputStream())
+                   .withContent(inputStream)
                    .withName(filename).build();
     }
 
-    private static String extractMimeType(ScopusFile file, HttpResponse<InputStream> fetchFileResponse) {
-        return hasSupportedMimeType(file)
-                   ? file.mimeType()
-                   : fetchFileResponse.headers().firstValue(Header.CONTENT_TYPE).orElse(null);
-    }
+//    private static String extractMimeType(ScopusFile file, HttpResponse<InputStream> fetchFileResponse) {
+//        return hasSupportedMimeType(file)
+//                   ? file.mimeType()
+//                   : fetchFileResponse.headers().firstValue(Header.CONTENT_TYPE).orElse(null);
+//    }
 
     private List<ScopusFile> getScopusFiles(CrossrefResponse response) {
         var licenses = extractLicenses(response);
@@ -320,9 +319,9 @@ public class ScopusFileConverter {
         return nonNull(contentType) && !HTML_CONTENT_TYPE.equals(contentType) && !XML_CONTENT_TYPE.equals(contentType);
     }
 
-    private static boolean hasSupportedMimeType(ScopusFile file) {
-        return nonNull(file.mimeType()) && !UNSPECIFIED.getValue().equals(file.mimeType());
-    }
+//    private static boolean hasSupportedMimeType(ScopusFile file) {
+//        return nonNull(file.mimeType()) && !UNSPECIFIED.getValue().equals(file.mimeType());
+//    }
 
     private List<License> extractLicenses(CrossrefResponse doiResponse) {
         return Optional.ofNullable(doiResponse.getMessage().getLicense()).orElse(List.of());

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/ContentVersion.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/ContentVersion.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.scopus.conversion.files.model;
 
+import nva.commons.core.JacocoGenerated;
+
 public enum ContentVersion {
 
     VOR("vor"), AM("am"), TDM("tdm"), UNSPECIFIED("unspecified");
@@ -9,6 +11,7 @@ public enum ContentVersion {
         this.value = type;
     }
 
+    @JacocoGenerated
     public String getValue() {
         return value;
     }

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
@@ -368,7 +368,7 @@ class ScopusHandlerTest extends ResourcesLocalTest {
         var s3Event = createNewScopusPublicationEvent();
         var importCandidate = scopusHandler.handleRequest(s3Event, CONTEXT);
 
-        assertThat(((File) importCandidate.getAssociatedArtifacts().get(0)).getName(), is(equalTo(expectedFilename)));
+        assertThat(((File) importCandidate.getAssociatedArtifacts().getFirst()).getName(), is(equalTo(expectedFilename)));
     }
 
     @Test
@@ -1271,7 +1271,7 @@ class ScopusHandlerTest extends ResourcesLocalTest {
         var filename = randomString() + ".pdf";
         var testUrl = "/" + UriWrapper.fromUri(downloadUrl.getLastPathElement()).getLastPathElement();
         stubFor(WireMock.get(urlPathEqualTo(testUrl))
-                    .willReturn(aResponse().withBody("abcde")
+                    .willReturn(aResponse().withBody("abcdesafogrpeopoernhopnerpohn")
                                     .withHeader("Content-Type", "application/pdf;charset=UTF-8")
                                     .withHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"")
                                     .withStatus(HttpURLConnection.HTTP_OK)));

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
@@ -368,7 +368,7 @@ class ScopusHandlerTest extends ResourcesLocalTest {
         var s3Event = createNewScopusPublicationEvent();
         var importCandidate = scopusHandler.handleRequest(s3Event, CONTEXT);
 
-        assertThat(((File) importCandidate.getAssociatedArtifacts().getFirst()).getName(), is(equalTo(expectedFilename)));
+        assertThat(((File) importCandidate.getAssociatedArtifacts().get(0)).getName(), is(equalTo(expectedFilename)));
     }
 
     @Test
@@ -1271,7 +1271,7 @@ class ScopusHandlerTest extends ResourcesLocalTest {
         var filename = randomString() + ".pdf";
         var testUrl = "/" + UriWrapper.fromUri(downloadUrl.getLastPathElement()).getLastPathElement();
         stubFor(WireMock.get(urlPathEqualTo(testUrl))
-                    .willReturn(aResponse().withBody("abcdesafogrpeopoernhopnerpohn")
+                    .willReturn(aResponse().withBody("abcde")
                                     .withHeader("Content-Type", "application/pdf;charset=UTF-8")
                                     .withHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"")
                                     .withStatus(HttpURLConnection.HTTP_OK)));

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -157,16 +157,6 @@ public class ScopusFileConverterTest {
         assertThat(files, is(emptyIterable()));
     }
 
-//    @Test
-//    void shouldExtractFileMimeTypeFromDownloadFileUrlResponseHeaderWhenCrossRefResponseMissesContentType()
-//        throws IOException, InterruptedException {
-//        mockResponsesWithoutHeaders("crossrefResponseMissingFields.json");
-//        mockDownloadUrlResponse();
-//        var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).get(0);
-//
-//        assertThat(file.getMimeType(), is(equalTo(HEADER_CONTENT_TYPE)));
-//    }
-
     @Test
     void shouldCreateRandomFileNameWithFileTypeFromContentTypeHeaderWhenUrlAndContentDispositionMissingFileName()
         throws IOException, InterruptedException {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -37,10 +37,6 @@ import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.sikt.nva.scopus.utils.ScopusGenerator;
 import no.unit.nva.model.associatedartifacts.file.PublishedFile;
 import nva.commons.core.ioutils.IoUtils;
-import org.apache.tika.config.TikaConfig;
-import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.TikaInputStream;
-import org.apache.tika.metadata.Metadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.http.Header;
@@ -199,15 +195,6 @@ public class ScopusFileConverterTest {
         var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).get(0);
 
         assertThat(file.getName(), is(notNullValue()));
-    }
-
-    @Test
-    void some() throws IOException, TikaException {
-        var tis =  TikaInputStream.get(URI.create("https://www.cambridge.org/core/services/aop-cambridge-core/content/view/S0305000922000484"));
-        var config = new TikaConfig();
-        var tikaDetector = config.getDetector();
-        var mediaType = tikaDetector.detect(tis, new Metadata());
-        var s = "";
     }
 
     private void mockDownloadUrlResponse() throws IOException, InterruptedException {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -37,6 +37,10 @@ import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.sikt.nva.scopus.utils.ScopusGenerator;
 import no.unit.nva.model.associatedartifacts.file.PublishedFile;
 import nva.commons.core.ioutils.IoUtils;
+import org.apache.tika.config.TikaConfig;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.http.Header;
@@ -195,6 +199,15 @@ public class ScopusFileConverterTest {
         var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).get(0);
 
         assertThat(file.getName(), is(notNullValue()));
+    }
+
+    @Test
+    void some() throws IOException, TikaException {
+        var tis =  TikaInputStream.get(URI.create("https://www.cambridge.org/core/services/aop-cambridge-core/content/view/S0305000922000484"));
+        var config = new TikaConfig();
+        var tikaDetector = config.getDetector();
+        var mediaType = tikaDetector.detect(tis, new Metadata());
+        var s = "";
     }
 
     private void mockDownloadUrlResponse() throws IOException, InterruptedException {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -161,15 +161,15 @@ public class ScopusFileConverterTest {
         assertThat(files, is(emptyIterable()));
     }
 
-    @Test
-    void shouldExtractFileMimeTypeFromDownloadFileUrlResponseHeaderWhenCrossRefResponseMissesContentType()
-        throws IOException, InterruptedException {
-        mockResponsesWithoutHeaders("crossrefResponseMissingFields.json");
-        mockDownloadUrlResponse();
-        var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).get(0);
-
-        assertThat(file.getMimeType(), is(equalTo(HEADER_CONTENT_TYPE)));
-    }
+//    @Test
+//    void shouldExtractFileMimeTypeFromDownloadFileUrlResponseHeaderWhenCrossRefResponseMissesContentType()
+//        throws IOException, InterruptedException {
+//        mockResponsesWithoutHeaders("crossrefResponseMissingFields.json");
+//        mockDownloadUrlResponse();
+//        var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).get(0);
+//
+//        assertThat(file.getMimeType(), is(equalTo(HEADER_CONTENT_TYPE)));
+//    }
 
     @Test
     void shouldCreateRandomFileNameWithFileTypeFromContentTypeHeaderWhenUrlAndContentDispositionMissingFileName()


### PR DESCRIPTION
We may also consider to use TikaInputStream to fetch the file. It may have utils for extracting filenames as well.

var inputStream =  TikaInputStream.get(file.downloadFileUrl());
var mimeTypeDetector = TikaConfig.getDefaultConfig().getDetector();
var mediaType = mimeTypeDetector.detect(inputStream, new Metadata());