### PR TITLE
create period for event when one of period dates is missing

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -194,7 +194,7 @@ public class ReferenceBuilder extends CristinMappingModule {
     private Time extractTime() {
         var from = extractCristinEventFromDate();
         var to = extractCristinEventToDate();
-        return nonNull(from) && nonNull(to) ? new Period(from, to) : null;
+        return nonNull(from) || nonNull(to) ? new Period(from, to) : null;
     }
 
     private Instant extractCristinEventFromDate() {

--- a/cristin-import/src/test/java/cucumber/EventFeatures.java
+++ b/cristin-import/src/test/java/cucumber/EventFeatures.java
@@ -105,8 +105,8 @@ public class EventFeatures {
         assertThat(((Period) event.getTime()).getFrom().toString(), is(equalTo(value)));
     }
 
-    @Then("the Event has no a time Period with toDate")
-    public void theNvaEventHasNoAPeriodWithToDate() {
+    @Then("the Event toDate is null")
+    public void theNvaEventToDateIsNull() {
         var event = (Event) scenarioContext.getNvaEntry()
                                 .getEntityDescription()
                                 .getReference()

--- a/cristin-import/src/test/java/cucumber/EventFeatures.java
+++ b/cristin-import/src/test/java/cucumber/EventFeatures.java
@@ -3,6 +3,7 @@ package cucumber;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -102,6 +103,15 @@ public class EventFeatures {
                                 .getReference()
                                 .getPublicationContext();
         assertThat(((Period) event.getTime()).getFrom().toString(), is(equalTo(value)));
+    }
+
+    @Then("the Event has no a time Period with toDate")
+    public void theNvaEventHasNoAPeriodWithToDate() {
+        var event = (Event) scenarioContext.getNvaEntry()
+                                .getEntityDescription()
+                                .getReference()
+                                .getPublicationContext();
+        assertThat(((Period) event.getTime()).getTo(), is(nullValue()));
     }
 
     @Then("the Event has a time Period with toDate {string}")

--- a/cristin-import/src/test/resources/features/EventRules.feature
+++ b/cristin-import/src/test/resources/features/EventRules.feature
@@ -49,3 +49,21 @@ Feature: Event conversion rules
     And the Event has a place "Norge" and country code "NO"
     And the Event has a time Period with fromDate "2023-11-28T00:00:00Z"
     And the Event has a time Period with toDate "2023-11-29T00:00:00Z"
+
+  Scenario: Cristin Result of type foredrag is converted to NVA Resource
+  with Publication Context of type "Event" without period end date when missing
+    Given a valid Cristin Result with secondary category "VIT_FOREDRAG"
+    And the Cristin Result has a non empty LectureOrPoster
+    And the LectureOrPoster has an Event
+    And the PresentationEvent has a title "Some label"
+    And the PresentationEvent has an Agent "Some agent"
+    And the PresentationEvent has a country code "NO"
+    And the PresentationEvent has a place "Norge"
+    And the PresentationEvent has a from date "2023-11-28T00:00:00"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a PublicationContext of type "Event"
+    And the Event has a label "Some label"
+    And the Event has an agent "Some agent"
+    And the Event has a place "Norge" and country code "NO"
+    And the Event has a time Period with fromDate "2023-11-28T00:00:00Z"
+    And the Event has no a time Period with toDate

--- a/cristin-import/src/test/resources/features/EventRules.feature
+++ b/cristin-import/src/test/resources/features/EventRules.feature
@@ -66,4 +66,4 @@ Feature: Event conversion rules
     And the Event has an agent "Some agent"
     And the Event has a place "Norge" and country code "NO"
     And the Event has a time Period with fromDate "2023-11-28T00:00:00Z"
-    And the Event has no a time Period with toDate
+    And the Event toDate is null


### PR DESCRIPTION
When creating Event from Cristin publication and one of period dates is missing - create period with one date. 