### PR TITLE
Np 47254 fixing timeout when uploading files

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -87,7 +87,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     public PublicationRepresentation handleRequest(S3Event s3Event, Context context) {
         return attempt(() -> parseBrageRecord(s3Event))
                    .map(publicationRepresentation -> pushAssociatedFilesToPersistedStorage(publicationRepresentation,
-                                                                                           s3Event))
+                                                                                           s3Event, context))
                    .map(publicationRepresentation -> persistMetadataChange(s3Event, publicationRepresentation))
                    .orElse(fail -> handleSavingError(fail, s3Event));
     }
@@ -379,9 +379,8 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     }
 
     private PublicationRepresentation pushAssociatedFilesToPersistedStorage(
-        PublicationRepresentation publicationRepresentation,
-        S3Event s3Event) {
-        var associatedArtifactMover = new AssociatedArtifactMover(s3Client, s3Event);
+        PublicationRepresentation publicationRepresentation, S3Event s3Event, Context context) {
+        var associatedArtifactMover = new AssociatedArtifactMover(s3Client, s3Event, context);
         associatedArtifactMover.pushAssociatedArtifactsToPersistedStorage(publicationRepresentation.publication());
         return publicationRepresentation;
     }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactMover.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactMover.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.brage.migration.merger;
 
+import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import java.util.stream.Collectors;
 import no.unit.nva.model.Publication;
@@ -20,10 +21,12 @@ public class AssociatedArtifactMover {
     private final S3Client s3Client;
     private final S3Event s3Event;
     private final String persistedStorageBucket;
+    private final Context context;
 
-    public AssociatedArtifactMover(S3Client s3Client, S3Event s3Event) {
+    public AssociatedArtifactMover(S3Client s3Client, S3Event s3Event, Context context) {
         this.s3Client = s3Client;
         this.s3Event = s3Event;
+        this.context = context;
         this.persistedStorageBucket = new Environment().readEnv("NVA_PERSISTED_STORAGE_BUCKET_NAME");
     }
 
@@ -48,7 +51,7 @@ public class AssociatedArtifactMover {
                     .sourceBucket(getSourceBucket())
                     .destinationKey(objectKey)
                     .destinationBucket(persistedStorageBucket)
-                    .copy(s3Client);
+                    .copy(s3Client, context);
 
                 return extractMimeTypeAndSize(file, objectKey);
             } else {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/S3MultipartCopier.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/S3MultipartCopier.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.brage.migration.merger;
 
+import com.amazonaws.services.lambda.runtime.Context;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -25,7 +26,10 @@ public final class S3MultipartCopier {
     private static final String MISSING_REQUIRING_PARAMETERS_MESSAGE = "All required params have to be provided to "
                                                                        + "perform multipart copy!";
     private static final long PARTITION_SIZE = 5L * 1024 * 1024;
-    public static final int ZERO_LENGTH = 0;
+    private static final int ZERO_LENGTH = 0;
+    private static final int TIMEOUT_THRESHOLD_30_SECONDS = 30000;
+    private static final String TIMEOUT_THRESHOLD_EXCEEDED = "Timeout threshold exceeded when copying associated "
+                                                         + "artifacts!";
     private final Logger logger = LoggerFactory.getLogger(S3MultipartCopier.class);
     private final String sourceS3Key;
     private final String sourceS3Bucket;
@@ -55,9 +59,9 @@ public final class S3MultipartCopier {
                    .withDestinationBucket(this.destinationS3Bucket);
     }
 
-    public void copy(S3Client s3Client) {
+    public void copy(S3Client s3Client, Context context) {
         validateRequest();
-        performCopying(s3Client);
+        performCopying(s3Client, context);
     }
 
     public S3MultipartCopier sourceBucket(String sourceBucket) {
@@ -98,12 +102,12 @@ public final class S3MultipartCopier {
         return Stream.of(sourceS3Key, sourceS3Bucket, destinationS3Key, destinationS3Key).anyMatch(Objects::isNull);
     }
 
-    private void performCopying(S3Client s3Client) throws MultipartCopyException {
+    private void performCopying(S3Client s3Client, Context context) throws MultipartCopyException {
         var headOfObjectToCopy = getHeadOfObjectToCopy(s3Client);
         if (objectToCopyIsEmpty(headOfObjectToCopy)) {
             performSimpleCopy(s3Client);
         } else {
-            performMultiPartCopy(s3Client, headOfObjectToCopy);
+            performMultiPartCopy(s3Client, context, headOfObjectToCopy);
         }
     }
 
@@ -121,7 +125,7 @@ public final class S3MultipartCopier {
         s3Client.copyObject(copyObjRequest);
     }
 
-    private void performMultiPartCopy(S3Client s3Client, HeadObjectResponse headOfObjectToCopy) {
+    private void performMultiPartCopy(S3Client s3Client, Context context, HeadObjectResponse headOfObjectToCopy) {
         var request = initiateMultiUploadRequest(headOfObjectToCopy);
         var response = s3Client.createMultipartUpload(request);
         try {
@@ -129,6 +133,9 @@ public final class S3MultipartCopier {
             int partNumber = 1;
             long totalSize = headOfObjectToCopy.contentLength();
             while (position < totalSize) {
+                if (context.getRemainingTimeInMillis() < TIMEOUT_THRESHOLD_30_SECONDS) {
+                    throw MultipartCopyException.withMessage(TIMEOUT_THRESHOLD_EXCEEDED);
+                }
                 position = copyPartAndUpdatePosition(s3Client, position, totalSize, response, partNumber);
                 partNumber++;
             }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/S3MultipartCopier.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/S3MultipartCopier.java
@@ -27,7 +27,7 @@ public final class S3MultipartCopier {
                                                                        + "perform multipart copy!";
     private static final long PARTITION_SIZE = 5L * 1024 * 1024;
     private static final int ZERO_LENGTH = 0;
-    private static final int TIMEOUT_THRESHOLD_30_SECONDS = 30000;
+    private static final int SECONDS_30 = 30_000;
     private static final String TIMEOUT_THRESHOLD_EXCEEDED = "Timeout threshold exceeded when copying associated "
                                                          + "artifacts!";
     private final Logger logger = LoggerFactory.getLogger(S3MultipartCopier.class);
@@ -133,7 +133,7 @@ public final class S3MultipartCopier {
             int partNumber = 1;
             long totalSize = headOfObjectToCopy.contentLength();
             while (position < totalSize) {
-                if (context.getRemainingTimeInMillis() < TIMEOUT_THRESHOLD_30_SECONDS) {
+                if (context.getRemainingTimeInMillis() < SECONDS_30) {
                     throw MultipartCopyException.withMessage(TIMEOUT_THRESHOLD_EXCEEDED);
                 }
                 position = copyPartAndUpdatePosition(s3Client, position, totalSize, response, partNumber);

--- a/brage-import/src/main/resources/customers.json
+++ b/brage-import/src/main/resources/customers.json
@@ -59,6 +59,7 @@
     "username": "nmh@178.0.0.0",
     "cristinIdentifier": "178.0.0.0",
     "identifiers": {
+      "sandbox": "b075d6e7-4cec-4579-8c8b-ecae18affcc6",
       "test": "9efe66cc-ead0-49e0-b787-b73a188d4770",
       "dev": "2f148e5f-a017-4e7f-8f78-6a52eb6a9938"
     }

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -182,7 +182,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
 
     public static final UUID UUID = java.util.UUID.randomUUID();
-    public static final Context CONTEXT = null;
+    public static final Context CONTEXT = mock(Context.class);
     public static final long SOME_FILE_SIZE = 100L;
     public static final Type TYPE_BOOK = new Type(List.of(NvaType.BOOK.getValue()), NvaType.BOOK.getValue());
     public static final Type TYPE_CONFERENCE_REPORT = new Type(List.of(NvaType.CONFERENCE_REPORT.getValue()),
@@ -293,6 +293,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     @BeforeEach
     public void init() {
         super.init();
+        when(CONTEXT.getRemainingTimeInMillis()).thenReturn(100000)
         this.resourceService = getResourceServiceBuilder(client).build();
         this.s3Client = new ExtendedFakeS3Client();
         this.s3Driver = new S3Driver(s3Client, INPUT_BUCKET_NAME);

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -293,7 +293,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
     @BeforeEach
     public void init() {
         super.init();
-        when(CONTEXT.getRemainingTimeInMillis()).thenReturn(100000)
+        when(CONTEXT.getRemainingTimeInMillis()).thenReturn(100000);
         this.resourceService = getResourceServiceBuilder(client).build();
         this.s3Client = new ExtendedFakeS3Client();
         this.s3Driver = new S3Driver(s3Client, INPUT_BUCKET_NAME);


### PR DESCRIPTION
When lambda times out, it does not persist error report. It makes it hard to see if posts with large files have been imported or not. When lambda almost reaches timeout threshold when moving large s3 objects, throwing exception and persisting report. 