### PR TITLE
validating curator access right on ticket creation

### DIFF
--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -72,13 +72,14 @@ public final class TicketTestUtils {
 
     public static Stream<Arguments> ticketTypeAndAccessRightProvider() {
         return Stream.of(Arguments.of(PUBLISHED, DoiRequest.class, AccessRight.MANAGE_DOI),
-                         Arguments.of(DRAFT, PublishingRequestCase.class,
-                                      AccessRight.MANAGE_PUBLISHING_REQUESTS));
+                         Arguments.of(DRAFT, PublishingRequestCase.class, AccessRight.MANAGE_PUBLISHING_REQUESTS),
+                         Arguments.of(DRAFT, GeneralSupportRequest.class, AccessRight.SUPPORT));
     }
 
     public static Stream<Arguments> invalidAccessRightForTicketTypeProvider() {
         return Stream.of(Arguments.of(DoiRequest.class, AccessRight.MANAGE_PUBLISHING_REQUESTS),
-                         Arguments.of(PublishingRequestCase.class, AccessRight.MANAGE_DOI));
+                         Arguments.of(PublishingRequestCase.class, AccessRight.MANAGE_DOI),
+                         Arguments.of(GeneralSupportRequest.class, AccessRight.MANAGE_PUBLISHING_REQUESTS));
     }
 
     public static Publication createNonPersistedPublication(PublicationStatus status) {


### PR DESCRIPTION
Validation curator access rights when creating new ticket. 
Not sure about what access right curator should have to be able to create UnpublishRequest, so I have set `manage_publishing_request` access right. Without validating access right for UnpublishRequest creation anyone from the same institution will be able to persist UnpublishRequest ticket.