### PR TITLE
Np 46649 update existing Cristin publications

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -159,7 +159,14 @@ public class CristinEntryEventConsumer
         return attempt(() -> getExistingPublication(publicationRepresentation))
                    .map(publicationRepresentation::withExistingPublication)
                    .map(PublicationUpdater::update)
-                   .map(this::persistUpdatedPublication)
+                   .map(publicationRepresentations -> publicationRepresentations.updateHasEffectiveChanges()
+                                                          ? update(publicationRepresentations)
+                                                          : publicationRepresentations.getExistingPublication())
+                   .orElseThrow();
+    }
+
+    private Publication update(PublicationRepresentations publicationRepresentations) {
+        return attempt(() -> persistUpdatedPublication(publicationRepresentations))
                    .map(this::persistUpdateReport)
                    .orElseThrow();
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationRepresentations.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationRepresentations.java
@@ -91,6 +91,12 @@ public class PublicationRepresentations {
             cristinObject.getBookOrReportPartMetadata().getPartOf());
     }
 
+    public boolean updateHasEffectiveChanges() {
+        var existingPublication = getExistingPublication().copy().withModifiedDate(null).withIdentifier(null).build();
+        var incomingPublication = getIncomingPublication().copy().withModifiedDate(null).withIdentifier(null).build();
+        return !existingPublication.equals(incomingPublication);
+    }
+
     @JacocoGenerated
     @Override
     public int hashCode() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -1,11 +1,26 @@
 package no.unit.nva.cristin.lambda;
 
+import java.util.ArrayList;
+import no.unit.nva.cristin.mapper.AssociatedLinkExtractor;
+import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
+
 public final class PublicationUpdater {
 
     private PublicationUpdater() {
     }
 
     public static PublicationRepresentations update(PublicationRepresentations publicationRepresentations) {
+        var existingPublication = publicationRepresentations.getExistingPublication();
+        existingPublication.setAssociatedArtifacts(updatedAssociatedLinks(publicationRepresentations));
         return publicationRepresentations;
+    }
+
+    private static AssociatedArtifactList updatedAssociatedLinks(
+        PublicationRepresentations publicationRepresentations) {
+        var incomingAssociatedLinks = publicationRepresentations.getIncomingPublication().getAssociatedArtifacts();
+        var existingAssociatedLinks = publicationRepresentations.getExistingPublication().getAssociatedArtifacts();
+        var list = new ArrayList<>(existingAssociatedLinks);
+        list.addAll(incomingAssociatedLinks);
+        return new AssociatedArtifactList(list.stream().distinct().toList());
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -2,14 +2,24 @@ package no.unit.nva.cristin.lambda;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static nva.commons.core.attempt.Try.attempt;
 import java.util.ArrayList;
 import java.util.List;
+import no.unit.nva.cristin.mapper.CristinSecondaryCategory;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.contexttypes.Event;
 import no.unit.nva.model.contexttypes.PublicationContext;
+import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.instancetypes.journal.AcademicArticle;
+import no.unit.nva.model.instancetypes.journal.AcademicLiteratureReview;
+import no.unit.nva.model.instancetypes.journal.JournalArticle;
+import no.unit.nva.model.instancetypes.journal.PopularScienceArticle;
+import no.unit.nva.model.instancetypes.journal.ProfessionalArticle;
+import no.unit.nva.model.pages.Pages;
+import nva.commons.core.JacocoGenerated;
 
 public final class PublicationUpdater {
 
@@ -41,8 +51,79 @@ public final class PublicationUpdater {
     private static Reference updateReference(PublicationRepresentations publicationRepresentations) {
         var existinReference = publicationRepresentations.getExistingPublication().getEntityDescription().getReference();
         existinReference.setPublicationContext(updatePublicationContext(publicationRepresentations));
+        existinReference.setPublicationInstance(updatePublicationInstance(publicationRepresentations));
         return existinReference;
 
+    }
+
+    private static PublicationInstance<? extends Pages> updatePublicationInstance(
+        PublicationRepresentations publicationRepresentations) {
+        var existingPublicationInstance = getPublicationInstance(publicationRepresentations.getExistingPublication());
+        var incomingPublicationInstance = getPublicationInstance(publicationRepresentations.getIncomingPublication());
+
+        if (existingPublicationInstance instanceof JournalArticle existingJournalArticle
+            && incomingPublicationInstance instanceof JournalArticle incomingJournalArticle
+            && existingPublicationInstance.getInstanceType().equals(incomingPublicationInstance.getInstanceType())) {
+                return updateJournalArticle(existingJournalArticle, incomingJournalArticle);
+        } else {
+            return existingPublicationInstance;
+        }
+    }
+
+    @JacocoGenerated
+    private static PublicationInstance<? extends Pages> updateJournalArticle(JournalArticle existingJournalArticle,
+                                                                             JournalArticle incomingJournalArticle) {
+        return switch (existingJournalArticle) {
+            case ProfessionalArticle professionalArticle ->
+                getProfessionalArticle(existingJournalArticle, incomingJournalArticle);
+            case PopularScienceArticle popularScienceArticle ->
+                getPopularScienceArticle(existingJournalArticle, incomingJournalArticle);
+            case AcademicArticle academicArticle ->
+                getAcademicArticle(existingJournalArticle, incomingJournalArticle);
+            case AcademicLiteratureReview academicLiteratureReview ->
+                getAcademicLiteratureReview(existingJournalArticle, incomingJournalArticle);
+            case null, default -> existingJournalArticle;
+        };
+    }
+
+    @JacocoGenerated
+    private static AcademicLiteratureReview getAcademicLiteratureReview(JournalArticle existingJournalArticle,
+                                                                        JournalArticle incomingJournalArticle) {
+        return new AcademicLiteratureReview(existingJournalArticle.getPages(),
+                                            existingJournalArticle.getVolume(),
+                                            existingJournalArticle.getIssue(),
+                                            incomingJournalArticle.getArticleNumber());
+    }
+
+    @JacocoGenerated
+    private static AcademicArticle getAcademicArticle(JournalArticle existingJournalArticle,
+                                                      JournalArticle incomingJournalArticle) {
+        return new AcademicArticle(existingJournalArticle.getPages(), existingJournalArticle.getVolume(),
+                                   existingJournalArticle.getIssue(),
+                                   incomingJournalArticle.getArticleNumber());
+    }
+
+    @JacocoGenerated
+    private static PopularScienceArticle getPopularScienceArticle(JournalArticle existingJournalArticle,
+                                                                  JournalArticle incomingJournalArticle) {
+        return new PopularScienceArticle(existingJournalArticle.getPages(), existingJournalArticle.getVolume(),
+                                         existingJournalArticle.getIssue(),
+                                         incomingJournalArticle.getArticleNumber());
+    }
+
+    @JacocoGenerated
+    private static ProfessionalArticle getProfessionalArticle(JournalArticle existingJournalArticle,
+                                                              JournalArticle incomingJournalArticle) {
+        return new ProfessionalArticle(existingJournalArticle.getPages(), existingJournalArticle.getVolume(),
+                                       existingJournalArticle.getIssue(),
+                                       incomingJournalArticle.getArticleNumber());
+    }
+
+    private static PublicationInstance<? extends Pages> getPublicationInstance(Publication publication) {
+        return publication
+                   .getEntityDescription()
+                   .getReference()
+                   .getPublicationInstance();
     }
 
     private static PublicationContext updatePublicationContext(PublicationRepresentations publicationRepresentations) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -3,6 +3,7 @@ package no.unit.nva.cristin.lambda;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import java.util.ArrayList;
+import java.util.List;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Reference;
@@ -25,7 +26,16 @@ public final class PublicationUpdater {
     private static EntityDescription updatedEntityDescription(PublicationRepresentations publicationRepresentations) {
         return publicationRepresentations.getExistingPublication().getEntityDescription().copy()
                    .withReference(updateReference(publicationRepresentations))
+                   .withTags(updatedTags(publicationRepresentations))
                    .build();
+    }
+
+    private static List<String> updatedTags(PublicationRepresentations publicationRepresentations) {
+        var existingTags = publicationRepresentations.getExistingPublication().getEntityDescription().getTags();
+        var incomingTags = publicationRepresentations.getIncomingPublication().getEntityDescription().getTags();
+        var list = new ArrayList<>(existingTags);
+        list.addAll(incomingTags);
+        return list.stream().distinct().toList();
     }
 
     private static Reference updateReference(PublicationRepresentations publicationRepresentations) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -1,8 +1,14 @@
 package no.unit.nva.cristin.lambda;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import java.util.ArrayList;
-import no.unit.nva.cristin.mapper.AssociatedLinkExtractor;
+import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.Publication;
+import no.unit.nva.model.Reference;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
+import no.unit.nva.model.contexttypes.Event;
+import no.unit.nva.model.contexttypes.PublicationContext;
 
 public final class PublicationUpdater {
 
@@ -12,7 +18,51 @@ public final class PublicationUpdater {
     public static PublicationRepresentations update(PublicationRepresentations publicationRepresentations) {
         var existingPublication = publicationRepresentations.getExistingPublication();
         existingPublication.setAssociatedArtifacts(updatedAssociatedLinks(publicationRepresentations));
+        existingPublication.setEntityDescription(updatedEntityDescription(publicationRepresentations));
         return publicationRepresentations;
+    }
+
+    private static EntityDescription updatedEntityDescription(PublicationRepresentations publicationRepresentations) {
+        return publicationRepresentations.getExistingPublication().getEntityDescription().copy()
+                   .withReference(updateReference(publicationRepresentations))
+                   .build();
+    }
+
+    private static Reference updateReference(PublicationRepresentations publicationRepresentations) {
+        var existinReference = publicationRepresentations.getExistingPublication().getEntityDescription().getReference();
+        existinReference.setPublicationContext(updatePublicationContext(publicationRepresentations));
+        return existinReference;
+
+    }
+
+    private static PublicationContext updatePublicationContext(PublicationRepresentations publicationRepresentations) {
+        var existingPublicationContext = getPublicationContext(publicationRepresentations.getExistingPublication());
+        var incomingPublicationContext = getPublicationContext(publicationRepresentations.getIncomingPublication());
+        if (existingPublicationContext instanceof Event existingEvent && incomingPublicationContext instanceof Event incomingEvent) {
+            var existingPlace = existingEvent.getPlace();
+            var incomingPlace = incomingEvent.getPlace();
+            if (isNull(existingPlace) && nonNull(incomingPlace)) {
+                return new Event.Builder()
+                           .withLabel(existingEvent.getLabel())
+                           .withAgent(existingEvent.getAgent())
+                           .withTime(existingEvent.getTime())
+                           .withProduct(existingEvent.getProduct().orElse(null))
+                           .withSubEvent(existingEvent.getSubEvent().orElse(null))
+                           .withPlace(incomingPlace)
+                           .build();
+            } else {
+                return existingEvent;
+            }
+        } else {
+            return existingPublicationContext;
+        }
+    }
+
+    private static PublicationContext getPublicationContext(Publication publication) {
+        return publication
+                   .getEntityDescription()
+                   .getReference()
+                   .getPublicationContext();
     }
 
     private static AssociatedArtifactList updatedAssociatedLinks(

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -466,6 +466,7 @@ public final class CristinDataGenerator {
                    .withTags(randomTagList())
                    .withCristinAssociatedUris(List.of(new CristinAssociatedUri("DATA", randomUri().toString())))
                    .withLectureOrPosterMetaData(randomLectureOrPosterMetaData())
+                   .withJournalPublication(randomJournalPublication())
                    .build();
     }
 
@@ -815,6 +816,7 @@ public final class CristinDataGenerator {
                    .withPagesEnd(String.valueOf(pagesBegin + smallRandomNumber()))
                    .withVolume(String.valueOf(smallRandomNumber()))
                    .withDoi(randomDoiString())
+                   .withArticleNumber(randomString())
                    .build();
     }
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -18,6 +18,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomDoi;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +36,7 @@ import java.util.stream.Stream;
 import net.datafaker.providers.base.BaseFaker;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.cristin.lambda.constants.HardcodedValues;
+import no.unit.nva.cristin.mapper.CristinAssociatedUri;
 import no.unit.nva.cristin.mapper.CristinLocale;
 import no.unit.nva.cristin.mapper.CristinLectureOrPosterMetaData;
 import no.unit.nva.cristin.mapper.PresentationEvent;
@@ -289,15 +291,19 @@ public final class CristinDataGenerator {
         return cristinObject;
     }
 
-    public static JsonNode objectWithTags() throws JsonProcessingException {
-        var cristingTagsList = List.of(CristinTags.builder()
-                                           .withBokmal(randomString())
-                                           .withEnglish(randomString())
-                                           .withNynorsk(randomString())
-                                           .build());
+    public static CristinObject objectWithTags() {
+        var cristingTagsList = randomTagList();
         var cristinObject = randomObject();
         cristinObject.setTags(cristingTagsList);
-        return cristinObjectAsObjectNode(cristinObject);
+        return cristinObject;
+    }
+
+    private static List<CristinTags> randomTagList() {
+        return List.of(CristinTags.builder()
+                           .withBokmal(randomString())
+                           .withEnglish(randomString())
+                           .withNynorsk(randomString())
+                           .build());
     }
 
     public static JsonNode objectWithCristinHrcsCategoriesAndActivities() throws JsonProcessingException {
@@ -426,7 +432,7 @@ public final class CristinDataGenerator {
         return createRandomMediaWithSpecifiedSecondaryCategory(secondaryCategory);
     }
 
-    private static CristinObject createRandomMediaWithSpecifiedSecondaryCategory(
+    public static CristinObject createRandomMediaWithSpecifiedSecondaryCategory(
         CristinSecondaryCategory secondaryCategory) {
         return CristinObject.builder()
                    .withYearReported(2001)
@@ -439,6 +445,27 @@ public final class CristinDataGenerator {
                    .withPublicationOwner(randomString())
                    .withContributors(randomContributors())
                    .withMediaContribution(randomMediaContribution())
+                   .withTags(randomTagList())
+                   .withCristinAssociatedUris(List.of(new CristinAssociatedUri("DATA", randomUri().toString())))
+                   .build();
+    }
+
+    public static CristinObject createObjectWithCategory(CristinMainCategory mainCategory,
+        CristinSecondaryCategory secondaryCategory) {
+        return CristinObject.builder()
+                   .withYearReported(2001)
+                   .withCristinTitles(List.of(randomCristinTitle(FIRST_TITLE)))
+                   .withEntryCreationDate(LocalDate.now())
+                   .withMainCategory(mainCategory)
+                   .withSecondaryCategory(secondaryCategory)
+                   .withId(largeRandomNumber())
+                   .withPublicationYear(randomYear())
+                   .withPublicationOwner(randomString())
+                   .withContributors(randomContributors())
+                   .withMediaContribution(randomMediaContribution())
+                   .withTags(randomTagList())
+                   .withCristinAssociatedUris(List.of(new CristinAssociatedUri("DATA", randomUri().toString())))
+                   .withLectureOrPosterMetaData(randomLectureOrPosterMetaData())
                    .build();
     }
 
@@ -662,7 +689,7 @@ public final class CristinDataGenerator {
                    .withTitle(randomString())
                    .withAgent(randomString())
                    .withCountryCode(randomString())
-                   .withPlace(randomDoiString())
+                   .withPlace(randomString())
                    .withFrom("2023-11-28T00:00:00")
                    .withTo("2023-11-29T00:00:00")
                    .build();


### PR DESCRIPTION
Doing following when updating existing publication:

- Updating Event place when null
- Updating AssociatedArtifacts with NEW AssociatedLink when no present
- Updating EntityDescription.tags when new tags
- Removing update of publication when update has no effective changes (removing database update + update report persistance)