### PR TITLE
mapping briefs to empty report

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AbstractBookReportBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AbstractBookReportBuilder.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.mapper;
 
+import java.util.Optional;
 import no.unit.nva.model.pages.MonographPages;
 
 public abstract class AbstractBookReportBuilder extends AbstractPublicationInstanceBuilder {
@@ -15,6 +16,9 @@ public abstract class AbstractBookReportBuilder extends AbstractPublicationInsta
     }
     
     private String extractNumberOfPages() {
-        return getCristinObject().getBookOrReportMetadata().getNumberOfPages();
+        return Optional.ofNullable(getCristinObject())
+                   .map(CristinObject::getBookOrReportMetadata)
+                   .map(CristinBookOrReportMetadata::getNumberOfPages)
+                   .orElse(null);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -149,6 +149,10 @@ public enum CristinSecondaryCategory {
         return CristinSecondaryCategory.COMPENDIUM.equals(cristinObject.getSecondaryCategory());
     }
 
+    public static boolean isBriefs(CristinObject cristinObject) {
+        return CristinSecondaryCategory.BRIEFS.equals(cristinObject.getSecondaryCategory());
+    }
+
     public static boolean isInterview(CristinObject cristinObject) {
         return CristinSecondaryCategory.INTERVIEW.equals(cristinObject.getSecondaryCategory())
                || CristinSecondaryCategory.WRITTEN_INTERVIEW.equals(cristinObject.getSecondaryCategory());

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublicationInstanceBuilderImpl.java
@@ -5,10 +5,10 @@ import static no.unit.nva.cristin.mapper.CristinMainCategory.isBook;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isChapter;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isEvent;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isExhibition;
-import static no.unit.nva.cristin.mapper.CristinMainCategory.isInformationMaterial;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isJournal;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isMediaContribution;
 import static no.unit.nva.cristin.mapper.CristinMainCategory.isReport;
+import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isBriefs;
 import static no.unit.nva.cristin.mapper.nva.ReferenceBuilder.NIFU_CUSTOMER_NAME;
 import java.util.Objects;
 import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedMainCategoryException;
@@ -52,7 +52,7 @@ public class PublicationInstanceBuilderImpl {
             return new ArtBuilder(cristinObject, s3Client).build();
         } else if (isExhibition(cristinObject)) {
             return new ExhibitionProductionBuilder(cristinObject).build();
-        } else if (isInformationalMaterialThatShouldBeMapped(cristinObject)) {
+        } else if (isBriefsThatShouldBeMapped(cristinObject)) {
             return new ReportPolicy(new MonographPages());
         } else if (cristinObject.getMainCategory().isUnknownCategory()) {
             throw new UnsupportedMainCategoryException();
@@ -62,7 +62,7 @@ public class PublicationInstanceBuilderImpl {
         throw new RuntimeException(ERROR_PARSING_MAIN_OR_SECONDARY_CATEGORIES);
     }
 
-    private boolean isInformationalMaterialThatShouldBeMapped(CristinObject cristinObject) {
-        return isInformationMaterial(cristinObject) && NIFU_CUSTOMER_NAME.equals(cristinObject.getOwnerCodeCreated());
+    private boolean isBriefsThatShouldBeMapped(CristinObject cristinObject) {
+        return isBriefs(cristinObject) && NIFU_CUSTOMER_NAME.equals(cristinObject.getOwnerCodeCreated());
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/InformationMaterialBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/InformationMaterialBuilder.java
@@ -1,0 +1,36 @@
+package no.unit.nva.cristin.mapper.nva;
+
+import java.net.URI;
+import no.unit.nva.cristin.mapper.CristinObject;
+import no.unit.nva.model.contexttypes.Publisher;
+import no.unit.nva.model.contexttypes.Report;
+import no.unit.nva.model.exceptions.InvalidIssnException;
+import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
+
+public final class InformationMaterialBuilder {
+
+    public static final String PUBLISHER = "publisher";
+    public static final String PUBLICATION_CHANNELS_V2 = "publication-channels-v2";
+    public static final String NIFU_CHANNEL_REGISTER_IDENTIFIER = "42997513-9974-48C2-A9A6-6AE1AC1F908D";
+
+    private InformationMaterialBuilder() {
+    }
+
+    public static Report buildPublicationContext(CristinObject cristinObject)
+        throws InvalidIssnException, InvalidUnconfirmedSeriesException {
+        return new Report.Builder()
+                   .withPublisher(new Publisher(hardcodedNifuPublisher(cristinObject)))
+                   .build();
+    }
+
+    private static URI hardcodedNifuPublisher(CristinObject cristinObject) {
+        return UriWrapper.fromHost(new Environment().readEnv("DOMAIN_NAME"))
+                   .addChild(PUBLICATION_CHANNELS_V2)
+                   .addChild(PUBLISHER)
+                   .addChild(NIFU_CHANNEL_REGISTER_IDENTIFIER)
+                   .addChild(cristinObject.getPublicationYear().toString())
+                   .getUri();
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -47,7 +47,6 @@ import no.unit.nva.model.contexttypes.Event;
 import no.unit.nva.model.contexttypes.ExhibitionContent;
 import no.unit.nva.model.contexttypes.MediaContribution;
 import no.unit.nva.model.contexttypes.PublicationContext;
-import no.unit.nva.model.contexttypes.Report;
 import no.unit.nva.model.contexttypes.media.MediaFormat;
 import no.unit.nva.model.contexttypes.media.MediaSubType;
 import no.unit.nva.model.contexttypes.media.MediaSubTypeEnum;
@@ -126,7 +125,7 @@ public class ReferenceBuilder extends CristinMappingModule {
             return new Artistic();
         }
         if (isInformationalMaterialThatShouldBeMapped()) {
-            return new Report.Builder().build();
+            return InformationMaterialBuilder.buildPublicationContext(cristinObject);
         }
         return null;
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -47,6 +47,7 @@ import no.unit.nva.model.contexttypes.Event;
 import no.unit.nva.model.contexttypes.ExhibitionContent;
 import no.unit.nva.model.contexttypes.MediaContribution;
 import no.unit.nva.model.contexttypes.PublicationContext;
+import no.unit.nva.model.contexttypes.Report;
 import no.unit.nva.model.contexttypes.media.MediaFormat;
 import no.unit.nva.model.contexttypes.media.MediaSubType;
 import no.unit.nva.model.contexttypes.media.MediaSubTypeEnum;
@@ -106,7 +107,7 @@ public class ReferenceBuilder extends CristinMappingModule {
                                               channelRegistryMapper, s3Client)
                        .buildMediaPeriodicalForPublicationContext();
         }
-        if (isReport(cristinObject) || isInformationalMaterialThatShouldBeMapped()) {
+        if (isReport(cristinObject)) {
             return buildPublicationContextWhenMainCategoryIsReport();
         }
         if (isChapter(cristinObject)) {
@@ -123,6 +124,9 @@ public class ReferenceBuilder extends CristinMappingModule {
         }
         if (isArt(cristinObject)) {
             return new Artistic();
+        }
+        if (isInformationalMaterialThatShouldBeMapped()) {
+            return new Report.Builder().build();
         }
         return null;
     }


### PR DESCRIPTION
Briefs does not have any book/report metadata in Cristin, import from yesterday ended up with nullpointers for all Briefs. 