### PR TITLE
persisting report for WrongChannelType exception

### DIFF
--- a/cristin-import/build.gradle
+++ b/cristin-import/build.gradle
@@ -82,6 +82,7 @@ test {
     environment "CRISTIN_IMPORT_PATCH_QUEUE_URL", "https://sqs.eu-west-1.amazonaws.com/someAccount/someQueue"
     environment "TABLE_NAME", "sometable"
     environment "AWS_REGION", "eu-west-1"
+    environment "CRISTIN_IMPORT_BUCKET", "cristinBucket"
 }
 
 configurations {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -202,7 +202,7 @@ public class CristinEntryEventConsumer
     private PublicationRepresentations generatePublicationRepresentations(
         CristinObject cristinObject,
         FileContentsEvent<JsonNode> eventBody) {
-        var publication = new CristinMapper(cristinObject, cristinUnitsUtil).generatePublication();
+        var publication = new CristinMapper(cristinObject, cristinUnitsUtil, s3Client).generatePublication();
         return new PublicationRepresentations(cristinObject, publication, eventBody);
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
@@ -1,0 +1,83 @@
+package no.unit.nva.cristin.lambda;
+
+import static nva.commons.core.attempt.Try.attempt;
+import no.unit.nva.s3.S3Driver;
+import nva.commons.core.Environment;
+import nva.commons.core.paths.UnixPath;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public final class ErrorReport {
+
+    public static final String CRISTIN_IMPORT_BUCKET = new Environment().readEnv("CRISTIN_IMPORT_BUCKET");
+    public static final String ERROR_REPORT = "ERROR_REPORT";
+    private String exceptionName;
+    private String body;
+    private String cristinId;
+
+
+
+    public static ErrorReport exceptionName(String exceptionName) {
+        return builder().withException(exceptionName).build();
+    }
+
+    public ErrorReport withCristinId(Integer cristinId) {
+        return copy().withCristinId(cristinId.toString()).build();
+    }
+
+    public ErrorReport withBody(String body) {
+        return copy().withBody(body).build();
+    }
+
+    public void persist(S3Client s3Client) {
+        var driver = new S3Driver(s3Client, CRISTIN_IMPORT_BUCKET);
+        var location = createLocation();
+        attempt(() -> driver.insertFile(location, body)).orElseThrow();
+    }
+
+    private UnixPath createLocation() {
+        return UnixPath.fromString(ERROR_REPORT)
+                   .addChild(exceptionName)
+                   .addChild(cristinId);
+    }
+
+    private static Builder builder() {
+        return new Builder();
+    }
+
+    private Builder copy() {
+        return builder().withBody(this.body).withException(this.exceptionName);
+    }
+
+    public static final class Builder {
+
+        private String exceptionName;
+        private String body;
+        private String cristinId;
+
+        private Builder() {
+        }
+
+        public Builder withException(String exception) {
+            this.exceptionName = exception;
+            return this;
+        }
+
+        public Builder withCristinId(String cristinId) {
+            this.cristinId = cristinId;
+            return this;
+        }
+
+        public Builder withBody(String body) {
+            this.body = body;
+            return this;
+        }
+
+        public ErrorReport build() {
+            ErrorReport errorReport = new ErrorReport();
+            errorReport.exceptionName = this.exceptionName;
+            errorReport.body = this.body;
+            errorReport.cristinId = this.cristinId;
+            return errorReport;
+        }
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -59,6 +59,7 @@ import nva.commons.core.StringUtils;
 import nva.commons.core.attempt.Try;
 import nva.commons.core.language.LanguageMapper;
 import nva.commons.core.paths.UriWrapper;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @SuppressWarnings({"PMD.GodClass",
     "PMD.CouplingBetweenObjects",
@@ -85,10 +86,12 @@ public class CristinMapper extends CristinMappingModule {
                                                                    "api.nva.unit.no",
                                                                    "22139870-8d31-4df9-bc45-14eb68287c4a");
     private final CristinUnitsUtil cristinUnitsUtil;
+    private final S3Client s3Client;
 
-    public CristinMapper(CristinObject cristinObject, CristinUnitsUtil cristinUnitsUtil) {
-        super(cristinObject, ChannelRegistryMapper.getInstance());
+    public CristinMapper(CristinObject cristinObject, CristinUnitsUtil cristinUnitsUtil, S3Client s3Client) {
+        super(cristinObject, ChannelRegistryMapper.getInstance(), s3Client);
         this.cristinUnitsUtil = cristinUnitsUtil;
+        this.s3Client = s3Client;
     }
 
     public static ZoneOffset zoneOffset() {
@@ -335,7 +338,7 @@ public class CristinMapper extends CristinMappingModule {
                    .withLanguage(extractLanguage())
                    .withMainTitle(extractMainTitle())
                    .withPublicationDate(extractPublicationDate())
-                   .withReference(new ReferenceBuilder(cristinObject, channelRegistryMapper).buildReference())
+                   .withReference(new ReferenceBuilder(cristinObject, channelRegistryMapper, s3Client).buildReference())
                    .withContributors(extractContributors())
                    .withNpiSubjectHeading(extractNpiSubjectHeading())
                    .withAbstract(extractAbstract())

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/MediaPeriodicalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/MediaPeriodicalBuilder.java
@@ -9,11 +9,13 @@ import no.unit.nva.model.contexttypes.MediaContributionPeriodical;
 import no.unit.nva.model.contexttypes.Periodical;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.UnconfirmedMediaContributionPeriodical;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class MediaPeriodicalBuilder extends CristinMappingModule {
 
-    public MediaPeriodicalBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public MediaPeriodicalBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper,
+                                  S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     public PublicationContext buildMediaPeriodicalForPublicationContext() {
@@ -28,7 +30,8 @@ public class MediaPeriodicalBuilder extends CristinMappingModule {
     private Periodical createMediaContributionPeriodical() {
         Integer nsdCode = cristinObject.getJournalPublication().getJournal().getNsdCode();
         int publicationYear = extractYearReportedInNvi();
-        var journalUri = new Nsd(nsdCode, publicationYear, channelRegistryMapper).createJournal();
+        var journalUri =
+            new Nsd(nsdCode, publicationYear, channelRegistryMapper, s3Client, cristinObject.getId()).createJournal();
         return new MediaContributionPeriodical(journalUri);
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/Nsd.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/Nsd.java
@@ -5,23 +5,29 @@ import static no.unit.nva.cristin.lambda.constants.MappingConstants.NSD_PROXY_PA
 import static no.unit.nva.cristin.lambda.constants.MappingConstants.NVA_API_DOMAIN;
 import java.net.URI;
 import java.util.Optional;
+import no.unit.nva.cristin.lambda.ErrorReport;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryEntry;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryEntry.ChannelType;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.cristin.mapper.nva.exceptions.ChannelRegistryException;
 import no.unit.nva.cristin.mapper.nva.exceptions.WrongChannelTypeException;
 import nva.commons.core.paths.UriWrapper;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class Nsd {
 
     private final int nsdCode;
     private final int year;
     private final ChannelRegistryMapper channelRegistryMapper;
+    private final S3Client s3Client;
+    private final Integer cristinId;
 
-    public Nsd(int nsdCode, int year, ChannelRegistryMapper channelRegistryMapper) {
+    public Nsd(int nsdCode, int year, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client, Integer cristinId) {
         this.nsdCode = nsdCode;
         this.year = year;
         this.channelRegistryMapper = channelRegistryMapper;
+        this.s3Client = s3Client;
+        this.cristinId = cristinId;
     }
 
     public URI getPublisherUri() {
@@ -44,11 +50,14 @@ public class Nsd {
     }
 
     private URI toSeriesUri(ChannelRegistryEntry channelRegistryEntry) {
-        if (ChannelType.SERIES.equals(channelRegistryEntry.type())) {
-            return getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
-        } else {
-            throw new WrongChannelTypeException(channelRegistryEntry);
+        var uri = getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
+        if (!ChannelType.SERIES.equals(channelRegistryEntry.type())) {
+            ErrorReport.exceptionName(WrongChannelTypeException.class.getSimpleName())
+                .withBody(uri.toString())
+                .withCristinId(cristinId)
+                .persist(s3Client);
         }
+        return uri;
     }
 
     private Optional<URI> lookUpNsdJournal() {
@@ -57,11 +66,14 @@ public class Nsd {
     }
 
     private URI toJournalUri(ChannelRegistryEntry channelRegistryEntry) {
-        if (ChannelType.JOURNAL.equals(channelRegistryEntry.type())) {
-            return getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
-        } else {
-            throw new WrongChannelTypeException(channelRegistryEntry);
+        var uri = getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
+        if (!ChannelType.JOURNAL.equals(channelRegistryEntry.type())) {
+            ErrorReport.exceptionName(WrongChannelTypeException.class.getSimpleName())
+                .withBody(uri.toString())
+                .withCristinId(cristinId)
+                .persist(s3Client);
         }
+        return uri;
     }
 
     private Optional<URI> lookupNsdPublisherProxyUri() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
@@ -8,13 +8,15 @@ import no.unit.nva.cristin.mapper.nva.CristinMappingModule;
 import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.Periodical;
 import no.unit.nva.model.contexttypes.UnconfirmedJournal;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class PeriodicalBuilder extends CristinMappingModule {
 
     private final CristinObject cristinObject;
 
-    public PeriodicalBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public PeriodicalBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper,
+                             S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
         this.cristinObject = cristinObject;
     }
 
@@ -35,7 +37,7 @@ public class PeriodicalBuilder extends CristinMappingModule {
     private Periodical createJournal() {
         Integer nsdCode = cristinObject.getJournalPublication().getJournal().getNsdCode();
         int publicationYear = extractYearReportedInNvi();
-        var journalUri = new Nsd(nsdCode, publicationYear, channelRegistryMapper).createJournal();
+        var journalUri = new Nsd(nsdCode, publicationYear, channelRegistryMapper, s3Client, cristinObject.getId()).createJournal();
         return new Journal(journalUri);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/CristinMappingModule.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/CristinMappingModule.java
@@ -7,6 +7,7 @@ import no.unit.nva.cristin.mapper.CristinBookOrReportPartMetadata;
 import no.unit.nva.cristin.mapper.CristinJournalPublication;
 import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * Class containing common functionality for the different modules implementing the mapping logic of Cristin entries to
@@ -20,10 +21,12 @@ public class CristinMappingModule {
     protected final CristinObject cristinObject;
 
     protected final ChannelRegistryMapper channelRegistryMapper;
+    protected final S3Client s3Client;
 
-    public CristinMappingModule(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
+    public CristinMappingModule(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
         this.cristinObject = cristinObject;
         this.channelRegistryMapper = channelRegistryMapper;
+        this.s3Client = s3Client;
     }
 
     protected CristinJournalPublication extractCristinJournalPublication() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookBuilder.java
@@ -3,11 +3,12 @@ package no.unit.nva.cristin.mapper.nva;
 import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.model.contexttypes.Book;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaBookBuilder extends NvaBookLikeBuilder {
 
-    public NvaBookBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public NvaBookBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     public Book buildBookForPublicationContext() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
@@ -18,14 +18,16 @@ import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.contexttypes.PublishingHouse;
 import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
 import nva.commons.core.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaBookLikeBuilder extends CristinMappingModule {
 
     public static final String CUSTOM_VOLUME_SERIES_DELIMITER = ";";
     private static final String EMPTY_STRING = null;
 
-    public NvaBookLikeBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public NvaBookLikeBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper,
+                              S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     protected String constructSeriesNumber() {
@@ -45,7 +47,7 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
     }
 
     protected BookSeries buildSeries() {
-        return new NvaBookSeriesBuilder(cristinObject, channelRegistryMapper)
+        return new NvaBookSeriesBuilder(cristinObject, channelRegistryMapper, s3Client)
                    .createBookSeries();
     }
 
@@ -65,7 +67,8 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
 
     private Optional<PublishingHouse> createConfirmedPublisherIfPublisherReferenceHasNsdCode() {
         return extractPublishersNsdCode()
-                   .map(nsdCode -> new Nsd(nsdCode, extractYearReportedInNvi(), channelRegistryMapper))
+                   .map(nsdCode -> new Nsd(nsdCode, extractYearReportedInNvi(), channelRegistryMapper, s3Client,
+                                           cristinObject.getId()))
                    .map(Nsd::getPublisherUri)
                    .map(this::createConfirmedPublisher);
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookSeriesBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookSeriesBuilder.java
@@ -13,11 +13,12 @@ import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.model.contexttypes.BookSeries;
 import no.unit.nva.model.contexttypes.Series;
 import no.unit.nva.model.contexttypes.UnconfirmedSeries;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaBookSeriesBuilder extends CristinMappingModule {
 
-    public NvaBookSeriesBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public NvaBookSeriesBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     public BookSeries createBookSeries() {
@@ -45,7 +46,7 @@ public class NvaBookSeriesBuilder extends CristinMappingModule {
     private BookSeries createConfirmedBookSeries(CristinJournalPublicationJournal b) {
         int nsdCode = b.getNsdCode();
         int publicationYear = cristinObject.getPublicationYear();
-        URI seriesUri = new Nsd(nsdCode, publicationYear, channelRegistryMapper)
+        URI seriesUri = new Nsd(nsdCode, publicationYear, channelRegistryMapper, s3Client, cristinObject.getId())
                             .createSeries();
         return new Series(seriesUri);
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaDegreeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaDegreeBuilder.java
@@ -5,11 +5,12 @@ import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.model.contexttypes.Degree;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaDegreeBuilder extends NvaBookLikeBuilder {
 
-    public NvaDegreeBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public NvaDegreeBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     public Degree buildDegree() throws InvalidIsbnException, InvalidUnconfirmedSeriesException {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaReportBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaReportBuilder.java
@@ -6,11 +6,12 @@ import no.unit.nva.model.contexttypes.Report;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaReportBuilder extends NvaBookLikeBuilder {
 
-    public NvaReportBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public NvaReportBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
     }
 
     public Report buildNvaReport()

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -58,14 +58,16 @@ import no.unit.nva.model.time.Time;
 import nva.commons.core.SingletonCollector;
 import nva.commons.doi.DoiConverter;
 import nva.commons.doi.DoiValidator;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class ReferenceBuilder extends CristinMappingModule {
 
     private final DoiConverter doiConverter;
 
-    public ReferenceBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper) {
-        super(cristinObject, channelRegistryMapper);
+    public ReferenceBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper, S3Client s3Client) {
+        super(cristinObject, channelRegistryMapper, s3Client);
         doiConverter = new DoiConverter(DoiValidator::validateOffline);
+
     }
 
     public Reference buildReference() {
@@ -84,14 +86,14 @@ public class ReferenceBuilder extends CristinMappingModule {
     private PublicationContext buildPublicationContext()
         throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
         if (isBook(cristinObject)) {
-            return new NvaBookBuilder(cristinObject, channelRegistryMapper).buildBookForPublicationContext();
+            return new NvaBookBuilder(cristinObject, channelRegistryMapper, s3Client).buildBookForPublicationContext();
         }
         if (isJournal(cristinObject)) {
-            return new PeriodicalBuilder(cristinObject, channelRegistryMapper).buildPeriodicalForPublicationContext();
+            return new PeriodicalBuilder(cristinObject, channelRegistryMapper, s3Client).buildPeriodicalForPublicationContext();
         }
         if (isMediaFeatureArticle(cristinObject)) {
             return new MediaPeriodicalBuilder(cristinObject,
-                                              channelRegistryMapper)
+                                              channelRegistryMapper, s3Client)
                        .buildMediaPeriodicalForPublicationContext();
         }
         if (isReport(cristinObject)) {
@@ -141,9 +143,9 @@ public class ReferenceBuilder extends CristinMappingModule {
     private PublicationContext buildPublicationContextWhenMainCategoryIsReport()
         throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
         if (isDegreePhd(cristinObject) || isDegreeMaster(cristinObject) || isDegreeLicentiate(cristinObject)) {
-            return new NvaDegreeBuilder(cristinObject, channelRegistryMapper).buildDegree();
+            return new NvaDegreeBuilder(cristinObject, channelRegistryMapper, s3Client).buildDegree();
         }
-        return new NvaReportBuilder(cristinObject, channelRegistryMapper).buildNvaReport();
+        return new NvaReportBuilder(cristinObject, channelRegistryMapper, s3Client).buildNvaReport();
     }
 
     private Anthology buildChapterForPublicationContext() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/WrongChannelTypeException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/WrongChannelTypeException.java
@@ -1,12 +1,6 @@
 package no.unit.nva.cristin.mapper.nva.exceptions;
 
-import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryEntry;
+public final class WrongChannelTypeException {
 
-public class WrongChannelTypeException extends RuntimeException {
-
-    private static final String MESSAGE_FORMAT = "Channel for PID %s has wrong value: %s";
-
-    public WrongChannelTypeException(ChannelRegistryEntry channelRegistryEntry) {
-        super(String.format(MESSAGE_FORMAT, channelRegistryEntry.id(), channelRegistryEntry.type().getValue()));
-    }
+    private WrongChannelTypeException() {}
 }

--- a/cristin-import/src/test/java/cucumber/ScenarioContext.java
+++ b/cristin-import/src/test/java/cucumber/ScenarioContext.java
@@ -62,7 +62,8 @@ public class ScenarioContext {
     }
 
     public void convertToNvaEntry() {
-        mappingAttempt = attempt(() -> new CristinMapper(cristinEntry, cristinUnitsUtil).generatePublication());
+        mappingAttempt =
+            attempt(() -> new CristinMapper(cristinEntry, cristinUnitsUtil, mock(S3Client.class)).generatePublication());
     }
 
     public Publication getNvaEntry() {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -259,7 +259,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
     }
 
     private Publication mapToPublication(CristinObject cristinObject) {
-        return new CristinMapper(cristinObject, cristinUnitsUtil).generatePublication();
+        return new CristinMapper(cristinObject, cristinUnitsUtil, s3Client).generatePublication();
     }
 
     @Test
@@ -590,28 +590,30 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
     }
 
     @Test
-    void shouldPersistWrongChannelTypeExceptionWhenCreatingJournalForNonJournal() throws IOException {
+    void shouldPersistWrongChannelTypeErrorReportWhenCreatingJournalForNonJournal() throws IOException {
         var cristinObject = CristinDataGenerator.randomObject(FEATURE_ARTICLE.getValue());
         cristinObject.getJournalPublication().getJournal().setNsdCode(SERIES_NSD_CODE);
         var eventBody = createEventBody(cristinObject);
         var sqsEvent = createSqsEvent(eventBody);
         handler.handleRequest(sqsEvent, CONTEXT);
-        var expectedErrorFileLocation = constructExpectedErrorFilePaths(eventBody, "WrongChannelTypeException");
+        var expectedErrorFileLocation =  UnixPath.of("ERROR_REPORT").addChild("WrongChannelTypeException").addChild(String.valueOf(cristinObject.getId()));
         var s3Driver = new S3Driver(s3Client, NOT_IMPORTANT);
         var file = s3Driver.getFile(expectedErrorFileLocation);
+
         assertThat(file, is(not(emptyString())));
     }
 
     @Test
-    void shouldPersistWrongChannelTypeExceptionWhenCreatingSeriesForNonSeries() throws IOException {
+    void shouldPersistWrongChannelTypeReportWhenCreatingSeriesForNonSeries() throws IOException {
         var cristinObject = CristinDataGenerator.randomBook();
         cristinObject.getBookOrReportMetadata().getBookSeries().setNsdCode(JOURNAL_NSD_CODE);
         var eventBody = createEventBody(cristinObject);
         var sqsEvent = createSqsEvent(eventBody);
         handler.handleRequest(sqsEvent, CONTEXT);
-        var expectedErrorFileLocation = constructExpectedErrorFilePaths(eventBody, "WrongChannelTypeException");
+        var expectedErrorFileLocation =  UnixPath.of("ERROR_REPORT").addChild("WrongChannelTypeException").addChild(String.valueOf(cristinObject.getId()));
         var s3Driver = new S3Driver(s3Client, NOT_IMPORTANT);
         var file = s3Driver.getFile(expectedErrorFileLocation);
+
         assertThat(file, is(not(emptyString())));
     }
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.awssdk.services.s3.S3Client;
 
 class CristinMapperTest extends AbstractCristinImportTest {
 
@@ -91,7 +92,7 @@ class CristinMapperTest extends AbstractCristinImportTest {
     }
 
     private Publication mapToPublication(CristinObject cristinObject) {
-        return new CristinMapper(cristinObject, cristinUnitsUtil).generatePublication();
+        return new CristinMapper(cristinObject, cristinUnitsUtil, mock(S3Client.class)).generatePublication();
     }
 
     @Test

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
@@ -11,6 +11,7 @@ import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.publication.utils.CristinUnitsUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaBookLikeBuilderTest {
 
@@ -34,7 +35,7 @@ public class NvaBookLikeBuilderTest {
 
     private static Publication mapToPublication(CristinObject randomBook) {
         var cristinUnitsUtil = mock(CristinUnitsUtil.class);
-        return new CristinMapper(randomBook, cristinUnitsUtil).generatePublication();
+        return new CristinMapper(randomBook, cristinUnitsUtil, mock(S3Client.class)).generatePublication();
     }
 
     @ParameterizedTest(name = "nvaBookLikeBuilder returns Series that does contain blank String represetations"

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -200,10 +200,3 @@ Feature: Book conversion rules
     And the book has series which has NSD code which does not exist in channel registry lookup file
     When the Cristin Result is converted to an NVA Resource
     Then an error is reported.
-
-  Scenario: When the cristin entry is mapped to Book, but NSD code from channel-registry file is of type journal,
-  then an exception is thrown
-    Given a random book
-    And the Book Publication has a reference to an NSD journal with identifier 339738
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.

--- a/cristin-import/src/test/resources/features/JournalArticleRules.feature
+++ b/cristin-import/src/test/resources/features/JournalArticleRules.feature
@@ -93,12 +93,3 @@ Feature: Mapping of "Article in business/trade/industry journal", "Academic arti
     Given the Journal Publication has a reference to an NSD journal with identifier 12345
     When the Cristin Result is converted to an NVA Resource
     Then an error is reported.
-
-
-  Scenario: When the cristin entry is mapped to Journal, but NSD code from channel-registry file is of type series,
-  then an exception is thrown
-    Given the Journal Publication has a reference to an NSD journal with identifier 339741
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
-
-


### PR DESCRIPTION
Instead of throwing exception under import of Cristin post, we want to import publication, but store invalid data in report, in order to be able to fix it after we have migrated Cristin.

I store report in CRISTIN_BUCKET/ERROR_REPORT/EXCEPTION_NAME/CRISTIN_ID/SOME_RELEVANT_DATA