### PR TITLE
mapping npi subject heading for chapter

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -80,7 +80,20 @@ public final class PublicationUpdater {
                    .withReference(updateReference(publicationRepresentations))
                    .withTags(updatedTags(publicationRepresentations))
                    .withContributors(updateContributors(publicationRepresentations))
+                   .withNpiSubjectHeading(updateNpiSubjectHeading(publicationRepresentations))
                    .build();
+    }
+
+    private static String updateNpiSubjectHeading(PublicationRepresentations publicationRepresentations) {
+        var existingNpiSubjectHeading = getNpiSubjectHeading(publicationRepresentations.getExistingPublication());
+        var incomingNpiSubjectHeading = getNpiSubjectHeading(publicationRepresentations.getIncomingPublication());
+        return shouldBeUpdated(existingNpiSubjectHeading, incomingNpiSubjectHeading)
+                   ? incomingNpiSubjectHeading
+                   : existingNpiSubjectHeading;
+    }
+
+    private static String getNpiSubjectHeading(Publication existingPublication) {
+        return existingPublication.getEntityDescription().getNpiSubjectHeading();
     }
 
     private static List<Contributor> updateContributors(PublicationRepresentations publicationRepresentations) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinBookOrReportPartMetadata.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinBookOrReportPartMetadata.java
@@ -19,14 +19,14 @@ import nva.commons.core.JacocoGenerated;
 @Getter
 @Setter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
-@JsonIgnoreProperties({"antall_sider_totalt",
-    "status_utgitt_av_forlag", "delangivelse", "sprakkode_oversatt_fra", "fagfelt"})
+@JsonIgnoreProperties({"antall_sider_totalt", "status_utgitt_av_forlag", "delangivelse", "sprakkode_oversatt_fra"})
 public class CristinBookOrReportPartMetadata {
 
     public static final String PAGES_START = "sidenr_fra";
     public static final String PAGES_END = "sidenr_til";
     public static final String PART_OF = "varbeidlopenr_inngar_i";
     private static final String DOI = "doi";
+    public static final String SUBJECT_FIELD = "fagfelt";
 
     @JsonProperty(PAGES_START)
     private String pagesStart;
@@ -38,6 +38,8 @@ public class CristinBookOrReportPartMetadata {
 
     @JsonProperty(DOI)
     private String doi;
+    @JsonProperty(SUBJECT_FIELD)
+    private CristinSubjectField subjectField;
 
     @JacocoGenerated
     public CristinBookOrReportPartMetadata() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -11,6 +11,7 @@ import static no.unit.nva.cristin.lambda.constants.MappingConstants.PATH_CUSTOME
 import static no.unit.nva.cristin.mapper.CristinHrcsCategoriesAndActivities.HRCS_ACTIVITY_URI;
 import static no.unit.nva.cristin.mapper.CristinHrcsCategoriesAndActivities.HRCS_CATEGORY_URI;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isBook;
+import static no.unit.nva.cristin.mapper.CristinMainCategory.isChapter;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isReport;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static nva.commons.core.attempt.Try.attempt;
@@ -25,8 +26,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -493,25 +494,20 @@ public class CristinMapper extends CristinMappingModule {
 
     private String extractNpiSubjectHeading() {
         return Optional.ofNullable(extractSubjectField())
-                   .map(this::extractSubjectFieldCode)
+                   .map(CristinSubjectField::getSubjectFieldCode)
+                   .map(String::valueOf)
                    .orElse(null);
     }
 
-    private String extractSubjectFieldCode(CristinSubjectField subjectField) {
-        return Optional.ofNullable(subjectField.getSubjectFieldCode())
-                   .map(String::valueOf)
-                   .orElseThrow(() -> new MissingFieldsException(CristinSubjectField.MISSING_SUBJECT_FIELD_CODE));
-    }
-
-    private boolean resourceTypeIsNotExpectedToHaveAnNpiSubjectHeading() {
-        return !(isBook(cristinObject) || isReport(cristinObject));
-    }
-
     private CristinSubjectField extractSubjectField() {
-        if (resourceTypeIsNotExpectedToHaveAnNpiSubjectHeading()) {
+        if (isBook(cristinObject) || isReport(cristinObject)) {
+            return extractCristinBookReport().getSubjectField();
+        }
+        if (isChapter(cristinObject)) {
+            return cristinObject.getBookOrReportPartMetadata().getSubjectField();
+        } else {
             return null;
         }
-        return extractCristinBookReport().getSubjectField();
     }
 
     private List<CristinTags> extractCristinTags() {

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -17,6 +17,7 @@ import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomDoi;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,6 +38,7 @@ import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.cristin.lambda.constants.HardcodedValues;
 import no.unit.nva.cristin.mapper.CristinAssociatedUri;
 import no.unit.nva.cristin.mapper.CristinBookOrReportMetadata;
+import no.unit.nva.cristin.mapper.CristinBookOrReportPartMetadata;
 import no.unit.nva.cristin.mapper.CristinContributor;
 import no.unit.nva.cristin.mapper.CristinContributorRole;
 import no.unit.nva.cristin.mapper.CristinContributorRoleCode;
@@ -467,7 +469,14 @@ public final class CristinDataGenerator {
                    .withTags(randomTagList())
                    .withCristinAssociatedUris(List.of(new CristinAssociatedUri("DATA", randomUri().toString())))
                    .withLectureOrPosterMetaData(randomLectureOrPosterMetaData())
+                   .withBookOrReportPartMetadata(randomBookOrReportPartMetadata())
                    .withJournalPublication(randomJournalPublication())
+                   .build();
+    }
+
+    private static CristinBookOrReportPartMetadata randomBookOrReportPartMetadata() {
+        return CristinBookOrReportPartMetadata.builder()
+                   .withSubjectField(CristinSubjectField.builder().withSubjectFieldCode(randomInteger()).build())
                    .build();
     }
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -442,16 +442,6 @@ class CristinMapperTest extends AbstractCristinImportTest {
     }
 
     @Test
-    void constructorThrowsExceptionWhenABookReportHasASubjectFieldButSubjectFieldCodeIsNull() {
-        CristinObject cristinObject = CristinDataGenerator.randomBook();
-        cristinObject.getBookOrReportMetadata().getSubjectField().setSubjectFieldCode(null);
-
-        System.out.println(cristinObject);
-
-        assertThrows(MissingFieldsException.class, () -> mapToPublication(cristinObject));
-    }
-
-    @Test
     void mapThrowsMissingFieldsExceptionWhenNonIgnoredFieldIsMissing() {
         //re-use the test for the author's name
         mapSetsNameToNullWhenBothFamilyNameAndGivenNameAreMissing();


### PR DESCRIPTION
- Mapping `npiSubjectHeading` for `Chapter`
- Removing exception when npiSubjectHeading is missing for `Book` or `Report`
- Updating npiSubjectHeading when existing publication is missing npiSubjectHeading