### PR TITLE
fixing publication tombstone missing context bug

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/DeletedPublicationResponse.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/DeletedPublicationResponse.java
@@ -1,27 +1,29 @@
 package no.unit.nva.publication.fetch;
 
 import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
+import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
 import nva.commons.core.JacocoGenerated;
 
+@JsonTypeName("Publication")
 public final class DeletedPublicationResponse {
 
     @JacocoGenerated
     private DeletedPublicationResponse() {
-
     }
 
-    public static Object craftDeletedPublicationResponse(Publication publication) {
+    public static Object fromPublication(Publication publication) {
         var publicationWithoutAssociatedArtifacts = publication.copy()
                                                         .withAssociatedArtifacts(List.of())
                                                         .build();
-        return attempt(() -> JsonUtils.dtoObjectMapper
-                                 .convertValue(publicationWithoutAssociatedArtifacts,
-                                               new TypeReference<Map<String, Object>>() {}))
-                   .orElseThrow();
+        var tombstone = PublicationResponseElevatedUser.fromPublication(publicationWithoutAssociatedArtifacts);
+        return attempt(() -> JsonUtils.dtoObjectMapper.convertValue(tombstone,
+                                                                    new TypeReference<Map<String, Object>>() {})).orElseThrow();
+
     }
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -10,7 +10,6 @@ import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.publication.PublicationServiceConfig.ENVIRONMENT;
-import static no.unit.nva.publication.fetch.DeletedPublicationResponse.craftDeletedPublicationResponse;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_DATACITE_XML;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_JSON_LD;
 import static nva.commons.apigateway.MediaTypes.SCHEMA_ORG;
@@ -120,8 +119,7 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
         if (nonNull(publication.getDuplicateOf()) && shouldRedirect(requestInfo)) {
             return produceRedirect(publication.getDuplicateOf());
         } else {
-            throw new GoneException(GONE_MESSAGE,
-                                    craftDeletedPublicationResponse(publication));
+            throw new GoneException(GONE_MESSAGE, DeletedPublicationResponse.fromPublication(publication));
         }
     }
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/fetch/DeletedPublicationResponseTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/fetch/DeletedPublicationResponseTest.java
@@ -5,8 +5,8 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Set;
+import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
 import org.junit.jupiter.api.Test;
@@ -14,14 +14,15 @@ import org.junit.jupiter.api.Test;
 public class DeletedPublicationResponseTest {
 
     @Test
-    void deletePublicationResponseShouldPreserveAllFieldsExceptAssociatedArtifacts() throws JsonProcessingException {
+    void deletePublicationResponseShouldPreserveAllFieldsExceptAssociatedArtifacts() {
         var publication = randomPublication();
         assertThat(publication, doesNotHaveEmptyValuesIgnoringFields(Set.of("entityDescription.reference")));
-        var deletedPublicationResponseJson = DeletedPublicationResponse.craftDeletedPublicationResponse(publication);
+        var deletedPublicationResponseJson = DeletedPublicationResponse.fromPublication(publication);
         var deletedPublicationResponse = JsonUtils.dtoObjectMapper.convertValue(deletedPublicationResponseJson,
-                                                                                Publication.class);
+                                                                                PublicationResponseElevatedUser.class);
 
-        var expectedPublication = publication.copy().withAssociatedArtifacts(null).build();
+        var expectedPublication =
+            PublicationResponseElevatedUser.fromPublication(publication.copy().withAssociatedArtifacts(null).build());
         assertThat(deletedPublicationResponse, is(equalTo(expectedPublication)));
     }
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
@@ -50,6 +50,7 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import no.unit.nva.api.PublicationResponse;
+import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.doi.model.Customer;
 import no.unit.nva.identifiers.SortableIdentifier;
@@ -275,10 +276,11 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
         fetchPublicationHandler.handleRequest(generateHandlerRequest(publication.getIdentifier().toString()), output,
                                               context);
         var gatewayResponse = parseFailureResponse();
-        var expectedTombstone = publication.copy().withAssociatedArtifacts(List.of()).build();
+        var expectedTombstone =
+            PublicationResponseElevatedUser.fromPublication(publication.copy().withAssociatedArtifacts(List.of()).build());
         var problem = JsonUtils.dtoObjectMapper.readValue(gatewayResponse.getBody(), Problem.class);
         var actualPublication = JsonUtils.dtoObjectMapper.convertValue(problem.getParameters().get(RESOURCE),
-                                                                       Publication.class);
+                                                                       PublicationResponseElevatedUser.class);
         assertThat(actualPublication, is(equalTo(expectedTombstone)));
     }
 
@@ -289,13 +291,13 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
         fetchPublicationHandler.handleRequest(generateHandlerRequest(publication.getIdentifier().toString()), output,
                                               context);
         var gatewayResponse = parseFailureResponse();
-        var expectedTombstone = publication.copy().withAssociatedArtifacts(List.of()).build();
+        var expectedTombstone = PublicationResponseElevatedUser.fromPublication(publication.copy().withAssociatedArtifacts(List.of()).build());
 
         var problem = JsonUtils.dtoObjectMapper.readValue(gatewayResponse.getBody(), Problem.class);
-        var resource = JsonUtils.dtoObjectMapper.convertValue(problem.getParameters().get(RESOURCE),
-                                                              Publication.class);
+        var actualPublication = JsonUtils.dtoObjectMapper.convertValue(problem.getParameters().get(RESOURCE),
+                                                                       PublicationResponseElevatedUser.class);
 
-        assertThat(resource, is(equalTo(expectedTombstone)));
+        assertThat(actualPublication, is(equalTo(expectedTombstone)));
     }
 
     @Test
@@ -333,11 +335,12 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
         fetchPublicationHandler.handleRequest(handlerRequest,
                                               output,
                                               context);
-        var expectedTombstone = publication.copy().withAssociatedArtifacts(List.of()).build();
+        var expectedTombstone =
+            PublicationResponseElevatedUser.fromPublication(publication.copy().withAssociatedArtifacts(List.of()).build());
         var gatewayResponse = parseFailureResponse();
         var problem = JsonUtils.dtoObjectMapper.readValue(gatewayResponse.getBody(), Problem.class);
         var actualPublication = JsonUtils.dtoObjectMapper.convertValue(problem.getParameters().get(RESOURCE),
-                                                                       Publication.class);
+                                                                       PublicationResponseElevatedUser.class);
         assertThat(actualPublication, is(equalTo(expectedTombstone)));
     }
 


### PR DESCRIPTION
Problem: Some frontend components use publication.@context.id -> field generated when creating json-ld context for publication. Tombstone needs this is as well.