### PR TITLE
make title comparison non case sensitive - brage-import

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
@@ -2,6 +2,7 @@ package no.sikt.nva.brage.migration.lambda;
 
 import static java.util.Objects.isNull;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
@@ -114,8 +115,8 @@ public final class PublicationComparator {
     private static boolean titlesMatch(Publication existingPublication, Publication incomingPublication) {
         var existingPublicationTitle = existingPublication.getEntityDescription().getMainTitle();
         var incomingPublicationTitle = incomingPublication.getEntityDescription().getMainTitle();
-        return levenshteinDistanceIsLessThan(existingPublicationTitle,
-                                             incomingPublicationTitle,
+        return levenshteinDistanceIsLessThan(existingPublicationTitle.toLowerCase(Locale.ROOT),
+                                             incomingPublicationTitle.toLowerCase(Locale.ROOT),
                                              MAX_ACCEPTABLE_TITLE_LEVENSHTEIN_DISTANCE);
     }
 }

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
@@ -13,10 +13,12 @@ import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
 import no.unit.nva.model.instancetypes.event.Lecture;
 import no.unit.nva.model.instancetypes.report.ConferenceReport;
 import no.unit.nva.model.pages.MonographPages;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 class PublicationComparatorTest {
+
+    public static final String SENTENCE_STYLE_TITLE = "An integrative systematic review of promoting patient safety within prehospital emergency medical services by paramedics : A role theory perspective";
+    public static final String HEADLINE_STYLE = "An Integrative Systematic Review of Promoting Patient Safety Within Prehospital Emergency Medical Services by Paramedics: A Role Theory Perspective";
 
     @Test
     void shouldReturnTrueWhenComparingBrageConferenceReportWithExistingLecture()
@@ -58,6 +60,19 @@ class PublicationComparatorTest {
                                            .withEntityDescription(addEmptyReference(existingPublication))
                                            .build();
         assertTrue(PublicationComparator.publicationsMatch(existingPublication, incomingConferenceReport));
+    }
+
+    @Test
+    void shouldReturnTrueWhenPublicationsTitleAreIdenticalButNotStyleTheyAreWrittenIn()
+        throws InvalidIssnException, InvalidUnconfirmedSeriesException {
+        var existingLecture = randomPublication(Lecture.class);
+        existingLecture.getEntityDescription().setMainTitle(SENTENCE_STYLE_TITLE);
+        existingLecture.getEntityDescription().setPublicationDate(publicationDateWithYear());
+        var incomingConferenceReport = existingLecture.copy()
+                                           .withEntityDescription(createConferenceReport(existingLecture))
+                                           .build();
+        incomingConferenceReport.getEntityDescription().setMainTitle(HEADLINE_STYLE);
+        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
     }
 
     private static EntityDescription addEmptyReference(Publication existingPublication) {


### PR DESCRIPTION
When comparing titles before merging identical publications - accept that titles can have different capitalization styles. 