### PR TITLE
updating event time

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -278,7 +278,8 @@ public final class PublicationUpdater {
         var existingPlace = getPlaceCountry(existingEvent);
         var incomingPlace = getPlaceCountry(incomingEvent);
         if (shouldBeUpdated(existingPlace, incomingPlace)
-            || shouldBeUpdated(getLabel(existingPlace), getLabel(incomingPlace))) {
+            || shouldBeUpdated(getLabel(existingPlace), getLabel(incomingPlace))
+            || shouldBeUpdated(existingEvent.getTime(), incomingEvent.getTime())) {
             return new Event.Builder()
                        .withLabel(
                            nonNull(existingEvent.getLabel()) ? existingEvent.getLabel() : incomingEvent.getLabel())

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
@@ -32,7 +32,7 @@ class PublicationUpdaterTest {
     }
 
     @Test
-    void shouldUpdatedEventWithTimeWhenExistingEventIsMissingTimeButNewEventHasTimeMissing() {
+    void shouldUpdatedEventWithTimeWhenExistingEventIsMissingTimeButNewEventHasTime() {
         var existingPublication = randomPublication(ConferenceLecture.class);
         existingPublication.getEntityDescription().getReference().setPublicationContext(emptyEvent());
         var incomingPublication = randomPublication(ConferenceLecture.class);

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/PublicationUpdaterTest.java
@@ -10,8 +10,11 @@ import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.contexttypes.Event;
+import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import no.unit.nva.model.instancetypes.event.ConferenceLecture;
+import no.unit.nva.model.time.Instant;
+import no.unit.nva.model.time.Time;
 import org.junit.jupiter.api.Test;
 
 class PublicationUpdaterTest {
@@ -26,6 +29,29 @@ class PublicationUpdaterTest {
         var publication = PublicationUpdater.update(publicationRepresentations).getExistingPublication();
 
         assertEquals(publication.getEntityDescription().getReference().getPublicationContext(), emptyEvent());
+    }
+
+    @Test
+    void shouldUpdatedEventWithTimeWhenExistingEventIsMissingTimeButNewEventHasTimeMissing() {
+        var existingPublication = randomPublication(ConferenceLecture.class);
+        existingPublication.getEntityDescription().getReference().setPublicationContext(emptyEvent());
+        var incomingPublication = randomPublication(ConferenceLecture.class);
+        var eventWithTime = eventWithTime();
+        incomingPublication.getEntityDescription().getReference().setPublicationContext(eventWithTime);
+        var publicationRepresentations = getPublicationRepresentations(incomingPublication, existingPublication);
+        var publication = PublicationUpdater.update(publicationRepresentations).getExistingPublication();
+
+        var event = (Event) publication.getEntityDescription().getReference().getPublicationContext();
+
+        assertEquals(event.getTime(), eventWithTime.getTime());
+    }
+
+    private static Event eventWithTime() {
+        return new Event(null, null,
+                         new Instant(
+                             java.time.Instant.now()),
+                         null,
+                         null, null);
     }
 
     @Test


### PR DESCRIPTION
When Cristin publication of type Event has been imported without time
And incoming publication has time
Then update publication with time.

- We have updated import rule for event, before we did not map time when time was missing one of values, start date or end date, now we import time when it is missing one of dates. 