### PR TITLE
mapping abstracts from brage

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -303,7 +303,7 @@ public final class BrageNvaMapper {
         var abstractList = extractAbstract(brageRecord);
         return new EntityDescription.Builder()
                    .withLanguage(extractLanguage(brageRecord))
-                   .withAbstract(!abstractList.isEmpty() ? abstractList.getFirst() : null)
+                   .withAbstract(Optional.ofNullable(abstractList).map(List::getFirst).orElse(null))
                    .withAlternativeAbstracts(extractAlternativeAbstracts(abstractList))
                    .withDescription(extractDescription(brageRecord))
                    .withPublicationDate(extractDate(brageRecord))
@@ -316,10 +316,10 @@ public final class BrageNvaMapper {
     }
 
     private static Map<String, String> extractAlternativeAbstracts(List<String> abstractList) {
-        return !abstractList.isEmpty()
+        return nonNull(abstractList) && !abstractList.isEmpty()
                    ? abstractList.subList(1, abstractList.size()).stream()
-                   .collect(Collectors.collectingAndThen(Collectors.joining(TWO_NEWLINES),
-                                                         joined -> Map.of(UNDEFINED_LANGUAGE, joined)))
+                   .collect(Collectors.collectingAndThen(
+                       Collectors.joining(TWO_NEWLINES), joined -> Map.of(UNDEFINED_LANGUAGE, joined)))
             : Map.of();
     }
 

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -80,6 +80,7 @@ public final class BrageNvaMapper {
         "Klausulert: Kan bare tillates lest etter nærmere avtale med forfatter");
     public static final String UNDEFINED_LANGUAGE = "und";
     public static final String TWO_NEWLINES = "\n\n";
+    public static final String NO_ABSTRACT = null;
 
     private BrageNvaMapper() {
 
@@ -303,7 +304,7 @@ public final class BrageNvaMapper {
         var abstractList = extractAbstract(brageRecord);
         return new EntityDescription.Builder()
                    .withLanguage(extractLanguage(brageRecord))
-                   .withAbstract(Optional.ofNullable(abstractList).map(List::getFirst).orElse(null))
+                   .withAbstract(abstractList.isEmpty() ? NO_ABSTRACT : abstractList.getFirst())
                    .withAlternativeAbstracts(extractAlternativeAbstracts(abstractList))
                    .withDescription(extractDescription(brageRecord))
                    .withPublicationDate(extractDate(brageRecord))

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
@@ -64,6 +64,22 @@ class BrageNvaMapperTest {
         assertThat(degreePhd.getRelated(), is(equalTo(expectedRelatedDocuments)));
     }
 
+    @Test
+    void shouldMapFirstAlternativeAbstractAsAbstractAndAllOthersAsAlternativeAbstracts()
+        throws InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
+        var firstAbstract = randomString();
+        var secondAbstract = randomString();
+        var thirdAbstract = randomString();
+        var generator =  new NvaBrageMigrationDataGenerator.Builder()
+                             .withType(new Type(List.of(), NvaType.DOCTORAL_THESIS.getValue()))
+                             .withAbstracts(List.of(firstAbstract, secondAbstract, thirdAbstract))
+                             .build();
+        var publication = BrageNvaMapper.toNvaPublication(generator.getBrageRecord());
+        assertThat(publication.getEntityDescription().getAbstract(), is(equalTo(firstAbstract)));
+        assertThat(publication.getEntityDescription().getAlternativeAbstracts().get("und"),
+                   is(equalTo(secondAbstract + "\n\n" + thirdAbstract)));
+    }
+
     private ContentFile createRandomContentFileWithBundleType(BundleType bundleType) {
         return new ContentFile(randomString(), bundleType, randomString(), UUID.randomUUID(), null, null);
     }


### PR DESCRIPTION
When mapping abstracts from Brage and brage-record has multiple abstracts:
- First abstract will be mapped to Abstract
- All other abstract will be mapped to alternativeAbstract with undefined language separated by two new lines. 
