### PR TITLE
fixing doi expansion

### DIFF
--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -209,6 +209,7 @@
   },
   "@type": "Publication",
   "entityDescription": {
+    "@type": "EntityDescription",
     "contributors": {
       "@default": "@null",
       "identity": {
@@ -232,6 +233,13 @@
           "@embed": "@always",
           "@default": "@null"
         }
+      }
+    },
+    "reference":  {
+      "@type": "Reference",
+      "doi": {
+        "@embed": "@never",
+        "@default": "@null"
       }
     },
     "metadataSource": {


### PR DESCRIPTION
This fixes following OpenSearch error:
```

{
    "error": {
        "root_cause": [
            {
                "type": "mapper_parsing_exception",
                "reason": "failed to parse field [entityDescription.reference.doi] of type [text] in document with id '018dc18c52d8-aec0f858-a6fc-4fed-8a6a-71d3d687b528'. Preview of field's value: '{id=https://doi.org/10.1093/nutrit/nuad055, type=AssociatedLink}'"
            }
        ],
        "type": "mapper_parsing_exception",
        "reason": "failed to parse field [entityDescription.reference.doi] of type [text] in document with id '018dc18c52d8-aec0f858-a6fc-4fed-8a6a-71d3d687b528'. Preview of field's value: '{id=https://doi.org/10.1093/nutrit/nuad055, type=AssociatedLink}'",
        "caused_by": {
            "type": "illegal_state_exception",
            "reason": "Can't get text on a START_OBJECT at 155:15"
        }
    },
    "status": 400
}
```