### PR TITLE
Np 46038 recover queue

### DIFF
--- a/publication-commons/build.gradle
+++ b/publication-commons/build.gradle
@@ -17,7 +17,9 @@ dependencies {
     implementation libs.aws.sdk.dynamodb
     implementation libs.aws.sdk2.secrets
     implementation libs.aws.sdk2.urlconnectionclient
+    implementation libs.aws.apache.client
     implementation libs.aws.sdk2.s3
+    implementation libs.aws.sdk2.sqs
 
 
     implementation libs.guava

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
@@ -1,0 +1,9 @@
+package no.unit.nva.publication.queue;
+
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public interface QueueClient {
+
+    void sendMessage(SendMessageRequest sendMessageRequest);
+
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -1,0 +1,50 @@
+package no.unit.nva.publication.queue;
+
+import java.time.Duration;
+import nva.commons.core.Environment;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public class ResourceQueueClient implements QueueClient{
+
+    public static final String AWS_REGION = "AWS_REGION";
+    private static final int MAX_CONNECTIONS = 10000;
+    private static final long IDLE_TIME = 30;
+    private static final long TIMEOUT_TIME = 30;
+    private final SqsClient sqsClient;
+
+    public static ResourceQueueClient defaultResourceQueueClient() {
+        return new ResourceQueueClient(defaultClient());
+    }
+
+    private ResourceQueueClient(SqsClient sqsClient) {
+        this.sqsClient = sqsClient;
+    }
+
+    private static SqsClient defaultClient() {
+        return SqsClient.builder()
+                   .region(getRegion())
+                   .httpClient(httpClientForConcurrentQueries())
+                   .build();
+    }
+    @Override
+    public void sendMessage(SendMessageRequest sendMessageRequest) {
+        sqsClient.sendMessage(sendMessageRequest);
+    }
+
+    private static Region getRegion() {
+        return new Environment().readEnvOpt(AWS_REGION).map(Region::of).orElse(Region.EU_WEST_1);
+    }
+
+    private static SdkHttpClient httpClientForConcurrentQueries() {
+        return ApacheHttpClient.builder()
+                   .useIdleConnectionReaper(true)
+                   .maxConnections(MAX_CONNECTIONS)
+                   .connectionMaxIdleTime(Duration.ofSeconds(IDLE_TIME))
+                   .connectionTimeout(Duration.ofSeconds(TIMEOUT_TIME))
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -2,12 +2,14 @@ package no.unit.nva.publication.queue;
 
 import java.time.Duration;
 import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
+@JacocoGenerated
 public class ResourceQueueClient implements QueueClient{
 
     public static final String AWS_REGION = "AWS_REGION";

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -10,10 +10,10 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 @JacocoGenerated
-public class ResourceQueueClient implements QueueClient{
+public final class ResourceQueueClient implements QueueClient{
 
     public static final String AWS_REGION = "AWS_REGION";
-    private static final int MAX_CONNECTIONS = 10000;
+    private static final int MAX_CONNECTIONS = 10_000;
     private static final long IDLE_TIME = 30;
     private static final long TIMEOUT_TIME = 30;
     private final SqsClient sqsClient;

--- a/publication-commons/src/test/java/no/unit/nva/publication/queue/ResourceQueueClientTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/queue/ResourceQueueClientTest.java
@@ -1,0 +1,13 @@
+package no.unit.nva.publication.queue;
+
+import no.unit.nva.publication.service.FakeSqsClient;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public class ResourceQueueClientTest {
+
+    @Test
+    void shouldSendMessage() {
+        new FakeSqsClient().sendMessage(SendMessageRequest.builder().build());
+    }
+}

--- a/publication-event-handlers/build.gradle
+++ b/publication-event-handlers/build.gradle
@@ -69,4 +69,5 @@ test {
     environment "OUTPUT_EVENT_TOPIC", "someEvent"
     environment "API_HOST", "api.test.nva.aws.unit.no"
     environment "ALLOWED_ORIGIN", "*"
+    environment "RECOVERY_QUEUE", "queue"
 }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -5,13 +5,11 @@ import static no.unit.nva.model.PublicationStatus.DELETED;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED_METADATA;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
-import static no.unit.nva.publication.PublicationServiceConfig.DEFAULT_DYNAMODB_CLIENT;
 import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
-import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 import no.unit.nva.events.handlers.DestinationsEventBridgeEventHandler;
@@ -20,6 +18,7 @@ import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.expansion.ResourceExpansionService;
 import no.unit.nva.expansion.ResourceExpansionServiceImpl;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.external.services.AuthorizedBackendUriRetriever;
@@ -27,6 +26,8 @@ import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.Entity;
 import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.queue.QueueClient;
+import no.unit.nva.publication.queue.ResourceQueueClient;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
 import no.unit.nva.s3.S3Driver;
@@ -39,8 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class ExpandDataEntriesHandler
-    extends DestinationsEventBridgeEventHandler<EventReference, EventReference> {
+public class ExpandDataEntriesHandler extends DestinationsEventBridgeEventHandler<EventReference, EventReference> {
 
     public static final String ERROR_EXPANDING_RESOURCE_WARNING = "Error expanding resource:";
     public static final String HANDLER_EVENTS_FOLDER = "PublicationService-DataEntryExpansion";
@@ -49,25 +49,30 @@ public class ExpandDataEntriesHandler
     public static final Environment ENVIRONMENT = new Environment();
     public static final List<PublicationStatus> PUBLICATION_STATUS_TO_BE_ENRICHED = List.of(PUBLISHED,
                                                                                             PUBLISHED_METADATA,
-                                                                                            UNPUBLISHED,
-                                                                                            DELETED);
-    private static final Logger logger = LoggerFactory.getLogger(ExpandDataEntriesHandler.class);
+                                                                                            UNPUBLISHED, DELETED);
     public static final String BACKEND_CLIENT_AUTH_URL = "BACKEND_CLIENT_AUTH_URL";
     public static final String BACKEND_CLIENT_SECRET_NAME = "BACKEND_CLIENT_SECRET_NAME";
+    private static final Logger logger = LoggerFactory.getLogger(ExpandDataEntriesHandler.class);
+    private final QueueClient sqsClient;
     private final S3Driver s3Driver;
     private final ResourceExpansionService resourceExpansionService;
 
     @JacocoGenerated
     public ExpandDataEntriesHandler() {
-        this(new S3Driver(EVENTS_BUCKET), defaultResourceExpansionService());
+        this(ResourceQueueClient.defaultResourceQueueClient(),
+             new S3Driver(EVENTS_BUCKET),
+             defaultResourceExpansionService());
     }
 
-    public ExpandDataEntriesHandler(S3Client s3Client, ResourceExpansionService resourceExpansionService) {
-        this(new S3Driver(s3Client, EVENTS_BUCKET), resourceExpansionService);
+    public ExpandDataEntriesHandler(QueueClient sqsClient, S3Client s3Client,
+                                    ResourceExpansionService resourceExpansionService) {
+        this(sqsClient, new S3Driver(s3Client, EVENTS_BUCKET), resourceExpansionService);
     }
 
-    private ExpandDataEntriesHandler(S3Driver s3Driver, ResourceExpansionService resourceExpansionService) {
+    private ExpandDataEntriesHandler(QueueClient sqsClient, S3Driver s3Driver,
+                                     ResourceExpansionService resourceExpansionService) {
         super(EventReference.class);
+        this.sqsClient = sqsClient;
         this.s3Driver = s3Driver;
         this.resourceExpansionService = resourceExpansionService;
     }
@@ -77,27 +82,48 @@ public class ExpandDataEntriesHandler
                                                  AwsEventBridgeEvent<AwsEventBridgeDetail<EventReference>> event,
                                                  Context context) {
         var blobObject = readBlobFromS3(input);
-        if (shouldBeEnriched(blobObject.getNewData())) {
-            return createEnrichedEventReference(blobObject.getNewData()).orElseGet(this::emptyEvent);
-        }
+        return attempt(() -> processDataEntryUpdateEvent(blobObject)).orElse(
+            failure -> persistRecoveryMessage(failure, blobObject));
+    }
 
-        return emptyEvent();
+    private static String getType(DataEntryUpdateEvent blobObject) {
+        return Optional.ofNullable(blobObject.getOldData())
+                   .map(Entity::getType)
+                   .orElseGet(() -> blobObject.getNewData().getType());
+    }
+
+    private static SortableIdentifier getIdentifier(DataEntryUpdateEvent blobObject) {
+        return Optional.ofNullable(blobObject.getOldData())
+                   .map(Entity::getIdentifier)
+                   .orElseGet(() -> blobObject.getNewData().getIdentifier());
     }
 
     @JacocoGenerated
     private static ResourceExpansionService defaultResourceExpansionService() {
         var uriRetriever = new UriRetriever();
         var authorizedUriRetriever = new AuthorizedBackendUriRetriever(ENVIRONMENT.readEnv(BACKEND_CLIENT_AUTH_URL),
-                                                                   ENVIRONMENT.readEnv(BACKEND_CLIENT_SECRET_NAME));
-        return new ResourceExpansionServiceImpl(defaultResourceService(),
-                                                TicketService.defaultService(),
-                                                authorizedUriRetriever,
-                                                uriRetriever);
+                                                                       ENVIRONMENT.readEnv(BACKEND_CLIENT_SECRET_NAME));
+        return new ResourceExpansionServiceImpl(defaultResourceService(), TicketService.defaultService(),
+                                                authorizedUriRetriever, uriRetriever);
     }
 
     @JacocoGenerated
     private static ResourceService defaultResourceService() {
         return ResourceService.defaultService();
+    }
+
+    private EventReference persistRecoveryMessage(Failure<EventReference> failure, DataEntryUpdateEvent blobObject) {
+        RecoveryEntry.fromIdentifier(getIdentifier(blobObject))
+            .resourceType(getType(blobObject))
+            .withException(failure.getException())
+            .persist(sqsClient);
+        return null;
+    }
+
+    private EventReference processDataEntryUpdateEvent(DataEntryUpdateEvent blobObject) {
+        return shouldBeEnriched(blobObject.getNewData())
+                   ? createEnrichedEventReference(blobObject.getNewData()).orElseThrow()
+                   : emptyEvent();
     }
 
     private Optional<EventReference> createEnrichedEventReference(Entity newData) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -115,7 +115,6 @@ public class ExpandDataEntriesHandler extends DestinationsEventBridgeEventHandle
 
     private EventReference persistRecoveryMessage(Failure<EventReference> failure, DataEntryUpdateEvent blobObject) {
         var identifier = getIdentifier(blobObject);
-        logger.info("sending entry to recovery queue: {}", identifier);
         RecoveryEntry.fromIdentifier(identifier)
             .resourceType(getType(blobObject))
             .withException(failure.getException())

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/RecoveryEntry.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/RecoveryEntry.java
@@ -1,0 +1,100 @@
+package no.unit.nva.publication.events.handlers.expandresources;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.queue.QueueClient;
+import nva.commons.core.Environment;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public class RecoveryEntry {
+
+    private static final String ID = "id";
+    private static final String RECOVERY_QUEUE = "RECOVERY_QUEUE";
+    private static final String TYPE = "type";
+    private final SortableIdentifier identifier;
+    private final String type;
+    private final String exception;
+    private RecoveryEntry(SortableIdentifier identifier, String type, String exception) {
+        this.identifier = identifier;
+        this.type = type;
+        this.exception = exception;
+    }
+
+    public static RecoveryEntry fromIdentifier(SortableIdentifier identifier) {
+        return builder().withIdentifier(identifier).build();
+    }
+
+    public void persist(QueueClient queueClient) {
+        queueClient.sendMessage(createSendMessageRequest());
+    }
+
+    private SendMessageRequest createSendMessageRequest() {
+        return SendMessageRequest.builder()
+                   .messageAttributes(Map.of(ID, convertToMessageAttribute(identifier.toString()),
+                                             TYPE, convertToMessageAttribute(type)))
+                   .messageBody(exception)
+                   .queueUrl(new Environment().readEnv(RECOVERY_QUEUE))
+                   .build();
+    }
+
+    private MessageAttributeValue convertToMessageAttribute(String value) {
+        return MessageAttributeValue.builder()
+                   .stringValue(value)
+                   .dataType(String.class.getCanonicalName())
+                   .build();
+    }
+
+    public RecoveryEntry withException(Exception exception) {
+        return this.copy().withException(getStackTrace(exception)).build();
+    }
+
+    public RecoveryEntry resourceType(String type) {
+        return this.copy().withType(type).build();
+    }
+
+    private String getStackTrace(Exception exception) {
+        var stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
+
+    private static Builder builder() {
+        return new Builder();
+    }
+
+    private Builder copy() {
+        return new Builder().withIdentifier(this.identifier).withType(this.type).withException(this.exception);
+    }
+
+    private static final class Builder {
+
+        private SortableIdentifier identifier;
+        private String type;
+        private String failure;
+
+        private Builder() {
+        }
+
+        public Builder withIdentifier(SortableIdentifier identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withException(String failure) {
+            this.failure = failure;
+            return this;
+        }
+
+        public RecoveryEntry build() {
+            return new RecoveryEntry(identifier, type,failure);
+        }
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/RecoveryEntry.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/RecoveryEntry.java
@@ -9,7 +9,7 @@ import nva.commons.core.Environment;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
-public class RecoveryEntry {
+public final class RecoveryEntry {
 
     private static final String ID = "id";
     private static final String RECOVERY_QUEUE = "RECOVERY_QUEUE";

--- a/publication-testing/build.gradle
+++ b/publication-testing/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     implementation libs.aws.sdk.dynamodb
     implementation libs.aws.sdk2.s3
+    implementation libs.aws.sdk2.sqs
 
     implementation libs.bundles.testing
     implementation libs.bundles.jackson

--- a/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
@@ -1,0 +1,20 @@
+package no.unit.nva.publication.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import no.unit.nva.publication.queue.QueueClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public class FakeSqsClient implements QueueClient {
+
+    private final List<SendMessageRequest> deliveredMessages = new ArrayList<>();
+
+    public List<SendMessageRequest> getDeliveredMessages() {
+        return deliveredMessages;
+    }
+
+    @Override
+    public void sendMessage(SendMessageRequest sendMessageRequest) {
+        deliveredMessages.add(sendMessageRequest);
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -324,6 +324,11 @@ Resources:
     Type: "AWS::SQS::Queue"
   BrageMergingRollbackHandlerDLQ:
     Type: "AWS::SQS::Queue"
+  RecoveryQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 #14 days
+
 
 
   #==============================ROLES=======================================================================
@@ -1189,6 +1194,7 @@ Resources:
           TABLE_NAME: !Ref NvaResourcesTable
           BACKEND_CLIENT_SECRET_NAME: 'BackendCognitoClientCredentials'
           BACKEND_CLIENT_AUTH_URL: !Ref CognitoAuthorizationUri
+          RECOVERY_QUEUE: !Ref RecoveryQueue
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule


### PR DESCRIPTION
Creating Object RecoveryEntry which will be persisted as message on RecoveryQueue. 
The plan is to use this strategy in all handlers that deliver publications from dynamo to search index, i.e.:

DynamoDbToEventBridgeStreamHandler -> DataEntryUpdateHandler -> ResourceExpansionHandler -> 
ExpandedResourcePersistenceHandler -> IndexResourcesHandler

Next step will be to implement an alarm on recovery queue and lambda which does batch scan on recovery queue. 
