### PR TITLE
Np 46695 update unpublish allowance

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
@@ -10,6 +10,7 @@ import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.associatedartifacts.file.PublishedFile;
+import no.unit.nva.model.associatedartifacts.file.UnpublishedFile;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
 import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
@@ -49,8 +50,12 @@ public abstract class PermissionStrategy {
     }
 
 
-    protected boolean hasPublishedFiles() {
+    protected boolean hasPublishedFile() {
         return publication.getAssociatedArtifacts().stream().anyMatch(PublishedFile.class::isInstance);
+    }
+
+    protected boolean hasUnpublishedFile() {
+        return publication.getAssociatedArtifacts().stream().anyMatch(UnpublishedFile.class::isInstance);
     }
 
     protected Boolean isOwner() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
@@ -9,6 +9,7 @@ import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Reference;
+import no.unit.nva.model.associatedartifacts.file.PublishedFile;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
 import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
@@ -45,6 +46,11 @@ public abstract class PermissionStrategy {
 
     protected boolean isVerifiedContributor(Contributor contributor) {
         return contributor.getIdentity() != null && contributor.getIdentity().getId() != null;
+    }
+
+
+    protected boolean hasPublishedFiles() {
+        return publication.getAssociatedArtifacts().stream().anyMatch(PublishedFile.class::isInstance);
     }
 
     protected Boolean isOwner() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategy.java
@@ -14,8 +14,8 @@ import no.unit.nva.publication.permission.strategy.grant.EditorPermissionStrateg
 import no.unit.nva.publication.permission.strategy.grant.GrantPermissionStrategy;
 import no.unit.nva.publication.permission.strategy.grant.ResourceOwnerPermissionStrategy;
 import no.unit.nva.publication.permission.strategy.grant.TrustedThirdPartyStrategy;
-import no.unit.nva.publication.permission.strategy.restrict.NonDegreePermissionStrategy;
 import no.unit.nva.publication.permission.strategy.restrict.DenyPermissionStrategy;
+import no.unit.nva.publication.permission.strategy.restrict.NonDegreePermissionStrategy;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,8 +109,6 @@ public class PublicationPermissionStrategy {
             throw new UnauthorizedException(formatUnauthorizedMessage(requestedPermission));
         }
     }
-
-
 
     private void validateGrantStrategies(PublicationOperation requestedPermission) throws UnauthorizedException {
         var strategies = findAllowances(requestedPermission).stream()

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/ContributorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/ContributorPermissionStrategy.java
@@ -19,7 +19,7 @@ public class ContributorPermissionStrategy extends GrantPermissionStrategy {
     public boolean allowsAction(PublicationOperation permission) {
         return switch (permission) {
             case UPDATE -> userIsVerifiedContributor();
-            case UNPUBLISH -> userIsVerifiedContributor() && !hasPublishedFiles();
+            case UNPUBLISH -> userIsVerifiedContributor() && !hasPublishedFile();
             default -> false;
         };
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/ContributorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/ContributorPermissionStrategy.java
@@ -18,7 +18,8 @@ public class ContributorPermissionStrategy extends GrantPermissionStrategy {
     @Override
     public boolean allowsAction(PublicationOperation permission) {
         return switch (permission) {
-            case UPDATE, UNPUBLISH -> userIsVerifiedContributor();
+            case UPDATE -> userIsVerifiedContributor();
+            case UNPUBLISH -> userIsVerifiedContributor() && !hasPublishedFiles();
             default -> false;
         };
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/CuratorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/CuratorPermissionStrategy.java
@@ -4,7 +4,6 @@ import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
-import no.unit.nva.model.associatedartifacts.file.UnpublishedFile;
 import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.utils.CuratingInstitutionsUtil;
@@ -59,12 +58,6 @@ public class CuratorPermissionStrategy extends GrantPermissionStrategy {
                     userTopLevelOrg);
 
         return contributorTopLevelOrgs.stream().anyMatch(org -> org.equals(userTopLevelOrg));
-    }
-
-
-
-    private boolean hasUnpublishedFile() {
-        return publication.getAssociatedArtifacts().stream().anyMatch(UnpublishedFile.class::isInstance);
     }
 
     private boolean canManagePublishingRequests() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
@@ -361,7 +361,7 @@ class PublicationPermissionStrategyTest {
     }
 
     @Test
-    void shouldGivePermissionToUnpublishPublicationWhenUserIsContributor()
+    void shouldNotGivePermissionToUnpublishPublicationWhenUserIsContributor()
         throws JsonProcessingException, UnauthorizedException {
         var contributorName = randomString();
         var contributorCristinId = randomUri();
@@ -372,7 +372,7 @@ class PublicationPermissionStrategyTest {
         var publication = createPublicationWithContributor(contributorName, contributorCristinId, Role.CREATOR,
                                                            randomUri(), topLevelCristinOrgId);
 
-        Assertions.assertTrue(PublicationPermissionStrategy
+        Assertions.assertFalse(PublicationPermissionStrategy
                                   .create(publication, RequestUtil.createUserInstanceFromRequest(
                                       requestInfo, identityServiceClient), uriRetriever)
                                   .allowsAction(UNPUBLISH));
@@ -541,7 +541,7 @@ class PublicationPermissionStrategyTest {
         PublicationPermissionStrategy
             .create(publication, RequestUtil.createUserInstanceFromRequest(
                 requestInfo, identityServiceClient), uriRetriever)
-            .authorize(UNPUBLISH);
+            .authorize(UPDATE);
         assertThat(appender.getMessages(), containsString(contributorName));
         assertThat(appender.getMessages(), containsString(publication.getIdentifier().toString()));
         assertThat(appender.getMessages(), containsString("ContributorPermissionStrategy"));

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
@@ -361,7 +361,7 @@ class PublicationPermissionStrategyTest {
     }
 
     @Test
-    void shouldNotGivePermissionToUnpublishPublicationWhenUserIsContributor()
+    void shouldNotGivePermissionToUnpublishPublicationWithPublishedFilesWhenUserIsContributor()
         throws JsonProcessingException, UnauthorizedException {
         var contributorName = randomString();
         var contributorCristinId = randomUri();

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerRightsRetentionTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerRightsRetentionTest.java
@@ -56,7 +56,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
                                   .build();
 
         var persistedPublication = Resource.fromPublication(academicArticle)
-                                       .persistNew(publicationService, UserInstance.fromPublication(academicArticle));
+                                       .persistNew(resourceService, UserInstance.fromPublication(academicArticle));
         var username = academicArticle.getResourceOwner().getOwner().getValue();
 
 
@@ -76,7 +76,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
         var response = GatewayResponse.fromOutputStream(output, Publication.class);
         assertThat(response.getStatusCode(), is(equalTo(SC_OK)));
 
-        var updatedPublication = publicationService.getPublicationByIdentifier(persistedPublication.getIdentifier());
+        var updatedPublication = resourceService.getPublicationByIdentifier(persistedPublication.getIdentifier());
         var insertedFile = (File) updatedPublication.getAssociatedArtifacts().getFirst();
 
         assertTrue(insertedFile.getRightsRetentionStrategy() instanceof OverriddenRightsRetentionStrategy);
@@ -100,7 +100,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
                                   .build();
 
         var persistedPublication = Resource.fromPublication(academicArticle)
-                                       .persistNew(publicationService, UserInstance.fromPublication(academicArticle));
+                                       .persistNew(resourceService, UserInstance.fromPublication(academicArticle));
 
         var update = persistedPublication.copy().withEntityDescription(
             randomEntityDescription(DegreeBachelor.class)
@@ -114,7 +114,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
         var response = GatewayResponse.fromOutputStream(output, Publication.class);
         assertThat(response.getStatusCode(), is(equalTo(SC_OK)));
 
-        var updatedPublication = publicationService.getPublicationByIdentifier(persistedPublication.getIdentifier());
+        var updatedPublication = resourceService.getPublicationByIdentifier(persistedPublication.getIdentifier());
         var insertedFile = (File) updatedPublication.getAssociatedArtifacts().getFirst();
 
         assertTrue(insertedFile.getRightsRetentionStrategy() instanceof NullRightsRetentionStrategy);
@@ -138,7 +138,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
                                   .build();
 
         var persistedPublication = Resource.fromPublication(academicArticle)
-                                       .persistNew(publicationService, UserInstance.fromPublication(academicArticle));
+                                       .persistNew(resourceService, UserInstance.fromPublication(academicArticle));
 
         var update = persistedPublication.copy().withAssociatedArtifacts(
             List.of(updatedFile)
@@ -152,7 +152,7 @@ class UpdatePublicationHandlerRightsRetentionTest extends UpdatePublicationHandl
         var response = GatewayResponse.fromOutputStream(output, Publication.class);
         assertThat(response.getStatusCode(), is(equalTo(SC_OK)));
 
-        var updatedPublication = publicationService.getPublicationByIdentifier(persistedPublication.getIdentifier());
+        var updatedPublication = resourceService.getPublicationByIdentifier(persistedPublication.getIdentifier());
         var insertedFile = (File) updatedPublication.getAssociatedArtifacts().getFirst();
 
         assertTrue(insertedFile.getRightsRetentionStrategy() instanceof OverriddenRightsRetentionStrategy);

--- a/publication-testing/src/main/java/no/unit/nva/publication/testing/http/RandomPersonServiceResponse.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/testing/http/RandomPersonServiceResponse.java
@@ -5,7 +5,7 @@ import java.net.URI;
 
 public class RandomPersonServiceResponse {
     
-    private URI affiliationUri;
+    private final URI affiliationUri;
     
     public RandomPersonServiceResponse() {
         this(randomUri());

--- a/tickets-test/build.gradle
+++ b/tickets-test/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation libs.guava
     implementation libs.aws.sdk.dynamodb
     implementation libs.junit.jupiter.params
+    implementation libs.nva.testutils
     testImplementation(project(':publication-testing'))
     testImplementation libs.nva.testutils
     testImplementation libs.jsonassert


### PR DESCRIPTION
Changed allowances:

- Contributor can not longer `unpublish` publication with `published files`
- Registrator can not longer `unpublish` publication with` published files`
---
- Contributor can still `unpublish` publication without `published files`
- Registrator can still `unpublish` publication without `published files`

--- 
- Curator can still `unpublish` publication with `published files`
- Editor can still `unpublish` publication with `published files`