### PR TITLE
merging brage publication

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -75,6 +75,8 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private static final String APPLICATION_JSON = "application/json";
     public static final String TITLE = "title";
     public static final String INSTANCE_TYPE = "instanceType";
+    public static final String AGGREGATION = "aggregation";
+    public static final String NONE = "none";
     private final S3Client s3Client;
     private final ResourceService resourceService;
     private String brageRecordFile;
@@ -172,6 +174,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
                    .addChild(RESOURCES)
                    .addQueryParameter(TITLE, getMainTitle(publication))
                    .addQueryParameter(INSTANCE_TYPE, getInstanceType(publication))
+                   .addQueryParameter(AGGREGATION, NONE)
                    .getUri();
     }
 
@@ -221,6 +224,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
                    .addChild(SEARCH)
                    .addChild(RESOURCES)
                    .addQueryParameter(DOI, doi.toString())
+                   .addQueryParameter(AGGREGATION, NONE)
                    .getUri();
     }
 

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -116,16 +116,16 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         if (nonNull(cristinIdentifier)) {
             publicationsToMerge = getPublicationsByCristinIdentifier(cristinIdentifier);
             boolean shouldMerge = !publicationsToMerge.isEmpty();
-            source = shouldMerge ? MergeSource.CRISTIN : null;
+            source = shouldMerge ? MergeSource.CRISTIN : MergeSource.NOT_RELEVANT;
             return shouldMerge;
         }
         if (hasDoi(publication)) {
             var shouldMerge= existingPublicationHasSameDoi(publication);
-            source = shouldMerge ? MergeSource.DOI : null;
+            source = shouldMerge ? MergeSource.DOI : MergeSource.NOT_RELEVANT;
             return shouldMerge;
         } else {
             var shouldMerge = existingPublicationHasSamePublicationContent(publication);
-            source = shouldMerge ? MergeSource.SEARCH : null;
+            source = shouldMerge ? MergeSource.SEARCH : MergeSource.NOT_RELEVANT;
             return shouldMerge;
         }
     }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -154,7 +154,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
 
     private Optional<String> fetchResponse(URI uri) {
         var response = uriRetriever.fetchResponse(uri);
-        if (!isHttpOk(response)) {
+        if (isNotHttpOk(response)) {
             logger.info("Search-api responded with statusCode: {} for request: {}", response.statusCode(), uri);
             return Optional.empty();
         } else {
@@ -162,8 +162,8 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         }
     }
 
-    private boolean isHttpOk(HttpResponse<String> response) {
-        return response.statusCode() == HTTP_OK;
+    private static boolean isNotHttpOk(HttpResponse<String> response) {
+        return response.statusCode() != HTTP_OK;
     }
 
     private URI searchByTypeAndTitleUri(Publication publication) {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/MergeSource.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/MergeSource.java
@@ -1,5 +1,5 @@
 package no.sikt.nva.brage.migration.lambda;
 
 public enum MergeSource {
-    CRISTIN, DOI, SEARCH
+    CRISTIN, DOI, SEARCH, NOT_RELEVANT
 }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/MergeSource.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/MergeSource.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.brage.migration.lambda;
+
+public enum MergeSource {
+    CRISTIN, DOI, SEARCH
+}

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
@@ -639,9 +639,6 @@ public class NvaBrageMigrationDataGenerator {
             if (isNull(alternativeTitlesMap)) {
                 alternativeTitlesMap = createCorrespondingMap();
             }
-            if (isNull(doi) && randomBoolean()) {
-                doi = randomDoi();
-            }
             if (isNull(language)) {
                 language = randomLanguage1();
             }

--- a/publication-commons/src/main/java/no/unit/nva/publication/external/services/UriRetriever.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/external/services/UriRetriever.java
@@ -14,6 +14,7 @@ import nva.commons.core.JacocoGenerated;
 public class UriRetriever implements RawContentRetriever {
 
     public static final String ACCEPT = "Accept";
+    private static final String APPLICATION_JSON = "application/json";
     private final HttpClient httpClient;
 
     public UriRetriever() {
@@ -55,5 +56,9 @@ public class UriRetriever implements RawContentRetriever {
                    .toOptional();
     }
 
-
+    public HttpResponse<String> fetchResponse(URI uri) {
+        return attempt(() -> httpClient.send(createHttpRequest(uri, APPLICATION_JSON),
+                                             BodyHandlers.ofString(StandardCharsets.UTF_8)))
+                   .orElseThrow();
+    }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/SearchResourceApiResponse.java
@@ -6,9 +6,15 @@ import nva.commons.core.JacocoGenerated;
 
 public record SearchResourceApiResponse(int totalHits, List<ResourceWithId> hits) implements JsonSerializable {
 
+    public static final int SINGLE_HIT = 1;
+
     @JacocoGenerated
     @Override
     public String toString() {
         return toJsonString();
+    }
+
+    public boolean containsSingleHit() {
+        return this.totalHits == SINGLE_HIT;
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/SearchResourceApiResponseTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/SearchResourceApiResponseTest.java
@@ -21,6 +21,7 @@ public class SearchResourceApiResponseTest {
         var json = searchResponse.toJsonString();
         var parsedSearchResponse = JsonUtils.dtoObjectMapper.readValue(json, SearchResourceApiResponse.class);
         assertThat(parsedSearchResponse, is(equalTo(searchResponse)));
+        assertThat(parsedSearchResponse.containsSingleHit(), is(true));
     }
 
     @Test

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/update/ScopusUpdater.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/update/ScopusUpdater.java
@@ -26,6 +26,8 @@ public class ScopusUpdater {
     private static final String SEARCH = "search";
     private static final String IMPORT_CANDIDATES_2 = "import-candidates2";
     private static final String SCOPUS_IDENTIFIER = "scopusIdentifier";
+    private static final String AGGREGATION = "aggregation";
+    private static final String NONE = "none";
     private final ResourceService resourceService;
     private final UriRetriever uriRetriever;
     private static final String APPLICATION_JSON = "application/json";
@@ -79,6 +81,7 @@ public class ScopusUpdater {
                    .addChild(SEARCH)
                    .addChild(IMPORT_CANDIDATES_2)
                    .addQueryParameter(SCOPUS_IDENTIFIER, scopusIdentifier)
+                   .addQueryParameter(AGGREGATION, NONE)
                    .getUri();
     }
 


### PR DESCRIPTION
Adding new merge flow for Brage entries. 

- When we get single hit from search-api when searching for existing publication using incoming publication title and instanceType, we merge these two publications.

- Adding new path subpath to UPDATE_REPORTS for merged Brage publications. Adding merge source to update reports path, so we know the source/ cause of this merge. -> Ex. UPDATE_REPORTS/DOI  

- So from now on we will be able to see how many publications have been merged by cristinIdentifier, doi (via search-api) and publication content (search-api) as well:

```
public enum MergeSource {
    CRISTIN, DOI, SEARCH
}
```

