### PR TITLE
NP-46416 Add identifier to expanded organization

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -108,7 +108,11 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
                                              .map(UriWrapper::getLastPathElement)
                                              .orElse(null);
 
-            var partOf = RdfUtils.getAllNestedPartOfs(uriRetriever, organizationId);
+            var partOf = RdfUtils.getAllNestedPartOfs(uriRetriever, organizationId)
+                             .stream()
+                             .map(uri -> new ExpandedOrganization(uri, UriWrapper.fromUri(uri).getLastPathElement(), null))
+                             .toList();
+
             return new ExpandedOrganization(organizationId, organizationIdentifier, partOf);
         }
         return null;

--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -102,8 +102,12 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
                                       : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                           .getResourceOwner().getOwnerAffiliation();
 
+            var organizationIdentifier = Objects.nonNull(organizationId)
+                                             ? UriWrapper.fromUri(organizationId).getLastPathElement()
+                                             : "";
+
             var partOf = RdfUtils.getAllNestedPartOfs(uriRetriever, organizationId);
-            return new ExpandedOrganization(organizationId, partOf);
+            return new ExpandedOrganization(organizationId, organizationIdentifier, partOf);
         }
         return null;
     }

--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 import no.unit.nva.expansion.model.ExpandedDataEntry;
 import no.unit.nva.expansion.model.ExpandedMessage;
 import no.unit.nva.expansion.model.ExpandedOrganization;
@@ -102,9 +103,10 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
                                       : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                           .getResourceOwner().getOwnerAffiliation();
 
-            var organizationIdentifier = Objects.nonNull(organizationId)
-                                             ? UriWrapper.fromUri(organizationId).getLastPathElement()
-                                             : "";
+            var organizationIdentifier = Optional.ofNullable(organizationId)
+                                             .map(UriWrapper::fromUri)
+                                             .map(UriWrapper::getLastPathElement)
+                                             .orElse(null);
 
             var partOf = RdfUtils.getAllNestedPartOfs(uriRetriever, organizationId);
             return new ExpandedOrganization(organizationId, organizationIdentifier, partOf);

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedOrganization.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedOrganization.java
@@ -8,7 +8,7 @@ import java.util.List;
 @JsonTypeName(ExpandedOrganization.TYPE)
 public record ExpandedOrganization(@JsonProperty(ID_FIELD) URI id,
                                    @JsonProperty(IDENTIFIER_FIELD) String identifier,
-                                   @JsonProperty(PART_OF_FIELD) List<URI> partOf) {
+                                   @JsonProperty(PART_OF_FIELD) List<ExpandedOrganization> partOf) {
 
     public static final String TYPE = "Organization";
     public static final String ID_FIELD = "id";

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedOrganization.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedOrganization.java
@@ -7,9 +7,11 @@ import java.util.List;
 
 @JsonTypeName(ExpandedOrganization.TYPE)
 public record ExpandedOrganization(@JsonProperty(ID_FIELD) URI id,
+                                   @JsonProperty(IDENTIFIER_FIELD) String identifier,
                                    @JsonProperty(PART_OF_FIELD) List<URI> partOf) {
 
     public static final String TYPE = "Organization";
     public static final String ID_FIELD = "id";
+    public static final String IDENTIFIER_FIELD = "identifier";
     public static final String PART_OF_FIELD = "partOf";
 }

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -321,6 +321,21 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         assertThat(partOf, is(equalTo(expectedPartOf)));
     }
 
+    @ParameterizedTest
+    @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
+    void shouldGetOrganizationIdentifierForAffiliations(Class<? extends TicketEntry> ticketType,
+                                                     PublicationStatus status)
+        throws ApiGatewayException {
+        var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
+        var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+
+        var publicationOwnerId = publication.getResourceOwner().getOwnerAffiliation();
+        var expectedIdentifier = UriWrapper.fromUri(publicationOwnerId).getLastPathElement();
+        var actualIdentifier = expansionService.getOrganization(ticket).identifier();
+
+        assertThat(actualIdentifier, is(equalTo(expectedIdentifier)));
+    }
+
     @Test
     void shouldReturnNullIfNotTicketEntry() throws NotFoundException {
         var message = Message.builder()

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -47,6 +47,7 @@ import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.expansion.model.ExpandedDoiRequest;
 import no.unit.nva.expansion.model.ExpandedGeneralSupportRequest;
 import no.unit.nva.expansion.model.ExpandedMessage;
+import no.unit.nva.expansion.model.ExpandedOrganization;
 import no.unit.nva.expansion.model.ExpandedPerson;
 import no.unit.nva.expansion.model.ExpandedPublishingRequest;
 import no.unit.nva.expansion.model.ExpandedResource;
@@ -60,6 +61,7 @@ import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Corporation;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
+import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Username;
@@ -314,7 +316,10 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
 
         var expectedPartOf = List.of(
-            URI.create("https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0")
+            new ExpandedOrganization(
+                URI.create("https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"),
+                "20754.0.0.0",
+                null)
         );
         var partOf = expansionService.getOrganization(ticket).partOf();
 

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -329,8 +329,8 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
 
-        var publicationOwnerId = publication.getResourceOwner().getOwnerAffiliation();
-        var expectedIdentifier = UriWrapper.fromUri(publicationOwnerId).getLastPathElement();
+        var publicationOwnerAffiliationId = publication.getResourceOwner().getOwnerAffiliation();
+        var expectedIdentifier = UriWrapper.fromUri(publicationOwnerAffiliationId).getLastPathElement();
         var actualIdentifier = expansionService.getOrganization(ticket).identifier();
 
         assertThat(actualIdentifier, is(equalTo(expectedIdentifier)));


### PR DESCRIPTION
Add identifier to the expanded organization so that search-api can implement parameters for organization identifiers as well as id's. (For use in viewingScope-parameter)