### PR TITLE
extracting licenses under expansion instead of opensearch

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/model/License.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/License.java
@@ -1,0 +1,64 @@
+package no.unit.nva.expansion.model;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Optional;
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record License(String type, String label) implements JsonSerializable {
+
+    public static License fromUri(URI uri) {
+        return LicenseType.fromUri(uri).toLicense();
+    }
+
+    public enum LicenseType{
+
+        CC_NC_ND("CC-NC-ND", "by-nc-nd", Constants.CC_NC_ND_LABEL),
+        CC_NC_SA("CC-NC-SA", "by-nc-sa", Constants.CC_NC_SA_LABEL),
+        CC_NC("CC-NC", "by-nc", Constants.CC_NC_LABEL),
+        CC_ND("CC-ND", "by-nd", Constants.CC_ND_LABEL),
+        CC_SA("CC-SA", "by-sa", Constants.CC_SA_LABEL),
+        CC_BY("CC-BY", "by", Constants.CC_BY_LABEL),
+        OTHER("Other", "ignored", Constants.OTHER_LABEL);
+
+        private final String value;
+        private final String pathParameter;
+        private final String label;
+
+        LicenseType(String value, String pathParameter, String label) {
+            this.value = value;
+            this.pathParameter = pathParameter;
+            this.label = label;
+        }
+
+        public static LicenseType fromUri(URI uri) {
+            return Arrays.stream(LicenseType.values())
+                       .filter(licenseType -> licenseType.hasPathParam(uri))
+                       .findFirst()
+                       .orElse(OTHER);
+        }
+
+        public boolean hasPathParam(URI uri) {
+            return Optional.ofNullable(uri).map(URI::getPath).map(this::containsPathParameter).orElse(false);
+        }
+
+        public License toLicense() {
+            return new License(this.value, this.label);
+        }
+
+        private boolean containsPathParameter(String value) {
+            return value.contains(this.pathParameter);
+        }
+
+        private static class Constants {
+
+            public static final String CC_NC_ND_LABEL = "Creative Commons - Attribution-NonCommercial-NoDerivs";
+            public static final String CC_NC_SA_LABEL = "Creative Commons - Attribution-NonCommercial-ShareAlike";
+            public static final String CC_NC_LABEL = "Creative Commons - Attribution-NonCommercial";
+            public static final String CC_ND_LABEL = "Creative Commons - Attribution-NoDerivs";
+            public static final String CC_SA_LABEL = "Creative Commons - Attribution-ShareAlike";
+            public static final String CC_BY_LABEL = "Creative Commons - Attribution";
+            public static final String OTHER_LABEL = "Other license";
+        }
+    }
+}

--- a/expansion/src/main/java/no/unit/nva/expansion/model/License.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/License.java
@@ -22,6 +22,7 @@ public record License(String name, Map<String, String> labels) implements JsonSe
         CC_ND("CC-ND", "by-nd", Constants.CC_ND_LABELS),
         CC_SA("CC-SA", "by-sa", Constants.CC_SA_LABELS),
         CC_BY("CC-BY", "by", Constants.CC_BY_LABELS),
+        CC_ZERO("CC0", "zero", Constants.CC_ZERO_LABELS),
         OTHER("Other", "ignored", Constants.OTHER_LABELS);
 
         private final String value;
@@ -59,30 +60,34 @@ public record License(String name, Map<String, String> labels) implements JsonSe
             public static final String NORWEGIAN_LABEL = "nb";
             public static final Map<String, String> CC_NC_ND_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial-NoDerivs",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse-IkkeKommersiell-IngenBearbeidelser");
             public static final Map<String, String> CC_NC_SA_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial-ShareAlike",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse-IkkeKommersiell-DelPåSammeVilkår");
 
             public static final Map<String, String> CC_NC_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse-IkkeKommersiell");
 
             public static final Map<String, String> CC_ND_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution-NoDerivs",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse-IngenBearbeidelse");
 
             public static final Map<String, String> CC_SA_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution-ShareAlike",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse-DelPåSammeVilkår");
 
             public static final Map<String, String> CC_BY_LABELS = Map.of(
                 ENGLISH_LABEL, "Creative Commons - Attribution",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Creative Commons - Navngivelse");
+
+            public static final Map<String, String> CC_ZERO_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - No Rights Reserved",
+                NORWEGIAN_LABEL, "Creative Commons - Ingen opphavsrett");
 
             public static final Map<String, String> OTHER_LABELS = Map.of(
                 ENGLISH_LABEL, "Other license",
-                NORWEGIAN_LABEL, "Mangler");
+                NORWEGIAN_LABEL, "Andre lisenser");
         }
     }
 }

--- a/expansion/src/main/java/no/unit/nva/expansion/model/License.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/License.java
@@ -1,11 +1,14 @@
 package no.unit.nva.expansion.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import no.unit.nva.commons.json.JsonSerializable;
 
-public record License(String type, String label) implements JsonSerializable {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record License(String name, Map<String, String> labels) implements JsonSerializable {
 
     public static License fromUri(URI uri) {
         return LicenseType.fromUri(uri).toLicense();
@@ -13,22 +16,22 @@ public record License(String type, String label) implements JsonSerializable {
 
     public enum LicenseType{
 
-        CC_NC_ND("CC-NC-ND", "by-nc-nd", Constants.CC_NC_ND_LABEL),
-        CC_NC_SA("CC-NC-SA", "by-nc-sa", Constants.CC_NC_SA_LABEL),
-        CC_NC("CC-NC", "by-nc", Constants.CC_NC_LABEL),
-        CC_ND("CC-ND", "by-nd", Constants.CC_ND_LABEL),
-        CC_SA("CC-SA", "by-sa", Constants.CC_SA_LABEL),
-        CC_BY("CC-BY", "by", Constants.CC_BY_LABEL),
-        OTHER("Other", "ignored", Constants.OTHER_LABEL);
+        CC_NC_ND("CC-NC-ND", "by-nc-nd", Constants.CC_NC_ND_LABELS),
+        CC_NC_SA("CC-NC-SA", "by-nc-sa", Constants.CC_NC_SA_LABELS),
+        CC_NC("CC-NC", "by-nc", Constants.CC_NC_LABELS),
+        CC_ND("CC-ND", "by-nd", Constants.CC_ND_LABELS),
+        CC_SA("CC-SA", "by-sa", Constants.CC_SA_LABELS),
+        CC_BY("CC-BY", "by", Constants.CC_BY_LABELS),
+        OTHER("Other", "ignored", Constants.OTHER_LABELS);
 
         private final String value;
         private final String pathParameter;
-        private final String label;
+        private final Map<String, String> labels;
 
-        LicenseType(String value, String pathParameter, String label) {
+        LicenseType(String value, String pathParameter, Map<String, String> label) {
             this.value = value;
             this.pathParameter = pathParameter;
-            this.label = label;
+            this.labels = label;
         }
 
         public static LicenseType fromUri(URI uri) {
@@ -43,7 +46,7 @@ public record License(String type, String label) implements JsonSerializable {
         }
 
         public License toLicense() {
-            return new License(this.value, this.label);
+            return new License(this.value, this.labels);
         }
 
         private boolean containsPathParameter(String value) {
@@ -52,13 +55,34 @@ public record License(String type, String label) implements JsonSerializable {
 
         private static class Constants {
 
-            public static final String CC_NC_ND_LABEL = "Creative Commons - Attribution-NonCommercial-NoDerivs";
-            public static final String CC_NC_SA_LABEL = "Creative Commons - Attribution-NonCommercial-ShareAlike";
-            public static final String CC_NC_LABEL = "Creative Commons - Attribution-NonCommercial";
-            public static final String CC_ND_LABEL = "Creative Commons - Attribution-NoDerivs";
-            public static final String CC_SA_LABEL = "Creative Commons - Attribution-ShareAlike";
-            public static final String CC_BY_LABEL = "Creative Commons - Attribution";
-            public static final String OTHER_LABEL = "Other license";
+            public static final String ENGLISH_LABEL = "en";
+            public static final String NORWEGIAN_LABEL = "nb";
+            public static final Map<String, String> CC_NC_ND_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial-NoDerivs",
+                NORWEGIAN_LABEL, "Mangler");
+            public static final Map<String, String> CC_NC_SA_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial-ShareAlike",
+                NORWEGIAN_LABEL, "Mangler");
+
+            public static final Map<String, String> CC_NC_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution-NonCommercial",
+                NORWEGIAN_LABEL, "Mangler");
+
+            public static final Map<String, String> CC_ND_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution-NoDerivs",
+                NORWEGIAN_LABEL, "Mangler");
+
+            public static final Map<String, String> CC_SA_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution-ShareAlike",
+                NORWEGIAN_LABEL, "Mangler");
+
+            public static final Map<String, String> CC_BY_LABELS = Map.of(
+                ENGLISH_LABEL, "Creative Commons - Attribution",
+                NORWEGIAN_LABEL, "Mangler");
+
+            public static final Map<String, String> OTHER_LABELS = Map.of(
+                ENGLISH_LABEL, "Other license",
+                NORWEGIAN_LABEL, "Mangler");
         }
     }
 }

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -232,7 +232,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var licensesAsString = indexDoc.asJsonNode().get("licenses").toString();
         var license = JsonUtils.dtoObjectMapper.readValue(licensesAsString, License[].class)[0];
 
-        assertThat(license.type(), is(equalTo(expectedLicense.toLicense().type())));
+        assertThat(license.name(), is(equalTo(expectedLicense.toLicense().name())));
     }
 
     private File randomPublishedFile(String license) {
@@ -733,7 +733,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
                        Arguments.of("https://creativecommons.org/licenses/by-nd/4.0", LicenseType.CC_ND),
                        Arguments.of("https://creativecommons.org/licenses/by-sa/4.0", LicenseType.CC_SA),
                        Arguments.of("https://creativecommons.org/licenses/by/4.0", LicenseType.CC_BY),
-                       Arguments.of("https://creativecommons.org/unknown/license", LicenseType.OTHER)
+                       Arguments.of("https://something.else.com", LicenseType.OTHER)
         );
     }
 

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -733,6 +733,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
                        Arguments.of("https://creativecommons.org/licenses/by-nd/4.0", LicenseType.CC_ND),
                        Arguments.of("https://creativecommons.org/licenses/by-sa/4.0", LicenseType.CC_SA),
                        Arguments.of("https://creativecommons.org/licenses/by/4.0", LicenseType.CC_BY),
+                       Arguments.of("https://creativecommons.org/publicdomain/zero/1.0/", LicenseType.CC_ZERO),
                        Arguments.of("https://something.else.com", LicenseType.OTHER)
         );
     }


### PR DESCRIPTION
Adding following json list to IndexDocument:

```
  "licenses": [
    {
      "type": "Other",
      "label": "Other license"
    }
  ]
```

For now we are doing it under aggregations generating, which is not effective. 