### PR TITLE
adding administrative agreement boolean + more

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactMover.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactMover.java
@@ -69,15 +69,16 @@ public class AssociatedArtifactMover {
 
     private static File buildFile(File file, String mimeType, Long size) {
         var builder =  File.builder()
-                   .withName(file.getName())
-                   .withIdentifier(file.getIdentifier())
-                   .withLicense(file.getLicense())
-                   .withPublisherVersion(file.getPublisherVersion())
-                   .withEmbargoDate(file.getEmbargoDate().orElse(null))
-                   .withMimeType(mimeType)
-                   .withSize(size)
-                   .withLegalNote(file.getLegalNote())
-                   .withUploadDetails(file.getUploadDetails());
+                           .withName(file.getName())
+                           .withIdentifier(file.getIdentifier())
+                           .withLicense(file.getLicense())
+                           .withPublisherVersion(file.getPublisherVersion())
+                           .withEmbargoDate(file.getEmbargoDate().orElse(null))
+                           .withMimeType(mimeType)
+                           .withSize(size)
+                           .withLegalNote(file.getLegalNote())
+                           .withAdministrativeAgreement(file.isAdministrativeAgreement())
+                           .withUploadDetails(file.getUploadDetails());
         if (file instanceof AdministrativeAgreement) {
             return builder.buildUnpublishableFile();
         } else  {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/QueryParam.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/QueryParam.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.brage.migration.merger.findexistingpublication;
+
+public record QueryParam(String name, String value) {
+
+}

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageTestRecord.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageTestRecord.java
@@ -1,0 +1,24 @@
+package no.sikt.nva.brage.migration.lambda;
+
+import no.sikt.nva.brage.migration.testutils.NvaBrageMigrationDataGenerator;
+import no.sikt.nva.brage.migration.testutils.NvaBrageMigrationDataGenerator.Builder;
+import no.unit.nva.model.Publication;
+
+public class BrageTestRecord {
+
+    private final NvaBrageMigrationDataGenerator.Builder generatorBuilder;
+    private final Publication existingPublication;
+
+    public Builder getGeneratorBuilder() {
+        return generatorBuilder;
+    }
+
+    public Publication getExistingPublication() {
+        return existingPublication;
+    }
+
+    public BrageTestRecord(Builder generatorBuilder, Publication existingPublication) {
+        this.generatorBuilder = generatorBuilder;
+        this.existingPublication = existingPublication;
+    }
+}


### PR DESCRIPTION
- Adding isAdministrativeAgreement boolean when copying file. 
- This [task](https://unit.atlassian.net/browse/NP-46847) has not been implemented correctly -> I have extended PublicationComparator - but not search-api call:
