### PR TITLE
NP-46825 Set logged in user as finlizedBy for autocompleted tickets

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -353,9 +353,10 @@ public class PublishingRequestCase extends TicketEntry {
                && Objects.equals(getApprovedFiles(), that.getApprovedFiles());
     }
 
-    public PublishingRequestCase persistAutoComplete(TicketService ticketService, Publication publication)
+    public PublishingRequestCase persistAutoComplete(TicketService ticketService, Publication publication,
+                                                     Username finalizedBy)
         throws ApiGatewayException {
-        var completed = this.complete(publication, publication.getResourceOwner().getOwner());
+        var completed = this.complete(publication, finalizedBy);
         return ticketService.createTicket(completed);
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -678,7 +678,9 @@ public class TicketServiceTest extends ResourcesLocalTest {
         var publication = persistPublication(owner, validPublicationStatusForTicketApproval(ticketType));
         var ticket = TicketTestUtils.createNonPersistedTicket(publication, ticketType);
 
-        var persistedCompletedTicket = ((PublishingRequestCase) ticket).persistAutoComplete(ticketService, publication);
+        var persistedCompletedTicket = ((PublishingRequestCase) ticket).persistAutoComplete(ticketService,
+                                                                                            publication,
+                                                                                            new Username(owner.getUsername()));
 
         assertThat(persistedCompletedTicket.getStatus(), is(equalTo(COMPLETED)));
     }

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -557,7 +557,8 @@ public class UpdatePublicationHandler
         throws ApiGatewayException {
         return requestInfo.userIsAuthorized(MANAGE_PUBLISHING_REQUESTS)
                || useIsAllowedToPublishFiles(customer)
-                   ? publishingRequest.persistAutoComplete(ticketService, publicationUpdate)
+                   ? publishingRequest.persistAutoComplete(ticketService, publicationUpdate,
+                                                           new Username(requestInfo.getUserName()))
                    : publishingRequest.persistNewTicket(ticketService);
     }
 

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
@@ -100,7 +100,7 @@ public class CreateTicketHandler extends ApiGatewayHandler<TicketDto, Void> {
     }
 
     private static boolean hasValidAccessRights(RequestInfo requestInfo) {
-        return requestInfo.userIsAuthorized(AccessRight.MANAGE_DOI) || requestInfo.userIsAuthorized(AccessRight.MANAGE_PUBLISHING_REQUESTS);
+        return requestInfo.userIsAuthorized(AccessRight.MANAGE_DOI);
     }
 
     private Publication fetchPublication(SortableIdentifier publicationIdentifier, UserInstance user,

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
@@ -100,7 +100,7 @@ public class CreateTicketHandler extends ApiGatewayHandler<TicketDto, Void> {
     }
 
     private static boolean hasValidAccessRights(RequestInfo requestInfo) {
-        return requestInfo.userIsAuthorized(AccessRight.MANAGE_DOI);
+        return requestInfo.userIsAuthorized(AccessRight.MANAGE_DOI) || requestInfo.userIsAuthorized(AccessRight.MANAGE_PUBLISHING_REQUESTS);
     }
 
     private Publication fetchPublication(SortableIdentifier publicationIdentifier, UserInstance user,

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -84,14 +84,14 @@ public class TicketResolver {
     }
 
     private PublishingRequestCase createPublishingRequestForNonCurator(PublishingRequestCase publishingRequestCase,
-                                                           Publication publication, Username finalizedBy) throws ApiGatewayException {
+                                                           Publication publication, Username curator) throws ApiGatewayException {
         if (REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(publishingRequestCase.getWorkflow())) {
             publishPublicationAndFiles(publication);
-            return createAutoApprovedTicket(publishingRequestCase, publication, finalizedBy);
+            return createAutoApprovedTicket(publishingRequestCase, publication, curator);
         }
         if (REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(publishingRequestCase.getWorkflow())) {
             publishMetadata(publication);
-            return createAutoApprovedTicketWhenPublicationContainsMetadataOnly(publishingRequestCase, publication, finalizedBy);
+            return createAutoApprovedTicketWhenPublicationContainsMetadataOnly(publishingRequestCase, publication, curator);
         } else {
             return (PublishingRequestCase) publishingRequestCase.persistNewTicket(ticketService);
         }


### PR DESCRIPTION
Earlier, when tickets were autocompleted, the publication owner was set as `finalizedBy`. Now, the logged in user is set instead.