### PR TITLE
adding abstract to PublicationSummary

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -1,7 +1,6 @@
 package no.unit.nva.publication.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
@@ -152,7 +151,7 @@ public class PublicationSummary {
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getStatus(),
-                            getPublicationInstance(), getPublishedDate(), getContributors());
+                            getPublicationInstance(), getPublishedDate(), getContributors(), getAbstract());
     }
 
     @Override
@@ -171,7 +170,8 @@ public class PublicationSummary {
                && getStatus() == that.getStatus()
                && Objects.equals(getPublicationInstance(), that.getPublicationInstance())
                && Objects.equals(getPublishedDate(), that.getPublishedDate())
-               && Objects.equals(getContributors(), that.getContributors());
+               && Objects.equals(getContributors(), that.getContributors())
+               && Objects.equals(getAbstract(), that.getAbstract());
     }
 
     private static String extractTitle(EntityDescription entityDescription) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -1,6 +1,7 @@
 package no.unit.nva.publication.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
@@ -45,6 +46,8 @@ public class PublicationSummary {
     private Instant publishedDate;
     @JsonProperty
     private List<Contributor> contributors;
+    @JsonProperty("abstract")
+    private String mainLanguageAbstract;
 
     public static PublicationSummary create(Publication publication) {
         var publicationSummary = new PublicationSummary();
@@ -56,6 +59,7 @@ public class PublicationSummary {
         publicationSummary.setTitle(extractTitle(publication.getEntityDescription()));
         publicationSummary.setPublicationInstance(extractPublicationInstance(publication.getEntityDescription()));
         publicationSummary.setContributors(extractContributors(publication.getEntityDescription()));
+        publicationSummary.setAbstract(publication.getEntityDescription().getAbstract());
         return publicationSummary;
     }
 
@@ -65,6 +69,15 @@ public class PublicationSummary {
         publicationSummary.setPublicationId(publicationId);
         publicationSummary.setTitle(publicationTitle);
         return publicationSummary;
+    }
+
+    @JsonProperty("abstract")
+    public String getAbstract() {
+        return mainLanguageAbstract;
+    }
+
+    public void setAbstract(String mainLanguageAbstract) {
+        this.mainLanguageAbstract = mainLanguageAbstract;
     }
 
     public Instant getPublishedDate() {
@@ -139,8 +152,7 @@ public class PublicationSummary {
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getStatus(),
-                            getPublicationInstance(), getPublishedDate(),
-                            getContributors());
+                            getPublicationInstance(), getPublishedDate(), getContributors());
     }
 
     @Override
@@ -149,10 +161,9 @@ public class PublicationSummary {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof PublicationSummary)) {
+        if (!(o instanceof PublicationSummary that)) {
             return false;
         }
-        PublicationSummary that = (PublicationSummary) o;
         return Objects.equals(getPublicationId(), that.getPublicationId())
                && Objects.equals(getIdentifier(), that.getIdentifier())
                && Objects.equals(getTitle(), that.getTitle())
@@ -164,9 +175,7 @@ public class PublicationSummary {
     }
 
     private static String extractTitle(EntityDescription entityDescription) {
-        return Optional.ofNullable(entityDescription)
-                   .map(EntityDescription::getMainTitle)
-                   .orElse(null);
+        return Optional.ofNullable(entityDescription).map(EntityDescription::getMainTitle).orElse(null);
     }
 
     private static List<Contributor> extractContributors(EntityDescription entityDescription) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/PublicationsByOwnerHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/PublicationsByOwnerHandler.java
@@ -1,10 +1,7 @@
 package no.unit.nva.publication.fetch;
 
 import static no.unit.nva.publication.RequestUtil.createUserInstanceFromRequest;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
-import java.time.Clock;
-import java.util.List;
 import java.util.stream.Collectors;
 import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.publication.model.PublicationSummary;
@@ -15,12 +12,9 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PublicationsByOwnerHandler extends ApiGatewayHandler<Void, PublicationsByOwnerResponse> {
     
-    private static final Logger logger = LoggerFactory.getLogger(PublicationsByOwnerHandler.class);
     private final ResourceService resourceService;
     private final IdentityServiceClient identityServiceClient;
 
@@ -50,19 +44,10 @@ public class PublicationsByOwnerHandler extends ApiGatewayHandler<Void, Publicat
 
         var userInstance = createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
-        logger.info(String.format("Requested publications for owner with username/feideId=%s and publisher with "
-                                  + "customerId=%s",
-            userInstance.getUsername(),
-            userInstance.getCustomerId())
-        );
-        
-        List<PublicationSummary> publicationsByOwner;
-        publicationsByOwner = resourceService.getPublicationsByOwner(userInstance)
-                                  .stream()
-                                  .map(PublicationSummary::create)
-                                  .collect(Collectors.toList());
-        
-        return new PublicationsByOwnerResponse(publicationsByOwner);
+        return resourceService.getPublicationsByOwner(userInstance)
+                   .stream()
+                   .map(PublicationSummary::create)
+                   .collect(Collectors.collectingAndThen(Collectors.toList(), PublicationsByOwnerResponse::new));
     }
     
     @Override


### PR DESCRIPTION
Adding `abstract` to `PublicationSummary`. Is needed for fronted to use `/publication/by-owner` endpoint to show the same view as for documents returned by search-api.