### PR TITLE
NP-46888 Update who can delete messages

### DIFF
--- a/messages/src/test/java/no/unit/nva/publication/messages/delete/DeleteMessageHandlerTest.java
+++ b/messages/src/test/java/no/unit/nva/publication/messages/delete/DeleteMessageHandlerTest.java
@@ -82,7 +82,10 @@ class DeleteMessageHandlerTest extends ResourcesLocalTest {
     }
 
     @ParameterizedTest
-    @ValueSource(classes = {DoiRequest.class, PublishingRequestCase.class, GeneralSupportRequest.class})
+    @ValueSource(classes = {
+        DoiRequest.class,
+        PublishingRequestCase.class,
+        GeneralSupportRequest.class})
     void shouldReturnUnauthorizedWhenUserIsAttemptingToDeleteTicketUserDoesNotOwn(
         Class<? extends TicketEntry> ticketType)
         throws ApiGatewayException, IOException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -89,8 +89,8 @@ public class UserInstance implements JsonSerializable {
         return UserInstance.create(ticket.getOwner(), ticket.getCustomerId());
     }
 
-    public boolean isOwner(Message message) {
-        return this.user.equals(message.getOwner())
+    public boolean isSender(Message message) {
+        return this.user.equals(message.getSender())
                && this.customerId.equals(message.getCustomerId());
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
@@ -23,6 +23,7 @@ import no.unit.nva.publication.model.business.Message;
 import no.unit.nva.publication.model.business.MessageStatus;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.TicketEntry;
+import no.unit.nva.publication.model.business.UnpublishRequest;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.MessageDao;
@@ -115,6 +116,7 @@ public class MessageService extends ServiceWithTransactions {
             case PublishingRequestCase publishingRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_PUBLISHING_REQUESTS);
             case GeneralSupportRequest supportRequest -> userInstance.getAccessRights().contains(AccessRight.SUPPORT);
             case DoiRequest doiRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_DOI);
+            case UnpublishRequest unpublishRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_RESOURCES_STANDARD);
             default -> false;
         };
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
@@ -13,13 +13,23 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.associatedartifacts.file.AdministrativeAgreement;
+import no.unit.nva.model.associatedartifacts.file.PublishedFile;
+import no.unit.nva.model.associatedartifacts.file.UnpublishedFile;
 import no.unit.nva.publication.external.services.UriRetriever;
+import no.unit.nva.publication.model.business.DoiRequest;
+import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.Message;
 import no.unit.nva.publication.model.business.MessageStatus;
+import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.MessageDao;
+import no.unit.nva.publication.utils.RequestUtils;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
@@ -29,7 +39,8 @@ import org.slf4j.LoggerFactory;
 public class MessageService extends ServiceWithTransactions {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageService.class);
-    public static final String OWNER_ONLY_MESSAGE = "Message owner only can perform this action!";
+    public static final String SENDER_OR_CURATOR_ONLY_MESSAGE = "Only message sender and curator can perform this "
+                                                               + "action!";
     public static final String MESSAGE_NOT_FOUND_ERROR = "Could not find message with identifier:";
     private static final String MESSAGE_REFRESHED_MESSAGE =
         "Message {} for ticket {} for publication {} has been refreshed successfully";
@@ -74,15 +85,29 @@ public class MessageService extends ServiceWithTransactions {
                    .toOptional();
     }
 
-    public void deleteMessage(UserInstance userInstance, Message message) throws UnauthorizedException {
-        if (!userInstance.isOwner(message)) {
-            throw new UnauthorizedException(OWNER_ONLY_MESSAGE);
+    public void deleteMessage(UserInstance userInstance, Message message)
+        throws UnauthorizedException, NotFoundException {
+        if (!userInstance.isSender(message) && !isCuratorOnTicket(message, userInstance)) {
+            throw new UnauthorizedException(SENDER_OR_CURATOR_ONLY_MESSAGE);
         }
         message.setModifiedDate(Instant.now());
         message.setStatus(MessageStatus.DELETED);
         var dao = message.toDao();
         var transactionRequest = dao.createInsertionTransactionRequest();
         getClient().transactWriteItems(transactionRequest);
+    }
+
+    private boolean isCuratorOnTicket(Message message, UserInstance userInstance) throws NotFoundException {
+        if (!message.getCustomerId().equals(userInstance.getCustomerId())) {
+            return false;
+        }
+        var ticket = ticketService.fetchTicketByIdentifier(message.getTicketIdentifier());
+        return switch (ticket) {
+            case PublishingRequestCase publishingRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_PUBLISHING_REQUESTS);
+            case GeneralSupportRequest supportRequest -> userInstance.getAccessRights().contains(AccessRight.SUPPORT);
+            case DoiRequest doiRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_DOI);
+            default -> false;
+        };
     }
 
     public void refresh(SortableIdentifier identifier) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.Period;
@@ -148,25 +149,13 @@ class MessageServiceTest extends ResourcesLocalTest {
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
         var persistedMessage = messageService.createMessage(ticket, owner, randomString());
 
-        var doiCurator = UserInstance.create(
-            randomString(), owner.getCustomerId(), randomUri(), List.of(AccessRight.MANAGE_DOI), randomUri()
-        );
-        var supportCurator = UserInstance.create(
-            randomString(), owner.getCustomerId(), randomUri(), List.of(AccessRight.SUPPORT), randomUri()
-        );
-        var publishingCurator = UserInstance.create(
-            randomString(), owner.getCustomerId(), randomUri(), List.of(AccessRight.MANAGE_PUBLISHING_REQUESTS), randomUri()
-        );
+        var doiCurator = randomUserInstance(AccessRight.MANAGE_DOI, owner.getCustomerId());
+        var supportCurator = randomUserInstance(AccessRight.SUPPORT, owner.getCustomerId());
+        var publishingCurator = randomUserInstance(AccessRight.MANAGE_PUBLISHING_REQUESTS, owner.getCustomerId());
 
-        var doiCuratorFromAnotherInstitution = UserInstance.create(
-            randomString(), randomUri(), randomUri(), List.of(AccessRight.MANAGE_DOI), randomUri()
-        );
-        var supportCuratorFromAnotherInstitution = UserInstance.create(
-            randomString(), randomUri(), randomUri(), List.of(AccessRight.SUPPORT), randomUri()
-        );
-        var publishingCuratorFromAnotherInstitution = UserInstance.create(
-            randomString(), randomUri(), randomUri(), List.of(AccessRight.MANAGE_PUBLISHING_REQUESTS), randomUri()
-        );
+        var doiCuratorFromAnotherInstitution = randomUserInstance(AccessRight.MANAGE_DOI);
+        var supportCuratorFromAnotherInstitution = randomUserInstance(AccessRight.SUPPORT);
+        var publishingCuratorFromAnotherInstitution = randomUserInstance(AccessRight.MANAGE_PUBLISHING_REQUESTS);
 
         if (ticketType == DoiRequest.class) {
             assertDoesNotThrow(() -> messageService.deleteMessage(doiCurator, persistedMessage));
@@ -190,12 +179,16 @@ class MessageServiceTest extends ResourcesLocalTest {
         }
     }
 
-    private static UserInstance randomUserInstance() {
+    private UserInstance randomUserInstance() {
         return UserInstance.create(new User(randomString()), randomUri());
     }
 
-    private static UserInstance randomUserInstanceWithAccessRight(AccessRight accessRight) {
-        return UserInstance.create(new User(randomString()), randomUri());
+    private UserInstance randomUserInstance(AccessRight accessRight) {
+        return UserInstance.create(randomString(), randomUri(), randomUri(), List.of(accessRight), randomUri());
+    }
+
+    private UserInstance randomUserInstance(AccessRight accessRight, URI customerId) {
+        return UserInstance.create(randomString(), customerId, randomUri(), List.of(accessRight), randomUri());
     }
 
     private Message publicationOwnerSendsMessage(TicketEntry ticket, String messageText) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/MessageServiceTest.java
@@ -30,7 +30,6 @@ import no.unit.nva.publication.ticket.test.TicketTestUtils;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
-import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -184,7 +183,7 @@ class MessageServiceTest extends ResourcesLocalTest {
     }
 
     private UserInstance randomUserInstance(AccessRight accessRight) {
-        return UserInstance.create(randomString(), randomUri(), randomUri(), List.of(accessRight), randomUri());
+        return randomUserInstance(accessRight, randomUri());
     }
 
     private UserInstance randomUserInstance(AccessRight accessRight, URI customerId) {


### PR DESCRIPTION
[NP-46888](https://unit.atlassian.net/browse/NP-46888)

Up until now, only `messageOwner` could delete messages. The problem with this, is that `messageOwner` is the same as the `ticketOwner`, which in turn is the `publicationOwner`. Now, it isn't necessarily the `publicationOwner` that creates a message. It could be a contributor or even a curator. Therefore, the `messageSender` is now allowed to delete a message.

Moreover, a curator with correct `accessRights` are also allowed to delete messages within their institution, to help clean up if necessary. 

[NP-46888]: https://unit.atlassian.net/browse/NP-46888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ