### PR TITLE
keeping files when merging with list of links

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -216,10 +216,14 @@ public class CristinImportPublicationMerger {
     }
 
     private AssociatedArtifactList determineAssociatedArtifacts() {
-        if (existingPublication.getAssociatedArtifacts().isEmpty()) {
+        if (existingAssociatedArtifactsAreEmpty()) {
             return bragePublicationRepresentation.publication().getAssociatedArtifacts();
         }
-
+        if (existingPublicationHasNoFiles()) {
+            var mergedAssociatedArtifacts = new ArrayList<>(existingPublication.getAssociatedArtifacts());
+            mergedAssociatedArtifacts.addAll(bragePublicationRepresentation.publication().getAssociatedArtifacts());
+            return new AssociatedArtifactList(mergedAssociatedArtifacts);
+        }
         if (shouldOverWriteWithBrageArtifacts()) {
             return keepBrageAssociatedArtifactAndKeepDublinCoreFromExistsing();
         }
@@ -231,6 +235,16 @@ public class CristinImportPublicationMerger {
             return new AssociatedArtifactList(associatedArtifacts);
         }
         return existingPublication.getAssociatedArtifacts();
+    }
+
+    private boolean existingAssociatedArtifactsAreEmpty() {
+        return existingPublication.getAssociatedArtifacts().isEmpty();
+    }
+
+    private boolean existingPublicationHasNoFiles() {
+        return existingPublication.getAssociatedArtifacts()
+                   .stream()
+                   .noneMatch(File.class::isInstance);
     }
 
     private AssociatedArtifactList keepBrageAssociatedArtifactAndKeepDublinCoreFromExistsing() {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -219,7 +219,7 @@ public class CristinImportPublicationMerger {
         if (existingAssociatedArtifactsAreEmpty()) {
             return bragePublicationRepresentation.publication().getAssociatedArtifacts();
         }
-        if (existingPublicationHasNoFiles()) {
+        if (existingPublicationHasNoPublishedFiles()) {
             var mergedAssociatedArtifacts = new ArrayList<>(existingPublication.getAssociatedArtifacts());
             mergedAssociatedArtifacts.addAll(bragePublicationRepresentation.publication().getAssociatedArtifacts());
             return new AssociatedArtifactList(mergedAssociatedArtifacts);
@@ -241,10 +241,10 @@ public class CristinImportPublicationMerger {
         return existingPublication.getAssociatedArtifacts().isEmpty();
     }
 
-    private boolean existingPublicationHasNoFiles() {
+    private boolean existingPublicationHasNoPublishedFiles() {
         return existingPublication.getAssociatedArtifacts()
                    .stream()
-                   .noneMatch(File.class::isInstance);
+                   .noneMatch(PublishedFile.class::isInstance);
     }
 
     private AssociatedArtifactList keepBrageAssociatedArtifactAndKeepDublinCoreFromExistsing() {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMergerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMergerTest.java
@@ -319,12 +319,38 @@ class CristinImportPublicationMergerTest {
                    containsInAnyOrder(associatedLink, newPublishedFile));
     }
 
+    @Test
+    void shouldKeepFileFromNewPublicationWhenExistingPublicationHasAdministrativeAgreementOnly()
+        throws InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
+        var administrativeAgreement = randomAdministrativeAgreement();
+        var newPublishedFile = randomPublishedFile();
+
+        var existingPublication = randomPublication(Map.class);
+        existingPublication.setAssociatedArtifacts(new AssociatedArtifactList(List.of(administrativeAgreement)));
+        var bragePublication = randomPublication(Map.class);
+        bragePublication.setAssociatedArtifacts(new AssociatedArtifactList(List.of(newPublishedFile)));
+
+        var updatedPublication = mergePublications(existingPublication, bragePublication);
+
+        assertThat(updatedPublication.getAssociatedArtifacts(),
+                   containsInAnyOrder(administrativeAgreement, newPublishedFile));
+    }
+
     private File randomPublishedFile() {
         return File.builder()
                    .withName(randomString())
                    .withIdentifier(UUID.randomUUID())
                    .withLicense(randomUri())
                    .buildPublishedFile();
+    }
+
+    private File randomAdministrativeAgreement() {
+        return File.builder()
+                   .withName(randomString())
+                   .withIdentifier(UUID.randomUUID())
+                   .withLicense(randomUri())
+                   .withAdministrativeAgreement(true)
+                   .buildUnpublishableFile();
     }
 
     private static AssociatedLink randomAssociatedLink() {


### PR DESCRIPTION
Following publication has not kept brage file cause existing associatedArtifacts are not empty, but contains associatedLink only. 

[publication from vid](https://dev.nva.sikt.no/registration/019054b57bbb-723d3ea3-e07c-4d5d-af02-8239a26f7f7a)

Merging associatedArtifacts when existing associatedArtifacts does not have published files.