### PR TITLE
updating template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1932,7 +1932,7 @@ Resources:
     Properties:
       CodeUri: brage-import
       Handler: no.sikt.nva.brage.migration.lambda.BragePatchEventConsumer::handleRequest
-      Timeout: 900
+      Timeout: 30
       Role: !GetAtt LambdaRole.Arn
       ReservedConcurrentExecutions: 1
       Environment:


### PR DESCRIPTION
Build in aws is failing because "queue visibility timeout is less than function timeout"

Updating function timeout to be equal queue visibility timeout, it should be enough i think :)

`Resource handler returned message: "Invalid request provided: Queue visibility timeout: 30 seconds is less than Function timeout: 900 seconds (Service: Lambda, Status Code: 400, Request ID: 2ac9766b-7fe0-4598-b971-6d8eb5faa2b4)" (RequestToken: 77181180-d3ac-4002-d9a0-f49ba6d07a88, HandlerErrorCode: InvalidRequest)`