### PR TITLE
importing Cristin publications without associatedLinks when invalid link

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AssociatedLinkExtractor.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AssociatedLinkExtractor.java
@@ -17,6 +17,7 @@ public final class AssociatedLinkExtractor {
                    .stream()
                    .filter(AssociatedLinkExtractor::isNotAHandle)
                    .filter(AssociatedLinkExtractor::isAssociatedLink)
+                   .filter(CristinAssociatedUri::isValidUri)
                    .map(AssociatedLinkExtractor::toAssociatedLink)
                    .toList();
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinAssociatedUri.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinAssociatedUri.java
@@ -1,11 +1,10 @@
 package no.unit.nva.cristin.mapper;
 
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.net.URI;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,8 +13,7 @@ import lombok.Setter;
 import no.unit.nva.cristin.mapper.nva.exceptions.InvalidArchiveException;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
-
-import static nva.commons.core.attempt.Try.attempt;
+import org.apache.commons.validator.routines.UrlValidator;
 
 @Builder(
     builderClassName = "CristinAssociatedUriBuilder",
@@ -44,10 +42,14 @@ public class CristinAssociatedUri {
     }
 
     public URI toURI() {
-        return attempt(() -> UriWrapper.fromUri(url).getUri())
+        return attempt(() -> UriWrapper.fromUri(url.trim()).getUri())
             .orElseThrow(fail -> new InvalidArchiveException(fail.getException()));
     }
 
+    @JsonIgnore
+    public boolean isValidUri() {
+        return UrlValidator.getInstance().isValid(url.trim());
+    }
 
     @JsonIgnore
     public boolean isArchive() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinAssociatedUri.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinAssociatedUri.java
@@ -1,6 +1,5 @@
 package no.unit.nva.cristin.mapper;
 
-import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,7 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import no.unit.nva.cristin.mapper.nva.exceptions.InvalidArchiveException;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 import org.apache.commons.validator.routines.UrlValidator;
@@ -42,8 +40,7 @@ public class CristinAssociatedUri {
     }
 
     public URI toURI() {
-        return attempt(() -> UriWrapper.fromUri(url.trim()).getUri())
-            .orElseThrow(fail -> new InvalidArchiveException(fail.getException()));
+        return UriWrapper.fromUri(url.trim()).getUri();
     }
 
     @JsonIgnore

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -132,6 +132,7 @@ public class CristinMapper extends CristinMappingModule {
                    .stream()
                    .filter(CristinAssociatedUri::isArchive)
                    .findFirst() // Analysis of the cristin dataset shows that there is either 0 or 1 archive uri present
+                   .filter(CristinAssociatedUri::isValidUri)
                    .map(CristinAssociatedUri::toURI);
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -131,8 +131,7 @@ public class CristinMapper extends CristinMappingModule {
         return associatedUris
                    .stream()
                    .filter(CristinAssociatedUri::isArchive)
-                   .findFirst() // Analysis of the cristin dataset shows that there is either 0 or 1 archive uri
-                   // present.
+                   .findFirst() // Analysis of the cristin dataset shows that there is either 0 or 1 archive uri present
                    .map(CristinAssociatedUri::toURI);
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ExceptionHandling.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ExceptionHandling.java
@@ -33,9 +33,6 @@ public final class ExceptionHandling {
         if (exception instanceof DuplicateDoiException) {
             return (DuplicateDoiException) exception;
         }
-        if (exception instanceof InvalidArchiveException) {
-            return (InvalidArchiveException) exception;
-        }
         if (exception instanceof RuntimeException) {
             return (RuntimeException) exception;
         }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/InvalidArchiveException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/InvalidArchiveException.java
@@ -1,8 +1,0 @@
-package no.unit.nva.cristin.mapper.nva.exceptions;
-
-public class InvalidArchiveException extends RuntimeException {
-
-    public InvalidArchiveException(Exception e) {
-        super(e);
-    }
-}

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -623,6 +623,11 @@ public class GeneralMappingRules {
         contributors.get(0).setAffiliations(List.of());
     }
 
+    @Then("the NVA resource is imported without handle.")
+    public void theNVAResourceIsImportedWithoutHandle() {
+        assertThat(scenarioContext.getNvaEntry().getHandle(), is(nullValue()));
+    }
+
     private void injectAffiliationsIntoContributors(List<CristinContributorsAffiliation> desiredInjectedAffiliations,
                                                     List<CristinContributor> contributors) {
         for (int contributorsIndex = 0; contributorsIndex < contributors.size(); contributorsIndex++) {

--- a/cristin-import/src/test/resources/features/GeneralMappingRules.feature
+++ b/cristin-import/src/test/resources/features/GeneralMappingRules.feature
@@ -421,12 +421,12 @@ Feature: Mappings that hold for all types of Cristin Results
     When the Cristin Result is converted to an NVA Resource
     Then the NVA Resource should have the handle set to null
 
-  Scenario: when brage-archive is set to non-url, an exception is thrown
+  Scenario: when brage-archive is set to non-url, import without brage-archive
     Given the Cristin Result has the following varbeid_url present:
       | urltypekode | url                       |
       | ARKIV       | Voyage Television, France |
     When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
+    Then the NVA resource is imported without handle.
 
   Scenario: Cristin notes should be mapped to NVA notes
     Given a valid Cristin Result

--- a/cristin-import/src/test/resources/features/MediaRules.feature
+++ b/cristin-import/src/test/resources/features/MediaRules.feature
@@ -56,8 +56,8 @@ Feature: Rules that apply for Media
     When the Cristin Result is converted to an NVA Resource
     Then the NVA publication should contain associatedArtifacts containing associatedLink with "<url>"
     Examples:
-      | urltypekode | url              |
-      | FULLTEKST   | www.example.com  |
-      | DATA        | www.example.com  |
-      | OMTALE      | www.example.com  |
+      | urltypekode | url                     |
+      | FULLTEKST   | https://www.example.com |
+      | DATA        | https://www.example.com |
+      | OMTALE      | https://www.example.com |
 


### PR DESCRIPTION
When importing Cristin publication
And publication has link
And link is not valid url
Then import publication without that link