### PR TITLE
persisting reports instead of throwing exceptions

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
@@ -45,7 +45,7 @@ public final class ErrorReport {
     }
 
     private Builder copy() {
-        return builder().withBody(this.body).withException(this.exception);
+        return builder().withBody(this.body).withCristinId(this.cristinId).withException(this.exception);
     }
 
     public static final class Builder {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AbstractPublicationInstanceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AbstractPublicationInstanceBuilder.java
@@ -5,12 +5,26 @@ import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryExc
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
 import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public abstract class AbstractPublicationInstanceBuilder {
 
     public static final String ERROR_NOT_CORRECT_TYPE
         = "The cristin object can not be accepted by the %s constructor as it is not of type %s";
     private final CristinObject cristinObject;
+    private S3Client s3Client;
+
+    public AbstractPublicationInstanceBuilder(CristinObject cristinObject, S3Client s3Client) {
+        if (!isExpectedType(cristinObject)) {
+            throw notExpectedType();
+        }
+        this.cristinObject = cristinObject;
+        this.s3Client = s3Client;
+    }
+
+    public S3Client getS3Client() {
+        return s3Client;
+    }
 
     public AbstractPublicationInstanceBuilder(CristinObject cristinObject) {
         if (!isExpectedType(cristinObject)) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ArtBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ArtBuilder.java
@@ -9,6 +9,7 @@ import no.unit.nva.model.instancetypes.artistic.architecture.Architecture;
 import no.unit.nva.model.pages.Pages;
 
 import java.util.Set;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static java.util.Objects.nonNull;
 
@@ -18,8 +19,8 @@ public class ArtBuilder extends AbstractPublicationInstanceBuilder {
         Set.of(CristinSecondaryCategory.MUSICAL_PERFORMANCE,
             CristinSecondaryCategory.MUSICAL_PIECE);
 
-    public ArtBuilder(CristinObject cristinObject) {
-        super(cristinObject);
+    public ArtBuilder(CristinObject cristinObject, S3Client s3Client) {
+        super(cristinObject, s3Client);
     }
 
     @Override
@@ -57,7 +58,8 @@ public class ArtBuilder extends AbstractPublicationInstanceBuilder {
     }
 
     private MusicPerformance createMusicPerformance() {
-        return getCristinObject().getCristinArtisticProduction().toMusicPerformance();
+        var cristinObject = getCristinObject();
+        return cristinObject.getCristinArtisticProduction().toMusicPerformance(cristinObject.getId(), super.getS3Client());
     }
 
     private MovingPicture createMovingPicture() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
@@ -19,11 +19,12 @@ import no.unit.nva.model.instancetypes.journal.PopularScienceArticle;
 import no.unit.nva.model.instancetypes.journal.ProfessionalArticle;
 import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class JournalBuilder extends AbstractPublicationInstanceBuilder {
 
-    public JournalBuilder(CristinObject cristinObject) {
-        super(cristinObject);
+    public JournalBuilder(CristinObject cristinObject, S3Client s3Client) {
+        super(cristinObject, s3Client);
     }
 
     @Override

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
@@ -13,6 +13,7 @@ import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedMainCategoryExceptio
 import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryException;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class PublicationInstanceBuilderImpl {
 
@@ -22,10 +23,12 @@ public class PublicationInstanceBuilderImpl {
                                                                             + "categories";
 
     private final CristinObject cristinObject;
+    private final S3Client s3Client;
 
-    public PublicationInstanceBuilderImpl(CristinObject cristinObject) {
+    public PublicationInstanceBuilderImpl(CristinObject cristinObject, S3Client s3Client) {
         Objects.requireNonNull(cristinObject, ERROR_CRISTIN_OBJECT_IS_NULL);
         this.cristinObject = cristinObject;
+        this.s3Client = s3Client;
     }
 
     public PublicationInstance<? extends Pages> build() {
@@ -34,7 +37,7 @@ public class PublicationInstanceBuilderImpl {
         } else if (isReport(cristinObject)) {
             return new ReportBuilder(cristinObject).build();
         } else if (isJournal(cristinObject)) {
-            return new JournalBuilder(cristinObject).build();
+            return new JournalBuilder(cristinObject, s3Client).build();
         } else if (isChapter(cristinObject)) {
             return new ChapterArticleBuilder(cristinObject).build();
         } else if (isEvent(cristinObject)) {
@@ -42,7 +45,7 @@ public class PublicationInstanceBuilderImpl {
         } else if (isMediaContribution(cristinObject)) {
             return new MediaContributionBuilder(cristinObject).build();
         } else if (isArt(cristinObject)) {
-            return new ArtBuilder(cristinObject).build();
+            return new ArtBuilder(cristinObject, s3Client).build();
         } else if (isExhibition(cristinObject)) {
             return new ExhibitionProductionBuilder(cristinObject).build();
         } else if (cristinObject.getMainCategory().isUnknownCategory()) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/InvalidIsrcException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/InvalidIsrcException.java
@@ -1,8 +1,12 @@
 package no.unit.nva.cristin.mapper.nva.exceptions;
 
-public class InvalidIsrcException extends RuntimeException {
+public final class InvalidIsrcException extends RuntimeException {
 
-    public InvalidIsrcException(Exception e) {
-        super(e);
+    private InvalidIsrcException() {
+        super();
+    }
+
+    public static String name() {
+        return InvalidIsrcException.class.getSimpleName();
     }
 }

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/AbstractPublicationInstanceBuilderImplTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/AbstractPublicationInstanceBuilderImplTest.java
@@ -3,9 +3,11 @@ package no.unit.nva.cristin.mapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class AbstractPublicationInstanceBuilderImplTest {
 
@@ -15,7 +17,7 @@ public class AbstractPublicationInstanceBuilderImplTest {
         AtomicReference<PublicationInstanceBuilderImpl> publicationInstanceBuilder = null;
         Executable action = () ->
                                 publicationInstanceBuilder.set(
-                                    new PublicationInstanceBuilderImpl(cristinObjectThatIsNull));
+                                    new PublicationInstanceBuilderImpl(cristinObjectThatIsNull, mock(S3Client.class)));
         NullPointerException exception = assertThrows(NullPointerException.class, action);
         assertThat(exception.getMessage(), containsString(PublicationInstanceBuilderImpl.ERROR_CRISTIN_OBJECT_IS_NULL));
     }

--- a/cristin-import/src/test/resources/features/ArtisticRules.feature
+++ b/cristin-import/src/test/resources/features/ArtisticRules.feature
@@ -116,25 +116,12 @@ Feature: Rules that apply for Artistic results
       | Lydfil            | DigitalFile  |
 
 
-  Scenario: Cristin musical performance that contains an invalid ISRC should throw an exception
-    Given a valid Cristin Result with secondary category "MUSIKK_FRAMFORIN"
-    And the performance has a ISRC equal to "not a valid isrc"
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
-
-
   Scenario: A cristin result with valid ISMN preserved the ISMN when converting it to NVA resource
     Given a valid Cristin Result with secondary category "MUSIKK_FRAMFORIN"
     And the performance has a ISMN equal to "M-2306-7118-7"
     When the Cristin Result is converted to an NVA Resource
     Then the NVA resource has a MusicScore
     And the MusicScore has a ISMN equal to "M-2306-7118-7"
-
-  Scenario: A cristin result with invalid ISMN should throw an exception
-    Given a valid Cristin Result with secondary category "MUSIKK_FRAMFORIN"
-    And the performance has a ISMN equal to "not a valid ismn"
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
 
   Scenario: A cristin result with ensemble name should be mapped to musicScore
     Given a valid Cristin Result with secondary category "MUSIKK_FRAMFORIN"


### PR DESCRIPTION
Third part of replacing exceptions with report persistance. 

Persisting following reports instead of throwing exceptions:

InvalidDoiException
InvalidIsrcException
InvalidIsmnException