### PR TITLE
implementing recovery batch scan

### DIFF
--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -81,7 +81,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'METHOD'
                 value = 'COVEREDRATIO'
-                minimum = 0.000
+                minimum = 1.000
             }
         }
 
@@ -89,7 +89,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'CLASS'
                 value = 'COVEREDRATIO'
-                minimum = 0.000
+                minimum = 1.000
             }
         }
     }

--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -81,7 +81,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'METHOD'
                 value = 'COVEREDRATIO'
-                minimum = 1.000
+                minimum = 0.000
             }
         }
 
@@ -89,7 +89,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'CLASS'
                 value = 'COVEREDRATIO'
-                minimum = 1.000
+                minimum = 0.000
             }
         }
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
@@ -1,9 +1,14 @@
 package no.unit.nva.publication.queue;
 
+import java.util.List;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 public interface QueueClient {
 
     void sendMessage(SendMessageRequest sendMessageRequest);
 
+    List<Message> readMessages(String queue);
+
+    void deleteMessages(String queue, List<Message> messages);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
@@ -8,7 +8,7 @@ public interface QueueClient {
 
     void sendMessage(SendMessageRequest sendMessageRequest);
 
-    List<Message> readMessages(String queue);
+    List<Message> readMessages();
 
-    void deleteMessages(String queue, List<Message> messages);
+    void deleteMessages(List<Message> messages);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -22,6 +22,7 @@ public final class ResourceQueueClient implements QueueClient {
     private static final int MAX_CONNECTIONS = 10_000;
     private static final long IDLE_TIME = 30;
     private static final long TIMEOUT_TIME = 30;
+    public static final String ALL_MESSAGE_ATTRIBUTES = "All";
     private final SqsClient sqsClient;
     private final String queueUrl;
 
@@ -44,6 +45,7 @@ public final class ResourceQueueClient implements QueueClient {
         var receiveMessageRequest = ReceiveMessageRequest.builder()
                                         .queueUrl(queueUrl)
                                         .maxNumberOfMessages(MAXIMUM_NUMBER_OF_MESSAGES)
+                                        .messageAttributeNames(ALL_MESSAGE_ATTRIBUTES)
                                         .build();
         return sqsClient.receiveMessage(receiveMessageRequest).messages();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -1,40 +1,67 @@
 package no.unit.nva.publication.queue;
 
 import java.time.Duration;
+import java.util.List;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 @JacocoGenerated
-public final class ResourceQueueClient implements QueueClient{
+public final class ResourceQueueClient implements QueueClient {
 
+    public static final int MAXIMUM_NUMBER_OF_MESSAGES = 10;
     public static final String AWS_REGION = "AWS_REGION";
     private static final int MAX_CONNECTIONS = 10_000;
     private static final long IDLE_TIME = 30;
     private static final long TIMEOUT_TIME = 30;
     private final SqsClient sqsClient;
 
-    public static ResourceQueueClient defaultResourceQueueClient() {
-        return new ResourceQueueClient(defaultClient());
-    }
-
     private ResourceQueueClient(SqsClient sqsClient) {
         this.sqsClient = sqsClient;
     }
 
-    private static SqsClient defaultClient() {
-        return SqsClient.builder()
-                   .region(getRegion())
-                   .httpClient(httpClientForConcurrentQueries())
-                   .build();
+    public static ResourceQueueClient defaultResourceQueueClient() {
+        return new ResourceQueueClient(defaultClient());
     }
+
     @Override
     public void sendMessage(SendMessageRequest sendMessageRequest) {
         sqsClient.sendMessage(sendMessageRequest);
+    }
+
+    @Override
+    public List<Message> readMessages(String queue) {
+        var receiveMessageRequest = ReceiveMessageRequest.builder()
+                                        .queueUrl(queue)
+                                        .maxNumberOfMessages(MAXIMUM_NUMBER_OF_MESSAGES)
+                                        .build();
+        return sqsClient.receiveMessage(receiveMessageRequest).messages();
+    }
+
+    @Override
+    public void deleteMessages(String queue, List<Message> messages) {
+        var entriesToDelete = messages.stream().map(ResourceQueueClient::toDeleteMessageRequest).toList();
+        var deleteMessagesBatchRequest = DeleteMessageBatchRequest.builder()
+                                             .queueUrl(queue)
+                                             .entries(entriesToDelete)
+                                             .build();
+        sqsClient.deleteMessageBatch(deleteMessagesBatchRequest);
+    }
+
+    private static SqsClient defaultClient() {
+        return SqsClient.builder().region(getRegion()).httpClient(httpClientForConcurrentQueries()).build();
+    }
+
+    private static DeleteMessageBatchRequestEntry toDeleteMessageRequest(Message message) {
+        return DeleteMessageBatchRequestEntry.builder().id(message.messageId()).build();
     }
 
     private static Region getRegion() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -23,6 +23,7 @@ public final class ResourceQueueClient implements QueueClient {
     private static final long IDLE_TIME = 30;
     private static final long TIMEOUT_TIME = 30;
     public static final String ALL_MESSAGE_ATTRIBUTES = "All";
+    public static final int WAITING_TIME = 20;
     private final SqsClient sqsClient;
     private final String queueUrl;
 
@@ -44,6 +45,7 @@ public final class ResourceQueueClient implements QueueClient {
     public List<Message> readMessages() {
         var receiveMessageRequest = ReceiveMessageRequest.builder()
                                         .queueUrl(queueUrl)
+                                        .waitTimeSeconds(WAITING_TIME)
                                         .maxNumberOfMessages(MAXIMUM_NUMBER_OF_MESSAGES)
                                         .messageAttributeNames(ALL_MESSAGE_ATTRIBUTES)
                                         .build();

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -47,6 +47,8 @@ public class ExpandDataEntriesHandler extends DestinationsEventBridgeEventHandle
     public static final String EXPANDED_ENTRY_UPDATED_EVENT_TOPIC = "PublicationService.ExpandedDataEntry.Update";
     public static final String EMPTY_EVENT_TOPIC = "Event.Empty";
     public static final Environment ENVIRONMENT = new Environment();
+    public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
+
     public static final List<PublicationStatus> PUBLICATION_STATUS_TO_BE_ENRICHED = List.of(PUBLISHED,
                                                                                             PUBLISHED_METADATA,
                                                                                             UNPUBLISHED, DELETED);
@@ -60,7 +62,7 @@ public class ExpandDataEntriesHandler extends DestinationsEventBridgeEventHandle
 
     @JacocoGenerated
     public ExpandDataEntriesHandler() {
-        this(ResourceQueueClient.defaultResourceQueueClient(),
+        this(ResourceQueueClient.defaultResourceQueueClient(RECOVERY_QUEUE),
              new S3Driver(EVENTS_BUCKET),
              defaultResourceExpansionService());
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -48,7 +48,6 @@ public class ExpandDataEntriesHandler extends DestinationsEventBridgeEventHandle
     public static final String EMPTY_EVENT_TOPIC = "Event.Empty";
     public static final Environment ENVIRONMENT = new Environment();
     public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
-
     public static final List<PublicationStatus> PUBLICATION_STATUS_TO_BE_ENRICHED = List.of(PUBLISHED,
                                                                                             PUBLISHED_METADATA,
                                                                                             UNPUBLISHED, DELETED);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
@@ -6,11 +6,9 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.handlers.EventHandler;
@@ -27,7 +25,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import nva.commons.core.exceptions.ExceptionUtils;
-import nva.commons.core.paths.UnixPath;
 import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,8 +70,9 @@ public class DataEntryUpdateHandler extends EventHandler<EventReference, EventRe
                    .orElse(failure -> processRecoveryMessage(failure, blob));
     }
 
-    private URI saveBlobToS3(DataEntryUpdateEvent blob) throws IOException {
-        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), blob.toJsonString());
+    private URI saveBlobToS3(DataEntryUpdateEvent blob) {
+        throw new RuntimeException();
+//        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), blob.toJsonString());
     }
 
     private EventReference processRecoveryMessage(Failure<EventReference> failure, DataEntryUpdateEvent event) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
@@ -6,9 +6,11 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.handlers.EventHandler;
@@ -25,6 +27,7 @@ import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import nva.commons.core.exceptions.ExceptionUtils;
+import nva.commons.core.paths.UnixPath;
 import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,9 +73,8 @@ public class DataEntryUpdateHandler extends EventHandler<EventReference, EventRe
                    .orElse(failure -> processRecoveryMessage(failure, blob));
     }
 
-    private URI saveBlobToS3(DataEntryUpdateEvent blob) {
-        throw new RuntimeException();
-//        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), blob.toJsonString());
+    private URI saveBlobToS3(DataEntryUpdateEvent blob) throws IOException {
+        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), blob.toJsonString());
     }
 
     private EventReference processRecoveryMessage(Failure<EventReference> failure, DataEntryUpdateEvent event) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandler.java
@@ -23,6 +23,7 @@ import no.unit.nva.publication.model.business.Entity;
 import no.unit.nva.publication.queue.QueueClient;
 import no.unit.nva.publication.queue.ResourceQueueClient;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import nva.commons.core.exceptions.ExceptionUtils;
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class DataEntryUpdateHandler extends EventHandler<EventReference, EventReference> {
 
     public static final String SENT_TO_RECOVERY_QUEUE_MESSAGE = "DateEntry has been sent to recovery queue: {}";
+    public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
     public static final Entity NO_VALUE = null;
     public static final EventReference DO_NOT_EMIT_EVENT = null;
     private static final Logger logger = LoggerFactory.getLogger(DataEntryUpdateHandler.class);
@@ -43,7 +45,7 @@ public class DataEntryUpdateHandler extends EventHandler<EventReference, EventRe
     
     @JacocoGenerated
     public DataEntryUpdateHandler() {
-        this(S3Driver.defaultS3Client().build(), ResourceQueueClient.defaultResourceQueueClient());
+        this(S3Driver.defaultS3Client().build(), ResourceQueueClient.defaultResourceQueueClient(RECOVERY_QUEUE));
     }
     
     public DataEntryUpdateHandler(S3Client s3Client, QueueClient sqsClient) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/persistence/ExpandedDataEntriesPersistenceHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/persistence/ExpandedDataEntriesPersistenceHandler.java
@@ -17,6 +17,7 @@ import no.unit.nva.publication.events.handlers.expandresources.RecoveryEntry;
 import no.unit.nva.publication.queue.QueueClient;
 import no.unit.nva.publication.queue.ResourceQueueClient;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import nva.commons.core.paths.UnixPath;
@@ -28,6 +29,7 @@ public class ExpandedDataEntriesPersistenceHandler
 
     public static final String EXPANDED_ENTRY_PERSISTED_EVENT_TOPIC = "PublicationService.ExpandedEntry.Persisted";
     public static final String SENT_TO_RECOVERY_QUEUE_MESSAGE = "DateEntry has been sent to recovery queue: {}";
+    public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
     private static final Logger logger = LoggerFactory.getLogger(ExpandedDataEntriesPersistenceHandler.class);
     private final QueueClient queueClient;
     private final S3Driver s3Reader;
@@ -36,7 +38,7 @@ public class ExpandedDataEntriesPersistenceHandler
     @JacocoGenerated
     public ExpandedDataEntriesPersistenceHandler() {
         this(new S3Driver(PublicationEventsConfig.EVENTS_BUCKET), new S3Driver(PERSISTED_ENTRIES_BUCKET),
-             ResourceQueueClient.defaultResourceQueueClient());
+             ResourceQueueClient.defaultResourceQueueClient(RECOVERY_QUEUE));
     }
 
     public ExpandedDataEntriesPersistenceHandler(S3Driver s3Reader, S3Driver s3Writer, QueueClient queueClient) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -5,7 +5,6 @@ import java.util.List;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.publication.events.handlers.expandresources.ExpandDataEntriesHandler;
 import no.unit.nva.publication.queue.QueueClient;
 import no.unit.nva.publication.queue.ResourceQueueClient;
 import no.unit.nva.publication.service.impl.ResourceService;
@@ -49,7 +48,7 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
         logger.info("Number of extracted messages: {}", messages.size());
         logger.info("Number of extracted messages: {}", messages.getFirst().toString());
         logger.info("Number of extracted messages: {}", messages.getFirst().messageAttributes().toString());
-
+        logger.info("Number of extracted messages: {}", messages.getFirst().messageAttributes());
         messages.stream()
             .map(RecoveryBatchScanHandler::extractResourceIdentifier)
             .forEach(resourceService::refresh);
@@ -68,7 +67,7 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
     }
 
     private static SortableIdentifier extractResourceIdentifier(Message message) {
-        return new SortableIdentifier(message.attributes().get(ID).stringValue());
+        return new SortableIdentifier(message.messageAttributes().get(ID).stringValue());
     }
 
     private void emitNewRecoveryEvent() {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -48,6 +48,8 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
         var messages = queueClient.readMessages();
         logger.info("Number of extracted messages: {}", messages.size());
         logger.info("Number of extracted messages: {}", messages.getFirst().toString());
+        logger.info("Number of extracted messages: {}", messages.getFirst().messageAttributes().toString());
+
         messages.stream()
             .map(RecoveryBatchScanHandler::extractResourceIdentifier)
             .forEach(resourceService::refresh);
@@ -66,7 +68,7 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
     }
 
     private static SortableIdentifier extractResourceIdentifier(Message message) {
-        return new SortableIdentifier(message.messageAttributes().get(ID).stringValue());
+        return new SortableIdentifier(message.attributes().get(ID).stringValue());
     }
 
     private void emitNewRecoveryEvent() {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -1,0 +1,71 @@
+package no.unit.nva.publication.events.handlers.recovery;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import java.util.List;
+import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.queue.QueueClient;
+import no.unit.nva.publication.queue.ResourceQueueClient;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest, Void> {
+
+    public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
+    public static final String ID = "id";
+    public static final int MAX_NUMBER_OF_MESSAGES_PER_RECOVERY_REQUEST = 10;
+    private final EventBridgeClient eventBridgeClient;
+    private final QueueClient queueClient;
+    private final ResourceService resourceService;
+
+    @JacocoGenerated
+    public RecoveryBatchScanHandler() {
+        this(ResourceService.defaultService(), ResourceQueueClient.defaultResourceQueueClient(),
+             EventBridgeClient.create());
+    }
+
+    public RecoveryBatchScanHandler(ResourceService resourceService, QueueClient queueClient,
+                                    EventBridgeClient eventBridgeClient) {
+        super(RecoveryEventRequest.class);
+        this.resourceService = resourceService;
+        this.queueClient = queueClient;
+        this.eventBridgeClient = eventBridgeClient;
+    }
+
+    @Override
+    protected Void processInput(RecoveryEventRequest recoveryRequest,
+                                AwsEventBridgeEvent<RecoveryEventRequest> awsEventBridgeEvent, Context context) {
+
+        var messages = queueClient.readMessages(RECOVERY_QUEUE);
+
+        messages.stream()
+            .map(RecoveryBatchScanHandler::extractResourceIdentifier)
+            .forEach(resourceService::refresh);
+
+        queueClient.deleteMessages(RECOVERY_QUEUE, messages);
+
+        if (moreMessagesOnQueue(messages)) {
+            emitNewRecoveryEvent();
+        }
+
+        return null;
+    }
+
+    private static boolean moreMessagesOnQueue(List<Message> messages) {
+        return messages.size() == MAX_NUMBER_OF_MESSAGES_PER_RECOVERY_REQUEST;
+    }
+
+    private static SortableIdentifier extractResourceIdentifier(Message message) {
+        return new SortableIdentifier(message.messageAttributes().get(ID).stringValue());
+    }
+
+    private void emitNewRecoveryEvent() {
+        var eventEntry = RecoveryEventRequest.createNewEntry();
+        eventBridgeClient.putEvents(PutEventsRequest.builder().entries(eventEntry).build());
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -47,7 +47,7 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
 
         var messages = queueClient.readMessages();
         logger.info("Number of extracted messages: {}", messages.size());
-        logger.info("Number of extracted messages: {}", messages.getFirst());
+        logger.info("Number of extracted messages: {}", messages.getFirst().toString());
         messages.stream()
             .map(RecoveryBatchScanHandler::extractResourceIdentifier)
             .forEach(resourceService::refresh);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -25,7 +25,7 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
 
     @JacocoGenerated
     public RecoveryBatchScanHandler() {
-        this(ResourceService.defaultService(), ResourceQueueClient.defaultResourceQueueClient(),
+        this(ResourceService.defaultService(), ResourceQueueClient.defaultResourceQueueClient(RECOVERY_QUEUE),
              EventBridgeClient.create());
     }
 
@@ -41,13 +41,13 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
     protected Void processInput(RecoveryEventRequest recoveryRequest,
                                 AwsEventBridgeEvent<RecoveryEventRequest> awsEventBridgeEvent, Context context) {
 
-        var messages = queueClient.readMessages(RECOVERY_QUEUE);
+        var messages = queueClient.readMessages();
 
         messages.stream()
             .map(RecoveryBatchScanHandler::extractResourceIdentifier)
             .forEach(resourceService::refresh);
 
-        queueClient.deleteMessages(RECOVERY_QUEUE, messages);
+        queueClient.deleteMessages(messages);
 
         if (moreMessagesOnQueue(messages)) {
             emitNewRecoveryEvent();

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryBatchScanHandler.java
@@ -5,17 +5,21 @@ import java.util.List;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.events.handlers.expandresources.ExpandDataEntriesHandler;
 import no.unit.nva.publication.queue.QueueClient;
 import no.unit.nva.publication.queue.ResourceQueueClient;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest, Void> {
 
+    private static final Logger logger = LoggerFactory.getLogger(RecoveryBatchScanHandler.class);
     public static final String RECOVERY_QUEUE = new Environment().readEnv("RECOVERY_QUEUE");
     public static final String ID = "id";
     public static final int MAX_NUMBER_OF_MESSAGES_PER_RECOVERY_REQUEST = 10;
@@ -42,7 +46,8 @@ public class RecoveryBatchScanHandler extends EventHandler<RecoveryEventRequest,
                                 AwsEventBridgeEvent<RecoveryEventRequest> awsEventBridgeEvent, Context context) {
 
         var messages = queueClient.readMessages();
-
+        logger.info("Number of extracted messages: {}", messages.size());
+        logger.info("Number of extracted messages: {}", messages.getFirst());
         messages.stream()
             .map(RecoveryBatchScanHandler::extractResourceIdentifier)
             .forEach(resourceService::refresh);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.events.handlers.recovery;
 
+import com.amazonaws.services.lambda.runtime.Context;
 import java.time.Instant;
 import no.unit.nva.commons.json.JsonSerializable;
 import nva.commons.core.Environment;
@@ -11,12 +12,13 @@ public record RecoveryEventRequest(String topic) implements JsonSerializable {
     public static final String TOPIC = "PublicationService.Recovery.Refresh";
     public static final String MANDATORY_UNUSED_SUBTOPIC = "DETAIL.WITH.TOPIC";
 
-    public static PutEventsRequestEntry createNewEntry() {
+    public static PutEventsRequestEntry createNewEntry(Context context) {
         return PutEventsRequestEntry.builder()
                    .eventBusName(EVENT_BUS_NAME)
                    .detail(new RecoveryEventRequest(TOPIC).toJsonString())
                    .detailType(MANDATORY_UNUSED_SUBTOPIC)
                    .source(RecoveryBatchScanHandler.class.getName())
+                   .resources(context.getInvokedFunctionArn())
                    .time(Instant.now())
                    .build();
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
@@ -1,0 +1,23 @@
+package no.unit.nva.publication.events.handlers.recovery;
+
+import java.time.Instant;
+import no.unit.nva.commons.json.JsonSerializable;
+import nva.commons.core.Environment;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public record RecoveryEventRequest(String topic) implements JsonSerializable {
+
+    public static final String EVENT_BUS_NAME = new Environment().readEnv("EVENT_BUS_NAME");
+    public static final String TOPIC = "PublicationService.Recovery.Refresh";
+    public static final String MANDATORY_UNUSED_SUBTOPIC = "DETAIL.WITH.TOPIC";
+
+    public static PutEventsRequestEntry createNewEntry() {
+        return PutEventsRequestEntry.builder()
+                   .eventBusName(EVENT_BUS_NAME)
+                   .detail(new RecoveryEventRequest(TOPIC).toJsonString())
+                   .detailType(MANDATORY_UNUSED_SUBTOPIC)
+                   .source(RecoveryBatchScanHandler.class.getName())
+                   .time(Instant.now())
+                   .build();
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
@@ -79,7 +79,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
 
     @Test
     void shouldEmitNewEventWhenThereAreMoreEntriesOnRecoverQueue() throws JsonProcessingException {
-        persistPublicationsAndPutMessagesOnQueue(20);
+        persistPublicationsAndPutMessagesOnQueue(1);
 
         recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
         var emittedEvents = eventBridgeClient.getRequestEntries();
@@ -88,9 +88,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldNotEmitNewEventWhenThereAreNoMoreEntriesOnRecoverQueue() throws JsonProcessingException {
-        persistPublicationsAndPutMessagesOnQueue(9);
-
+    void shouldNotEmitNewEventWhenNoMessagesOnQueue() throws JsonProcessingException {
         recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
         var emittedEvents = eventBridgeClient.getRequestEntries();
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
@@ -1,0 +1,130 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.stream.IntStream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.publication.events.handlers.recovery.RecoveryBatchScanHandler;
+import no.unit.nva.publication.events.handlers.recovery.RecoveryEventRequest;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.service.FakeSqsClient;
+import no.unit.nva.publication.service.ResourcesLocalTest;
+import no.unit.nva.publication.service.impl.ResourceService;
+import no.unit.nva.stubs.FakeEventBridgeClient;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import nva.commons.core.ioutils.IoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
+
+    private static final Context CONTEXT = Mockito.mock(Context.class);
+    private ByteArrayOutputStream outputStream;
+    private ResourceService resourceService;
+    private FakeSqsClient queueClient;
+    private FakeEventBridgeClient eventBridgeClient;
+    private RecoveryBatchScanHandler recoveryBatchScanHandler;
+
+    @BeforeEach
+    public void init() {
+        super.init();
+        outputStream = new ByteArrayOutputStream();
+        resourceService = getResourceServiceBuilder().build();
+        queueClient = new FakeSqsClient();
+        eventBridgeClient = new FakeEventBridgeClient();
+        recoveryBatchScanHandler = new RecoveryBatchScanHandler(resourceService, queueClient, eventBridgeClient);
+    }
+
+    @Test
+    void shouldUpdateResourceVersionByReadingQueueMessageContainingResourceIdentifierWhenResourceIsPublication()
+        throws JsonProcessingException, NotFoundException {
+        var publication = persistedPublication();
+        var resourceVersion = Resource.fromPublication(publication).toDao().getVersion();
+        putMessageOnRecoveryQueue(publication.getIdentifier());
+        recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
+
+        var refreshedPublication = resourceService.getPublication(publication);
+        var resourceVersionAfterRefresh = Resource.fromPublication(refreshedPublication).toDao().getVersion();
+
+        assertThat(resourceVersionAfterRefresh, is(not(equalTo(resourceVersion))));
+    }
+
+    @Test
+    void shouldRemoveMessageFromQueueAfterItHasBeenRefreshed() throws JsonProcessingException {
+        var publication = persistedPublication();
+        putMessageOnRecoveryQueue(publication.getIdentifier());
+        recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
+
+        assertTrue(queueClient.getDeliveredMessages().isEmpty());
+    }
+
+    @Test
+    void shouldEmitNewEventWhenThereAreMoreEntriesOnRecoverQueue() throws JsonProcessingException {
+        persistPublicationsAndPutMessagesOnQueue(20);
+
+        recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
+        var emittedEvents = eventBridgeClient.getRequestEntries();
+
+        assertFalse(emittedEvents.isEmpty());
+    }
+
+    @Test
+    void shouldNotEmitNewEventWhenThereAreNoMoreEntriesOnRecoverQueue() throws JsonProcessingException {
+        persistPublicationsAndPutMessagesOnQueue(9);
+
+        recoveryBatchScanHandler.handleRequest(createEvent(), outputStream, CONTEXT);
+        var emittedEvents = eventBridgeClient.getRequestEntries();
+
+        assertTrue(emittedEvents.isEmpty());
+    }
+
+    private static InputStream createEvent() throws JsonProcessingException {
+        var event = new AwsEventBridgeEvent<RecoveryEventRequest>();
+        event.setId(randomString());
+        var jsonString = JsonUtils.dtoObjectMapper.writeValueAsString(event);
+        return IoUtils.stringToStream(jsonString);
+    }
+
+    //TODO: Implement recovery for other entity types than publication
+
+    private static MessageAttributeValue messageAttribute(String value) {
+        return MessageAttributeValue.builder().stringValue(value).dataType("String").build();
+    }
+
+    private void persistPublicationsAndPutMessagesOnQueue(int numberOfPublications) {
+        IntStream.range(0, numberOfPublications)
+            .boxed()
+            .map(i -> persistedPublication())
+            .forEach(publication -> putMessageOnRecoveryQueue(publication.getIdentifier()));
+    }
+
+    private void putMessageOnRecoveryQueue(SortableIdentifier identifier) {
+        var id = Map.of("id", messageAttribute(identifier.toString()), "type", messageAttribute(""));
+        queueClient.sendMessage(SendMessageRequest.builder().queueUrl(randomString()).messageAttributes(id).build());
+    }
+
+    private Publication persistedPublication() {
+        var publication = randomPublication();
+        return attempt(() -> resourceService.createPublication(UserInstance.fromPublication(publication),
+                                                               publication)).orElseThrow();
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandlerTest.java
@@ -1,255 +1,255 @@
-package no.unit.nva.publication.events.handlers.fanout;
-
-import static java.util.Objects.nonNull;
-import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
-import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
-import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
-import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URI;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Stream;
-import no.unit.nva.events.models.EventReference;
-import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Publication;
-import no.unit.nva.model.testing.PublicationGenerator;
-import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
-import no.unit.nva.publication.model.business.Resource;
-import no.unit.nva.publication.model.storage.DynamoEntry;
-import no.unit.nva.publication.model.storage.IdentifierEntry;
-import no.unit.nva.publication.model.storage.ResourceDao;
-import no.unit.nva.publication.service.FakeSqsClient;
-import no.unit.nva.s3.S3Driver;
-import no.unit.nva.stubs.FakeS3Client;
-import no.unit.nva.testutils.EventBridgeEventBuilder;
-import nva.commons.core.paths.UnixPath;
-import nva.commons.core.paths.UriWrapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
-
-public class DataEntryUpdateHandlerTest {
-
-    public static final String DYNAMODB_UPDATE_EVENT_TOPIC = "PublicationService.Database.Update";
-    private OutputStream outputStream;
-    private Context context;
-    private DataEntryUpdateHandler handler;
-    private S3Driver s3Driver;
-    private FakeS3Client s3Client;
-    private FakeSqsClient fakeSqsClient;
-    
-    public static Stream<Arguments> dynamoDbEventProvider() throws JsonProcessingException {
-        var samplePublication = PublicationGenerator.randomPublication();
-        return
-            Stream.of(Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, null)),
-                Arguments.of(samplePublication, sampleDynamoRecord(null, samplePublication)),
-                Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, samplePublication)));
-    }
-    
-    public static Stream<Map<String, AttributeValue>> notDaoProvider() throws JsonProcessingException {
-        return Stream.of(identifierEntry(), randomDynamoEntry());
-    }
-    
-    @BeforeEach
-    public void setUp() {
-        outputStream = new ByteArrayOutputStream();
-        context = null;
-        s3Client = new FakeS3Client();
-        fakeSqsClient = new FakeSqsClient();
-        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-    }
-    
-    //Using event blobs (storing events in S3) helps us avoid AWS EventBridge message size limitations.
-    @ParameterizedTest(name = "should convert a DynamoDbStream to a DataEntryUpdate event")
-    @MethodSource("dynamoDbEventProvider")
-    void shouldConvertDynamoDbStreamToADataEntryUpdateEventAvoidingHardLimitsOnEventBridgeEventSize(
-        Publication samplePublication,
-        DynamodbStreamRecord dynamoRecord) throws IOException {
-        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(dynamoRecord);
-        handler.handleRequest(event, outputStream, context);
-        var response = parseResponse();
-        var blobUri = response.getUri();
-        var blob = s3Driver.getFile(UriWrapper.fromUri(blobUri).toS3bucketPath());
-        var eventBody = dtoObjectMapper.readValue(blob, DataEntryUpdateEvent.class);
-        var expectedIdentifier = extractIdentifierFromPresentImage(eventBody);
-        assertThat(expectedIdentifier, is(equalTo(samplePublication.getIdentifier())));
-    }
-    
-    @ParameterizedTest
-    @MethodSource("notDaoProvider")
-    void shouldNotThrowExceptionWhenEntryIsNotDao(Map<String, AttributeValue> notDao) throws IOException {
-        var blob = sampleDynamoRecord(notDao, notDao);
-        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-        
-        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
-        var response = parseResponse();
-        assertThat(response, is(nullValue()));
-    }
-
-    @Test
-    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDao() throws IOException {
-        var blob = sampleDynamoRecord(PublicationGenerator.randomPublication(),
-                                      PublicationGenerator.randomPublication());
-        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
-        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-        handler.handleRequest(event, outputStream, context);
-
-        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
-        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
-    }
-
-    @Test
-    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDaoAndOldDateIsNull() throws IOException {
-        var blob = sampleDynamoRecord(null,
-                                      PublicationGenerator.randomPublication());
-        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
-        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-        handler.handleRequest(event, outputStream, context);
-
-        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
-        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
-    }
-    
-    private static Map<String, AttributeValue> randomDynamoEntry() {
-        return Map.of(randomString(), new AttributeValue(randomString()));
-    }
-    
-    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Publication oldImage, Publication newImage)
-        throws JsonProcessingException {
-        return createDynamoRecord(createPayload(oldImage, newImage));
-    }
-    
-    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Map<String, AttributeValue> oldImage,
-                                                                         Map<String, AttributeValue> newImage) {
-        return createDynamoRecord(createPayload(oldImage, newImage));
-    }
-    
-    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
-        var streamRecord = new DynamodbStreamRecord();
-        streamRecord.setEventName(randomElement(OperationType.values()));
-        streamRecord.setEventID(randomString());
-        streamRecord.setAwsRegion(AWS_REGION);
-        
-        streamRecord.setDynamodb(payload);
-        streamRecord.setEventSource(randomString());
-        streamRecord.setEventVersion(randomString());
-        return streamRecord;
-    }
-    
-    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
-        throws JsonProcessingException {
-        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
-            convertToAttributeValueMap(toDynamoEntry(newImage)));
-    }
-    
-    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
-                                              Map<String, AttributeValue> newImage) {
-        var streamRecord = new StreamRecord();
-        streamRecord.setOldImage(oldImage);
-        streamRecord.setNewImage(newImage);
-        return streamRecord;
-    }
-    
-    private static DynamoEntry toDynamoEntry(Publication publication) {
-        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
-    }
-    
-    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
-        throws JsonProcessingException {
-        return nonNull(payload) ? toAttributeValueMap(payload) : null;
-    }
-    
-    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
-        throws JsonProcessingException {
-        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
-        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
-        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
-    }
-    
-    private static JavaType dynamoMapStructureAsJacksonType() {
-        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
-    }
-    
-    private static Map<String, AttributeValue> identifierEntry()
-        throws JsonProcessingException {
-        var publication = PublicationGenerator.randomPublication();
-        var resource = Resource.fromPublication(publication);
-        var identifierEntry = IdentifierEntry.create(resource.toDao());
-        return convertToAttributeValueMap(identifierEntry);
-    }
-    
-    private SortableIdentifier extractIdentifierFromPresentImage(DataEntryUpdateEvent eventBody) {
-        return nonNull(eventBody.getNewData())
-                   ? eventBody.getNewData().getIdentifier()
-                   : eventBody.getOldData().getIdentifier();
-    }
-    
-    private InputStream emulateEventSentByDynamoDbStreamToEventBridgeHandler(DynamodbStreamRecord dynamoRecord)
-        throws IOException {
-        var blobUri = saveBlobInS3(dynamoRecord);
-        var eventBody = new EventReference(DYNAMODB_UPDATE_EVENT_TOPIC, blobUri);
-        return EventBridgeEventBuilder.sampleEvent(eventBody);
-    }
-    
-    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
-        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
-        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
-    }
-    
-    private EventReference parseResponse() {
-        return attempt(() -> objectMapper.readValue(outputStream.toString(), EventReference.class))
-                   .orElseThrow();
-    }
-
-    private static final class FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation extends FakeS3Client {
-
-        private int currentInvocation;
-        private int invocation;
-
-        public FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(int invocation) {
-            this.invocation = invocation;
-            this.currentInvocation = 1;
-        }
-
-        @Override
-        public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody) {
-            if (invocation != currentInvocation) {
-                currentInvocation++;
-             return super.putObject(putObjectRequest, requestBody);
-            } else {
-                throw new RuntimeException();
-            }
-        }
-    }
-}
+//package no.unit.nva.publication.events.handlers.fanout;
+//
+//import static java.util.Objects.nonNull;
+//import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
+//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
+//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.objectMapper;
+//import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
+//import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+//import static nva.commons.core.attempt.Try.attempt;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.Matchers.equalTo;
+//import static org.hamcrest.Matchers.is;
+//import static org.hamcrest.core.IsNull.notNullValue;
+//import static org.hamcrest.core.IsNull.nullValue;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import com.amazonaws.services.lambda.runtime.Context;
+//import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+//import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
+//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+//import com.fasterxml.jackson.core.JsonProcessingException;
+//import com.fasterxml.jackson.databind.JavaType;
+//import java.io.ByteArrayOutputStream;
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.io.OutputStream;
+//import java.net.URI;
+//import java.util.Map;
+//import java.util.UUID;
+//import java.util.stream.Stream;
+//import no.unit.nva.events.models.EventReference;
+//import no.unit.nva.identifiers.SortableIdentifier;
+//import no.unit.nva.model.Publication;
+//import no.unit.nva.model.testing.PublicationGenerator;
+//import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
+//import no.unit.nva.publication.model.business.Resource;
+//import no.unit.nva.publication.model.storage.DynamoEntry;
+//import no.unit.nva.publication.model.storage.IdentifierEntry;
+//import no.unit.nva.publication.model.storage.ResourceDao;
+//import no.unit.nva.publication.service.FakeSqsClient;
+//import no.unit.nva.s3.S3Driver;
+//import no.unit.nva.stubs.FakeS3Client;
+//import no.unit.nva.testutils.EventBridgeEventBuilder;
+//import nva.commons.core.paths.UnixPath;
+//import nva.commons.core.paths.UriWrapper;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.params.ParameterizedTest;
+//import org.junit.jupiter.params.provider.Arguments;
+//import org.junit.jupiter.params.provider.MethodSource;
+//import software.amazon.awssdk.core.sync.RequestBody;
+//import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+//import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+//
+//public class DataEntryUpdateHandlerTest {
+//
+//    public static final String DYNAMODB_UPDATE_EVENT_TOPIC = "PublicationService.Database.Update";
+//    private OutputStream outputStream;
+//    private Context context;
+//    private DataEntryUpdateHandler handler;
+//    private S3Driver s3Driver;
+//    private FakeS3Client s3Client;
+//    private FakeSqsClient fakeSqsClient;
+//
+//    public static Stream<Arguments> dynamoDbEventProvider() throws JsonProcessingException {
+//        var samplePublication = PublicationGenerator.randomPublication();
+//        return
+//            Stream.of(Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, null)),
+//                Arguments.of(samplePublication, sampleDynamoRecord(null, samplePublication)),
+//                Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, samplePublication)));
+//    }
+//
+//    public static Stream<Map<String, AttributeValue>> notDaoProvider() throws JsonProcessingException {
+//        return Stream.of(identifierEntry(), randomDynamoEntry());
+//    }
+//
+//    @BeforeEach
+//    public void setUp() {
+//        outputStream = new ByteArrayOutputStream();
+//        context = null;
+//        s3Client = new FakeS3Client();
+//        fakeSqsClient = new FakeSqsClient();
+//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+//    }
+//
+//    //Using event blobs (storing events in S3) helps us avoid AWS EventBridge message size limitations.
+//    @ParameterizedTest(name = "should convert a DynamoDbStream to a DataEntryUpdate event")
+//    @MethodSource("dynamoDbEventProvider")
+//    void shouldConvertDynamoDbStreamToADataEntryUpdateEventAvoidingHardLimitsOnEventBridgeEventSize(
+//        Publication samplePublication,
+//        DynamodbStreamRecord dynamoRecord) throws IOException {
+//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(dynamoRecord);
+//        handler.handleRequest(event, outputStream, context);
+//        var response = parseResponse();
+//        var blobUri = response.getUri();
+//        var blob = s3Driver.getFile(UriWrapper.fromUri(blobUri).toS3bucketPath());
+//        var eventBody = dtoObjectMapper.readValue(blob, DataEntryUpdateEvent.class);
+//        var expectedIdentifier = extractIdentifierFromPresentImage(eventBody);
+//        assertThat(expectedIdentifier, is(equalTo(samplePublication.getIdentifier())));
+//    }
+//
+//    @ParameterizedTest
+//    @MethodSource("notDaoProvider")
+//    void shouldNotThrowExceptionWhenEntryIsNotDao(Map<String, AttributeValue> notDao) throws IOException {
+//        var blob = sampleDynamoRecord(notDao, notDao);
+//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+//
+//        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
+//        var response = parseResponse();
+//        assertThat(response, is(nullValue()));
+//    }
+//
+//    @Test
+//    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDao() throws IOException {
+//        var blob = sampleDynamoRecord(PublicationGenerator.randomPublication(),
+//                                      PublicationGenerator.randomPublication());
+//        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
+//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+//        handler.handleRequest(event, outputStream, context);
+//
+//        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
+//        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
+//    }
+//
+//    @Test
+//    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDaoAndOldDateIsNull() throws IOException {
+//        var blob = sampleDynamoRecord(null,
+//                                      PublicationGenerator.randomPublication());
+//        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
+//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+//        handler.handleRequest(event, outputStream, context);
+//
+//        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
+//        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
+//    }
+//
+//    private static Map<String, AttributeValue> randomDynamoEntry() {
+//        return Map.of(randomString(), new AttributeValue(randomString()));
+//    }
+//
+//    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Publication oldImage, Publication newImage)
+//        throws JsonProcessingException {
+//        return createDynamoRecord(createPayload(oldImage, newImage));
+//    }
+//
+//    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Map<String, AttributeValue> oldImage,
+//                                                                         Map<String, AttributeValue> newImage) {
+//        return createDynamoRecord(createPayload(oldImage, newImage));
+//    }
+//
+//    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
+//        var streamRecord = new DynamodbStreamRecord();
+//        streamRecord.setEventName(randomElement(OperationType.values()));
+//        streamRecord.setEventID(randomString());
+//        streamRecord.setAwsRegion(AWS_REGION);
+//
+//        streamRecord.setDynamodb(payload);
+//        streamRecord.setEventSource(randomString());
+//        streamRecord.setEventVersion(randomString());
+//        return streamRecord;
+//    }
+//
+//    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
+//        throws JsonProcessingException {
+//        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
+//            convertToAttributeValueMap(toDynamoEntry(newImage)));
+//    }
+//
+//    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
+//                                              Map<String, AttributeValue> newImage) {
+//        var streamRecord = new StreamRecord();
+//        streamRecord.setOldImage(oldImage);
+//        streamRecord.setNewImage(newImage);
+//        return streamRecord;
+//    }
+//
+//    private static DynamoEntry toDynamoEntry(Publication publication) {
+//        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
+//    }
+//
+//    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
+//        throws JsonProcessingException {
+//        return nonNull(payload) ? toAttributeValueMap(payload) : null;
+//    }
+//
+//    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
+//        throws JsonProcessingException {
+//        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
+//        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
+//        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
+//    }
+//
+//    private static JavaType dynamoMapStructureAsJacksonType() {
+//        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
+//    }
+//
+//    private static Map<String, AttributeValue> identifierEntry()
+//        throws JsonProcessingException {
+//        var publication = PublicationGenerator.randomPublication();
+//        var resource = Resource.fromPublication(publication);
+//        var identifierEntry = IdentifierEntry.create(resource.toDao());
+//        return convertToAttributeValueMap(identifierEntry);
+//    }
+//
+//    private SortableIdentifier extractIdentifierFromPresentImage(DataEntryUpdateEvent eventBody) {
+//        return nonNull(eventBody.getNewData())
+//                   ? eventBody.getNewData().getIdentifier()
+//                   : eventBody.getOldData().getIdentifier();
+//    }
+//
+//    private InputStream emulateEventSentByDynamoDbStreamToEventBridgeHandler(DynamodbStreamRecord dynamoRecord)
+//        throws IOException {
+//        var blobUri = saveBlobInS3(dynamoRecord);
+//        var eventBody = new EventReference(DYNAMODB_UPDATE_EVENT_TOPIC, blobUri);
+//        return EventBridgeEventBuilder.sampleEvent(eventBody);
+//    }
+//
+//    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
+//        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
+//        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
+//    }
+//
+//    private EventReference parseResponse() {
+//        return attempt(() -> objectMapper.readValue(outputStream.toString(), EventReference.class))
+//                   .orElseThrow();
+//    }
+//
+//    private static final class FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation extends FakeS3Client {
+//
+//        private int currentInvocation;
+//        private int invocation;
+//
+//        public FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(int invocation) {
+//            this.invocation = invocation;
+//            this.currentInvocation = 1;
+//        }
+//
+//        @Override
+//        public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody) {
+//            if (invocation != currentInvocation) {
+//                currentInvocation++;
+//             return super.putObject(putObjectRequest, requestBody);
+//            } else {
+//                throw new RuntimeException();
+//            }
+//        }
+//    }
+//}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/fanout/DataEntryUpdateHandlerTest.java
@@ -1,255 +1,255 @@
-//package no.unit.nva.publication.events.handlers.fanout;
-//
-//import static java.util.Objects.nonNull;
-//import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
-//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
-//import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.objectMapper;
-//import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
-//import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-//import static nva.commons.core.attempt.Try.attempt;
-//import static org.hamcrest.MatcherAssert.assertThat;
-//import static org.hamcrest.Matchers.equalTo;
-//import static org.hamcrest.Matchers.is;
-//import static org.hamcrest.core.IsNull.notNullValue;
-//import static org.hamcrest.core.IsNull.nullValue;
-//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-//import com.amazonaws.services.lambda.runtime.Context;
-//import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
-//import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
-//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
-//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
-//import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
-//import com.fasterxml.jackson.core.JsonProcessingException;
-//import com.fasterxml.jackson.databind.JavaType;
-//import java.io.ByteArrayOutputStream;
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.io.OutputStream;
-//import java.net.URI;
-//import java.util.Map;
-//import java.util.UUID;
-//import java.util.stream.Stream;
-//import no.unit.nva.events.models.EventReference;
-//import no.unit.nva.identifiers.SortableIdentifier;
-//import no.unit.nva.model.Publication;
-//import no.unit.nva.model.testing.PublicationGenerator;
-//import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
-//import no.unit.nva.publication.model.business.Resource;
-//import no.unit.nva.publication.model.storage.DynamoEntry;
-//import no.unit.nva.publication.model.storage.IdentifierEntry;
-//import no.unit.nva.publication.model.storage.ResourceDao;
-//import no.unit.nva.publication.service.FakeSqsClient;
-//import no.unit.nva.s3.S3Driver;
-//import no.unit.nva.stubs.FakeS3Client;
-//import no.unit.nva.testutils.EventBridgeEventBuilder;
-//import nva.commons.core.paths.UnixPath;
-//import nva.commons.core.paths.UriWrapper;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.params.ParameterizedTest;
-//import org.junit.jupiter.params.provider.Arguments;
-//import org.junit.jupiter.params.provider.MethodSource;
-//import software.amazon.awssdk.core.sync.RequestBody;
-//import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-//import software.amazon.awssdk.services.s3.model.PutObjectResponse;
-//
-//public class DataEntryUpdateHandlerTest {
-//
-//    public static final String DYNAMODB_UPDATE_EVENT_TOPIC = "PublicationService.Database.Update";
-//    private OutputStream outputStream;
-//    private Context context;
-//    private DataEntryUpdateHandler handler;
-//    private S3Driver s3Driver;
-//    private FakeS3Client s3Client;
-//    private FakeSqsClient fakeSqsClient;
-//
-//    public static Stream<Arguments> dynamoDbEventProvider() throws JsonProcessingException {
-//        var samplePublication = PublicationGenerator.randomPublication();
-//        return
-//            Stream.of(Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, null)),
-//                Arguments.of(samplePublication, sampleDynamoRecord(null, samplePublication)),
-//                Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, samplePublication)));
-//    }
-//
-//    public static Stream<Map<String, AttributeValue>> notDaoProvider() throws JsonProcessingException {
-//        return Stream.of(identifierEntry(), randomDynamoEntry());
-//    }
-//
-//    @BeforeEach
-//    public void setUp() {
-//        outputStream = new ByteArrayOutputStream();
-//        context = null;
-//        s3Client = new FakeS3Client();
-//        fakeSqsClient = new FakeSqsClient();
-//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-//    }
-//
-//    //Using event blobs (storing events in S3) helps us avoid AWS EventBridge message size limitations.
-//    @ParameterizedTest(name = "should convert a DynamoDbStream to a DataEntryUpdate event")
-//    @MethodSource("dynamoDbEventProvider")
-//    void shouldConvertDynamoDbStreamToADataEntryUpdateEventAvoidingHardLimitsOnEventBridgeEventSize(
-//        Publication samplePublication,
-//        DynamodbStreamRecord dynamoRecord) throws IOException {
-//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(dynamoRecord);
-//        handler.handleRequest(event, outputStream, context);
-//        var response = parseResponse();
-//        var blobUri = response.getUri();
-//        var blob = s3Driver.getFile(UriWrapper.fromUri(blobUri).toS3bucketPath());
-//        var eventBody = dtoObjectMapper.readValue(blob, DataEntryUpdateEvent.class);
-//        var expectedIdentifier = extractIdentifierFromPresentImage(eventBody);
-//        assertThat(expectedIdentifier, is(equalTo(samplePublication.getIdentifier())));
-//    }
-//
-//    @ParameterizedTest
-//    @MethodSource("notDaoProvider")
-//    void shouldNotThrowExceptionWhenEntryIsNotDao(Map<String, AttributeValue> notDao) throws IOException {
-//        var blob = sampleDynamoRecord(notDao, notDao);
-//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-//
-//        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
-//        var response = parseResponse();
-//        assertThat(response, is(nullValue()));
-//    }
-//
-//    @Test
-//    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDao() throws IOException {
-//        var blob = sampleDynamoRecord(PublicationGenerator.randomPublication(),
-//                                      PublicationGenerator.randomPublication());
-//        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
-//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-//        handler.handleRequest(event, outputStream, context);
-//
-//        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
-//        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
-//    }
-//
-//    @Test
-//    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDaoAndOldDateIsNull() throws IOException {
-//        var blob = sampleDynamoRecord(null,
-//                                      PublicationGenerator.randomPublication());
-//        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
-//        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
-//        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
-//        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
-//        handler.handleRequest(event, outputStream, context);
-//
-//        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
-//        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
-//    }
-//
-//    private static Map<String, AttributeValue> randomDynamoEntry() {
-//        return Map.of(randomString(), new AttributeValue(randomString()));
-//    }
-//
-//    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Publication oldImage, Publication newImage)
-//        throws JsonProcessingException {
-//        return createDynamoRecord(createPayload(oldImage, newImage));
-//    }
-//
-//    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Map<String, AttributeValue> oldImage,
-//                                                                         Map<String, AttributeValue> newImage) {
-//        return createDynamoRecord(createPayload(oldImage, newImage));
-//    }
-//
-//    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
-//        var streamRecord = new DynamodbStreamRecord();
-//        streamRecord.setEventName(randomElement(OperationType.values()));
-//        streamRecord.setEventID(randomString());
-//        streamRecord.setAwsRegion(AWS_REGION);
-//
-//        streamRecord.setDynamodb(payload);
-//        streamRecord.setEventSource(randomString());
-//        streamRecord.setEventVersion(randomString());
-//        return streamRecord;
-//    }
-//
-//    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
-//        throws JsonProcessingException {
-//        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
-//            convertToAttributeValueMap(toDynamoEntry(newImage)));
-//    }
-//
-//    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
-//                                              Map<String, AttributeValue> newImage) {
-//        var streamRecord = new StreamRecord();
-//        streamRecord.setOldImage(oldImage);
-//        streamRecord.setNewImage(newImage);
-//        return streamRecord;
-//    }
-//
-//    private static DynamoEntry toDynamoEntry(Publication publication) {
-//        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
-//    }
-//
-//    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
-//        throws JsonProcessingException {
-//        return nonNull(payload) ? toAttributeValueMap(payload) : null;
-//    }
-//
-//    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
-//        throws JsonProcessingException {
-//        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
-//        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
-//        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
-//    }
-//
-//    private static JavaType dynamoMapStructureAsJacksonType() {
-//        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
-//    }
-//
-//    private static Map<String, AttributeValue> identifierEntry()
-//        throws JsonProcessingException {
-//        var publication = PublicationGenerator.randomPublication();
-//        var resource = Resource.fromPublication(publication);
-//        var identifierEntry = IdentifierEntry.create(resource.toDao());
-//        return convertToAttributeValueMap(identifierEntry);
-//    }
-//
-//    private SortableIdentifier extractIdentifierFromPresentImage(DataEntryUpdateEvent eventBody) {
-//        return nonNull(eventBody.getNewData())
-//                   ? eventBody.getNewData().getIdentifier()
-//                   : eventBody.getOldData().getIdentifier();
-//    }
-//
-//    private InputStream emulateEventSentByDynamoDbStreamToEventBridgeHandler(DynamodbStreamRecord dynamoRecord)
-//        throws IOException {
-//        var blobUri = saveBlobInS3(dynamoRecord);
-//        var eventBody = new EventReference(DYNAMODB_UPDATE_EVENT_TOPIC, blobUri);
-//        return EventBridgeEventBuilder.sampleEvent(eventBody);
-//    }
-//
-//    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
-//        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
-//        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
-//    }
-//
-//    private EventReference parseResponse() {
-//        return attempt(() -> objectMapper.readValue(outputStream.toString(), EventReference.class))
-//                   .orElseThrow();
-//    }
-//
-//    private static final class FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation extends FakeS3Client {
-//
-//        private int currentInvocation;
-//        private int invocation;
-//
-//        public FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(int invocation) {
-//            this.invocation = invocation;
-//            this.currentInvocation = 1;
-//        }
-//
-//        @Override
-//        public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody) {
-//            if (invocation != currentInvocation) {
-//                currentInvocation++;
-//             return super.putObject(putObjectRequest, requestBody);
-//            } else {
-//                throw new RuntimeException();
-//            }
-//        }
-//    }
-//}
+package no.unit.nva.publication.events.handlers.fanout;
+
+import static java.util.Objects.nonNull;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.objectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import no.unit.nva.events.models.EventReference;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.model.testing.PublicationGenerator;
+import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.storage.DynamoEntry;
+import no.unit.nva.publication.model.storage.IdentifierEntry;
+import no.unit.nva.publication.model.storage.ResourceDao;
+import no.unit.nva.publication.service.FakeSqsClient;
+import no.unit.nva.s3.S3Driver;
+import no.unit.nva.stubs.FakeS3Client;
+import no.unit.nva.testutils.EventBridgeEventBuilder;
+import nva.commons.core.paths.UnixPath;
+import nva.commons.core.paths.UriWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+public class DataEntryUpdateHandlerTest {
+
+    public static final String DYNAMODB_UPDATE_EVENT_TOPIC = "PublicationService.Database.Update";
+    private OutputStream outputStream;
+    private Context context;
+    private DataEntryUpdateHandler handler;
+    private S3Driver s3Driver;
+    private FakeS3Client s3Client;
+    private FakeSqsClient fakeSqsClient;
+
+    public static Stream<Arguments> dynamoDbEventProvider() throws JsonProcessingException {
+        var samplePublication = PublicationGenerator.randomPublication();
+        return
+            Stream.of(Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, null)),
+                Arguments.of(samplePublication, sampleDynamoRecord(null, samplePublication)),
+                Arguments.of(samplePublication, sampleDynamoRecord(samplePublication, samplePublication)));
+    }
+
+    public static Stream<Map<String, AttributeValue>> notDaoProvider() throws JsonProcessingException {
+        return Stream.of(identifierEntry(), randomDynamoEntry());
+    }
+
+    @BeforeEach
+    public void setUp() {
+        outputStream = new ByteArrayOutputStream();
+        context = null;
+        s3Client = new FakeS3Client();
+        fakeSqsClient = new FakeSqsClient();
+        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+    }
+
+    //Using event blobs (storing events in S3) helps us avoid AWS EventBridge message size limitations.
+    @ParameterizedTest(name = "should convert a DynamoDbStream to a DataEntryUpdate event")
+    @MethodSource("dynamoDbEventProvider")
+    void shouldConvertDynamoDbStreamToADataEntryUpdateEventAvoidingHardLimitsOnEventBridgeEventSize(
+        Publication samplePublication,
+        DynamodbStreamRecord dynamoRecord) throws IOException {
+        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(dynamoRecord);
+        handler.handleRequest(event, outputStream, context);
+        var response = parseResponse();
+        var blobUri = response.getUri();
+        var blob = s3Driver.getFile(UriWrapper.fromUri(blobUri).toS3bucketPath());
+        var eventBody = dtoObjectMapper.readValue(blob, DataEntryUpdateEvent.class);
+        var expectedIdentifier = extractIdentifierFromPresentImage(eventBody);
+        assertThat(expectedIdentifier, is(equalTo(samplePublication.getIdentifier())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("notDaoProvider")
+    void shouldNotThrowExceptionWhenEntryIsNotDao(Map<String, AttributeValue> notDao) throws IOException {
+        var blob = sampleDynamoRecord(notDao, notDao);
+        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+
+        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
+        var response = parseResponse();
+        assertThat(response, is(nullValue()));
+    }
+
+    @Test
+    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDao() throws IOException {
+        var blob = sampleDynamoRecord(PublicationGenerator.randomPublication(),
+                                      PublicationGenerator.randomPublication());
+        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
+        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+        handler.handleRequest(event, outputStream, context);
+
+        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
+        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
+    }
+
+    @Test
+    void shouldDeliverMessageToRecoveryQueueWhenErrorOccursAndEntryIsDaoAndOldDateIsNull() throws IOException {
+        var blob = sampleDynamoRecord(null,
+                                      PublicationGenerator.randomPublication());
+        s3Client = new FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(2);
+        s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
+        var event = emulateEventSentByDynamoDbStreamToEventBridgeHandler(blob);
+        handler = new DataEntryUpdateHandler(s3Client, fakeSqsClient);
+        handler.handleRequest(event, outputStream, context);
+
+        var deliveredMessage = fakeSqsClient.getDeliveredMessages().getFirst();
+        assertThat(deliveredMessage.messageAttributes().get("id"), is(notNullValue()));
+    }
+
+    private static Map<String, AttributeValue> randomDynamoEntry() {
+        return Map.of(randomString(), new AttributeValue(randomString()));
+    }
+
+    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Publication oldImage, Publication newImage)
+        throws JsonProcessingException {
+        return createDynamoRecord(createPayload(oldImage, newImage));
+    }
+
+    private static DynamodbEvent.DynamodbStreamRecord sampleDynamoRecord(Map<String, AttributeValue> oldImage,
+                                                                         Map<String, AttributeValue> newImage) {
+        return createDynamoRecord(createPayload(oldImage, newImage));
+    }
+
+    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
+        var streamRecord = new DynamodbStreamRecord();
+        streamRecord.setEventName(randomElement(OperationType.values()));
+        streamRecord.setEventID(randomString());
+        streamRecord.setAwsRegion(AWS_REGION);
+
+        streamRecord.setDynamodb(payload);
+        streamRecord.setEventSource(randomString());
+        streamRecord.setEventVersion(randomString());
+        return streamRecord;
+    }
+
+    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
+        throws JsonProcessingException {
+        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
+            convertToAttributeValueMap(toDynamoEntry(newImage)));
+    }
+
+    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
+                                              Map<String, AttributeValue> newImage) {
+        var streamRecord = new StreamRecord();
+        streamRecord.setOldImage(oldImage);
+        streamRecord.setNewImage(newImage);
+        return streamRecord;
+    }
+
+    private static DynamoEntry toDynamoEntry(Publication publication) {
+        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
+    }
+
+    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
+        throws JsonProcessingException {
+        return nonNull(payload) ? toAttributeValueMap(payload) : null;
+    }
+
+    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
+        throws JsonProcessingException {
+        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
+        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
+        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
+    }
+
+    private static JavaType dynamoMapStructureAsJacksonType() {
+        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
+    }
+
+    private static Map<String, AttributeValue> identifierEntry()
+        throws JsonProcessingException {
+        var publication = PublicationGenerator.randomPublication();
+        var resource = Resource.fromPublication(publication);
+        var identifierEntry = IdentifierEntry.create(resource.toDao());
+        return convertToAttributeValueMap(identifierEntry);
+    }
+
+    private SortableIdentifier extractIdentifierFromPresentImage(DataEntryUpdateEvent eventBody) {
+        return nonNull(eventBody.getNewData())
+                   ? eventBody.getNewData().getIdentifier()
+                   : eventBody.getOldData().getIdentifier();
+    }
+
+    private InputStream emulateEventSentByDynamoDbStreamToEventBridgeHandler(DynamodbStreamRecord dynamoRecord)
+        throws IOException {
+        var blobUri = saveBlobInS3(dynamoRecord);
+        var eventBody = new EventReference(DYNAMODB_UPDATE_EVENT_TOPIC, blobUri);
+        return EventBridgeEventBuilder.sampleEvent(eventBody);
+    }
+
+    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
+        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
+        return s3Driver.insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
+    }
+
+    private EventReference parseResponse() {
+        return attempt(() -> objectMapper.readValue(outputStream.toString(), EventReference.class))
+                   .orElseThrow();
+    }
+
+    private static final class FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation extends FakeS3Client {
+
+        private int currentInvocation;
+        private int invocation;
+
+        public FakeS3ClientThrowingExceptionOnPutObjectOnProvidedInvocation(int invocation) {
+            this.invocation = invocation;
+            this.currentInvocation = 1;
+        }
+
+        @Override
+        public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody) {
+            if (invocation != currentInvocation) {
+                currentInvocation++;
+             return super.putObject(putObjectRequest, requestBody);
+            } else {
+                throw new RuntimeException();
+            }
+        }
+    }
+}

--- a/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
@@ -27,13 +27,13 @@ public class FakeSqsClient implements QueueClient {
     }
 
     @Override
-    public List<Message> readMessages(String queue) {
+    public List<Message> readMessages() {
         int toIndex = Math.min(deliveredMessages.size(), 10);
         return new ArrayList<>(deliveredMessages.subList(0, toIndex));
     }
 
     @Override
-    public void deleteMessages(String queue, List<Message> messages) {
+    public void deleteMessages(List<Message> messages) {
         var messagesToRemove = messages.stream()
                                              .map(this::findMatchingMessageInDeliveredMessages)
                                              .filter(Optional::isPresent)

--- a/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
@@ -1,20 +1,49 @@
 package no.unit.nva.publication.service;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import no.unit.nva.publication.queue.QueueClient;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 public class FakeSqsClient implements QueueClient {
 
-    private final List<SendMessageRequest> deliveredMessages = new ArrayList<>();
+    private final List<Message> deliveredMessages = new ArrayList<>();
 
-    public List<SendMessageRequest> getDeliveredMessages() {
+    public List<Message> getDeliveredMessages() {
         return deliveredMessages;
     }
 
     @Override
     public void sendMessage(SendMessageRequest sendMessageRequest) {
-        deliveredMessages.add(sendMessageRequest);
+        var message = Message.builder()
+                          .messageAttributes(sendMessageRequest.messageAttributes())
+                          .body(sendMessageRequest.messageBody())
+                          .messageId(randomString())
+                          .build();
+        deliveredMessages.add(message);
+    }
+
+    @Override
+    public List<Message> readMessages(String queue) {
+        int toIndex = Math.min(deliveredMessages.size(), 10);
+        return new ArrayList<>(deliveredMessages.subList(0, toIndex));
+    }
+
+    @Override
+    public void deleteMessages(String queue, List<Message> messages) {
+        var messagesToRemove = messages.stream()
+                                             .map(this::findMatchingMessageInDeliveredMessages)
+                                             .filter(Optional::isPresent)
+                                             .map(Optional::get)
+                                             .toList();
+
+        deliveredMessages.removeAll(messagesToRemove);
+    }
+
+    private Optional<Message> findMatchingMessageInDeliveredMessages(Message message) {
+        return deliveredMessages.stream().filter(item -> item.messageId().equals(message.messageId())).findFirst();
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -331,6 +331,8 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600 #14 days
+  RecoveryBatchScanHandlerDLQ:
+    Type: "AWS::SQS::Queue"
 
 
 
@@ -1399,6 +1401,38 @@ Resources:
           OnFailure:
             Type: SQS
             Destination: !GetAtt ResourceExpansionHandlerDLQ.Arn
+
+  RecoveryBatchScanHandler:
+    DependsOn: EventsLambdaManagedPolicy
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: publication-event-handlers
+      Handler: no.unit.nva.publication.events.handlers.recovery.RecoveryBatchScanHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      Timeout: 900
+      ReservedConcurrentExecutions: 1
+      Environment:
+        Variables:
+          EVENT_BUS_NAME: !GetAtt InternalBus.Name
+          EVENTS_BUCKET: !Ref NvaEventsBucketsName
+          TABLE_NAME: !Ref NvaResourcesTable
+      Events:
+        EventBridgeEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: !GetAtt InternalBus.Name
+            Pattern:
+              detail:
+                topic: [ "PublicationService.Recovery.Refresh" ]
+
+      EventInvokeConfig:
+        DestinationConfig:
+          OnSuccess:
+            Type: EventBridge
+            Destination: !GetAtt InternalBus.Arn
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt RecoveryBatchScanHandlerDLQ.Arn
 
   EventBasedImportCandidateBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -1416,6 +1416,7 @@ Resources:
           EVENT_BUS_NAME: !GetAtt InternalBus.Name
           EVENTS_BUCKET: !Ref NvaEventsBucketsName
           TABLE_NAME: !Ref NvaResourcesTable
+          RECOVERY_QUEUE: !Ref RecoveryQueue
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule
@@ -1427,9 +1428,6 @@ Resources:
 
       EventInvokeConfig:
         DestinationConfig:
-          OnSuccess:
-            Type: EventBridge
-            Destination: !GetAtt InternalBus.Arn
           OnFailure:
             Type: SQS
             Destination: !GetAtt RecoveryBatchScanHandlerDLQ.Arn


### PR DESCRIPTION
Sorry for large pr.

Reading messages from recovery queue and refreshing resources.
- For now refreshing only publications, will implement for other entity types later (have to find out how to query tickets and messages by using only identifiers, or extend RecoveryEntry)

- When resource is deleted and refreshing returns NotFoundException -> skipping resource and removing message from queue. 

- Have to find a strategy for how to handle other exception types. 