### PR TITLE
Add hdbh object to cristin import model

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -181,10 +181,17 @@ public class CristinEntryEventConsumer
     }
 
     private void persistNviReportIfNeeded(PublicationRepresentations publicationRepresentations) {
-        var nviReport = NviReport.fromPublicationRepresentation(publicationRepresentations);
-        if (nviReport.hasBeenNviReported()) {
+        if (hasScientificResource(publicationRepresentations)) {
+            var nviReport = NviReport.fromPublicationRepresentation(publicationRepresentations);
             saveNviReport(publicationRepresentations, nviReport);
         }
+    }
+
+    private static boolean hasScientificResource(PublicationRepresentations publicationRepresentations) {
+        return Optional.ofNullable(publicationRepresentations.getCristinObject())
+                   .map(CristinObject::getScientificResources)
+                   .map(list -> !list.isEmpty())
+                   .orElse(false);
     }
 
     private void saveNviReport(PublicationRepresentations publicationRepresentations, NviReport nviReport) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinLocale.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinLocale.java
@@ -32,7 +32,7 @@ import nva.commons.core.paths.UriWrapper;
 @JsonIgnoreProperties({"brukernavn_opprettet", "dato_opprettet", "brukernavn_siste_endring",
     "dato_siste_endring", "status_bekreftet_arkivsporsmal",
     "brukernavn_avlvrt_arkivsystem", "dato_avlvrt_arkivsystem", "status_fulgt_medf_reg",
-    "brukernavn_svart_medforf_reg", "dato_svart_medforf_regel"})
+    "brukernavn_svart_medforf_reg", "dato_svart_medforf_regel", "person_kontrollert"})
 public class CristinLocale {
 
     public static final String OWNER_CODE_FIELD = "eierkode";
@@ -47,6 +47,7 @@ public class CristinLocale {
     public static final String CONTROLLED_BY_FIELD = "brukernavn_kontrollert";
     public static final String DATE_CONTROLLED_FIELD = "dato_kontrollert";
     public static final String CONTROL_STATUS_FIELD = "status_kontrollert";
+    public static final String CONTROLLED_BY_USER_FIELD = "person_kontrollert";
     @JsonProperty(OWNER_CODE_FIELD)
     private String ownerCode;
 
@@ -70,6 +71,8 @@ public class CristinLocale {
 
     @JsonProperty(CONTROL_STATUS_FIELD)
     private String controlStatus;
+    @JsonProperty(CONTROLLED_BY_USER_FIELD)
+    private CristinUser controlledByUser;
 
 
     @JacocoGenerated

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -69,7 +69,7 @@ public class CristinMapper extends CristinMappingModule {
     public static final String CRISTIN_INSTITUTION_CODE = "CRIS";
     public static final String UNIT_INSTITUTION_CODE = "UNIT";
     public static final ResourceOwner SIKT_OWNER = new CristinLocale("SIKT", "20754", "0", "0",
-                                                                     "0", null, null, null).toResourceOwner();
+                                                                     "0", null, null, null, null).toResourceOwner();
     private static final String SCOPUS_CASING_ACCEPTED_BY_FRONTEND = "Scopus";
     private static final String DOMAIN_NAME = new Environment().readEnv("DOMAIN_NAME");
     private static final Map<String, String> CUSTOMER_MAP = Map.of("api.sandbox.nva.aws.unit.no",

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -34,7 +34,7 @@ import no.unit.nva.model.Publication;
 @JsonIgnoreProperties({"brukernavn_opprettet", "peerreviewed",
     "brukernavn_siste_endring", "publiseringstatuskode", "merknadtekst_godkjenning",
     "arkivpost", "pubidnr", "eierkode_siste_endring",
-    "varbeid_vdisiplin", "arkivfil"})
+    "varbeid_vdisiplin", "arkivfil", "dbh_forskres_kontroll"})
 @SuppressWarnings({"PMD.TooManyFields"})
 public class CristinObject implements JsonSerializable {
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinObject.java
@@ -34,7 +34,7 @@ import no.unit.nva.model.Publication;
 @JsonIgnoreProperties({"brukernavn_opprettet", "peerreviewed",
     "brukernavn_siste_endring", "publiseringstatuskode", "merknadtekst_godkjenning",
     "arkivpost", "pubidnr", "eierkode_siste_endring",
-    "varbeid_vdisiplin", "arkivfil", "h_dbh_forskres_publikasjon"})
+    "varbeid_vdisiplin", "arkivfil"})
 @SuppressWarnings({"PMD.TooManyFields"})
 public class CristinObject implements JsonSerializable {
 
@@ -93,6 +93,9 @@ public class CristinObject implements JsonSerializable {
 
     @JsonProperty("vitenskapeligarbeid_lokal")
     private List<CristinLocale> cristinLocales;
+
+    @JsonProperty("h_dbh_forskres_publikasjon")
+    private List<ScientificResource> scientificResources;
 
     @JsonProperty("institusjonsnr_opprettet")
     private String institutionIdentifierCreated;

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinUser.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinUser.java
@@ -1,0 +1,41 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import nva.commons.core.JacocoGenerated;
+
+@Builder(
+    builderClassName = "CristinUserBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@Getter
+@Setter
+@Data
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class CristinUser {
+
+    @JsonProperty("personlopenr")
+    private String identifier;
+
+    @JsonProperty("fornavn")
+    private String firstName;
+
+    @JsonProperty("etternavn")
+    private String lastName;
+
+    @JacocoGenerated
+    @JsonCreator
+    public CristinUser() {
+
+    }
+
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ScientificPerson.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ScientificPerson.java
@@ -1,0 +1,45 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import nva.commons.core.JacocoGenerated;
+
+@Builder(builderClassName = "ScientificPersonBuilder", toBuilder = true, builderMethodName = "builder",
+    buildMethodName = "build", setterPrefix = "with")
+@Getter
+@Setter
+@Data
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"rekkefolgenr", "fornavn", "etternavn", "institusjonsnavn", "avdnavn", "undavdnavn",
+    "gruppenavn", "kjonn", "forfattere_sted", "vektingstall", "faktortall_samarbeid", "forfatterandel", "forfattervekt",
+    "forfattere_int", "faktortall_samarbeid_2003", "forfatterandel_2003", "forfattervekt_2003", "nsdstedkode",
+    "institusjonskode", "eierkode", "status_rbo", "forfattere_totalt", "sektorkode", "status_int_samarbeid", "landkode",
+    "landnavn", "landnavn_engelsk", "fodt_aar"})
+public class ScientificPerson {
+
+    public static final String AFFILIATION_DELIMITER = ".";
+    private static final String RESOURCE_OWNER_FORMAT = "%s@%s";
+    @JsonProperty("personlopenr")
+    private String cristinPersonIdentifier;
+    @JsonProperty("institusjonsnr")
+    private String institutionIdentifier;
+    @JsonProperty("avdnr")
+    private String departmentIdentifier;
+    @JsonProperty("undavdnr")
+    private String subDepartmentIdentifier;
+    @JsonProperty("gruppenr")
+    private String groupIdentifier;
+
+    @JacocoGenerated
+    @JsonCreator
+    private ScientificPerson() {
+
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ScientificResource.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ScientificResource.java
@@ -1,0 +1,46 @@
+package no.unit.nva.cristin.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import nva.commons.core.JacocoGenerated;
+
+@Builder(
+    builderClassName = "ScientificResourceBuilder",
+    toBuilder = true,
+    builderMethodName = "builder",
+    buildMethodName = "build",
+    setterPrefix = "with"
+)
+@Getter
+@Setter
+@Data
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@JsonIgnoreProperties({"seqdbh", "arstall_online", "arstall_trykket", "varbeidlopenr", "titteltekst",
+    "varbeidhovedkatkode", "varbeidunderkatkode", "pubidnr_itar", "publikasjonsform", "publikasjonsformnavn",
+    "publiseringskanal", "publiseringskanalnavn", "publiseringskanaltype", "publtypenavn", "issn", "isbn", "merknad",
+    "fagomradekode_npi", "fagomradenavn_npi", "fagfeltkode_npi", "fagfeltnavn_npi", "sprakkode", "spraknavn", "doi"})
+public class ScientificResource {
+
+    @JsonProperty("h_dbh_forskres_forfatter")
+    private List<ScientificPerson> scientificPeople;
+    @JsonProperty("kvalitetsnivakode")
+    private String qualityCode;
+    @JsonProperty("arstall")
+    private String reportedYear;
+
+    @JacocoGenerated
+    @JsonCreator
+    private ScientificResource() {
+    }
+}
+
+
+

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
@@ -1,7 +1,5 @@
 package no.unit.nva.cristin.mapper.nva;
 
-import static java.util.Objects.nonNull;
-import java.time.Instant;
 import java.util.List;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.cristin.lambda.PublicationRepresentations;
@@ -11,7 +9,8 @@ import no.unit.nva.model.PublicationDate;
 
 public record NviReport(String publicationIdentifier,
                         String cristinIdentifier,
-                        List<ScientificResource> nviReport,
+                        List<ScientificResource> scientificResources,
+                        List<CristinLocale> cristinLocales,
                         String yearReported,
                         PublicationDate publicationDate) implements JsonSerializable {
 
@@ -23,7 +22,8 @@ public record NviReport(String publicationIdentifier,
         return NviReport.builder()
                    .withPublicationIdentifier(publicationRepresentations.getNvaPublicationIdentifier())
                    .withCristinIdentifier(publicationRepresentations.getCristinObject().getSourceRecordIdentifier())
-                   .withNviReport(publicationRepresentations.getCristinObject().getScientificResources())
+                   .withCristinLocales(publicationRepresentations.getCristinObject().getCristinLocales())
+                   .withScientificResource(publicationRepresentations.getCristinObject().getScientificResources())
                    .withYearReported(publicationRepresentations.getCristinObject().getScientificResources().getFirst().getReportedYear())
                    .withPublicationDate(publicationRepresentations.getPublication().getEntityDescription().getPublicationDate())
                    .build();
@@ -33,9 +33,10 @@ public record NviReport(String publicationIdentifier,
 
         private String publicationIdentifier;
         private String cristinIdentifier;
-        private List<ScientificResource> nviReport;
+        private List<ScientificResource> scientificResources;
         private String yearReported;
         private PublicationDate publicationDate;
+        private List<CristinLocale> cristinLocales;
 
         private Builder() {
         }
@@ -50,8 +51,8 @@ public record NviReport(String publicationIdentifier,
             return this;
         }
 
-        public Builder withNviReport(List<ScientificResource> nviReport) {
-            this.nviReport = nviReport;
+        public Builder withScientificResource(List<ScientificResource> nviReport) {
+            this.scientificResources = nviReport;
             return this;
         }
 
@@ -65,8 +66,14 @@ public record NviReport(String publicationIdentifier,
             return this;
         }
 
+        public Builder withCristinLocales(List<CristinLocale> cristinLocales) {
+            this.cristinLocales = cristinLocales;
+            return this;
+        }
+
         public NviReport build() {
-            return new NviReport(publicationIdentifier, cristinIdentifier, nviReport, yearReported, publicationDate);
+            return new NviReport(publicationIdentifier, cristinIdentifier, scientificResources, cristinLocales,
+                                 yearReported, publicationDate);
         }
 
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
@@ -6,57 +6,36 @@ import java.util.List;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.cristin.lambda.PublicationRepresentations;
 import no.unit.nva.cristin.mapper.CristinLocale;
+import no.unit.nva.cristin.mapper.ScientificResource;
+import no.unit.nva.model.PublicationDate;
 
 public record NviReport(String publicationIdentifier,
                         String cristinIdentifier,
-                        List<CristinLocale> nviReport,
-                        Integer yearReported,
-                        Instant publicationDate) implements JsonSerializable {
+                        List<ScientificResource> nviReport,
+                        String yearReported,
+                        PublicationDate publicationDate) implements JsonSerializable {
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    public boolean hasBeenNviReported() {
-        return hasBeenReported() && isReportable();
-    }
-
-    private boolean hasBeenReported() {
-        return nonNull(nviReport())
-               && nviReport().stream()
-                      .anyMatch(NviReport::hasControlStatusJ);
-    }
-
-    private boolean isReportable() {
-        return nonNull(yearReported()) && yearReported() >= 2011;
-    }
-
-    private static boolean hasControlStatusJ(CristinLocale cristinLocale) {
-        return nonNull(cristinLocale.getControlStatus())
-               && "J".equals(cristinLocale.getControlStatus());
     }
 
     public static NviReport fromPublicationRepresentation(PublicationRepresentations publicationRepresentations) {
         return NviReport.builder()
                    .withPublicationIdentifier(publicationRepresentations.getNvaPublicationIdentifier())
                    .withCristinIdentifier(publicationRepresentations.getCristinObject().getSourceRecordIdentifier())
-                   .withNviReport(publicationRepresentations.getCristinObject().getCristinLocales())
-                   .withYearReported(getYearReported(publicationRepresentations))
-                   .withPublicationDate(publicationRepresentations.getPublication().getCreatedDate())
+                   .withNviReport(publicationRepresentations.getCristinObject().getScientificResources())
+                   .withYearReported(publicationRepresentations.getCristinObject().getScientificResources().getFirst().getReportedYear())
+                   .withPublicationDate(publicationRepresentations.getPublication().getEntityDescription().getPublicationDate())
                    .build();
-    }
-
-    private static Integer getYearReported(PublicationRepresentations publicationRepresentations) {
-        return publicationRepresentations.getCristinObject().getYearReported();
     }
 
     public static final class Builder {
 
         private String publicationIdentifier;
         private String cristinIdentifier;
-        private List<CristinLocale> nviReport;
-        private Integer yearReported;
-        private Instant publicationDate;
+        private List<ScientificResource> nviReport;
+        private String yearReported;
+        private PublicationDate publicationDate;
 
         private Builder() {
         }
@@ -71,17 +50,17 @@ public record NviReport(String publicationIdentifier,
             return this;
         }
 
-        public Builder withNviReport(List<CristinLocale> nviReport) {
+        public Builder withNviReport(List<ScientificResource> nviReport) {
             this.nviReport = nviReport;
             return this;
         }
 
-        public Builder withYearReported(Integer yearReported) {
+        public Builder withYearReported(String yearReported) {
             this.yearReported = yearReported;
             return this;
         }
 
-        public Builder withPublicationDate(Instant publicationDate) {
+        public Builder withPublicationDate(PublicationDate publicationDate) {
             this.publicationDate = publicationDate;
             return this;
         }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -38,6 +38,8 @@ import no.unit.nva.cristin.lambda.constants.HardcodedValues;
 import no.unit.nva.cristin.mapper.CristinLocale;
 import no.unit.nva.cristin.mapper.CristinLectureOrPosterMetaData;
 import no.unit.nva.cristin.mapper.PresentationEvent;
+import no.unit.nva.cristin.mapper.ScientificPerson;
+import no.unit.nva.cristin.mapper.ScientificResource;
 import no.unit.nva.cristin.mapper.artisticproduction.ArtisticGenre;
 import no.unit.nva.cristin.mapper.artisticproduction.ArtisticProductionTimeUnit;
 import no.unit.nva.cristin.mapper.artisticproduction.CristinArtisticProduction;
@@ -107,6 +109,7 @@ public final class CristinDataGenerator {
     private static final Integer VALID_PUBLISHER_NSD_NUMBER = 5269;
     public static final String J = "J";
     public static final int VALID_SERIES_NSD_CODE = 339741;
+    public static final String SCIENTIFIC_RESOURCES = "scientificResources";
 
     private CristinDataGenerator() {
 
@@ -180,7 +183,26 @@ public final class CristinDataGenerator {
         var cristinObject = newCristinObject(largeRandomNumber());
         cristinObject.setYearReported(year);
         cristinObject.setCristinLocales(randomCristinLocales());
+        cristinObject.setScientificResources(List.of(randomScientificResource()));
         return cristinObject;
+    }
+
+    private static ScientificResource randomScientificResource() {
+        return ScientificResource.builder()
+                   .withQualityCode(randomString())
+                   .withScientificPeople(List.of(randomScientificPerson()))
+                   .withReportedYear(randomString())
+                   .build();
+    }
+
+    private static ScientificPerson randomScientificPerson() {
+        return ScientificPerson.builder()
+                   .withCristinPersonIdentifier(randomString())
+                   .withDepartmentIdentifier(randomString())
+                   .withGroupIdentifier(randomString())
+                   .withInstitutionIdentifier(randomString())
+                   .withSubDepartmentIdentifier(randomString())
+                   .build();
     }
 
     public static CristinObject randomObject(String secondaryCategory) {
@@ -786,7 +808,8 @@ public final class CristinDataGenerator {
                    "cristinExhibition",
                    SOURCE_CODE, CRISTIN_PRESENTATIONAL_WORK, CRISTIN_SUBJECT_FIELD, BOOK_OR_REPORT_METADATA_FIELD,
                    BOOK_OR_REPORT_PART_METADATA, HRCS_CATEGORIES_AND_ACTIVITIES, CRISTIN_MODIFIED_DATE,
-                   LECTURE_OR_POSTER_METADATA, YEAR_REPORTED, CRISTIN_GRANTS, CRISTIN_SOURCES, MEDIA_CONTRIBUTION)));
+                   LECTURE_OR_POSTER_METADATA, YEAR_REPORTED, CRISTIN_GRANTS, CRISTIN_SOURCES, MEDIA_CONTRIBUTION,
+                   SCIENTIFIC_RESOURCES)));
 
         return (ObjectNode) eventHandlerObjectMapper.readTree(cristinObject.toJsonString());
     }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -63,7 +63,6 @@ import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedMainCategoryExceptio
 import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryException;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.instancetypes.artistic.music.Concert;
 import no.unit.nva.model.instancetypes.artistic.music.MusicPerformance;
@@ -213,10 +212,11 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
 
     private NviReport createExpectedNviReport(CristinObject cristinObject, Publication publication) {
         return NviReport.builder()
-                   .withNviReport(cristinObject.getScientificResources())
+                   .withScientificResource(cristinObject.getScientificResources())
+                   .withCristinLocales(cristinObject.getCristinLocales())
                    .withCristinIdentifier(cristinObject.getSourceRecordIdentifier())
                    .withPublicationIdentifier(publication.getIdentifier().toString())
-                   .withYearReported(cristinObject.getScientificResources().getFirst().getReportedYear().toString())
+                   .withYearReported(cristinObject.getScientificResources().getFirst().getReportedYear())
                    .withPublicationDate(publication.getEntityDescription().getPublicationDate())
                    .build();
     }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -63,6 +63,7 @@ import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedMainCategoryExceptio
 import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryException;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.instancetypes.artistic.music.Concert;
 import no.unit.nva.model.instancetypes.artistic.music.MusicPerformance;
@@ -195,7 +196,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         var eventBody = createEventBody(cristinObject);
         var sqsEvent = createSqsEvent(eventBody);
         var publications = handler.handleRequest(sqsEvent, CONTEXT);
-        var actualPublication = publications.get(0);
+        var actualPublication = publications.getFirst();
         var expectedFileNameStoredInS3 = actualPublication.getIdentifier().toString();
 
         var expectedTimestamp = eventBody.getTimestamp();
@@ -212,11 +213,11 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
 
     private NviReport createExpectedNviReport(CristinObject cristinObject, Publication publication) {
         return NviReport.builder()
-                   .withNviReport(cristinObject.getCristinLocales())
+                   .withNviReport(cristinObject.getScientificResources())
                    .withCristinIdentifier(cristinObject.getSourceRecordIdentifier())
                    .withPublicationIdentifier(publication.getIdentifier().toString())
-                   .withYearReported(cristinObject.getYearReported())
-                   .withPublicationDate(publication.getCreatedDate())
+                   .withYearReported(cristinObject.getScientificResources().getFirst().getReportedYear().toString())
+                   .withPublicationDate(publication.getEntityDescription().getPublicationDate())
                    .build();
     }
 
@@ -361,7 +362,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         var eventBody = createEventBody(cristinObjectWithoutContributors);
         var sqsEvent = createSqsEvent(eventBody);
         var publications = handler.handleRequest(sqsEvent, CONTEXT);
-        var actualtPublication = publications.get(0);
+        var actualtPublication = publications.getFirst();
         assertThat(actualtPublication.getEntityDescription().getContributors(), hasSize(0));
     }
 


### PR DESCRIPTION
- Have taken in use `h_dbh` tabel when mapping nvi data. 

- Have added ignored jsonProperties for `h_dbh` tabel to pojo, but it is possible there are more properties to ignore, as I have run quite small cristin sample. 
- Have updated rule for what is reported nvi-candidate (`h_dbh` tabel contains ONLY reported nvi candidates)