### PR TITLE
Persist updated nvi report

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumer.java
@@ -159,10 +159,17 @@ public class CristinEntryEventConsumer
         return attempt(() -> getExistingPublication(publicationRepresentation))
                    .map(publicationRepresentation::withExistingPublication)
                    .map(PublicationUpdater::update)
-                   .map(publicationRepresentations -> publicationRepresentations.updateHasEffectiveChanges()
-                                                          ? update(publicationRepresentations)
-                                                          : publicationRepresentations.getExistingPublication())
+                   .map(this::getPublication)
                    .orElseThrow();
+    }
+
+    private Publication getPublication(PublicationRepresentations publicationRepresentations) {
+        if (publicationRepresentations.updateHasEffectiveChanges()) {
+            return update(publicationRepresentations);
+        } else {
+            persistNviReportIfNeeded(publicationRepresentations);
+            return publicationRepresentations.getExistingPublication();
+        }
     }
 
     private Publication update(PublicationRepresentations publicationRepresentations) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationRepresentations.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationRepresentations.java
@@ -54,7 +54,9 @@ public class PublicationRepresentations {
     }
 
     public String getNvaPublicationIdentifier() {
-        return incomingPublication.getIdentifier().toString();
+        return nonNull(incomingPublication.getIdentifier())
+                   ? incomingPublication.getIdentifier().toString()
+                   : existingPublication.getIdentifier().toString();
     }
 
     public URI getOriginalEventFileUri() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
@@ -1,10 +1,12 @@
 package no.unit.nva.cristin.mapper.nva;
 
+import static java.util.Objects.nonNull;
 import java.util.List;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.cristin.lambda.PublicationRepresentations;
 import no.unit.nva.cristin.mapper.CristinLocale;
 import no.unit.nva.cristin.mapper.ScientificResource;
+import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.Reference;
 
@@ -21,19 +23,26 @@ public record NviReport(String publicationIdentifier,
     }
 
     public static NviReport fromPublicationRepresentation(PublicationRepresentations publicationRepresentations) {
+        var publication = getPublication(publicationRepresentations);
         return NviReport.builder()
                    .withPublicationIdentifier(publicationRepresentations.getNvaPublicationIdentifier())
                    .withCristinIdentifier(publicationRepresentations.getCristinObject().getSourceRecordIdentifier())
                    .withCristinLocales(publicationRepresentations.getCristinObject().getCristinLocales())
                    .withScientificResource(publicationRepresentations.getCristinObject().getScientificResources())
-                   .withYearReported(publicationRepresentations.getCristinObject().getScientificResources().getFirst().getReportedYear())
-                   .withPublicationDate(publicationRepresentations.getIncomingPublication().getEntityDescription().getPublicationDate())
-                   .withInstanceType(publicationRepresentations.getIncomingPublication().getEntityDescription()
+                   .withYearReported(publicationRepresentations.getCristinObject().getYearReported().toString())
+                   .withPublicationDate(publication.getEntityDescription().getPublicationDate())
+                   .withInstanceType(publication.getEntityDescription()
                                          .getReference()
                                          .getPublicationInstance()
                                          .getInstanceType())
-                   .withReference(publicationRepresentations.getIncomingPublication().getEntityDescription().getReference())
+                   .withReference(publication.getEntityDescription().getReference())
                    .build();
+    }
+
+    private static Publication getPublication(PublicationRepresentations publicationRepresentations) {
+        return nonNull(publicationRepresentations.getExistingPublication())
+                   ? publicationRepresentations.getExistingPublication()
+                   : publicationRepresentations.getIncomingPublication();
     }
 
     public static final class Builder {


### PR DESCRIPTION
- Persisting nvi report both on creation and update. 
- Makes it possible to generate data for "new" nvi-import, so each to we run cristin-import, we are also able to run new nvi import. 