### PR TITLE
NP-45823-brage-merging-persist-old-and-new-image

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/BrageMergingReport.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/BrageMergingReport.java
@@ -1,0 +1,12 @@
+package no.sikt.nva.brage.migration.merger;
+
+import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.model.Publication;
+
+public record BrageMergingReport(Publication oldImage, Publication newImage) implements JsonSerializable {
+
+    @Override
+    public String toString() {
+        return toJsonString();
+    }
+}


### PR DESCRIPTION
Need to know the modifiedDate of the updated publication when I am rolling back, if the updated publication has been modified after the brage-merging, we should not do a rollback, and instead throw an exception.