### PR TITLE
Persisting completed pub req when curator updates its own publication

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -21,6 +21,7 @@ import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.events.handlers.PublicationEventsConfig;
 import no.unit.nva.publication.model.PublishPublicationStatusResponse;
 import no.unit.nva.publication.model.business.DoiRequest;
+import no.unit.nva.publication.model.business.Entity;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.PublishingWorkflow;
 import no.unit.nva.publication.model.business.TicketStatus;
@@ -80,9 +81,21 @@ public class AcceptedPublishingRequestEventHandler
     }
 
     private static boolean noEffectiveChanges(DataEntryUpdateEvent updateEvent) {
-        var newStatus = updateEvent.getNewData().getStatusString();
-        var oldStatus = updateEvent.getOldData().getStatusString();
+        var newStatus = getNewStatus(updateEvent);
+        var oldStatus = getOldStatus(updateEvent);
         return oldStatus.equals(newStatus);
+    }
+
+    private static Optional<String> getOldStatus(DataEntryUpdateEvent updateEvent) {
+        return Optional.of(updateEvent)
+                   .map(DataEntryUpdateEvent::getOldData)
+                   .map(Entity::getStatusString);
+    }
+
+    private static Optional<String> getNewStatus(DataEntryUpdateEvent updateEvent) {
+        return Optional.of(updateEvent)
+                   .map(DataEntryUpdateEvent::getNewData)
+                   .map(Entity::getStatusString);
     }
 
     private boolean hasEffectiveChanges(String eventBlob) {

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -18,6 +18,7 @@ import static no.unit.nva.publication.RequestUtil.IDENTIFIER_IS_NOT_A_VALID_UUID
 import static no.unit.nva.publication.RequestUtil.PUBLICATION_IDENTIFIER;
 import static no.unit.nva.publication.delete.DeletePublicationHandler.LAMBDA_DESTINATIONS_INVOCATION_RESULT_SUCCESS;
 import static no.unit.nva.publication.delete.DeletePublicationHandler.NVA_PUBLICATION_DELETE_SOURCE;
+import static no.unit.nva.publication.model.business.TicketStatus.COMPLETED;
 import static no.unit.nva.publication.model.business.TicketStatus.PENDING;
 import static no.unit.nva.publication.service.impl.ReadResourceService.RESOURCE_NOT_FOUND_MESSAGE;
 import static no.unit.nva.testutils.HandlerRequestBuilder.CLIENT_ID_CLAIM;
@@ -29,8 +30,10 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_RESOURCES;
+import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
+import static nva.commons.apigateway.AccessRight.SUPPORT;
 import static nva.commons.apigateway.AccessRight.USER;
 import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static nva.commons.apigateway.ApiGatewayHandler.MESSAGE_FOR_RUNTIME_EXCEPTIONS_HIDING_IMPLEMENTATION_DETAILS_TO_API_CLIENTS;
@@ -322,6 +325,29 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         assertThat(gatewayResponse.getHeaders(), hasKey(CONTENT_TYPE));
         assertThat(gatewayResponse.getHeaders(), hasKey(ACCESS_CONTROL_ALLOW_ORIGIN));
         assertThat(ticket.map(PublishingRequestCase::getStatus).orElseThrow(), is(equalTo(PENDING)));
+    }
+
+    @Test
+    void shouldPersistApprovedPublishingRequestWhenUserHasPublishingAccessRight()
+        throws ApiGatewayException, IOException {
+        var publication = TicketTestUtils.createPersistedPublicationWithPublishedFiles(customerId,
+                                                                                       PublicationStatus.PUBLISHED,
+                                                                                       publicationService);
+
+        var existingTicket = TicketTestUtils.createCompletedTicket(publication, PublishingRequestCase.class,
+                                                                ticketService);
+        var publicationUpdate = addAnotherUnpublishedFile(publication);
+        var input = curatorPublicationOwnerUpdatesPublication(publicationUpdate);
+        updatePublicationHandler.handleRequest(input, output, context);
+        var gatewayResponse = GatewayResponse.fromOutputStream(output, PublicationResponse.class);
+        assertThat(gatewayResponse.getStatusCode(), is(equalTo(HTTP_OK)));
+
+        var autoCompletedTicket = ticketService.fetchTicketsForUser(UserInstance.fromPublication(publicationUpdate))
+                          .filter(PublishingRequestCase.class::isInstance)
+                          .map(PublishingRequestCase.class::cast)
+                          .filter(ticket -> !ticket.equals(existingTicket))
+                          .toList().getFirst();
+        assertThat(autoCompletedTicket.getStatus(), is(equalTo(COMPLETED)));
     }
 
     @Test
@@ -725,7 +751,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
 
         var publicationUpdate = updateTitle(savedPublication);
 
-        var event = curatorUpdatesPublicationAndHasRightToUpdate(publicationUpdate, customerId);
+        var event = curatorWithAccessRightsUpdatesPublication(publicationUpdate, customerId, MANAGE_DOI, MANAGE_RESOURCES_STANDARD);
         updatePublicationHandler.handleRequest(event, output, context);
 
         var response = GatewayResponse.fromOutputStream(output, Publication.class);
@@ -1138,6 +1164,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                           .withCurrentCustomer(institutionId)
                           .withAccessRights(institutionId, USER)
                           .withBody(unpublishRequest)
+                          .withPersonCristinId(randomUri())
+                          .withTopLevelCristinOrgId(randomUri())
                           .withPathParameters(
                               Map.of(PUBLICATION_IDENTIFIER, publication.getIdentifier().toString()));
 
@@ -1367,8 +1395,9 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                           .withCurrentCustomer(institutionId)
                           .withAccessRights(institutionId, accessRight)
                           .withBody(unpublishRequest)
-                          .withPathParameters(
-                              Map.of(PUBLICATION_IDENTIFIER, publicationIdentifier.toString()));
+                          .withTopLevelCristinOrgId(randomUri())
+                          .withPersonCristinId(randomUri())
+                          .withPathParameters(Map.of(PUBLICATION_IDENTIFIER, publicationIdentifier.toString()));
 
         if (nonNull(cristinId)) {
             request.withPersonCristinId(cristinId);
@@ -1385,8 +1414,9 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                           .withCurrentCustomer(institutionId)
                           .withAccessRights(institutionId, accessRight)
                           .withBody(new DeletePublicationRequest())
-                          .withPathParameters(
-                              Map.of(PUBLICATION_IDENTIFIER, publicationIdentifier.toString()));
+                          .withTopLevelCristinOrgId(randomUri())
+                          .withPersonCristinId(randomUri())
+                          .withPathParameters(Map.of(PUBLICATION_IDENTIFIER, publicationIdentifier.toString()));
 
         if (nonNull(cristinId)) {
             request.withPersonCristinId(cristinId);
@@ -1407,6 +1437,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                           .withUserName(username)
                           .withCurrentCustomer(institutionId)
                           .withAccessRights(institutionId, accessRight)
+                          .withTopLevelCristinOrgId(randomUri())
+                          .withPersonCristinId(randomUri())
                           .withBody(unpublishRequest)
                           .withPathParameters(Map.of(PUBLICATION_IDENTIFIER, publicationIdentifier.toString()));
 
@@ -1608,6 +1640,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withPathParameters(pathParameters)
                    .withCurrentCustomer(randomUri())
                    .withBody(publicationUpdate)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1620,6 +1654,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withCurrentCustomer(customerId)
                    .withBody(publicationUpdate)
                    .withAccessRights(customerId, MANAGE_DEGREE, MANAGE_RESOURCES_ALL)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1633,6 +1669,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withBody(publicationUpdate)
                    .withAccessRights(customerId, MANAGE_RESOURCES_ALL)
                    .withUserName(SOME_CURATOR)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1646,6 +1684,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withBody(publicationUpdate)
                    .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD)
                    .withUserName(SOME_CURATOR)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1661,6 +1701,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withPersonCristinId(cristinId)
                    .withBody(publicationUpdate)
                    .withAccessRights(customerId, MANAGE_OWN_RESOURCES)
+                   .withTopLevelCristinOrgId(randomUri())
                    .build();
     }
 
@@ -1673,6 +1714,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withPathParameters(pathParameters)
                    .withCurrentCustomer(customerId)
                    .withBody(publicationUpdate)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1687,6 +1730,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withBody(publicationUpdate)
                    .withPersonCristinId(randomUri())
                    .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 
@@ -1706,6 +1751,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                           .withUserName(publicationUpdate.getResourceOwner().getOwner().getValue())
                           .withCurrentCustomer(customerId)
                           .withBody(publicationUpdate)
+                          .withTopLevelCristinOrgId(randomUri())
+                          .withPersonCristinId(randomUri())
                           .withPathParameters(pathParameters);
 
         if (nonNull(cristinId)) {
@@ -1724,6 +1771,10 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .withAuthorizerClaim(ISS_CLAIM, EXTERNAL_ISSUER)
                    .withAuthorizerClaim(CLIENT_ID_CLAIM, EXTERNAL_CLIENT_ID)
                    .withBody(publicationUpdate)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
+                   .withUserName(randomString())
+                   .withCurrentCustomer(randomUri())
                    .withPathParameters(pathParameters)
                    .build();
     }
@@ -1810,15 +1861,32 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .build();
     }
 
-    private InputStream curatorUpdatesPublicationAndHasRightToUpdate(Publication publicationUpdate, URI customerId)
+    private InputStream curatorWithAccessRightsUpdatesPublication(Publication publication, URI customerId,
+                                                                  AccessRight... accessRights)
         throws JsonProcessingException {
-        var pathParameters = Map.of(PUBLICATION_IDENTIFIER, publicationUpdate.getIdentifier().toString());
+        var pathParameters = Map.of(PUBLICATION_IDENTIFIER, publication.getIdentifier().toString());
         return new HandlerRequestBuilder<Publication>(restApiMapper)
                    .withUserName(SOME_CURATOR)
                    .withPathParameters(pathParameters)
                    .withCurrentCustomer(customerId)
-                   .withBody(publicationUpdate)
-                   .withAccessRights(customerId, MANAGE_DOI, MANAGE_RESOURCES_STANDARD)
+                   .withBody(publication)
+                   .withAccessRights(customerId, accessRights)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
+                   .build();
+    }
+
+    private InputStream curatorPublicationOwnerUpdatesPublication(Publication publication)
+        throws JsonProcessingException {
+        var pathParameters = Map.of(PUBLICATION_IDENTIFIER, publication.getIdentifier().toString());
+        return new HandlerRequestBuilder<Publication>(restApiMapper)
+                   .withUserName(publication.getResourceOwner().getOwner().getValue())
+                   .withPathParameters(pathParameters)
+                   .withCurrentCustomer(publication.getPublisher().getId())
+                   .withBody(publication)
+                   .withAccessRights(customerId, MANAGE_PUBLISHING_REQUESTS, MANAGE_DOI, SUPPORT)
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withPersonCristinId(randomUri())
                    .build();
     }
 }

--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -151,6 +151,22 @@ public final class TicketTestUtils {
         return persistPublication(resourceService, publication);
     }
 
+    public static Publication createPersistedPublicationWithPublishedFiles(URI customerId, PublicationStatus status,
+                                                                             ResourceService resourceService)
+        throws ApiGatewayException {
+        var publisher = new Builder().withId(customerId).build();
+        var publication = randomPublicationWithPublishedFiles(status).copy().withPublisher(publisher).build();
+        return persistPublication(resourceService, publication);
+    }
+
+    private static Publication randomPublicationWithPublishedFiles(PublicationStatus status) {
+        var publication = randomPublication().copy()
+                              .withStatus(status)
+                              .build();
+        publishFiles(publication);
+        return publication;
+    }
+
     public static Publication createPersistedPublicationWithUnpublishedFiles(URI publisher,
                                                                              PublicationStatus status,
                                                                              ResourceService resourceService)
@@ -291,6 +307,16 @@ public final class TicketTestUtils {
                        .filter(File.class::isInstance)
                        .map(File.class::cast)
                        .map(File::toUnpublishedFile)
+                       .collect(Collectors.toCollection(() -> new ArrayList<AssociatedArtifact>()));
+        publication.setAssociatedArtifacts(new AssociatedArtifactList(list));
+    }
+
+    private static void publishFiles(Publication publication) {
+        var list = publication.getAssociatedArtifacts()
+                       .stream()
+                       .filter(File.class::isInstance)
+                       .map(File.class::cast)
+                       .map(File::toPublishedFile)
                        .collect(Collectors.toCollection(() -> new ArrayList<AssociatedArtifact>()));
         publication.setAssociatedArtifacts(new AssociatedArtifactList(list));
     }


### PR DESCRIPTION
When publishing curator updates his/her own publication, when publication update contains new files and there are no PENDING publishing request, files has to be published (this will be done in ApprovedPublishingRequestHandler), and persisted ticket has to be completed.