### PR TITLE
Calculating Levenshtein distance between title when merging

### DIFF
--- a/brage-import/build.gradle
+++ b/brage-import/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation libs.tika.core
     implementation libs.tika.langdetect.optimaize
 
+    implementation libs.apache.commons.text
+
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.646'
 
     testImplementation libs.cucumber.java

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,8 @@ httpcore = { require = '4.4.13' }
 dynamoDbLocal = { strictly = '2.0.0' }
 awsIon = { strictly = '1.5.1' }
 commonsValidator = { strictly = '1.8.0' }
-apacheCommons = { require = '4.4' }
+apacheCommonsCollections = { require = '4.4' }
+apacheCommonsText = { require = '1.12.0' }
 hamcrest = { strictly = '2.2' }
 cucumber = { strictly = '6.11.0' }
 junit = { strictly = '5.10.2' }
@@ -101,7 +102,8 @@ aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', 
 
 aws-ion = { group = 'software.amazon.ion', name = 'ion-java', version.ref = 'awsIon' }
 
-apache-commons-collections = { group = 'org.apache.commons', name = 'commons-collections4', version.ref = 'apacheCommons' }
+apache-commons-collections = { group = 'org.apache.commons', name = 'commons-collections4', version.ref = 'apacheCommonsCollections' }
+apache-commons-text = { group = 'org.apache.commons', name = 'commons-text', version.ref = 'apacheCommonsText' }
 
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commonsValidator' }
 jsonld = { group = 'com.github.jsonld-java', name = 'jsonld-java', version.ref = 'jsonld' }


### PR DESCRIPTION
- We calculate the Levenshtein Distance between the main titles of publications when merging. We assume that a distance of >10 is not significant, so we merge the publications