### PR TITLE
chore(libs.versions): upgrade datamodel, add support for additional identifier types #NP-47114

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -28,7 +28,7 @@ import no.sikt.nva.brage.migration.model.PublicationRepresentation;
 import no.sikt.nva.brage.migration.record.Record;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
@@ -305,12 +305,12 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         return publication.getAdditionalIdentifiers()
                    .stream()
                    .filter(this::isCristinIdentifier)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .collect(Collectors.toSet());
     }
 
-    private boolean isCristinIdentifier(AdditionalIdentifier identifier) {
-        return SOURCE_CRISTIN.equals(identifier.getSourceName());
+    private boolean isCristinIdentifier(AdditionalIdentifierBase identifier) {
+        return SOURCE_CRISTIN.equals(identifier.sourceName());
     }
 
     private void persistHandleReport(SortableIdentifier nvaPublicationIdentifier,

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -34,6 +34,7 @@ import no.sikt.nva.brage.migration.record.content.ContentFile;
 import no.sikt.nva.brage.migration.record.content.ResourceContent;
 import no.sikt.nva.brage.migration.record.content.ResourceContent.BundleType;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Corporation;
 import no.unit.nva.model.EntityDescription;
@@ -155,7 +156,7 @@ public final class BrageNvaMapper {
         return nonNull(brageRecord.getLink()) ? new AssociatedLink(brageRecord.getLink(), null, null) : null;
     }
 
-    private static Set<AdditionalIdentifier> extractAdditionalIdentifiers(Record brageRecord) {
+    private static Set<AdditionalIdentifierBase> extractAdditionalIdentifiers(Record brageRecord) {
         return Stream.of(extractCristinAdditionalIdentifier(brageRecord), extractBrageHandle(brageRecord))
                    .filter(Optional::isPresent)
                    .map(Optional::get)

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -21,7 +21,7 @@ import no.sikt.nva.brage.migration.merger.publicationcontextmerger.ReportMerger;
 import no.sikt.nva.brage.migration.merger.publicationcontextmerger.ResearchDataMerger;
 import no.sikt.nva.brage.migration.merger.publicationinstancemerger.PublicationInstanceMerger;
 import no.sikt.nva.brage.migration.model.PublicationRepresentation;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
@@ -285,7 +285,7 @@ public class CristinImportPublicationMerger {
                    : existingPublication.getSubjects();
     }
 
-    private Set<AdditionalIdentifier> mergeAdditionalIdentifiers() {
+    private Set<AdditionalIdentifierBase> mergeAdditionalIdentifiers() {
         var additionalIdentifiers = new HashSet<>(existingPublication.getAdditionalIdentifiers());
         additionalIdentifiers.addAll(bragePublicationRepresentation.publication().getAdditionalIdentifiers());
         return additionalIdentifiers;

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/PreMergeValidator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/PreMergeValidator.java
@@ -2,7 +2,7 @@ package no.sikt.nva.brage.migration.merger;
 
 import no.sikt.nva.brage.migration.lambda.HandleDuplicateException;
 import no.sikt.nva.brage.migration.model.PublicationRepresentation;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.contexttypes.Degree;
 import nva.commons.core.JacocoGenerated;
@@ -39,19 +39,19 @@ public final class PreMergeValidator {
 
     private static boolean hasBrageHandle(Publication publication) {
         return publication.getAdditionalIdentifiers().stream()
-                   .map(AdditionalIdentifier::getSourceName)
+                   .map(AdditionalIdentifierBase::sourceName)
                    .anyMatch(HANDLE::equals);
     }
 
     private static boolean containsHandle(Publication publication, String handle) {
         return publication.getAdditionalIdentifiers().stream()
                    .filter(PreMergeValidator::isHandle)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .anyMatch(handle::equals);
     }
 
-    private static boolean isHandle(AdditionalIdentifier additionalIdentifier) {
-        return HANDLE.equals(additionalIdentifier.getSourceName());
+    private static boolean isHandle(AdditionalIdentifierBase additionalIdentifier) {
+        return HANDLE.equals(additionalIdentifier.sourceName());
     }
 
     private static boolean isDegree(Publication publication) {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/CristinIdentifierFinder.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/CristinIdentifierFinder.java
@@ -8,7 +8,7 @@ import no.sikt.nva.brage.migration.lambda.MergeSource;
 import no.sikt.nva.brage.migration.lambda.PublicationComparator;
 import no.sikt.nva.brage.migration.model.PublicationForUpdate;
 import no.sikt.nva.brage.migration.model.PublicationRepresentation;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.service.impl.ResourceService;
 
@@ -57,11 +57,11 @@ public class CristinIdentifierFinder implements FindExistingPublicationService {
         return publication.getAdditionalIdentifiers()
                    .stream()
                    .filter(this::isCristinIdentifier)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .collect(Collectors.toSet());
     }
 
-    private boolean isCristinIdentifier(AdditionalIdentifier identifier) {
-        return SOURCE_CRISTIN.equals(identifier.getSourceName());
+    private boolean isCristinIdentifier(AdditionalIdentifierBase identifier) {
+        return SOURCE_CRISTIN.equals(identifier.sourceName());
     }
 }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/HandleFinder.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/HandleFinder.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import no.sikt.nva.brage.migration.lambda.MergeSource;
 import no.sikt.nva.brage.migration.model.PublicationForUpdate;
 import no.sikt.nva.brage.migration.model.PublicationRepresentation;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.service.impl.ResourceService;
@@ -55,8 +55,8 @@ public class HandleFinder implements FindExistingPublicationService {
                                                                                                               additionalIdentifier));
     }
 
-    private boolean matchesHandle(URI handle, AdditionalIdentifier additionalIdentifier) {
-        return "handle".equalsIgnoreCase(additionalIdentifier.getSourceName()) && additionalIdentifier.getValue()
+    private boolean matchesHandle(URI handle, AdditionalIdentifierBase additionalIdentifier) {
+        return "handle".equalsIgnoreCase(additionalIdentifier.sourceName()) && additionalIdentifier.value()
                                                                                       .equals(handle.toString());
     }
 }

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -116,6 +116,7 @@ import no.sikt.nva.brage.migration.testutils.NvaBrageMigrationDataGenerator;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.model.Organization;
@@ -156,7 +157,6 @@ import no.unit.nva.model.instancetypes.researchdata.DataSet;
 import no.unit.nva.model.pages.MonographPages;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
-import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.ResourceWithId;
 import no.unit.nva.publication.model.SearchResourceApiResponse;
 import no.unit.nva.publication.model.business.Resource;
@@ -961,7 +961,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
         var publicationRepresentation = handler.handleRequest(s3Event, CONTEXT);
         var handles = publicationRepresentation.publication()
                           .getAdditionalIdentifiers().stream()
-                          .filter(additionalIdentifier -> "handle".equals(additionalIdentifier.getSourceName()))
+                          .filter(additionalIdentifier -> "handle".equals(additionalIdentifier.sourceName()))
                           .toList();
 
 
@@ -1879,7 +1879,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     }
 
     private BrageTestRecord generateBrageRecordAndPersistDuplicateByCristinIdentifier(
-        PublicationInstance<?> publicationInstance, Type type, AdditionalIdentifier additionalIdentifier) {
+        PublicationInstance<?> publicationInstance, Type type, AdditionalIdentifierBase additionalIdentifier) {
         var cristinIdentifier = "1234";
         var publication = randomPublication(publicationInstance.getClass());
 

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
@@ -41,6 +41,7 @@ import no.sikt.nva.brage.migration.record.Type;
 import no.sikt.nva.brage.migration.record.content.ContentFile;
 import no.sikt.nva.brage.migration.record.content.ResourceContent;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Corporation;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Organization;
@@ -91,8 +92,8 @@ public class NvaBrageMigrationDataGenerator {
                                                                     resourceOwner.getOwnerAffiliation());
     }
 
-    private static Set<AdditionalIdentifier> generateCristinIdentifier(Builder builder) {
-        var additionalIdentifiers = new HashSet<AdditionalIdentifier>();
+    private static Set<AdditionalIdentifierBase> generateCristinIdentifier(Builder builder) {
+        var additionalIdentifiers = new HashSet<AdditionalIdentifierBase>();
         if (nonNull(builder.handle)) {
             additionalIdentifiers.add(new AdditionalIdentifier("handle", builder.handle.toString()));
         }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -41,6 +41,7 @@ import no.unit.nva.cristin.mapper.exhibition.CristinExhibition;
 import no.unit.nva.cristin.mapper.nva.CristinMappingModule;
 import no.unit.nva.cristin.mapper.nva.ReferenceBuilder;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Organization;
@@ -411,7 +412,7 @@ public class CristinMapper extends CristinMappingModule {
                    : LanguageMapper.LEXVO_URI_UNDEFINED;
     }
 
-    private Set<AdditionalIdentifier> extractAdditionalIdentifiers() {
+    private Set<AdditionalIdentifierBase> extractAdditionalIdentifiers() {
         var cristinId = new AdditionalIdentifier(CristinObject.IDENTIFIER_ORIGIN, cristinObject.getId().toString());
         var additionalIdentifiers = extractCristinSourceids(cristinObject);
         additionalIdentifiers.add(cristinId);
@@ -426,18 +427,18 @@ public class CristinMapper extends CristinMappingModule {
         return new AdditionalIdentifier(cristinObject.getSourceCode(), cristinObject.getSourceRecordIdentifier());
     }
 
-    private boolean sourceCodeHasNotBeenMappedAlready(Set<AdditionalIdentifier> additionalIdentifiers,
+    private boolean sourceCodeHasNotBeenMappedAlready(Set<AdditionalIdentifierBase> additionalIdentifiers,
                                                       String sourceCode) {
         return additionalIdentifiers
                    .stream()
                    .noneMatch(additionalIdentifier -> hasIdenticalSourceCode(sourceCode, additionalIdentifier));
     }
 
-    private boolean hasIdenticalSourceCode(String sourceCode, AdditionalIdentifier additionalIdentifier) {
-        return additionalIdentifier.getSourceName().equals(sourceCode);
+    private boolean hasIdenticalSourceCode(String sourceCode, AdditionalIdentifierBase additionalIdentifier) {
+        return additionalIdentifier.sourceName().equals(sourceCode);
     }
 
-    private Set<AdditionalIdentifier> extractCristinSourceids(CristinObject cristinObject) {
+    private Set<AdditionalIdentifierBase> extractCristinSourceids(CristinObject cristinObject) {
         if (isNull(cristinObject.getCristinSources())) {
             return new HashSet<>();
         }

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -43,6 +43,7 @@ import no.unit.nva.cristin.mapper.CristinPresentationalWork;
 import no.unit.nva.cristin.mapper.CristinTags;
 import no.unit.nva.cristin.mapper.CristinTitle;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.PublicationDate;
@@ -139,7 +140,7 @@ public class GeneralMappingRules {
     @Then("the NVA Resource has an additional identifier with key {string} and value {int}")
     public void theNvaEntryHasAnAdditionalIdentifierWithKeyAndValue(String cristinAdditionalIdentifierKey,
                                                                     int expectedCristinId) {
-        Set<AdditionalIdentifier> actualAdditionalIdentifiers =
+        Set<AdditionalIdentifierBase> actualAdditionalIdentifiers =
             scenarioContext.getNvaEntry().getAdditionalIdentifiers();
         AdditionalIdentifier expectedIdentifier =
             new AdditionalIdentifier(cristinAdditionalIdentifierKey, Integer.toString(expectedCristinId));
@@ -150,7 +151,7 @@ public class GeneralMappingRules {
     @Then("the NVA Resource has an additional identifier with key {string} and value {string}")
     public void theNvaEntryHasAnAdditionalIdentifierWithKeyAndValue(String cristinAdditionalIdentifierKey,
                                                                     String expectedCristinId) {
-        Set<AdditionalIdentifier> actualAdditionalIdentifiers =
+        Set<AdditionalIdentifierBase> actualAdditionalIdentifiers =
             scenarioContext.getNvaEntry().getAdditionalIdentifiers();
         AdditionalIdentifier expectedIdentifier =
             new AdditionalIdentifier(cristinAdditionalIdentifierKey, expectedCristinId);
@@ -458,7 +459,7 @@ public class GeneralMappingRules {
     @And("the NVA Resource does not have an additional identifier with key {string} and value "
          + "{string}")
     public void theNvaResourceDoesNotHaveAnAdditionalIdentifierWithKeyAndValue(String key, String value) {
-        Set<AdditionalIdentifier> actualAdditionalIdentifiers =
+        Set<AdditionalIdentifierBase> actualAdditionalIdentifiers =
             scenarioContext.getNvaEntry().getAdditionalIdentifiers();
         AdditionalIdentifier expectedIdentifier =
             new AdditionalIdentifier(key, value);

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinPatchEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinPatchEventConsumerTest.java
@@ -37,6 +37,7 @@ import no.unit.nva.cristin.patcher.exception.ParentPublicationException;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.contexttypes.Anthology;
 import no.unit.nva.model.instancetypes.book.AcademicMonograph;
@@ -427,7 +428,7 @@ public class CristinPatchEventConsumerTest extends ResourcesLocalTest {
         return resourceService.getPublicationByIdentifier(publicationIdentifier);
     }
 
-    private Set<AdditionalIdentifier> createAdditionalIdentifiersWithCristinId(String cristinId) {
+    private Set<AdditionalIdentifierBase> createAdditionalIdentifiersWithCristinId(String cristinId) {
         return Set.of(new AdditionalIdentifier("Cristin", cristinId));
     }
 

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -36,6 +36,7 @@ import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.cristin.mapper.nva.NvaBookBuilder;
 import no.unit.nva.cristin.mapper.nva.NvaBookSeriesBuilder;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
@@ -127,7 +128,7 @@ class CristinMapperTest extends AbstractCristinImportTest {
                                      .map(Publication::getAdditionalIdentifiers)
                                      .flatMap(Collection::stream)
                                      .filter(this::isCristinIdentifier)
-                                     .map(AdditionalIdentifier::getValue)
+                                     .map(AdditionalIdentifierBase::value)
                                      .map(Integer::parseInt)
                                      .collect(Collectors.toSet());
 
@@ -144,7 +145,7 @@ class CristinMapperTest extends AbstractCristinImportTest {
                 .map(this::createExspectedAdditionalIdentifier)
                 .toList();
 
-        List<AdditionalIdentifier> actualIds = cristinObjects.stream()
+        List<AdditionalIdentifierBase> actualIds = cristinObjects.stream()
                                                    .map(this::mapToPublication)
                                                    .map(Publication::getAdditionalIdentifiers)
                                                    .flatMap(Collection::stream)
@@ -644,10 +645,10 @@ class CristinMapperTest extends AbstractCristinImportTest {
 
     private List<ContributionReference> extractContributions(Publication publication) {
 
-        AdditionalIdentifier cristinIdentifier = publication.getAdditionalIdentifiers().stream()
+        AdditionalIdentifierBase cristinIdentifier = publication.getAdditionalIdentifiers().stream()
                                                      .filter(this::isCristinIdentifier)
                                                      .collect(SingletonCollector.collect());
-        Integer cristinIdentifierValue = Integer.parseInt(cristinIdentifier.getValue());
+        Integer cristinIdentifierValue = Integer.parseInt(cristinIdentifier.value());
 
         return publication.getEntityDescription()
                    .getContributors().stream()
@@ -663,8 +664,8 @@ class CristinMapperTest extends AbstractCristinImportTest {
                    .collect(Collectors.toList());
     }
 
-    private boolean isCristinIdentifier(AdditionalIdentifier identifier) {
-        return identifier.getSourceName().equals(IDENTIFIER_ORIGIN);
+    private boolean isCristinIdentifier(AdditionalIdentifierBase identifier) {
+        return identifier.sourceName().equals(IDENTIFIER_ORIGIN);
     }
 
     private ContributionReference extractContributionReference(Integer cristinIdentifierValue,

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
@@ -20,7 +20,7 @@ import no.unit.nva.expansion.JournalExpansionServiceImpl;
 import no.unit.nva.expansion.PublisherExpansionServiceImpl;
 import no.unit.nva.expansion.model.cristin.CristinOrganization;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.ContributorVerificationStatus;
 import no.unit.nva.model.EntityDescription;
@@ -86,7 +86,7 @@ public class ExpandedImportCandidate implements ExpandedDataEntry {
     @JsonProperty(ID_FIELD)
     private URI identifier;
     @JsonProperty(ADDITIONAL_IDENTIFIERS_FIELD)
-    private Set<AdditionalIdentifier> additionalIdentifiers;
+    private Set<AdditionalIdentifierBase> additionalIdentifiers;
     @JsonProperty(DOI_FIELD)
     private URI doi;
     @JsonProperty(PUBLICATION_INSTANCE_FIELD)
@@ -205,11 +205,11 @@ public class ExpandedImportCandidate implements ExpandedDataEntry {
     }
 
     @JacocoGenerated
-    public Set<AdditionalIdentifier> getAdditionalIdentifiers() {
+    public Set<AdditionalIdentifierBase> getAdditionalIdentifiers() {
         return additionalIdentifiers;
     }
 
-    public void setAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+    public void setAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
         this.additionalIdentifiers = additionalIdentifiers;
     }
 
@@ -558,7 +558,7 @@ public class ExpandedImportCandidate implements ExpandedDataEntry {
             return this;
         }
 
-        public Builder withAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+        public Builder withAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
             expandedImportCandidate.setAdditionalIdentifiers(additionalIdentifiers);
             return this;
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 
 nva = { strictly = '1.39.3' }
-nvaDatamodel = { strictly = '0.22.2' }
+nvaDatamodel = { strictly = '0.23.0' }
 nvaDoiPartnerData = { strictly = '0.5.8' }
 jackson = { strictly = '2.16.1' }
 awsSdk = { strictly = '1.12.668' }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.Organization;
@@ -73,7 +73,7 @@ public class Resource implements Entity {
     @JsonProperty
     private URI handle;
     @JsonProperty
-    private Set<AdditionalIdentifier> additionalIdentifiers;
+    private Set<AdditionalIdentifierBase> additionalIdentifiers;
     @JsonProperty
     private List<URI> subjects;
     @JsonProperty
@@ -204,11 +204,11 @@ public class Resource implements Entity {
         this.resourceOwner = resourceOwner;
     }
 
-    public Set<AdditionalIdentifier> getAdditionalIdentifiers() {
+    public Set<AdditionalIdentifierBase> getAdditionalIdentifiers() {
         return nonNull(additionalIdentifiers) ? additionalIdentifiers : Collections.emptySet();
     }
 
-    public void setAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+    public void setAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
         this.additionalIdentifiers = additionalIdentifiers;
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceBuilder.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceBuilder.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.Organization;
@@ -35,7 +35,7 @@ public final class ResourceBuilder {
     private EntityDescription entityDescription;
     private URI doi;
     private URI handle;
-    private Set<AdditionalIdentifier> additionalIdentifiers;
+    private Set<AdditionalIdentifierBase> additionalIdentifiers;
     private List<URI> subjects;
     private List<Funding> fundings;
     private String rightsHolder;
@@ -118,7 +118,7 @@ public final class ResourceBuilder {
         return this;
     }
 
-    public ResourceBuilder withAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+    public ResourceBuilder withAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
         this.additionalIdentifiers = additionalIdentifiers;
         return this;
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/importcandidate/ImportCandidate.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/importcandidate/ImportCandidate.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.Organization;
@@ -219,7 +219,7 @@ public class ImportCandidate extends Publication implements JsonSerializable {
             return this;
         }
 
-        public Builder withAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+        public Builder withAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
             importCandidate.setAdditionalIdentifiers(additionalIdentifiers);
             return this;
         }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/ResourceDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/ResourceDao.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.model.business.Resource;
@@ -217,7 +217,7 @@ public class ResourceDao extends Dao
                                             .stream()
                                             .flatMap(Collection::stream)
                                             .filter(this::keyEqualsCristin)
-                                            .map(AdditionalIdentifier::getValue)
+                                            .map(AdditionalIdentifierBase::value)
                                             .collect(SingletonCollector.collectOrElse(null));
         return Optional.ofNullable(cristinIdentifierValue);
     }
@@ -238,9 +238,9 @@ public class ResourceDao extends Dao
         return this.getIdentifier();
     }
     
-    private boolean keyEqualsCristin(AdditionalIdentifier identifier) {
+    private boolean keyEqualsCristin(AdditionalIdentifierBase identifier) {
         return Optional.ofNullable(identifier)
-                   .map(AdditionalIdentifier::getSourceName)
+                   .map(AdditionalIdentifierBase::sourceName)
                    .map(CRISTIN_SOURCE::equals)
                    .orElse(false);
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/CreatePublicationRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/CreatePublicationRequest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import no.unit.nva.WithAssociatedArtifact;
 import no.unit.nva.WithContext;
 import no.unit.nva.WithMetadata;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.PublicationNoteBase;
@@ -33,7 +33,7 @@ public class CreatePublicationRequest implements WithMetadata, WithAssociatedArt
     private JsonNode context;
     private List<ResearchProject> projects;
     private List<URI> subjects;
-    private Set<AdditionalIdentifier> additionalIdentifiers;
+    private Set<AdditionalIdentifierBase> additionalIdentifiers;
     private List<Funding> fundings;
     private String rightsHolder;
     private PublicationStatus status;
@@ -58,11 +58,11 @@ public class CreatePublicationRequest implements WithMetadata, WithAssociatedArt
         return createPublicationRequest;
     }
     
-    public Set<AdditionalIdentifier> getAdditionalIdentifiers() {
+    public Set<AdditionalIdentifierBase> getAdditionalIdentifiers() {
         return additionalIdentifiers;
     }
     
-    public void setAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
+    public void setAdditionalIdentifiers(Set<AdditionalIdentifierBase> additionalIdentifiers) {
         this.additionalIdentifiers = additionalIdentifiers;
     }
     

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/delete/DeleteImportCandidateEventConsumerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/delete/DeleteImportCandidateEventConsumerTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import no.unit.nva.expansion.model.ExpandedImportCandidate;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
@@ -112,14 +113,14 @@ public class DeleteImportCandidateEventConsumerTest extends ResourcesLocalTest {
         return Optional.of(new ImportCandidateSearchApiResponse(List.of(), ZERO_HITS).toString());
     }
 
-    private static boolean isScopus(AdditionalIdentifier identifier) {
-        return identifier.getSourceName().equals(SCOPUS_IDENTIFIER);
+    private static boolean isScopus(AdditionalIdentifierBase identifier) {
+        return identifier.sourceName().equals(SCOPUS_IDENTIFIER);
     }
 
     private String getScopusIdentifier(ImportCandidate importCandidate) {
         return importCandidate.getAdditionalIdentifiers().stream()
                    .filter(DeleteImportCandidateEventConsumerTest::isScopus)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .findFirst()
                    .orElseGet(RandomDataGenerator::randomString);
     }

--- a/publication-rest/src/main/java/no/unit/nva/publication/create/CreatePublicationFromImportCandidateHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/create/CreatePublicationFromImportCandidateHandler.java
@@ -8,7 +8,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import no.unit.nva.api.PublicationResponse;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Organization.Builder;
 import no.unit.nva.model.Publication;
@@ -148,9 +148,9 @@ public class CreatePublicationFromImportCandidateHandler extends ApiGatewayHandl
         return rawImportCandidate
                    .getAdditionalIdentifiers()
                    .stream()
-                   .filter(additionalIdentifier -> "scopus".equalsIgnoreCase(additionalIdentifier.getSourceName()))
+                   .filter(additionalIdentifier -> "scopus".equalsIgnoreCase(additionalIdentifier.sourceName()))
                    .findFirst()
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .orElseThrow();
     }
 
@@ -172,9 +172,9 @@ public class CreatePublicationFromImportCandidateHandler extends ApiGatewayHandl
         return Objects.equals(userAuid, rawAuid);
     }
 
-    private AdditionalIdentifier extractAuid(Contributor contributor) {
+    private AdditionalIdentifierBase extractAuid(Contributor contributor) {
         return contributor.getIdentity().getAdditionalIdentifiers().stream().filter(
-            additionalIdentifier -> "scopus-auid".equals(additionalIdentifier.getSourceName())
+            additionalIdentifier -> "scopus-auid".equals(additionalIdentifier.sourceName())
         ).findFirst().orElse(null);
     }
 
@@ -254,13 +254,13 @@ public class CreatePublicationFromImportCandidateHandler extends ApiGatewayHandl
         return importCandidate.getAdditionalIdentifiers()
                    .stream()
                    .filter(this::isScopusIdentifier)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .findFirst()
                    .orElse(null);
     }
 
-    private boolean isScopusIdentifier(AdditionalIdentifier identifier) {
-        return SCOPUS_IDENTIFIER.equals(identifier.getSourceName());
+    private boolean isScopusIdentifier(AdditionalIdentifierBase identifier) {
+        return SCOPUS_IDENTIFIER.equals(identifier.sourceName());
     }
 
     private BadGatewayException rollbackImportStatusUpdate(ImportCandidate importCandidate)

--- a/publication-rest/src/main/java/no/unit/nva/publication/create/pia/PiaUpdateRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/create/pia/PiaUpdateRequest.java
@@ -30,7 +30,7 @@ public record PiaUpdateRequest(PiaPublication publication,
     }
 
     private static String extractScopusAuid(Contributor contributor) {
-        return extractAuid(contributor).get().getValue();
+        return extractAuid(contributor).get().value();
     }
 
     private static String extractContributorCristinIdentifier(Contributor contributor) {
@@ -44,7 +44,7 @@ public record PiaUpdateRequest(PiaPublication publication,
                    .getAdditionalIdentifiers()
                    .stream()
                    .filter(additionalIdentifier ->
-                               "scopus-auid".equalsIgnoreCase(additionalIdentifier.getSourceName()))
+                               "scopus-auid".equalsIgnoreCase(additionalIdentifier.sourceName()))
                    .findFirst();
     }
 }

--- a/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationFromImportCandidateHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationFromImportCandidateHandlerTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
@@ -53,6 +52,7 @@ import java.util.UUID;
 import no.unit.nva.api.PublicationResponse;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
@@ -482,9 +482,8 @@ class CreatePublicationFromImportCandidateHandlerTest extends ResourcesLocalTest
         return
             importCandidate.getAdditionalIdentifiers()
                 .stream()
-                .filter(additionalIdentifier -> "scopus".equalsIgnoreCase(additionalIdentifier.getSourceName()))
-                .map(
-                    AdditionalIdentifier::getValue).findFirst().get();
+                .filter(additionalIdentifier -> "scopus".equalsIgnoreCase(additionalIdentifier.sourceName()))
+                .map(AdditionalIdentifierBase::value).findFirst().get();
     }
 
     private PiaClientConfig createPiaConfig(WireMockRuntimeInfo wireMockRuntimeInfo) {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -43,6 +43,7 @@ import no.sikt.nva.scopus.conversion.PublicationContextCreator;
 import no.sikt.nva.scopus.conversion.PublicationInstanceCreator;
 import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.PublicationDate;
@@ -296,7 +297,7 @@ public class ScopusConverter {
         return nonNull(titletextTp) && titletextTp.getOriginal().equals(YesnoAtt.Y);
     }
 
-    private Set<AdditionalIdentifier> generateAdditionalIdentifiers() {
+    private Set<AdditionalIdentifierBase> generateAdditionalIdentifiers() {
         return Set.of(extractScopusIdentifier());
     }
 

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
@@ -22,7 +22,7 @@ import no.sikt.nva.scopus.conversion.files.TikaUtils;
 import no.sikt.nva.scopus.exception.ExceptionMapper;
 import no.sikt.nva.scopus.update.ScopusUpdater;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
@@ -156,13 +156,13 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
         return importCandidate.getAdditionalIdentifiers()
                    .stream()
                    .filter(this::isScopusIdentifier)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .findFirst()
                    .orElse(null);
     }
 
-    private boolean isScopusIdentifier(AdditionalIdentifier identifier) {
-        return SCOPUS_IDENTIFIER.equals(identifier.getSourceName());
+    private boolean isScopusIdentifier(AdditionalIdentifierBase identifier) {
+        return SCOPUS_IDENTIFIER.equals(identifier.sourceName());
     }
 
     private RuntimeException handleSavingError(Failure<ImportCandidate> fail, S3Event event) {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/update/ScopusUpdater.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/update/ScopusUpdater.java
@@ -9,7 +9,7 @@ import no.sikt.nva.scopus.conversion.model.ImportCandidateSearchApiResponse;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.expansion.model.ExpandedImportCandidate;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.service.impl.ResourceService;
@@ -98,7 +98,7 @@ public class ScopusUpdater {
     private String getScopusIdentifier(ImportCandidate importCandidate) {
         return importCandidate.getAdditionalIdentifiers().stream()
                    .filter(this::isScopusIdentifier)
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .findFirst()
                    .orElse(null);
     }
@@ -107,7 +107,7 @@ public class ScopusUpdater {
         return uriRetriever.getRawContent(uri, APPLICATION_JSON);
     }
 
-    private boolean isScopusIdentifier(AdditionalIdentifier identifier) {
-        return ScopusHandler.SCOPUS_IDENTIFIER.equals(identifier.getSourceName());
+    private boolean isScopusIdentifier(AdditionalIdentifierBase identifier) {
+        return ScopusHandler.SCOPUS_IDENTIFIER.equals(identifier.sourceName());
     }
 }

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/ScopusHandlerTest.java
@@ -161,6 +161,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.language.Language;
 import no.unit.nva.language.LanguageConstants;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.ContributorVerificationStatus;
 import no.unit.nva.model.EntityDescription;
@@ -1261,9 +1262,9 @@ class ScopusHandlerTest extends ResourcesLocalTest {
     private static String getScopusIdentifier(Publication publication) {
         return publication.getAdditionalIdentifiers()
                    .stream()
-                   .filter(id -> SCOPUS_IDENTIFIER.equals(id.getSourceName()))
+                   .filter(id -> SCOPUS_IDENTIFIER.equals(id.sourceName()))
                    .findFirst()
-                   .map(AdditionalIdentifier::getValue)
+                   .map(AdditionalIdentifierBase::value)
                    .orElse(null);
     }
 
@@ -1283,7 +1284,7 @@ class ScopusHandlerTest extends ResourcesLocalTest {
                    .getAdditionalIdentifiers()
                    .stream()
                    .anyMatch(additionalIdentifier ->
-                                 "scopus-auid".equals(additionalIdentifier.getSourceName()));
+                                 "scopus-auid".equals(additionalIdentifier.sourceName()));
     }
 
     private String getEid() {
@@ -1590,8 +1591,8 @@ class ScopusHandlerTest extends ResourcesLocalTest {
         var authorId = contributor.getIdentity().getAdditionalIdentifiers()
                            .stream()
                            .filter(additionalIdentifier ->
-                                       "scopus-auid".equalsIgnoreCase(additionalIdentifier.getSourceName()))
-                           .map(AdditionalIdentifier::getValue)
+                                       "scopus-auid".equalsIgnoreCase(additionalIdentifier.sourceName()))
+                           .map(AdditionalIdentifierBase::value)
                            .collect(SingletonCollector.collectOrElse(""));
         return authorTp.getAuid().equals(authorId);
     }


### PR DESCRIPTION
just the lib-upgrade and usage of the new base class AdditionalIdentifierBase. AdditionalIdentifier is still used everywhere we create values and later PR will address creating new HandleIdentifiers