### PR TITLE
Expansion, frame hasPart

### DIFF
--- a/expansion/src/main/resources/frame.json
+++ b/expansion/src/main/resources/frame.json
@@ -90,6 +90,10 @@
     "handle": {
       "@type": "@id"
     },
+    "hasPart": {
+      "@container": "@set",
+      "@id": "hasPart"
+    },
     "id": "@id",
     "indexedDate": {
       "@type": "xsd:dateTime"
@@ -182,8 +186,8 @@
       "@id": "topLevelOrganization"
     },
     "contributorOrganizations": {
-      "@container" : "@set",
-      "@id" : "contributorOrganization",
+      "@container": "@set",
+      "@id": "contributorOrganization",
       "@type": "@id"
     },
     "nviType": {
@@ -235,7 +239,7 @@
         }
       }
     },
-    "reference":  {
+    "reference": {
       "@type": "Reference",
       "doi": {
         "@embed": "@never",

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -815,7 +814,12 @@ class ExpandedResourceTest {
             return null;
         }
         while (hasPartHasContent(jsonNode)) {
-            jsonNode = jsonNode.at(JSON_PTR_HAS_PART);
+            var hasPartArrayNode = (ArrayNode) jsonNode.at(JSON_PTR_HAS_PART);
+            if (hasPartArrayNode.size() == 1) {
+                jsonNode = hasPartArrayNode.get(0);
+            } else {
+                hasPartArrayNode.forEach(node -> findDeepestNestedSubUnit(node.at(JSON_PTR_HAS_PART)));
+            }
         }
         return jsonNode;
     }


### PR DESCRIPTION
Fix cases where `hasPart` only contains one object, it is not framed as an `ArrayNode`