### PR TITLE
comparator should allow to merge ConferenceReport with Lecture

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
@@ -5,6 +5,11 @@ import java.util.stream.Stream;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.contexttypes.PublicationContext;
+import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.instancetypes.event.Lecture;
+import no.unit.nva.model.instancetypes.report.ConferenceReport;
+import no.unit.nva.model.pages.Pages;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 
 public final class PublicationComparator {
@@ -28,11 +33,24 @@ public final class PublicationComparator {
     }
 
     private static boolean publicationContextTypeMatches(Publication existingPublication, Publication incomingPublication) {
-        var existingPublicationContext =
-            existingPublication.getEntityDescription().getReference().getPublicationContext().getClass();
-        var incomingPublicationContext =
-            incomingPublication.getEntityDescription().getReference().getPublicationContext().getClass();
-        return existingPublicationContext.equals(incomingPublicationContext);
+        var existingPublicationContext = getPublicationContext(existingPublication);
+        var incomingPublicationContext = getPublicationContext(incomingPublication);
+        var existingPublicationInstance = getPublicationInstance(existingPublication);
+        var incomingPublicationInstance = getPublicationInstance(incomingPublication);
+        if (incomingPublicationInstance instanceof ConferenceReport) {
+            return existingPublicationInstance instanceof Lecture
+                || existingPublicationContext.equals(incomingPublicationContext);
+        } else {
+            return existingPublicationContext.equals(incomingPublicationContext);
+        }
+    }
+
+    private static PublicationInstance<? extends Pages> getPublicationInstance(Publication publication) {
+        return publication.getEntityDescription().getReference().getPublicationInstance();
+    }
+
+    private static Class<? extends PublicationContext> getPublicationContext(Publication incomingPublication) {
+        return incomingPublication.getEntityDescription().getReference().getPublicationContext().getClass();
     }
 
     private static boolean publicationsDateAreClose(Publication existingPublication, Publication incomingPublication) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
@@ -1,0 +1,52 @@
+package no.sikt.nva.brage.migration.lambda;
+
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationDate;
+import no.unit.nva.model.Reference;
+import no.unit.nva.model.contexttypes.Report;
+import no.unit.nva.model.exceptions.InvalidIssnException;
+import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import no.unit.nva.model.instancetypes.event.Lecture;
+import no.unit.nva.model.instancetypes.report.ConferenceReport;
+import no.unit.nva.model.pages.MonographPages;
+import org.junit.jupiter.api.Test;
+
+class PublicationComparatorTest {
+
+    @Test
+    void shouldReturnTrueWhenComparingBrageConferenceReportWithExistingLecture()
+        throws InvalidIssnException, InvalidUnconfirmedSeriesException {
+        var existingLecture = randomPublication(Lecture.class);
+        existingLecture.getEntityDescription().setPublicationDate(new PublicationDate.Builder().withYear("2022").build());
+        var incomingConferenceReport = existingLecture.copy()
+                                           .withEntityDescription(createConferenceReport(existingLecture))
+                                           .build();
+        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
+    }
+
+    @Test
+    void shouldReturnTrueWhenComparingBrageConferenceReportWithExistingConferenceReport()
+        throws InvalidIssnException, InvalidUnconfirmedSeriesException {
+        var existingLecture = randomPublication(ConferenceReport.class);
+        existingLecture.getEntityDescription().setPublicationDate(new PublicationDate.Builder().withYear("2022").build());
+        var incomingConferenceReport = existingLecture.copy()
+                                           .withEntityDescription(createConferenceReport(existingLecture))
+                                           .build();
+        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
+    }
+
+    private EntityDescription createConferenceReport(Publication publication)
+        throws InvalidIssnException, InvalidUnconfirmedSeriesException {
+        var entityDescription = publication.getEntityDescription();
+        var conferenceReport = new ConferenceReport(new MonographPages.Builder().build());
+        var report = new Report.Builder().build();
+        return entityDescription.copy()
+                   .withReference(new Reference.Builder()
+                                      .withPublicationInstance(conferenceReport)
+                                      .withPublishingContext(report)
+                                      .build()).build();
+    }
+}


### PR DESCRIPTION
When mapping publications from Brage and Cristin to NVA publication, there is a case where the same publications getting mapped to two different types. We do not want to change mapping rules for both of imports.

Then we have to allow PublicationComparator to accept these two types for merging.

Here is a case:

Cristin publication: https://test.nva.sikt.no/registration/018dc276604b-b3397502-ab15-440a-af0d-c3d10ca4e9d1
Brage publication: https://test.nva.sikt.no/registration/018f3088a128-20192dcc-abad-448c-8f1d-3d21adef417e

