### PR TITLE
fixing concurrency + env var

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -961,7 +961,6 @@ Resources:
     Properties:
       CodeUri: brage-import
       Handler: no.sikt.nva.brage.migration.lambda.BrageEntryEventConsumer::handleRequest
-      ReservedConcurrentExecutions: 1
       Role: !GetAtt LambdaRole.Arn
       Timeout: 900
       Environment:
@@ -1942,6 +1941,7 @@ Resources:
           TABLE_NAME: !Ref NvaResourcesTable
           BATCH_EMISSION_INTERVAL_MILLIS: 0
           DOMAIN_NAME: !Ref ApiDomain
+          BRAGE_MIGRATION_ERROR_BUCKET_NAME: !Sub "${BrageMigrationErrorBucketName}-${AWS::AccountId}"
       Events:
         SqsEvent:
           Type: SQS


### PR DESCRIPTION
- Brage migration does not need ReservedConcurrentExecutions as default.
- Adding brage-migration-bucket to brage-patch handler in template as it is missing. 