### PR TITLE
updating cristin contributors that are missing cristin id

### DIFF
--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
@@ -1,8 +1,16 @@
 package no.unit.nva.cristin.lambda;
 
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import java.util.List;
+import no.unit.nva.model.Contributor;
+import no.unit.nva.model.Identity;
+import no.unit.nva.model.Publication;
 import no.unit.nva.model.contexttypes.Event;
+import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import no.unit.nva.model.instancetypes.event.ConferenceLecture;
 import org.junit.jupiter.api.Test;
 
@@ -14,16 +22,59 @@ class PublicationUpdaterTest {
         existingPublication.getEntityDescription().getReference().setPublicationContext(emptyEvent());
         var incomingPublication = randomPublication(ConferenceLecture.class);
         incomingPublication.getEntityDescription().getReference().setPublicationContext(emptyEvent());
-        var publicationRepresentations =
-            new PublicationRepresentations(null, incomingPublication, null)
-                .withExistingPublication(existingPublication);
+        var publicationRepresentations = getPublicationRepresentations(incomingPublication, existingPublication);
         var publication = PublicationUpdater.update(publicationRepresentations).getExistingPublication();
 
         assertEquals(publication.getEntityDescription().getReference().getPublicationContext(), emptyEvent());
     }
 
+    @Test
+    void shouldUpdateExistingContributorIdWhenMissingAndIncomingPublicationHasContributorWithId() {
+        var contributorName = randomString();
+        var existingPublication = randomPublication(DegreePhd.class);
+        var contributorWithoutId = new Contributor.Builder().withIdentity(
+            new Identity.Builder().withName(contributorName).build()).build();
+        existingPublication.getEntityDescription().setContributors(List.of(contributorWithoutId));
+
+        var incomingPublication = randomPublication(DegreePhd.class);
+        var contributorId = randomUri();
+        var contributorWithId = new Contributor.Builder().withIdentity(
+            new Identity.Builder().withName(contributorName).withId(contributorId).build()).build();
+        incomingPublication.getEntityDescription().setContributors(List.of(contributorWithId));
+
+        var publicationRepresentations = getPublicationRepresentations(incomingPublication, existingPublication);
+        var publication = PublicationUpdater.update(publicationRepresentations).getExistingPublication();
+
+        assertEquals(publication.getEntityDescription().getContributors().getFirst().getIdentity().getId(),
+                     contributorId);
+    }
+
+    @Test
+    void shouldNotUpdateExistingContributorIdWhenMissingAndIncomingContributorDoesNotHaveTheSameName() {
+        var existingPublication = randomPublication(DegreePhd.class);
+        var contributorWithoutId = new Contributor.Builder().withIdentity(
+            new Identity.Builder().withName(randomString()).build()).build();
+        existingPublication.getEntityDescription().setContributors(List.of(contributorWithoutId));
+
+        var incomingPublication = randomPublication(DegreePhd.class);
+        var contributorId = randomUri();
+        var contributorWithId = new Contributor.Builder().withIdentity(
+            new Identity.Builder().withName(randomString()).withId(contributorId).build()).build();
+        incomingPublication.getEntityDescription().setContributors(List.of(contributorWithId));
+
+        var publicationRepresentations = getPublicationRepresentations(incomingPublication, existingPublication);
+        var publication = PublicationUpdater.update(publicationRepresentations).getExistingPublication();
+
+        assertNull(publication.getEntityDescription().getContributors().getFirst().getIdentity().getId());
+    }
+
+    private static PublicationRepresentations getPublicationRepresentations(Publication incomingPublication,
+                                                                            Publication existingPublication) {
+        return new PublicationRepresentations(null, incomingPublication, null).withExistingPublication(
+            existingPublication);
+    }
+
     private static Event emptyEvent() {
-        return new Event(null, null, null,
-                         null, null, null);
+        return new Event(null, null, null, null, null, null);
     }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/Organization.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Organization.java
@@ -21,6 +21,10 @@ public class Organization extends Corporation {
         setId(builder.id);
     }
 
+    public static Organization fromUri(URI uri) {
+        return new Organization.Builder().withId(uri).build();
+    }
+
     public URI getId() {
         return id;
     }


### PR DESCRIPTION
When Brage publication has type Degree
And publication contributors have affiliation (the same affiliation is set for all Brage contributors)
When merging contributors with existing publication contributors
Then update all existing creators affiliations with affiliation from Brage. 

+ Adding code to "repair" existing contributors in Test, cause they were replaced in last import by Brage contributors and missed theirs Cristin id's. 