### PR TITLE
Np 46542 update publisher when merging files brage migration

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -258,9 +258,18 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     }
 
     private BrageMergingReport persistInDatabaseAndCreateMergeReport(Publication publicationForUpdate,
-                                                                     Publication existinPublication) {
-        var newImage = resourceService.updatePublication(publicationForUpdate);
-        return new BrageMergingReport(existinPublication, newImage);
+                                                                     Publication existingPublication) {
+        if (resouseOwnerIsNotOverriden(publicationForUpdate, existingPublication)) {
+            var newImage = resourceService.updatePublication(publicationForUpdate);
+            return new BrageMergingReport(existingPublication, newImage);
+        } else {
+            var newImage = resourceService.recreateWith(publicationForUpdate);
+            return new BrageMergingReport(existingPublication, newImage);
+        }
+    }
+
+    private static boolean resouseOwnerIsNotOverriden(Publication publicationForUpdate, Publication existingPublication) {
+        return existingPublication.getResourceOwner().equals(publicationForUpdate.getResourceOwner());
     }
 
     private Publication updatedPublication(Publication publication, Publication existingPublication)

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -39,6 +39,7 @@ import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.PublicationDate.Builder;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
@@ -92,6 +93,7 @@ public final class BrageNvaMapper {
                               .withAdditionalIdentifiers(extractCristinIdentifier(brageRecord))
                               .withRightsHolder(brageRecord.getRightsholder())
                               .withSubjects(extractSubjects(brageRecord))
+                              .withStatus(PublicationStatus.PUBLISHED)
                               .build();
         if (!isCristinRecord(brageRecord)) {
             assertPublicationDoesNotHaveEmptyFields(publication);

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -143,11 +143,26 @@ public class CristinImportPublicationMerger {
                    : Optional.of(bragePublication.getHandle());
     }
 
-    private Publication fillNewPublicationWithMetadataFromBrage(Publication publicationForUpdating) {
-        publicationForUpdating.getEntityDescription().setDescription(getCorrectDescription());
-        publicationForUpdating.getEntityDescription().setAbstract(getCorrectAbstract());
-        publicationForUpdating.setAssociatedArtifacts(determineAssociatedArtifacts());
-        return publicationForUpdating;
+    private Publication fillNewPublicationWithMetadataFromBrage(Publication publication) {
+        var associatedArtifacts = determineAssociatedArtifacts();
+        publication.getEntityDescription().setDescription(getCorrectDescription());
+        publication.getEntityDescription().setAbstract(getCorrectAbstract());
+
+        if (hasBeenUpdated(associatedArtifacts, publication)) {
+            updatePublicationResourceOwnerAndPublisher(publication);
+        }
+
+        publication.setAssociatedArtifacts(associatedArtifacts);
+        return publication;
+    }
+
+    private void updatePublicationResourceOwnerAndPublisher(Publication publication) {
+        publication.setResourceOwner(bragePublication.getResourceOwner());
+//        publication.setPublisher(bragePublication.getPublisher());
+    }
+
+    private boolean hasBeenUpdated(AssociatedArtifactList associatedArtifacts, Publication publication) {
+        return !associatedArtifacts.equals(publication.getAssociatedArtifacts());
     }
 
     private AssociatedArtifactList determineAssociatedArtifacts() {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -158,7 +158,7 @@ public class CristinImportPublicationMerger {
 
     private void updatePublicationResourceOwnerAndPublisher(Publication publication) {
         publication.setResourceOwner(bragePublication.getResourceOwner());
-//        publication.setPublisher(bragePublication.getPublisher());
+        publication.setPublisher(bragePublication.getPublisher());
     }
 
     private boolean hasBeenUpdated(AssociatedArtifactList associatedArtifacts, Publication publication) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -77,6 +77,7 @@ import no.sikt.nva.brage.migration.merger.BrageMergingReport;
 import no.sikt.nva.brage.migration.merger.DiscardedFilesReport;
 import no.sikt.nva.brage.migration.merger.DuplicatePublicationException;
 import no.sikt.nva.brage.migration.merger.UnmappableCristinRecordException;
+import no.sikt.nva.brage.migration.record.Customer;
 import no.sikt.nva.brage.migration.record.EntityDescription;
 import no.sikt.nva.brage.migration.record.PublicationDate;
 import no.sikt.nva.brage.migration.record.PublicationDateNva;
@@ -1235,13 +1236,15 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
                                  .withResourceContent(createResourceContent())
                                  .withAssociatedArtifacts(createCorrespondingAssociatedArtifactWithLegalNote(null))
                                  .build();
-        var expectedPublication = brageGenerator.getNvaPublication();
         var s3Event = createNewBrageRecordEvent(brageGenerator.getBrageRecord());
         var actualPublication = handler.handleRequest(s3Event, CONTEXT);
         var expectedResourceOwner = new no.unit.nva.model.ResourceOwner(new Username(newResourceOwner.getOwner()),
                                                                         newResourceOwner.getOwnerAffiliation());
+        var expectedPublisher =
+            new Organization.Builder().withId(brageGenerator.getBrageRecord().getCustomer().getId()).build();
 
         assertThat(actualPublication.getResourceOwner(), is(equalTo(expectedResourceOwner)));
+        assertThat(actualPublication.getPublisher(), is(equalTo(expectedPublisher)));
     }
 
     @Test
@@ -1411,6 +1414,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
         minimalRecord.setCristinId(cristinIdentifier);
         minimalRecord.setEntityDescription(new EntityDescription());
         minimalRecord.setType(new Type(List.of(), CRISTIN_RECORD.getValue()));
+        minimalRecord.setCustomer(new Customer(randomString(), randomUri()));
         return minimalRecord;
     }
 

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
@@ -205,7 +205,7 @@ public class NvaBrageMigrationDataGenerator {
 
     public static class Builder {
 
-        public static final URI CUSTOMER_URi = URI.create(
+        public static final URI CUSTOMER_URI = URI.create(
             "https://dev.nva.sikt.no/registration/0184ebf2c2ad" + "-0b4cd833-2f8c-4bd6-b11b-7b9cb15e9c05/edit");
         public static final URI RESOURCE_OWNER_URI = URI.create("https://api.nva.unit.no/customer/test");
         public ResourceOwner resourceOwner;
@@ -631,7 +631,7 @@ public class NvaBrageMigrationDataGenerator {
                 abstracts = List.of(randomString());
             }
             if (isNull(customer)) {
-                customer = new Customer("institution", CUSTOMER_URi);
+                customer = new Customer("institution", CUSTOMER_URI);
             }
             if (isNull(resourceOwner)) {
                 resourceOwner = new ResourceOwner("institution@someOwner", RESOURCE_OWNER_URI);

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
@@ -1,6 +1,5 @@
 package no.unit.nva.expansion.model;
 
-import static java.util.Objects.nonNull;
 import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
 import static no.unit.nva.expansion.utils.PublicationJsonPointers.AFFILIATIONS_POINTER;
 import static no.unit.nva.expansion.utils.PublicationJsonPointers.CONTEXT_TYPE_JSON_PTR;
@@ -38,7 +37,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.external.services.RawContentRetriever;
 import nva.commons.core.JacocoGenerated;
@@ -58,7 +56,6 @@ public final class ExpandedResource implements JsonSerializable, ExpandedDataEnt
     private static final String INSTANCE_TYPE_ACADEMIC_CHAPTER = "AcademicChapter";
     public static final JsonPointer CONTRIBUTORS_PTR = JsonPointer.compile("/entityDescription/contributors");
     public static final String CONTRIBUTOR_SEQUENCE = "sequence";
-    public static final int MAX_CONTRIBUTOR_SIZE = 100;
     @JsonAnySetter
     private final Map<String, Object> allFields;
 
@@ -68,30 +65,10 @@ public final class ExpandedResource implements JsonSerializable, ExpandedDataEnt
 
     public static ExpandedResource fromPublication(RawContentRetriever uriRetriever, Publication publication)
         throws JsonProcessingException {
-        var updatedPublication = reduceContributorsIfNeeded(publication);
         var documentWithId = transformToJsonLd(publication);
         var enrichedJson = enrichJson(uriRetriever, documentWithId);
         var sortedJson = addFields(enrichedJson, publication);
         return attempt(() -> objectMapper.treeToValue(sortedJson, ExpandedResource.class)).orElseThrow();
-    }
-
-    private static Publication reduceContributorsIfNeeded(Publication publication) {
-        var sortedAndLimitedContributors = reduceNumberOfContributorsIfNeeded(publication);
-        var entityDescription = publication.getEntityDescription().copy().withContributors(sortedAndLimitedContributors).build();
-        return publication.copy().withEntityDescription(entityDescription).build();
-    }
-
-    private static List<Contributor> reduceNumberOfContributorsIfNeeded(Publication publication) {
-        return publication.getEntityDescription().getContributors().stream()
-                   .filter(contributor -> nonNull(contributor.getIdentity()))
-                   .sorted(prioritizeContributorsWithId())
-                   .limit(MAX_CONTRIBUTOR_SIZE)
-                   .toList();
-    }
-
-    private static Comparator<Contributor> prioritizeContributorsWithId() {
-        return Comparator.comparing(contributor -> contributor.getIdentity().getId(),
-                                    Comparator.nullsLast(Comparator.naturalOrder()));
     }
 
     private static JsonNode addFields(String json, Publication publication) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -33,6 +33,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.publication.model.DeletePublicationStatusResponse;
 import no.unit.nva.publication.model.ListingResult;
 import no.unit.nva.publication.model.PublishPublicationStatusResponse;
@@ -353,8 +354,21 @@ public class ResourceService extends ServiceWithTransactions {
         updateResourceService.deletePublication(publication);
     }
 
-    public Publication updateCristinPublicationAndOwner(Publication publication) {
-        return updateResourceService.updatePublicationAndOwner(publication);
+    public void permanentlyRemovePublication(Publication publication) {
+        updateResourceService.permanentlyRemove(publication);
+    }
+
+    public void createEmptyPublicationForCustomer(ResourceOwner resourceOwner, Organization publisher,
+                                                  SortableIdentifier identifier) {
+        var publication = new Publication.Builder()
+                              .withResourceOwner(resourceOwner)
+                              .withPublisher(publisher)
+                              .withIdentifier(identifier)
+                              .withStatus(PUBLISHED)
+                              .build();
+        var newResource = Resource.fromPublication(publication);
+        newResource.setCreatedDate(publication.getCreatedDate());
+        insertResource(newResource);
     }
 
     private static boolean isNotRemoved(TicketEntry ticket) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -353,6 +353,10 @@ public class ResourceService extends ServiceWithTransactions {
         updateResourceService.deletePublication(publication);
     }
 
+    public Publication updateCristinPublicationAndOwner(Publication publication) {
+        return updateResourceService.updatePublicationAndOwner(publication);
+    }
+
     private static boolean isNotRemoved(TicketEntry ticket) {
         return !TicketStatus.REMOVED.equals(ticket.getStatus());
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1082,6 +1082,26 @@ class ResourceServiceTest extends ResourcesLocalTest {
                      () -> resourceService.deletePublication(resourceService.getPublication(publication)));
     }
 
+    @Test
+    void shouldPermanentlyDeletePublication() throws ApiGatewayException {
+        var publication = createPersistedPublicationWithDoi();
+        resourceService.permanentlyRemovePublication(publication);
+
+        assertThrows(NotFoundException.class,
+                     () -> resourceService.getPublication(publication));
+    }
+
+    @Test
+    void shouldCreateEmptyPublicationForCustomer() throws ApiGatewayException {
+        var publisher = new Organization.Builder().withId(randomUri()).build();
+        var resourceOwner = new ResourceOwner(new Username(randomString()), randomUri());
+        var identifier = SortableIdentifier.next();
+        resourceService.createEmptyPublicationForCustomer(resourceOwner, publisher, identifier);
+        var persistedPublication = resourceService.getPublicationByIdentifier(identifier);
+
+        assertThat(persistedPublication, is(not(nullValue())));
+    }
+
     private static AssociatedArtifactList createEmptyArtifactList() {
         return new AssociatedArtifactList(emptyList());
     }


### PR DESCRIPTION
When importing publication from Brage and updating files for existing publication we do following:

- Updating publisher to publisher from Brage publication (customer)
- Updating resourceOwner to resourceOwner from Brage publication
  
   On persistence:
   - Removing existing publication from database
   - Persisting empty publication with publisher and resourceOwner from Brage publication
   - Update empty publication to "updated" existing publication