### PR TITLE
migrate SAMMENDRAG from Cristin

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -60,6 +60,7 @@ public enum CristinSecondaryCategory {
     THEATRICAL_PRODUCTION("TEATERPRODUKSJON", "THEATRICAL_PRODUCTION"),
     VISUAL_ARTS("KUNST_OG_BILDE", "VISUAL_ARTS"),
     WRITTEN_INTERVIEW("INTERVJUSKRIFTL", "WRITTEN INTERVIEW"),
+    ABSTRACT("SAMMENDRAG", "ABSTRACT"),
     UNMAPPED;
 
     public static final int DEFAULT_VALUE = 0;
@@ -104,6 +105,10 @@ public enum CristinSecondaryCategory {
 
     public static boolean isJournalLeader(CristinObject cristinObject) {
         return CristinSecondaryCategory.JOURNAL_LEADER.equals(cristinObject.getSecondaryCategory());
+    }
+
+    public static boolean isAbstract(CristinObject cristinObject) {
+        return CristinSecondaryCategory.ABSTRACT.equals(cristinObject.getSecondaryCategory());
     }
 
     public static boolean isJournalCorrigendum(CristinObject cristinObject) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.mapper;
 
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isAbstract;
 import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isJournalArticle;
 import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isJournalCorrigendum;
 import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isJournalLeader;
@@ -11,6 +12,7 @@ import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryExc
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.journal.AcademicArticle;
 import no.unit.nva.model.instancetypes.journal.AcademicLiteratureReview;
+import no.unit.nva.model.instancetypes.journal.ConferenceAbstract;
 import no.unit.nva.model.instancetypes.journal.JournalCorrigendum;
 import no.unit.nva.model.instancetypes.journal.JournalLeader;
 import no.unit.nva.model.instancetypes.journal.JournalLetter;
@@ -39,9 +41,17 @@ public class JournalBuilder extends AbstractPublicationInstanceBuilder {
             return createJournalCorrigendum();
         } else if (isJournalArticle(getCristinObject())) {
             return createJournalArticle();
-        } else {
+        } else if (isAbstract(getCristinObject())) {
+            return createAbstract();
+        }
+        else {
             throw unknownSecondaryCategory();
         }
+    }
+
+    private PublicationInstance<? extends Pages> createAbstract() {
+        return new ConferenceAbstract(extractVolume(), extractIssue(), extractArticleNumber(),
+                                      new Range(extractPagesBegin(), extractPagesEnd()));
     }
 
     @Override

--- a/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/CristinDataGenerator.java
@@ -227,10 +227,11 @@ public final class CristinDataGenerator {
             case JOURNAL_LEADER -> randomJournalLeader();
             case JOURNAL_CORRIGENDUM -> randomJournalCorrigendum();
             case JOURNAL_ARTICLE,
-                     ARTICLE,
-                     POPULAR_ARTICLE,
-                     ACADEMIC_REVIEW,
-                     SHORT_COMMUNICATION -> randomJournalArticle(category);
+                 ARTICLE,
+                 POPULAR_ARTICLE,
+                 ACADEMIC_REVIEW,
+                 SHORT_COMMUNICATION,
+                 ABSTRACT -> randomJournalArticle(category);
             case RESEARCH_REPORT -> randomResearchReport();
             case DEGREE_PHD, MAGISTER_THESIS -> randomDegreePhd(category);
             case DEGREE_LICENTIATE -> randomDegreeLicentiate();

--- a/cristin-import/src/test/resources/features/ConferenceAbstractRules.feature
+++ b/cristin-import/src/test/resources/features/ConferenceAbstractRules.feature
@@ -1,0 +1,8 @@
+Feature: Mapping of "Abstract" entries
+
+  Background:
+    Given a valid Cristin Result with secondary category "SAMMENDRAG"
+
+  Scenario: Cristin Result of type "Abstract" maps to NVA "ConferenceAbstract".
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a Publication Instance of type "ConferenceAbstract"


### PR DESCRIPTION
Not sure if this is enough of testing when mapping new type in Cristin-import, but all other fields we scrape for ABSTRACT are already tested. 