### PR TITLE
NP-47118-scopus-import-set-upload-details

### DIFF
--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConstants.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConstants.java
@@ -1,13 +1,13 @@
 package no.sikt.nva.scopus;
 
 import java.net.URI;
+import no.unit.nva.model.Username;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 
 public class ScopusConstants {
     // Identifier field names:
     public static final String SCOPUS_IDENTIFIER = "Scopus";
-    public static final String SCOPUS_ITEM_IDENTIFIER_SCP_FIELD_NAME = "scp";
 
     // URI constants:
     public static final String DOI_OPEN_URL_FORMAT = "https://doi.org";
@@ -30,6 +30,9 @@ public class ScopusConstants {
     // Logger messages start:
     public static final String UNKNOWN_LANGUAGE_DETECTED = "Uknown language detected, the following language is not "
                                                            + "supported %s %s";
+
+    //UploadDetails username
+    public static final Username UPLOAD_DETAILS_USERNAME = new Username("central-import@20754.0.0.0");
 
     @JacocoGenerated
     public ScopusConstants() {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
@@ -7,6 +7,7 @@ import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
+import static no.sikt.nva.scopus.ScopusConstants.UPLOAD_DETAILS_USERNAME;
 import static no.sikt.nva.scopus.conversion.files.model.ContentVersion.AM;
 import static no.sikt.nva.scopus.conversion.files.model.ContentVersion.VOR;
 import static nva.commons.core.attempt.Try.attempt;
@@ -48,6 +49,7 @@ import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
+import no.unit.nva.model.associatedartifacts.file.UploadDetails;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
@@ -373,7 +375,12 @@ public class ScopusFileConverter {
                                       .withMimeType(mimeType)
                                       .withSize(inputStreamToSave.getLength())
                                       .withLicense(DEFAULT_LICENSE)
+                                      .withUploadDetails(createUploadDetails())
                                       .buildPublishedFile());
+    }
+
+    private UploadDetails createUploadDetails() {
+        return new UploadDetails(UPLOAD_DETAILS_USERNAME, Instant.now());
     }
 
     private List<AssociatedArtifact> extractAssociatedArtifactsFromFileReference(DocTp docTp) {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/ScopusFile.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/ScopusFile.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.scopus.conversion.files.model;
 
+import static no.sikt.nva.scopus.ScopusConstants.UPLOAD_DETAILS_USERNAME;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.UUID;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
+import no.unit.nva.model.associatedartifacts.file.UploadDetails;
 import org.apache.tika.io.TikaInputStream;
 
 public record ScopusFile(UUID identifier, String name, URI downloadFileUrl, TikaInputStream content, long size,
@@ -37,10 +39,15 @@ public record ScopusFile(UUID identifier, String name, URI downloadFileUrl, Tika
                    .withName(name)
                    .withMimeType(mimeType)
                    .withSize(size)
+                   .withUploadDetails(createUploadDetails())
                    .withLicense(license)
                    .withPublisherVersion(publisherVersion)
                    .withEmbargoDate(embargo)
                    .buildPublishedFile();
+    }
+
+    private UploadDetails createUploadDetails() {
+        return new UploadDetails(UPLOAD_DETAILS_USERNAME, Instant.now());
     }
 
     public boolean hasValidMimeType() {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.scopus.conversion;
 
+import static no.sikt.nva.scopus.ScopusConstants.UPLOAD_DETAILS_USERNAME;
 import static no.unit.nva.publication.testing.http.RandomPersonServiceResponse.randomUri;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -197,8 +198,8 @@ public class ScopusFileConverterTest {
         scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
         mockDownloadUrlResponse();
         var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-        var expectedUserName = "central-import@20754.0.0.0";
-        assertThat(file.getUploadDetails().getUploadedBy().getValue(), is(equalTo(expectedUserName)));
+        var expectedUserName = UPLOAD_DETAILS_USERNAME;
+        assertThat(file.getUploadDetails().getUploadedBy(), is(equalTo(expectedUserName)));
         assertThat(file.getUploadDetails().getUploadedDate(), is(notNullValue()));
     }
 
@@ -207,8 +208,8 @@ public class ScopusFileConverterTest {
         var responseBody = "crossrefResponseMissingFields.json";
         mockResponsesWithHeader(responseBody, Map.of());
         var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-        var expectedUserName = "central-import@20754.0.0.0";
-        assertThat(file.getUploadDetails().getUploadedBy().getValue(), is(equalTo(expectedUserName)));
+        var expectedUserName = UPLOAD_DETAILS_USERNAME;
+        assertThat(file.getUploadDetails().getUploadedBy(), is(equalTo(expectedUserName)));
         assertThat(file.getUploadDetails().getUploadedDate(), is(notNullValue()));
     }
 

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -191,6 +191,27 @@ public class ScopusFileConverterTest {
         assertThat(file.getName(), is(notNullValue()));
     }
 
+    @Test
+    void shouldSetUploadDetailsWhenFetchingAssociatedArtifactsFromXml() throws IOException, InterruptedException {
+        var firstUrl = randomUri();
+        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
+        mockDownloadUrlResponse();
+        var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var expectedUserName = "central-import@20754.0.0.0";
+        assertThat(file.getUploadDetails().getUploadedBy().getValue(), is(equalTo(expectedUserName)));
+        assertThat(file.getUploadDetails().getUploadedDate(), is(notNullValue()));
+    }
+
+    @Test
+    void shouldSetUploadDetailsWhenFetchingFileFromDoi() throws IOException, InterruptedException {
+        var responseBody = "crossrefResponseMissingFields.json";
+        mockResponsesWithHeader(responseBody, Map.of());
+        var file = (PublishedFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var expectedUserName = "central-import@20754.0.0.0";
+        assertThat(file.getUploadDetails().getUploadedBy().getValue(), is(equalTo(expectedUserName)));
+        assertThat(file.getUploadDetails().getUploadedDate(), is(notNullValue()));
+    }
+
     private void mockDownloadUrlResponse() throws IOException, InterruptedException {
         var fetchDownloadUrlResponse = (HttpResponse<InputStream>) mock(HttpResponse.class);
         var body = mock(ByteArrayInputStream.class);


### PR DESCRIPTION
Setter på uploadDetails på samme måte som Brage setter på upload details. Men det er en stor forskjell her: dette er ikke en engangs kjøring og så skal koden kastes.



