### PR TITLE
Fix VisibilityTimeout for HandleWorkQueue

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1403,6 +1403,7 @@ Resources:
   HandleWorkQueue:
     Type: AWS::SQS::Queue
     Properties:
+      VisibilityTimeout: 900 #Equal to or more than HandleIdentifierEventHandler Timeout
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt HandleDLQ.Arn
         maxReceiveCount: 5


### PR DESCRIPTION
VisibilityTimeout for HandleWorkQueue can not be less than Function Timeout. Default VisibilityTimeout is 30 seconds. 