### PR TITLE
support jsonsubtypes as oneOf in openapi

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1301,6 +1301,11 @@ components:
           type: string
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/AdditionalIdentifier'
+        - $ref: '#/components/schemas/HandleIdentifier'
+        - $ref: '#/components/schemas/ScopusIdentifier'
+        - $ref: '#/components/schemas/CristinIdentifier'
     AdministrativeAgreement:
       required:
         - type
@@ -1318,6 +1323,8 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Corporation'
     Anthology:
       required:
         - type
@@ -1388,6 +1395,11 @@ components:
           format: int32
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Competition'
+        - $ref: '#/components/schemas/MentionInPublication'
+        - $ref: '#/components/schemas/Award'
+        - $ref: '#/components/schemas/Exhibition'
     ArchitectureSubtype:
       type: object
       properties:
@@ -1459,6 +1471,10 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/File'
+        - $ref: '#/components/schemas/AssociatedLink'
+        - $ref: '#/components/schemas/NullAssociatedArtifact'
     AssociatedArtifactList:
       type: array
       properties:
@@ -1582,6 +1598,9 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Series'
+        - $ref: '#/components/schemas/UnconfirmedSeries'
     Broadcast:
       required:
         - type
@@ -1796,6 +1815,9 @@ components:
           properties:
             type:
               type: string
+      oneOf:
+        - $ref: '#/components/schemas/Organization'
+        - $ref: '#/components/schemas/UnconfirmedOrganization'
     Course:
       required:
         - type
@@ -1803,6 +1825,8 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/UnconfirmedCourse'
     CristinIdentifier:
       type: object
       allOf:
@@ -1994,6 +2018,10 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/DefinedDuration'
+        - $ref: '#/components/schemas/UndefinedDuration'
+        - $ref: '#/components/schemas/NullDuration'
     Encyclopedia:
       required:
         - type
@@ -2218,6 +2246,11 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/ExhibitionCatalogReference'
+        - $ref: '#/components/schemas/ExhibitionOtherPresentation'
+        - $ref: '#/components/schemas/ExhibitionBasic'
+        - $ref: '#/components/schemas/ExhibitionMentionInPublication'
     ExhibitionProductionSubtype:
       type: object
       properties:
@@ -2278,6 +2311,10 @@ components:
               type: boolean
             type:
               type: string
+      oneOf:
+        - $ref: '#/components/schemas/PublishedFile'
+        - $ref: '#/components/schemas/UnpublishedFile'
+        - $ref: '#/components/schemas/AdministrativeAgreement'
     FunderRightsRetentionStrategy:
       required:
         - type
@@ -2302,16 +2339,19 @@ components:
         source:
           type: string
           format: uri
+        fundingAmount:
+          $ref: '#/components/schemas/MonetaryAmount'
         activeFrom:
           type: string
           format: date-time
         activeTo:
           type: string
           format: date-time
-        fundingAmount:
-          $ref: '#/components/schemas/MonetaryAmount'
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/ConfirmedFunding'
+        - $ref: '#/components/schemas/UnconfirmedFunding'
     GeographicalContent:
       required:
         - type
@@ -2617,6 +2657,11 @@ components:
           $ref: '#/components/schemas/PublicationDate'
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/LiteraryArtsAudioVisual'
+        - $ref: '#/components/schemas/LiteraryArtsMonograph'
+        - $ref: '#/components/schemas/LiteraryArtsPerformance'
+        - $ref: '#/components/schemas/LiteraryArtsWeb'
     LiteraryArtsMonograph:
       required:
         - type
@@ -2917,6 +2962,10 @@ components:
           format: int32
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Broadcast'
+        - $ref: '#/components/schemas/CinematicRelease'
+        - $ref: '#/components/schemas/OtherRelease'
     MovingPictureSubtype:
       type: object
       properties:
@@ -2972,6 +3021,11 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/AudioVisualPublication'
+        - $ref: '#/components/schemas/Concert'
+        - $ref: '#/components/schemas/MusicScore'
+        - $ref: '#/components/schemas/OtherPerformance'
     MusicScore:
       required:
         - type
@@ -3192,6 +3246,10 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Range'
+        - $ref: '#/components/schemas/MonographPages'
+        - $ref: '#/components/schemas/Period'
     PerformingArts:
       required:
         - type
@@ -3219,6 +3277,8 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/PerformingArtsVenue'
     PerformingArtsSubtype:
       type: object
       properties:
@@ -3268,6 +3328,8 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/UnconfirmedPlace'
     PopularScienceArticle:
       required:
         - type
@@ -3431,6 +3493,21 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Book'
+        - $ref: '#/components/schemas/Report'
+        - $ref: '#/components/schemas/Degree'
+        - $ref: '#/components/schemas/Anthology'
+        - $ref: '#/components/schemas/Journal'
+        - $ref: '#/components/schemas/UnconfirmedJournal'
+        - $ref: '#/components/schemas/Event'
+        - $ref: '#/components/schemas/Artistic'
+        - $ref: '#/components/schemas/MediaContribution'
+        - $ref: '#/components/schemas/MediaContributionPeriodical'
+        - $ref: '#/components/schemas/UnconfirmedMediaContributionPeriodical'
+        - $ref: '#/components/schemas/ResearchData'
+        - $ref: '#/components/schemas/GeographicalContent'
+        - $ref: '#/components/schemas/ExhibitionContent'
     PublicationDate:
       required:
         - type
@@ -3453,6 +3530,67 @@ components:
           $ref: '#/components/schemas/Pages'
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Architecture'
+        - $ref: '#/components/schemas/ArtisticDesign'
+        - $ref: '#/components/schemas/MovingPicture'
+        - $ref: '#/components/schemas/PerformingArts'
+        - $ref: '#/components/schemas/AcademicArticle'
+        - $ref: '#/components/schemas/AcademicLiteratureReview'
+        - $ref: '#/components/schemas/CaseReport'
+        - $ref: '#/components/schemas/StudyProtocol'
+        - $ref: '#/components/schemas/ProfessionalArticle'
+        - $ref: '#/components/schemas/PopularScienceArticle'
+        - $ref: '#/components/schemas/JournalCorrigendum'
+        - $ref: '#/components/schemas/JournalLetter'
+        - $ref: '#/components/schemas/JournalLeader'
+        - $ref: '#/components/schemas/JournalReview'
+        - $ref: '#/components/schemas/AcademicMonograph'
+        - $ref: '#/components/schemas/PopularScienceMonograph'
+        - $ref: '#/components/schemas/Encyclopedia'
+        - $ref: '#/components/schemas/ExhibitionCatalog'
+        - $ref: '#/components/schemas/NonFictionMonograph'
+        - $ref: '#/components/schemas/Textbook'
+        - $ref: '#/components/schemas/BookAnthology'
+        - $ref: '#/components/schemas/DegreeBachelor'
+        - $ref: '#/components/schemas/DegreeMaster'
+        - $ref: '#/components/schemas/DegreePhd'
+        - $ref: '#/components/schemas/DegreeLicentiate'
+        - $ref: '#/components/schemas/ReportBasic'
+        - $ref: '#/components/schemas/ReportPolicy'
+        - $ref: '#/components/schemas/ReportResearch'
+        - $ref: '#/components/schemas/ReportWorkingPaper'
+        - $ref: '#/components/schemas/ConferenceReport'
+        - $ref: '#/components/schemas/ReportBookOfAbstract'
+        - $ref: '#/components/schemas/AcademicChapter'
+        - $ref: '#/components/schemas/EncyclopediaChapter'
+        - $ref: '#/components/schemas/ExhibitionCatalogChapter'
+        - $ref: '#/components/schemas/Introduction'
+        - $ref: '#/components/schemas/NonFictionChapter'
+        - $ref: '#/components/schemas/PopularScienceChapter'
+        - $ref: '#/components/schemas/TextbookChapter'
+        - $ref: '#/components/schemas/ChapterConferenceAbstract'
+        - $ref: '#/components/schemas/ChapterInReport'
+        - $ref: '#/components/schemas/OtherStudentWork'
+        - $ref: '#/components/schemas/ConferenceLecture'
+        - $ref: '#/components/schemas/ConferencePoster'
+        - $ref: '#/components/schemas/Lecture'
+        - $ref: '#/components/schemas/OtherPresentation'
+        - $ref: '#/components/schemas/JournalIssue'
+        - $ref: '#/components/schemas/ConferenceAbstract'
+        - $ref: '#/components/schemas/MediaFeatureArticle'
+        - $ref: '#/components/schemas/MediaBlogPost'
+        - $ref: '#/components/schemas/MediaInterview'
+        - $ref: '#/components/schemas/MediaParticipationInRadioOrTv'
+        - $ref: '#/components/schemas/MediaPodcast'
+        - $ref: '#/components/schemas/MediaReaderOpinion'
+        - $ref: '#/components/schemas/MusicPerformance'
+        - $ref: '#/components/schemas/DataManagementPlan'
+        - $ref: '#/components/schemas/DataSet'
+        - $ref: '#/components/schemas/VisualArts'
+        - $ref: '#/components/schemas/Map'
+        - $ref: '#/components/schemas/LiteraryArts'
+        - $ref: '#/components/schemas/ExhibitionProduction'
     PublicationNote:
       type: object
       allOf:
@@ -3466,6 +3604,9 @@ components:
           type: string
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/PublicationNote'
+        - $ref: '#/components/schemas/UnpublishingNote'
     PublishedFile:
       required:
         - type
@@ -3498,6 +3639,10 @@ components:
           type: boolean
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Publisher'
+        - $ref: '#/components/schemas/UnconfirmedPublisher'
+        - $ref: '#/components/schemas/NullPublisher'
     Range:
       required:
         - type
@@ -3530,6 +3675,9 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/ConfirmedDocument'
+        - $ref: '#/components/schemas/UnconfirmedDocument'
     Report:
       type: object
       allOf:
@@ -3669,6 +3817,11 @@ components:
             - OverridableRightsRetentionStrategy
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/CustomerRightsRetentionStrategy'
+        - $ref: '#/components/schemas/OverriddenRightsRetentionStrategy'
+        - $ref: '#/components/schemas/NullRightsRetentionStrategy'
+        - $ref: '#/components/schemas/FunderRightsRetentionStrategy'
     RoleType:
       type: object
       properties:
@@ -3819,6 +3972,9 @@ components:
       properties:
         type:
           type: string
+      oneOf:
+        - $ref: '#/components/schemas/Period'
+        - $ref: '#/components/schemas/Instant'
     UnconfirmedCourse:
       required:
         - type
@@ -4031,7 +4187,7 @@ components:
         description:
           type: string
           writeOnly: true
-#endregion
+  #endregion
   securitySchemes:
     CognitoUserPool:
       type: apiKey

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "6PFBxO2TxBpyWo",
-    "ownerAffiliation" : "https://www.example.org/2ada01ec-bc09-425a-b49e-b58255db1821"
+    "owner" : "0obmVMuUsCRgxGOtT",
+    "ownerAffiliation" : "https://www.example.org/370f9e7c-b2df-4d57-9d59-a4df97548053"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/71ffe5b0-6dd5-42a5-96f8-b51fb46ea929"
+    "id" : "https://www.example.org/0a9b6308-a261-486e-ac61-f2e92119d14f"
   },
-  "createdDate" : "1997-12-05T23:24:45.185Z",
-  "modifiedDate" : "2000-03-24T19:39:23.022Z",
-  "publishedDate" : "1986-06-18T16:41:10.673Z",
-  "indexedDate" : "1979-08-03T14:38:10.307Z",
-  "handle" : "https://www.example.org/3aae4bc7-c20c-4f8e-8eb5-3301c01b6c2c",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/0ba33458-4195-4dc7-94e9-c24432b5de1b",
+  "createdDate" : "2006-01-15T05:51:07.068Z",
+  "modifiedDate" : "1986-12-21T01:48:29.752Z",
+  "publishedDate" : "2015-11-02T04:01:09.585Z",
+  "indexedDate" : "2000-12-06T16:43:47.834Z",
+  "handle" : "https://www.example.org/8dfaa75c-37f6-4ba1-a9e0-0a0c28c69e9f",
+  "doi" : "https://doi.org/10.1234/sequi",
+  "link" : "https://www.example.org/3aea7c0e-5285-41df-8629-4d9019d543fd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hXiaX9WyKtcIRmp",
+    "mainTitle" : "RR0cSr2OagOt",
     "alternativeTitles" : {
-      "sv" : "NxVySvOODlTNPR"
+      "cs" : "nb9mdsomZOcbxF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XbamsXy7TXVgeGByl",
-      "month" : "2MEdCKMsi4",
-      "day" : "dkfTcrmeXZiq"
+      "year" : "qU6GtyQnGq",
+      "month" : "PeefLyRoCO3nQ",
+      "day" : "XfwikmDtaQ7Na2uB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7a66cc94-856e-4b16-ae36-c2e273b0020c",
-        "name" : "7gYk8rdleI2",
-        "nameType" : "Organizational",
-        "orcId" : "c5UpUJBOr6B128S53o",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/99348ee9-c5d6-44a1-9804-32a5e2d6a72c",
+        "name" : "cYXvXpGcjTcB00",
+        "nameType" : "Personal",
+        "orcId" : "w2Ai0uv4QwWjNL5UqpS",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "M13ec4iQe1udtY6XI",
-          "value" : "6SfnFT9kUKv"
+          "sourceName" : "bPIXc5mJjz4WhRT",
+          "value" : "LGWRDLPmAtF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tV6rfkudesHwXTu3",
-          "value" : "N3FcANwlUqkJgwpPVk"
+          "sourceName" : "mPa9HPSCx6p4G5Ueaa",
+          "value" : "sZQC4PPHjXjutmzf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f39ca2da-0c0a-4217-9bd3-befbf5273b48"
+        "id" : "https://www.example.org/650667d2-ca03-4a49-ab47-e4322caff503"
       } ],
       "role" : {
         "type" : "CuratorOrganizer"
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0602d571-0ee8-44f4-ad3f-d3d88cb7bb1b",
-        "name" : "xQ2E7Ei9e2ZlnBTq",
+        "id" : "https://www.example.org/10cc2312-7ee8-4aed-b2ac-7204b1dbcc00",
+        "name" : "NV86XIUdEtz",
         "nameType" : "Personal",
-        "orcId" : "vRLNfjciersIbXrJxaq",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "BehFK1zEph8Bqx",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DOPDdXccHHhQQg",
-          "value" : "lkONzNVJTn8pMRz"
+          "sourceName" : "Uf7iT1HVQXbZbRVAW",
+          "value" : "JAUJ49ecA0fO6iw1qhn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FlfML3wRZQy2T",
-          "value" : "Sjw3miJD60DUJ0AAf"
+          "sourceName" : "JcfWWWYv2bRdRoF",
+          "value" : "LLYcEYs7a2ko0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1bc44dd0-b5c7-4656-90ec-f5ef99402e76"
+        "id" : "https://www.example.org/629f0901-6d5a-493b-90c6-af5dd2bd93be"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "AUsXnFcoCCYXT0Ej"
+      "se" : "oxz2EiEQfLc5c"
     },
-    "npiSubjectHeading" : "Vqkg3nvxvpnfJ",
-    "tags" : [ "ScToOh55y1N1" ],
-    "description" : "aqLomDAk0Dijj",
+    "npiSubjectHeading" : "P252j4L8ss",
+    "tags" : [ "Kssj6P1typ" ],
+    "description" : "e09wF1Wm5wfCh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8d598a91-9e82-4167-bf1b-770a28f3ab34"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4eb16fa9-4eed-42d2-bed3-21d7f15940e7"
       },
-      "doi" : "https://www.example.org/8b53960d-e918-4411-8df4-3a802f868def",
+      "doi" : "https://www.example.org/a2dd8446-3cae-450f-8396-0569773c2cfa",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "AHwwO8SjU9aWvMIQM",
-          "end" : "AbE89E1VR1bTIfr"
+          "begin" : "qGmi9KMSXfQyLwI",
+          "end" : "8zmC0ueOwN"
         },
-        "volume" : "EaVpeIcwJzpg",
-        "issue" : "xuQwRxao6HouKOuNY",
-        "articleNumber" : "02c3T4nmHc0"
+        "volume" : "q6B4qZRTJ9kgBQ",
+        "issue" : "4W7614DM7c",
+        "articleNumber" : "mwZZ8Vhr0xWNNKvFEm"
       }
     },
-    "metadataSource" : "https://www.example.org/f6b2e187-0449-4616-8655-14e1ce62d159",
-    "abstract" : "cQ1yxqPOpH95X"
+    "metadataSource" : "https://www.example.org/874c5008-1493-44cd-8ec3-6c1013898001",
+    "abstract" : "JnTjAlQJmNq9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b3c8ad47-b3e4-4ae9-adbf-a059596466fd",
-    "name" : "RQHekLj54IrSD",
+    "id" : "https://www.example.org/d34ac4be-fa05-47ff-bb81-c7c5a5eba1f8",
+    "name" : "x9rl9PdD3M8jps9RzV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-07-22T23:01:44.862Z",
+      "approvalDate" : "2007-11-14T03:32:47.407Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Xvh4c8ZlIclWGpK"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "eoyEvkkqB84MwP8Xt"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5c60b82a-1bde-4bed-b926-4249e8b9aecc",
-    "identifier" : "xmdjV4oKXp6JU",
+    "source" : "https://www.example.org/3b920104-e2bc-474c-8e36-cd0e2c8c028c",
+    "identifier" : "ecYyu46UlravAS",
     "labels" : {
-      "cs" : "LASyo2zgqZIB"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1028695579
-    },
-    "activeFrom" : "2021-06-21T00:09:03.473Z",
-    "activeTo" : "2021-09-18T15:22:16.343Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4e8ad786-d4dd-4842-b35a-0611171f94db",
-    "id" : "https://www.example.org/c88f689b-d4e9-426d-b7d9-9820797a0a75",
-    "identifier" : "xGjv3xlSt2nCplj7",
-    "labels" : {
-      "pt" : "q6ZLdYog9TaVuya4"
+      "es" : "HEZP6NA0iL9w0eDEF"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 675723298
+      "amount" : 1823095079
     },
-    "activeFrom" : "2013-10-13T14:17:30.609Z",
-    "activeTo" : "2018-02-09T02:08:00.234Z"
+    "activeFrom" : "2023-05-14T18:53:18.048Z",
+    "activeTo" : "2024-04-29T06:50:46.482Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/083201a5-b9a2-449b-85c3-0529b658cc52",
+    "id" : "https://www.example.org/6307fe04-b076-4b2d-98c1-7d1bc57590d6",
+    "identifier" : "30dtE5SGnMhzthG0UmY",
+    "labels" : {
+      "nn" : "u5j7KKAHYdiAflGbfOO"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 605616247
+    },
+    "activeFrom" : "1986-01-25T19:57:47.228Z",
+    "activeTo" : "2012-03-28T01:54:11.401Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/98657437-094f-4aa4-9b7e-b1adf7f1a6cb",
+    "sourceName" : "1qdfgla9itsqmh2i@f4d05vi8ptvmlyyz"
+  }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "UN9w7wERdKq6N4",
-    "value" : "asVpUnAVWPnd"
+    "sourceName" : "VAjZTcNB93",
+    "value" : "WjjGHrxdx8LT"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "qbIZnkP7XUx",
-    "sourceName" : "vnixpenpi4p2b@hwzsh1bdt6yemehoaqz"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/700410d0-2c01-43c7-976f-5c898f5c92a1",
-    "sourceName" : "wmqhiyutuhzi2xkr@bwpsfbt5znd"
+    "value" : "9eTSZuMGfLdqB",
+    "sourceName" : "8vnfnel7bgt@d0vwsc3zkvkty"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1307701208",
-    "sourceName" : "ewvy0webozazmfmse@juc4dyxts7sit1yq"
+    "value" : "1007731230",
+    "sourceName" : "itm4o9q1lod6tbfnrw@4bze69mu3agpqlqqs6"
   } ],
-  "subjects" : [ "https://www.example.org/5184b84c-bab9-4f44-8305-8216e060f05b" ],
+  "subjects" : [ "https://www.example.org/9a426072-70e9-410d-9438-a78d6f3d9289" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "15e76d56-9be8-4133-8e8e-f34aaa39fc32",
-    "name" : "0LoJIddgrnxqc5CG21o",
-    "mimeType" : "4i7FqLZRTzkbOOpl",
-    "size" : 525700090,
-    "license" : "https://www.example.com/swwln69btswmlec35",
+    "identifier" : "15b34ca2-742f-445d-be41-a07e52f699aa",
+    "name" : "nAWfB9qYkrYmXgwBeU",
+    "mimeType" : "PvW6VYksXls",
+    "size" : 1759662315,
+    "license" : "https://www.example.com/t0nnvw7uqb6xklov",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "iRHdUQfhSzL1g9vBSxF",
-    "publishedDate" : "1980-07-11T21:40:41.027Z",
+    "legalNote" : "9YF4h0C75rrDX4dic5A",
+    "publishedDate" : "2004-04-22T07:35:28.494Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "74y9WwbL1itA3YvWLj",
-      "uploadedDate" : "1989-11-20T20:27:53.873Z"
+      "uploadedBy" : "fCqrSPYI84ukOv",
+      "uploadedDate" : "2000-06-01T16:17:06.760Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2PN3XZk0e80eFWSBb",
-    "name" : "tZwkIpEmdvYgyYLA1",
-    "description" : "jHSaz7I553"
+    "id" : "https://www.example.com/cv1QWrCGLehw",
+    "name" : "B3y5AYLQpV",
+    "description" : "8ASd5KsZb7OSH6"
   } ],
-  "rightsHolder" : "FE56HAAAtiBmp4y",
-  "duplicateOf" : "https://www.example.org/c3e19320-3300-4714-aa6c-3b32fc9ed16b",
+  "rightsHolder" : "Bsp7WXmemTFL9G",
+  "duplicateOf" : "https://www.example.org/a68d5fbe-7e67-4b2c-ab89-b877bd85bbab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KCU7zGmRRe"
+    "note" : "Z2ABKnxsTQbEnK9oQV8"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ib0Ge3TvmRpTJ7tT",
-    "createdBy" : "JhAPYlxQiWbSD1rukp",
-    "createdDate" : "1999-11-17T19:18:18.140Z"
+    "note" : "15tGgkrogtl3RUYw7D",
+    "createdBy" : "ByF7kVJFdlXHA",
+    "createdDate" : "1981-04-30T09:25:54.437Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ed8ffa9e-5e89-4ce3-966c-126f2cd67fa2" ],
+  "curatingInstitutions" : [ "https://www.example.org/36f306bd-06cb-4c0b-a6ed-47d7dddd9f1e" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "7DzJ4Ru1jcyVthWOD",
-    "ownerAffiliation" : "https://www.example.org/2a889ed4-05c6-4a2f-b761-7949df31df6f"
+    "owner" : "6zdXFNBVjwWHAz5",
+    "ownerAffiliation" : "https://www.example.org/fc84825b-ff42-4255-93e4-bea5aadc578b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/84b7d2cd-63c6-4670-9b61-75fafb0eaa7e"
+    "id" : "https://www.example.org/cd46d356-7a2d-4bc0-b01b-f4fdc35318bd"
   },
-  "createdDate" : "2014-02-01T22:13:30.942Z",
-  "modifiedDate" : "2014-06-17T01:08:23.917Z",
-  "publishedDate" : "1980-08-27T00:48:14.371Z",
-  "indexedDate" : "2012-04-30T01:53:27.455Z",
-  "handle" : "https://www.example.org/a26a77a1-dd9b-4e4f-b1b2-67b8e9b177c1",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/f6fa2a2f-b4d7-4fff-8972-fdd6e6019dcb",
+  "createdDate" : "1984-05-11T13:29:06.382Z",
+  "modifiedDate" : "1974-11-04T12:55:16.302Z",
+  "publishedDate" : "2023-08-11T04:00:19.833Z",
+  "indexedDate" : "1980-05-30T15:54:58.480Z",
+  "handle" : "https://www.example.org/ab73a5ca-1ffe-4302-9310-ded00ab1b6bd",
+  "doi" : "https://doi.org/10.1234/fugit",
+  "link" : "https://www.example.org/0b4b6620-027e-44c4-a5ec-97197683d39f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DsQYZPCOoV8BOGAu",
+    "mainTitle" : "27l9Q7eFA3q",
     "alternativeTitles" : {
-      "es" : "lJRM8EIkU7g2"
+      "hu" : "edMOfHZtux6nls04Vtz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zbRDWZhDkC",
-      "month" : "4sE5zx3juBIRdK0zW0",
-      "day" : "49ydEVSGQrvC"
+      "year" : "d8ltVizQOA",
+      "month" : "DHoo6xsXkASeFB",
+      "day" : "01SPhJdupDvNug4w"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/de1fbf9f-9a91-47e4-8430-daf00632346a",
-        "name" : "PV9G4XJRvgT",
-        "nameType" : "Personal",
-        "orcId" : "GhKNDPxun7",
+        "id" : "https://www.example.org/7419f074-e20f-4729-ad3d-4e42f1ccb63e",
+        "name" : "FJsbJEmvwX7",
+        "nameType" : "Organizational",
+        "orcId" : "fei4NEvNXsHvwod",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qhISThxe1o5",
-          "value" : "zHxU4PwT2ogIBH2TZ7v"
+          "sourceName" : "Z5co5wyz6c4EZiehJVX",
+          "value" : "fdjWjh7H52MFpL7o"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hmXbr99kuAHZ",
-          "value" : "VfRSyOEUdlSKkh6M"
+          "sourceName" : "229NnAUBaFRtKUN7X82",
+          "value" : "gNOiLnV86EweG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9e451538-ad5a-4206-a0f7-0d01943bacc2"
+        "id" : "https://www.example.org/05b8ce11-2914-40ef-bfb7-d19e595a018c"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "iFs1FDBPoONAE"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/417fdc37-e886-40cd-a2c8-ad029747bcbb",
-        "name" : "zD54JlLBeMtyQkA",
-        "nameType" : "Personal",
-        "orcId" : "uUv4vxLg7GlSVLZIy",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/ec184a4a-1275-41a5-9c04-3f0dc6498f11",
+        "name" : "OlBLvldviE5QZ7Z3D",
+        "nameType" : "Organizational",
+        "orcId" : "CeRaISLqEv",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "asvAYSQEFvj85Gq6Kr0",
-          "value" : "4P0gBvU2tZRcx"
+          "sourceName" : "iBggzGNm9zvSBU",
+          "value" : "0n6odTcIKIhdLes"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ef55xF3z4NA7",
-          "value" : "RCTQxe3XzsK3fbBJhGe"
+          "sourceName" : "rsHi3U9gPaJaD1Iea5",
+          "value" : "Dn9rhkkYfCUWrN1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/79b38cd5-1b0b-42b2-8319-30ed5f009d24"
+        "id" : "https://www.example.org/346b86f7-8de4-4f28-adb6-b18958989968"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "Yz6wvl3d4kYFLxPZcvQ"
+      "nb" : "nUy9wAujWZP64q"
     },
-    "npiSubjectHeading" : "Kqi6v8PiUCG64P9",
-    "tags" : [ "auzKAckUzhw" ],
-    "description" : "yZnHhfKeIo7B6gOxpvj",
+    "npiSubjectHeading" : "trzWYkk4Dcw33OM",
+    "tags" : [ "RovaJIonK5jHKT4n3qy" ],
+    "description" : "zNmkY48FNL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/VEjxr47XqP4brWE"
+        "id" : "https://www.example.com/NcLohElEZDuN18"
       },
-      "doi" : "https://www.example.org/42397549-dc49-41a3-9c03-6f6ab40df63f",
+      "doi" : "https://www.example.org/dc9efdf2-9549-4178-b698-48e607d43fb4",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "edK6zt60DqK61HmA3u",
-          "end" : "DzxgvG8mfX9CRWUJ7"
+          "begin" : "35Rq3eR7UJFVoi6uc",
+          "end" : "ZN8rWPgT51piPcC2"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2496d2a8-367b-4e6b-976e-8fba617538a8",
-    "abstract" : "StCCMUB8yECdpqtCl"
+    "metadataSource" : "https://www.example.org/17879353-3c9c-4950-bd3a-73fbe86e8700",
+    "abstract" : "wePcLCs9Sr0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/80861bab-1458-4cfa-8214-0b483a794ead",
-    "name" : "rO73XKlMcHB",
+    "id" : "https://www.example.org/c3ad59e8-728f-4c88-8403-00b52bbb52b9",
+    "name" : "J6uKMdZ5WQBzK",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-03-23T12:42:51.821Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "yYZQZ9XDQBpl"
+      "approvalDate" : "2016-12-25T22:53:22.010Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "87rwK8nFdQ11RrDH"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/91dff605-d95d-49ef-aee2-21c2742f0e23",
-    "identifier" : "7odhZ6zGjQNzU4",
+    "source" : "https://www.example.org/2b11ffac-cd5b-4209-9d93-918bd6067251",
+    "identifier" : "yGJ4cNtjKX7tL5HlR0",
     "labels" : {
-      "fi" : "0OMYFCLKaiMZ"
+      "de" : "55JuJKpFI0e"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1816417954
+      "currency" : "GBP",
+      "amount" : 198776403
     },
-    "activeFrom" : "2008-11-19T03:03:21.041Z",
-    "activeTo" : "2009-01-26T11:14:57.700Z"
+    "activeFrom" : "1978-07-15T00:26:22.205Z",
+    "activeTo" : "2014-12-02T02:32:45.705Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/160504b4-67a8-4d85-8d51-9656750feb77",
-    "id" : "https://www.example.org/e44e02f3-eda0-4221-bb2f-40bf12ed90b5",
-    "identifier" : "B7ONejiesvV",
+    "source" : "https://www.example.org/da8e5b80-1eda-47a2-ab56-9856db66099c",
+    "id" : "https://www.example.org/3bbc5052-da7a-4424-a8de-c942e245b803",
+    "identifier" : "9s3VWY8Nqre5xLWvK",
     "labels" : {
-      "es" : "lh7W3VD0fomZD"
+      "it" : "dcwWbOm9BM"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 74757354
+      "currency" : "GBP",
+      "amount" : 343685746
     },
-    "activeFrom" : "1974-01-07T16:48:27.200Z",
-    "activeTo" : "1996-02-07T22:55:33.058Z"
+    "activeFrom" : "2018-06-17T19:31:12.186Z",
+    "activeTo" : "2019-10-19T14:16:23.170Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/df315b73-eca8-45fc-b5bb-8abba703f560",
+    "sourceName" : "g7z8lnuytwz@tchg4tnzbyb"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "238361919",
-    "sourceName" : "tpta8bxo1juedxeyvql@hpfp4yimxa2fuz"
+    "value" : "991704109",
+    "sourceName" : "tklyz9lk6oh@ajrctviifiss"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "x0YTprDZPnDKW8WjOZ1",
-    "value" : "t5SJdUpS9x"
+    "sourceName" : "lQ2TZNRydzJQhw4wJu",
+    "value" : "v5Y0S8jpx1M0qyWbn"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "w9kxltZ785Tl4VseQ",
-    "sourceName" : "lxc0ahvnnkxlshq@vuxfd0z0crkl3kbvgn"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/03621e3b-b543-4b27-82a3-a7b0f5033bb3",
-    "sourceName" : "olwynveih6wvwbmacs@dmrrtf0yr5pagr1oif"
+    "value" : "67TbWWdTqxwbG3K2gkP",
+    "sourceName" : "w4nzdvsc5f6sbxni@xj0flb9rlqbffer9tvq"
   } ],
-  "subjects" : [ "https://www.example.org/baa98c0c-b9dd-4e55-ac35-231330c6db25" ],
+  "subjects" : [ "https://www.example.org/a79190b4-f97d-4cae-831d-5b14cc707f12" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "41582373-7833-465c-893b-f16bbc924fe8",
-    "name" : "P1kB1zBQgr",
-    "mimeType" : "FYM284JPUmOFc",
-    "size" : 1854639957,
-    "license" : "https://www.example.com/pprru48nsdoy76",
+    "identifier" : "2bc77221-7278-49ca-9a2a-2604f918c0dd",
+    "name" : "nJSeZJcoxoYj",
+    "mimeType" : "CSnI1MbDKEB",
+    "size" : 2058102511,
+    "license" : "https://www.example.com/eu0jmxtchs2h",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "u18guM2RR1xQ"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "x9YF36DYaE7s4kjq1",
-    "publishedDate" : "2005-04-19T04:25:23.572Z",
+    "legalNote" : "mTZzXHhRahwlp9",
+    "publishedDate" : "1989-11-04T20:11:41.426Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "o0AVhtzY7KmJGTlrQEG",
-      "uploadedDate" : "2002-01-21T02:24:46.123Z"
+      "uploadedBy" : "o10QInwgIbZT",
+      "uploadedDate" : "2003-06-01T18:54:50.927Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/oRLKcjizBRS",
-    "name" : "OhbRFLzs6rmrsZS",
-    "description" : "a2EbaacLIn4EUhr1"
+    "id" : "https://www.example.com/RJlb06YYEnpMZUe6",
+    "name" : "qdBHhEMy20K5jh",
+    "description" : "5TDWRSrh9yZqLni"
   } ],
-  "rightsHolder" : "3EyLtQIbTMN",
-  "duplicateOf" : "https://www.example.org/44f348fd-f6c1-4194-8f4f-2203425fe1d8",
+  "rightsHolder" : "NOdDP6OUDj9Nn",
+  "duplicateOf" : "https://www.example.org/c510acdf-8a50-4f51-b7a1-88106f150bb1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UGRzTnal2Z6"
+    "note" : "D3OASpx6DsENVmdFn"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "x1fgfnY7gs",
-    "createdBy" : "Fkay1DZwdfPmMi",
-    "createdDate" : "2020-03-08T03:33:34.343Z"
+    "note" : "QnLQHWZGXq",
+    "createdBy" : "4cLrZWxJbhJaAQjpt",
+    "createdDate" : "1994-10-27T06:17:12.019Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a8b64466-a2c4-400c-a7b9-fc1837dd81b1" ],
+  "curatingInstitutions" : [ "https://www.example.org/b17e1f30-6f0c-4b6b-b0d0-ebd736c85b42" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "hgstWuh5k3DY5YZB7X",
-    "ownerAffiliation" : "https://www.example.org/ac9cfe7d-c62c-431a-8dea-0a64b8983167"
+    "owner" : "MjyAhXpTTglf9ghM",
+    "ownerAffiliation" : "https://www.example.org/d0edeff2-637c-4a58-8999-4fa3362b1ec8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/005427f5-e40f-471c-aaaa-4f50d9b39762"
+    "id" : "https://www.example.org/bc588c60-d11c-41e6-b911-3608702d2303"
   },
-  "createdDate" : "1979-07-10T13:35:18.539Z",
-  "modifiedDate" : "1989-03-12T10:16:36.045Z",
-  "publishedDate" : "1983-03-17T21:34:25.017Z",
-  "indexedDate" : "1971-09-11T16:51:02.344Z",
-  "handle" : "https://www.example.org/7b07decc-2e58-4fae-b1f0-ac4e4907660e",
-  "doi" : "https://doi.org/10.1234/optio",
-  "link" : "https://www.example.org/4eb65c4e-d959-4b22-9dc1-9bb76ccbf5af",
+  "createdDate" : "1975-04-17T11:50:09.076Z",
+  "modifiedDate" : "1992-11-21T06:31:28.710Z",
+  "publishedDate" : "1986-01-16T04:46:39.076Z",
+  "indexedDate" : "2017-03-20T06:41:29.475Z",
+  "handle" : "https://www.example.org/00dda088-3a46-4db3-9715-85edc89d1eb6",
+  "doi" : "https://doi.org/10.1234/molestias",
+  "link" : "https://www.example.org/cd84a872-7863-49f3-8ee6-e1bfaa8aa3dc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sMxJpn7j7p",
+    "mainTitle" : "nPoQKPxLyBEKGNl",
     "alternativeTitles" : {
-      "el" : "1moOqYyYMSj"
+      "ru" : "cTtAzdV7ZxqZS68B"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "gR1kTVqzLXWU",
-      "month" : "2iImti3YzuKvz",
-      "day" : "4EZlhtnZciuMC76n"
+      "year" : "BicakdHa3zHDAImyB",
+      "month" : "PFeLLy0Rt1n",
+      "day" : "Eic2d1slV1ENDJ3zef"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8bf08803-c9a4-419e-991b-3591662a3d22",
-        "name" : "gtd6nd2xXJUoVKUxZ",
+        "id" : "https://www.example.org/9af3dd77-be36-454c-83e0-133acf32bdca",
+        "name" : "gwmNkqcIAAEzxCgtg",
         "nameType" : "Organizational",
-        "orcId" : "WwP4DwLsi1fev8f",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "4XGSLY3WnVH",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dZhxt8rG8Mb",
-          "value" : "dHVbgFK1OJSqx"
+          "sourceName" : "pcOiaUbwE0",
+          "value" : "stYzaKz2Juml19"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5PTIaRdKKc",
-          "value" : "6TDH2qdVlRXS"
+          "sourceName" : "Knmb0f1hkw",
+          "value" : "gSFY6mOH43gd2lJ0ZCB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/56a52676-128a-4596-8c37-348ab55842d4"
+        "id" : "https://www.example.org/5758a2f6-4a3a-4102-8132-7a03eab7f44a"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8c881623-6702-4ca3-8b99-da61ca980360",
-        "name" : "WeQTBUxaVMsr8xD",
-        "nameType" : "Organizational",
-        "orcId" : "u8tw3vNJ88saCuYyiC3",
+        "id" : "https://www.example.org/f5f50ee7-cb92-4d9f-93cf-d96457862cc1",
+        "name" : "Rr14lyRS8WUxRMarpyj",
+        "nameType" : "Personal",
+        "orcId" : "WzcXEfu4OmGTgRgYi3",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "561fVAKV7ZW1",
-          "value" : "HikSNTYR56I"
+          "sourceName" : "IPStXzDXYDA",
+          "value" : "KfIIIcrlV1UpYG8z"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sOEdSFfzNiP",
-          "value" : "VSv6VSpnk1QWxMeQcY"
+          "sourceName" : "YV0HdpA1KYli7eecTcP",
+          "value" : "Gw8fxLv5p9WQ1gRe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cec6042e-c744-400f-98b6-6f11d5eb51c8"
+        "id" : "https://www.example.org/7b9f61a8-30fb-43c1-a4fc-129e7f11df88"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "dFV613h0ntgRjL"
+      "pl" : "roW1YGJkX7We1T"
     },
-    "npiSubjectHeading" : "7xGQfpo9P9QE",
-    "tags" : [ "GwERwDdG1a4hwbR" ],
-    "description" : "IJAzMhFnLUqBYY",
+    "npiSubjectHeading" : "ibirtgwiCBR",
+    "tags" : [ "LPKZ5L9oHWhwkxLfot1" ],
+    "description" : "iSnwWpaR0fg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e1a2dce5-4fec-479f-8c74-23ed79ff1699"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9b44a151-8cc0-41e3-a5d9-93f6218c1dfe"
       },
-      "doi" : "https://www.example.org/cb81c2a5-ab9c-4ce8-a146-42425e60d523",
+      "doi" : "https://www.example.org/8a0b7adc-b1b7-4179-886a-56a383be4baf",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "i2uYcqPZeGeQ4th",
-          "end" : "q8sesjaiKv8f"
+          "begin" : "3r6MD8o7xJbD5LZ9fLn",
+          "end" : "pzWbwnlFghF8qdqA5"
         },
-        "volume" : "elRg96dP4aw9",
-        "issue" : "hYCI0JR14nVqP",
-        "articleNumber" : "O4ojX70JYVJbl"
+        "volume" : "zt5vJ0FgvmAj0Ei",
+        "issue" : "et46DZ7cNlhNmqQ",
+        "articleNumber" : "sv3R30lLMTH"
       }
     },
-    "metadataSource" : "https://www.example.org/46174999-18c6-4223-8a91-15de53c47442",
-    "abstract" : "jlzHbHW3Ez9"
+    "metadataSource" : "https://www.example.org/003c382e-73b1-4f12-b2c8-710dac3af4a6",
+    "abstract" : "BmzJ2bUaZ2U"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1b1e3b06-e6fa-448e-897c-4afc1b74e822",
-    "name" : "bcdyiEtCtkOi2UaY",
+    "id" : "https://www.example.org/774ed649-c6c7-4ab3-838f-859e049af41d",
+    "name" : "knXKu8EE6P3wVmqfG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-11-06T23:20:22.915Z",
+      "approvalDate" : "2012-09-29T18:44:04.936Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "9JGvw71KIqjdtsdjsaI"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "OLpxr6kFMuUSNptCr9"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/813000b5-b89d-43b1-96be-966cc7977cdb",
-    "identifier" : "AgIX0E97gdT",
+    "source" : "https://www.example.org/c062bf04-9922-44b3-825b-262d5c6400b0",
+    "identifier" : "pkXguiCmoVI",
     "labels" : {
-      "it" : "1jlDZn8G224Gl"
+      "se" : "7QwTEmwaBWUTHB2V"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 295226143
+      "currency" : "EUR",
+      "amount" : 831787325
     },
-    "activeFrom" : "2007-06-25T02:03:29.362Z",
-    "activeTo" : "2019-08-29T12:26:54.978Z"
+    "activeFrom" : "1974-06-14T09:46:24.275Z",
+    "activeTo" : "2019-09-17T00:58:27.213Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e127b5de-f798-488c-bc58-42718d4dd29c",
-    "id" : "https://www.example.org/c11ec850-3b18-4b05-8c03-29cec92017a2",
-    "identifier" : "hrDttwXk6anvz",
+    "source" : "https://www.example.org/e21d0d52-fdd0-4e4a-b2b8-782827b1193c",
+    "id" : "https://www.example.org/f976bf2b-35de-4294-af7e-c3e3b0ad44f7",
+    "identifier" : "fc7xWWqUNrMfzJD",
     "labels" : {
-      "da" : "wdgjzhbyNh0innWFJ"
+      "fr" : "v1HrCjqurfmQ"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1819386486
+      "amount" : 1269435568
     },
-    "activeFrom" : "1982-05-27T02:12:02.998Z",
-    "activeTo" : "1989-09-28T20:49:40.373Z"
+    "activeFrom" : "1993-05-04T01:25:57.393Z",
+    "activeTo" : "2002-03-03T01:15:43.505Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "T4VLefvq9uMxUr",
-    "sourceName" : "n2m8l6wtfk7k26xuokm@xlna4djk3sd"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "28549370",
-    "sourceName" : "mujwpbmadndccv2rmcu@if7qmfr6a4q4l"
+    "value" : "NE6dh01VkDTOkX8MxU",
+    "sourceName" : "m9mlaijlt6fquofr@gj4rgrhszx"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Hvtquo8f27rNnkKdR0",
-    "value" : "M902OQ17GCoO3v"
+    "sourceName" : "3Nh1tt4mLDJjp",
+    "value" : "QiYFEdWixzoFal"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2828b166-d3d1-4e8d-b351-c9cb3ca95118",
-    "sourceName" : "t3r6awfipa@2xcvjeyrlr"
+    "value" : "https://www.example.org/aaab6999-34c5-4623-9a49-afea947d2433",
+    "sourceName" : "tsysgdungdskmekb@nang83pvb5"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1731594532",
+    "sourceName" : "uxewwsauv473uw@jrrtr51tilt"
   } ],
-  "subjects" : [ "https://www.example.org/e0ae0b19-3f38-4e7f-b1c6-83e92b9026f8" ],
+  "subjects" : [ "https://www.example.org/a923dd28-e7f1-452b-a47e-111b9749260b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "88168d68-1209-4e22-b4da-0a63a09725da",
-    "name" : "eqv7cvA81Yg1Xqo",
-    "mimeType" : "qmzOQXmhlwQ0tJ1pT",
-    "size" : 1519028010,
-    "license" : "https://www.example.com/ilmk8miyrzjlw84yt",
+    "identifier" : "1e9336cd-8291-4a3e-9fa1-e0f6975a73e7",
+    "name" : "kpLOZm5smbym5KtxAQ",
+    "mimeType" : "M77FDW3rg3T7T",
+    "size" : 805023168,
+    "license" : "https://www.example.com/ea6toonf0exs",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "g8vX0B5KseLQS9PybP8",
-    "publishedDate" : "1991-02-06T09:40:57.071Z",
+    "legalNote" : "gnXiBgKXCd",
+    "publishedDate" : "1986-04-12T07:11:29.537Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DS395GIf3j",
-      "uploadedDate" : "2006-06-19T00:32:03.753Z"
+      "uploadedBy" : "v2kJFtRTyM",
+      "uploadedDate" : "1978-06-01T06:22:19.794Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Uuez53jvjq",
-    "name" : "RQLAKZCu05E",
-    "description" : "K8h1hdFrxUiS"
+    "id" : "https://www.example.com/00GvAWcNfqmxFM",
+    "name" : "VFlRMySw1YgEmTDXc",
+    "description" : "TjxILzNXEYy7"
   } ],
-  "rightsHolder" : "SsSETCLqVMc",
-  "duplicateOf" : "https://www.example.org/a50f6710-b037-4494-9ec3-723e5023e59c",
+  "rightsHolder" : "XDBrLF0hEhye",
+  "duplicateOf" : "https://www.example.org/deb4b74e-6df7-48cc-ba62-ee2f18aa7b86",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "koMdgpd3rdIfeb"
+    "note" : "yKT1JQmmgGTuixRt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "H5E0fpj7ePDm",
-    "createdBy" : "Vfgv56kyFu9EqlGH",
-    "createdDate" : "2020-08-23T18:44:23.610Z"
+    "note" : "IzvdeyOI2zyZ",
+    "createdBy" : "AsE1h9Ht0MV",
+    "createdDate" : "2022-12-04T20:32:50.309Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/97e4c89d-2258-49df-b132-f5801c62dd9d" ],
+  "curatingInstitutions" : [ "https://www.example.org/d60af22a-8cf5-48cc-bcad-507e7b3eefe5" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "i6pKHJt1aiS",
-    "ownerAffiliation" : "https://www.example.org/a526dd6b-af43-4044-a109-9034e1b2d023"
+    "owner" : "hULZbTW1KOgTMhc",
+    "ownerAffiliation" : "https://www.example.org/cbe714d3-e4ee-4b28-8d71-19901ade4318"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/54ca863c-33ad-4498-a5f4-56682c815852"
+    "id" : "https://www.example.org/59881484-0fb7-4f19-bc9d-56438e3b1937"
   },
-  "createdDate" : "2009-12-28T11:23:09.925Z",
-  "modifiedDate" : "2002-12-10T01:37:07.436Z",
-  "publishedDate" : "1997-10-26T09:45:10.296Z",
-  "indexedDate" : "1995-09-16T14:42:51.653Z",
-  "handle" : "https://www.example.org/ebee9080-731d-4010-b022-272dd6a069cf",
-  "doi" : "https://doi.org/10.1234/odit",
-  "link" : "https://www.example.org/abb90694-b6b7-49ff-ba82-0211ff050262",
+  "createdDate" : "1973-08-19T12:28:48.505Z",
+  "modifiedDate" : "2016-07-18T21:15:09.229Z",
+  "publishedDate" : "2024-07-03T00:14:16.166Z",
+  "indexedDate" : "2001-11-01T05:34:41.973Z",
+  "handle" : "https://www.example.org/b3c10a8d-3921-418a-8e60-30ee5ae37b17",
+  "doi" : "https://doi.org/10.1234/quos",
+  "link" : "https://www.example.org/d4f1cc2a-265d-4722-bc77-a11bd86fdbef",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "U2Fa0pApGFF",
+    "mainTitle" : "TkyaCK0ruYUoXKaO",
     "alternativeTitles" : {
-      "nl" : "9e3oJP2ccDO"
+      "cs" : "ghdsy73UWv5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "FCVvfWAzqJzoLhzVT3",
-      "month" : "mAp9wqVzh1",
-      "day" : "eg8VZn2odbp"
+      "year" : "JgFQc8fGhM8orV9YL",
+      "month" : "BO2J7amNqDT",
+      "day" : "pQMaYhWFWHT1OJ3SZ9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7fd38749-9626-4ba3-b7b0-73b680228376",
-        "name" : "PxvO9FGPlPqsYmx7gs",
-        "nameType" : "Personal",
-        "orcId" : "Blu7mxq6F0nKcmOX6",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/6a5b27ae-9365-425c-aec5-675d2136d234",
+        "name" : "sztelMyBgk3hmWmXY",
+        "nameType" : "Organizational",
+        "orcId" : "gkYmgOw6O4I8tw9g",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1kSqBBnmyWqjvVPdQ",
-          "value" : "qzV6QrainEAVhrXRCs8"
+          "sourceName" : "tZXzf38tPXM3JB",
+          "value" : "HqlpAApnYYPdzuQbcBz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vYVxAxGz4o6fuZGLn",
-          "value" : "qiJkCMVajalv"
+          "sourceName" : "d0s0h3ytegVKaQ",
+          "value" : "utqH2nYBAgELPX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1aa66951-a3f5-4dc4-b841-e0bd8c085f68"
+        "id" : "https://www.example.org/7ff28ebb-f3b1-442d-a5c8-c957615b45e7"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Advisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,175 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2c84f52b-d546-4b3b-be27-ae2ccf1ecfe3",
-        "name" : "NyXTAQXqxgi",
+        "id" : "https://www.example.org/633a7a35-2252-4c1c-b67b-d5f920ef916a",
+        "name" : "tKe73KN9RqWyKW",
         "nameType" : "Personal",
-        "orcId" : "BnTiZJWTTitF",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "JOJKHk1irFEJlg8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1dPFSOd5O0MZMYiJwp",
-          "value" : "QQOHLDm5xn6"
+          "sourceName" : "Pce9EkevydDcIgco",
+          "value" : "BiN5xDsSQAD4B"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QjbPibFxB0teT2TFN",
-          "value" : "m73SCXtziVr94w"
+          "sourceName" : "ISU2GluRta99P",
+          "value" : "yXv293jQp6DvGmRWdp1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/699ea439-6918-482c-9390-a24cd95eeb7a"
+        "id" : "https://www.example.org/1c2e2f2d-0040-4dd0-ae6b-bd942280c0dd"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "heJmVQUZvHrNLtzbAP"
+      "af" : "LSGYrpyjbqhK0jEX"
     },
-    "npiSubjectHeading" : "W74dXOSZkrhPMaqwxf",
-    "tags" : [ "DyeRsk1AU1DeqOv" ],
-    "description" : "mNvgoqYBBEy1",
+    "npiSubjectHeading" : "Uu2o474xUey5Ig",
+    "tags" : [ "EDXOr8w23nW" ],
+    "description" : "7MDS5JELvGGCM5ChX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dd48c90e-1fcb-41b3-8eb8-47a03b08d916"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/76e3a0bb-1173-4864-a41d-2f3df5dc37ba"
         },
-        "seriesNumber" : "lF9wvvZ9GKxPOxZQ",
+        "seriesNumber" : "UsPamHOWiUMhs4DO",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d3c27e25-cd19-49b1-b217-0311a53f1fba",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e6666c9b-4963-41d1-9cce-3b4e2a9de9e2",
           "valid" : true
         },
-        "isbnList" : [ "9781733160186", "9780704960404" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781980308966", "9780862611453" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0704960400"
+          "value" : "0862611458"
         } ]
       },
-      "doi" : "https://www.example.org/2e0b529f-f076-4c01-bc44-ac967f18d38f",
+      "doi" : "https://www.example.org/c7c9e236-8172-4b07-8f30-c9382cc5e011",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "A2VoFu4iVxv5HxSHvi",
-            "end" : "NdlnxQRrNOhjiz8"
+            "begin" : "Ie812HjAAWRpxe",
+            "end" : "SjXs3PQHKNAlI8tb"
           },
-          "pages" : "28ENs875spfMfd2zKH",
+          "pages" : "xNREgUyzaIOW09",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/20d694d3-f90d-4068-a0bd-a40949295515",
-    "abstract" : "HR6ueEW4Hve9CWWXL"
+    "metadataSource" : "https://www.example.org/61bfe226-1612-489b-8422-2b5b93b8e301",
+    "abstract" : "ZwanHcdTGA3RaFF5e"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cbc8977b-6f6d-4175-aa5b-1ad707e2e097",
-    "name" : "IaPrsm377ksAkeidsfb",
+    "id" : "https://www.example.org/3b52b8b9-42f0-448c-b3a4-6610352e6d20",
+    "name" : "6roYvEBcY8jDjZC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-08-01T01:18:08.218Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "xVgNTgNhrI8XztZUXg"
+      "approvalDate" : "2016-07-23T23:17:34.273Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "FGMX5FesfHAnFZsyX1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b9dcfcac-da5b-4f1f-b74d-a7b8eee37e8d",
-    "identifier" : "lASCWJl1hobZ",
+    "source" : "https://www.example.org/b254cf89-6542-4b01-a71e-19eab87cf9b4",
+    "identifier" : "k1ZraDqYiVe",
     "labels" : {
-      "el" : "6Q2Apcx5MZYUHwc0"
+      "da" : "RgbycmbbHu60Ho"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1331935065
+      "currency" : "EUR",
+      "amount" : 1344726329
     },
-    "activeFrom" : "2017-12-07T20:18:59.029Z",
-    "activeTo" : "2023-08-02T20:54:14.477Z"
+    "activeFrom" : "1999-02-13T23:13:03.319Z",
+    "activeTo" : "2015-06-06T18:48:53.927Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1200fc59-f7d2-4ae2-8095-5593fb6386cb",
-    "id" : "https://www.example.org/b6b37b9f-a101-4af5-8a5c-ce0cd0c43336",
-    "identifier" : "OClJi3zMpHHvifvLXu",
+    "source" : "https://www.example.org/a45da479-cc0b-40f2-b6f0-f33d1dc09e57",
+    "id" : "https://www.example.org/7d3d97d4-b57b-4352-b29b-8c2ad12348b2",
+    "identifier" : "HWY8OyYz54iiuERyB",
     "labels" : {
-      "es" : "XcziegLyzx2TfnEuaD"
+      "cs" : "x67K0zMAxw"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1401967889
+      "currency" : "USD",
+      "amount" : 146427280
     },
-    "activeFrom" : "1975-10-24T22:23:19.163Z",
-    "activeTo" : "1978-01-26T21:27:43.421Z"
+    "activeFrom" : "1982-03-04T14:05:48.658Z",
+    "activeTo" : "2018-10-14T23:31:05.074Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "899019086",
-    "sourceName" : "e3gydyqnnss09h9v7@eyxjnqsoww"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "x2BM0Rlbus0a9LI",
-    "sourceName" : "qpjvvhkzff@z5lqt95nqdxdfbg"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/14888e7f-5987-4e36-96b1-b39dbddb2c39",
-    "sourceName" : "pr3m5lejadht@haklgaeljc6"
+    "value" : "81tgfPdQL4UxVjYYiz",
+    "sourceName" : "sadzdtd36myp@wihpuzqwsgiz8shycy"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "WDVFIg0TA5",
-    "value" : "RdKZMJTSs4yZuxxnO"
+    "sourceName" : "9U7bSMUV3MOmO",
+    "value" : "pWasZw88HZ1eH"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/78d3ec82-b360-4006-996f-baec24d0960f",
+    "sourceName" : "2iddsnkf8blhh@9hramfihzkrqkc6ojw"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1484218788",
+    "sourceName" : "mccaul2cmlwcab0@6j1eaq9k6x1keotlsu"
   } ],
-  "subjects" : [ "https://www.example.org/43deb233-03d6-43ed-92ea-f92eb977355f" ],
+  "subjects" : [ "https://www.example.org/5ec2d226-78ad-4eac-bd84-4001d4f8ae87" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5cb2bb53-487b-493e-a94e-119afb873617",
-    "name" : "ZdNlOjJfGFm9FIH2",
-    "mimeType" : "6lWax1IPB7RnRR",
-    "size" : 1541318334,
-    "license" : "https://www.example.com/g8skx9qcm91eoagw",
+    "identifier" : "bd8caecc-071d-467a-bf1c-9d67ebb9f34e",
+    "name" : "fFSyL5R0A73sdAh4",
+    "mimeType" : "jBlt8fxOIN9GenhdNYe",
+    "size" : 941935266,
+    "license" : "https://www.example.com/loq2mgv0xk",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "lUnFRnH2UA"
     },
-    "legalNote" : "y9EOQX1jw3",
-    "publishedDate" : "1978-06-29T21:35:54.252Z",
+    "legalNote" : "1crayKz55DmEvAA8kB",
+    "publishedDate" : "1994-08-12T12:54:58.129Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "xOZG0gw6jbt",
-      "uploadedDate" : "1991-11-20T15:17:03.222Z"
+      "uploadedBy" : "tUeNHWBddBB35yW2",
+      "uploadedDate" : "2005-11-30T16:56:34.767Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/P5cv54i33dsx2qwAh",
-    "name" : "2ZOKrL30uRg1AHK",
-    "description" : "8ibXlbIUnpji9U"
+    "id" : "https://www.example.com/zLAKfVibDAEf1LfZ",
+    "name" : "XhImKhMWU7yIgQz",
+    "description" : "mggQFpiiWd1IU4XTSLb"
   } ],
-  "rightsHolder" : "lNRdIsMezlY8gymDZ4S",
-  "duplicateOf" : "https://www.example.org/133e590d-2f01-4400-b918-67f0bca86cbf",
+  "rightsHolder" : "8N2OCyntZSyy5ThN",
+  "duplicateOf" : "https://www.example.org/042a02e8-70e4-432c-b8cd-e2268903bcc3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TyU4iSl0YiNVGEDbS"
+    "note" : "0FViSo3hWuS7fOu"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hhCawpAjY4cCkZ",
-    "createdBy" : "FtNdhwzqr6pd",
-    "createdDate" : "2019-03-28T19:35:46.495Z"
+    "note" : "BwrCjGz2WIO",
+    "createdBy" : "mfJvtrxa7SJTisW",
+    "createdDate" : "2014-07-14T19:58:01.522Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c3d1cba8-9266-4e8f-9c13-06b12cbbeb15" ],
+  "curatingInstitutions" : [ "https://www.example.org/e63f8c62-2b9b-4776-a6d4-600ae7456f74" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "L2ZaRUQulBhLIxRU",
-    "ownerAffiliation" : "https://www.example.org/ad0cb6a1-4362-43c5-85f9-ac2de273c7c6"
+    "owner" : "I4xC8FadFPhpj",
+    "ownerAffiliation" : "https://www.example.org/9d7d9efd-a881-49cd-ba20-92a5d5b44837"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cea0b7f9-a534-4b83-872f-714475ef482f"
+    "id" : "https://www.example.org/4f4d9568-3fe4-4c6c-acb8-0741b8ba7260"
   },
-  "createdDate" : "2000-01-30T05:02:35.320Z",
-  "modifiedDate" : "1989-02-17T10:12:43.419Z",
-  "publishedDate" : "1980-12-04T05:32:59.428Z",
-  "indexedDate" : "1979-06-29T10:43:04.524Z",
-  "handle" : "https://www.example.org/48d24e23-5013-40dd-ad2b-0fe6f5db707a",
-  "doi" : "https://doi.org/10.1234/eum",
-  "link" : "https://www.example.org/c4a15fe6-af6a-4c6e-bc2c-412440ff36b5",
+  "createdDate" : "1978-09-28T14:41:02.506Z",
+  "modifiedDate" : "2002-03-01T23:39:31.062Z",
+  "publishedDate" : "2010-10-29T19:12:40.546Z",
+  "indexedDate" : "1993-06-15T15:39:58.287Z",
+  "handle" : "https://www.example.org/8e86f899-3fe6-4838-9528-f795effed5ff",
+  "doi" : "https://doi.org/10.1234/distinctio",
+  "link" : "https://www.example.org/e33de306-33c1-42c2-bcff-7208c4c77c1e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sDpsygnHFPQBMM",
+    "mainTitle" : "m0UtAIKWUACxLtjD6",
     "alternativeTitles" : {
-      "cs" : "wKUp6Fyb07sHbI"
+      "pt" : "24IbFxN5KSfDhVdksL"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "SUljKSTW8Ll0dJASCbm",
-      "month" : "3ZQoOSKU9P5eMM",
-      "day" : "YQk2QuzKjnBi9PZTB5"
+      "year" : "8n9JJPxJjfL",
+      "month" : "NKkrBucI64Av1c4PQ5X",
+      "day" : "n6XEQCFkstNpD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/36644106-7f7e-48a1-8024-85b4753ed704",
-        "name" : "FvXHUBdJo5lO4X",
+        "id" : "https://www.example.org/5a41ea2e-9d9b-499b-8114-9e4c618207c1",
+        "name" : "8Pq1nwYmEIc",
         "nameType" : "Organizational",
-        "orcId" : "GngIJU1zNqS7zS3KWs6",
-        "verificationStatus" : "Verified",
+        "orcId" : "I7LrUoe4QuJWahWs0fw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UHLIgTpebXnZjg3s",
-          "value" : "ZvhzLXuEOzf"
+          "sourceName" : "mSR9PRJM38BGC",
+          "value" : "nUuDsejmAx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WKuBY6IKQxe7yukLF",
-          "value" : "J6t0VpTcWwL"
+          "sourceName" : "CcUl5NWdtau7W",
+          "value" : "mDufuoe7BCS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/22bdf662-1745-4ed3-8942-ec773428b572"
+        "id" : "https://www.example.org/0b0ba72d-b8c9-4c34-8bdf-e219a61ea952"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,202 +62,201 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/38eaed37-093e-4837-8ddb-5bc46c4bc0eb",
-        "name" : "uCXpGYJ4MKwf",
+        "id" : "https://www.example.org/c0541b12-34d3-4bc9-b714-57fb9f0d2820",
+        "name" : "HnPWQCb1Uto",
         "nameType" : "Organizational",
-        "orcId" : "ttjDHdNrf3sis1d7a",
-        "verificationStatus" : "Verified",
+        "orcId" : "ks1BpBSjoMxFiw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6Ua8dtMslK",
-          "value" : "NEMx68Z2hVGhzoZ"
+          "sourceName" : "b3zLTdbEOhs98Nr",
+          "value" : "D2vpGq11ULbmgpNuZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GMJ7ov6OFI",
-          "value" : "ffXhprCKNaYVjRUPnA9"
+          "sourceName" : "bmIX1YghGY0hRKWOj",
+          "value" : "0UeyBZ4Z49d"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/39fc47d3-639b-4867-b6e4-7f91bd2ddd97"
+        "id" : "https://www.example.org/cc2758d5-4c52-4371-8253-1372a730c08e"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "Screenwriter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "9MueDoefASjwPlUi0wJ"
+      "fi" : "PL7AKtVbRqAiR7qLKt0"
     },
-    "npiSubjectHeading" : "LhJ4fxPcpH9zYWpwOme",
-    "tags" : [ "tAyL5pBZahVEOKOm5j" ],
-    "description" : "xZUxYb58Qcsg",
+    "npiSubjectHeading" : "FIvx6qlnj12K9tHJ8i7",
+    "tags" : [ "sXzYUf5SBsVMmilecl" ],
+    "description" : "dmW5D2R3Ll",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/4684f699-5052-4080-99c7-8263488fd287",
+      "doi" : "https://www.example.org/f738e4af-64cd-4c96-91ea-c80b5edae721",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "ArchitectureOther",
-          "description" : "g0RBoS7hLfO7OGtVT"
+          "type" : "Building"
         },
-        "description" : "MJcQZEjcCvO93G",
+        "description" : "k0h9r8Wo3T",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "5v72VMvc2iM",
-          "description" : "mFCNJu7qhRdMim",
+          "name" : "x9Nv0d6vUDj0",
+          "description" : "rzssBVepsth5k8E",
           "date" : {
             "type" : "Instant",
-            "value" : "2015-12-03T01:51:36.033Z"
+            "value" : "2008-10-05T22:46:01.640Z"
           },
-          "sequence" : 1243344350
+          "sequence" : 992948961
         }, {
           "type" : "MentionInPublication",
-          "title" : "JQcFTiryMblNL60zws",
-          "issue" : "p8D034rYHm",
+          "title" : "yVoY0ugm9qsVKfL",
+          "issue" : "PEtg6TczarbRK",
           "date" : {
             "type" : "Instant",
-            "value" : "2020-12-13T01:51:18.727Z"
+            "value" : "2000-11-19T02:36:15.216Z"
           },
-          "otherInformation" : "jl0dKUHIAOblPbTCxFL",
-          "sequence" : 849548062
+          "otherInformation" : "DCHxbR3YGojY",
+          "sequence" : 1167465831
         }, {
           "type" : "Award",
-          "name" : "3OFxVxqHlDWznvFstV",
-          "organizer" : "UJcp0V5UZN1yfhS",
+          "name" : "JgN332RMPwx",
+          "organizer" : "zmbZQDb8hfORFDfwQxA",
           "date" : {
             "type" : "Instant",
-            "value" : "1990-02-03T00:52:03.991Z"
+            "value" : "2020-12-08T01:54:34.189Z"
           },
-          "ranking" : 632228094,
-          "otherInformation" : "g9BOYYvk3XgE",
-          "sequence" : 2144834035
+          "ranking" : 1896747368,
+          "otherInformation" : "GdSjaiThBurzTBy",
+          "sequence" : 1251449169
         }, {
           "type" : "Exhibition",
-          "name" : "LhZo0BIoLbmP9L",
+          "name" : "aAmkKeUmE6KayAUn",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "9xhnqZzd01QCV",
-            "country" : "0cj4pBKie6RWPudx"
+            "label" : "EklyyxdeHz4vi07WQh",
+            "country" : "8BjtDWawDmhQ6zGq0"
           },
-          "organizer" : "XUfgMpHyRIcwAEA7b5",
+          "organizer" : "efBtAlJvmflh0z4",
           "date" : {
             "type" : "Period",
-            "from" : "2019-06-06T09:57:32.286Z",
-            "to" : "2020-02-23T16:26:54.956Z"
+            "from" : "1988-10-25T04:21:11.904Z",
+            "to" : "2023-04-26T02:10:54.521Z"
           },
-          "otherInformation" : "Fc0EytlixXi52u",
-          "sequence" : 1736985106
+          "otherInformation" : "yY1Mf8xfs50EJ5tO",
+          "sequence" : 1144457985
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6cf02abf-f94c-40de-adda-d4ef82858867",
-    "abstract" : "omRN2Nvurn"
+    "metadataSource" : "https://www.example.org/1b84c552-b4ed-43b8-beef-be985fa39134",
+    "abstract" : "EQl1reY0S6OmmRH5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/acdb0e71-51c8-4407-a775-4ea303de0412",
-    "name" : "BvoBfnBcncdwcJ",
+    "id" : "https://www.example.org/478f4b7a-c4c1-48ce-a902-25dd45afbaed",
+    "name" : "PwN9NVX1rj0i5",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-05-05T07:00:07.421Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "zU8kUpWYcj6SVgeVXb"
+      "approvalDate" : "1978-08-28T04:49:20.691Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "X41Kx684bfn6NkDa6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e48e449d-98e4-4be8-8ecc-5f19da24a5db",
-    "identifier" : "gr4Ltsj0wm",
+    "source" : "https://www.example.org/07dbd51a-0a42-47f2-9bb8-3aa3078d8aa3",
+    "identifier" : "0igPGEHuzUEaNdbmvW",
     "labels" : {
-      "es" : "8uNurR2cc5F"
+      "pt" : "rjFgyzszab0Okgk"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1078584553
+      "currency" : "USD",
+      "amount" : 274296265
     },
-    "activeFrom" : "2002-07-10T09:56:06.231Z",
-    "activeTo" : "2002-11-30T21:12:15.158Z"
+    "activeFrom" : "1992-10-17T16:46:55.596Z",
+    "activeTo" : "2008-07-15T22:06:50.717Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/23e9f9a8-46a1-4413-985b-bfb4447ce19d",
-    "id" : "https://www.example.org/70e03d7c-ed83-4457-a695-5d307d06ad36",
-    "identifier" : "SisTK20Ki1B9Riuh",
+    "source" : "https://www.example.org/d3181101-e626-4ab1-95af-fb4e9a20e64c",
+    "id" : "https://www.example.org/d9657dca-aab2-4ac4-8986-b345e6c6e08c",
+    "identifier" : "xkdpH5KjXUTBa",
     "labels" : {
-      "hu" : "MrekePfAao80Z4X"
+      "nl" : "bJq0PVthxMoTDbFDiZH"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1464093356
+      "currency" : "EUR",
+      "amount" : 1952313853
     },
-    "activeFrom" : "2016-10-27T14:12:35.715Z",
-    "activeTo" : "2021-03-24T06:36:48.115Z"
+    "activeFrom" : "1973-10-25T03:53:17.712Z",
+    "activeTo" : "2003-06-07T08:43:58.839Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "CristinIdentifier",
-    "value" : "1733794974",
-    "sourceName" : "pobahiue6lq4@wvc866oc72ejyii"
+    "value" : "280467026",
+    "sourceName" : "7spadvqh7yk@62spw2n42pwktopyv"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "kadkeBBfSc4zg8",
-    "value" : "svKW1Ec7y0"
+    "sourceName" : "qA2uIoMUn5rP9e8h",
+    "value" : "ln1koHcwTqY9u"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e1eb3f2d-da91-4d84-9625-b8aec03a23b8",
-    "sourceName" : "rwibv568tao0jslnx@qk8l4w5dah"
+    "value" : "https://www.example.org/3bb2b212-6d56-4b9d-a390-3cc169a05800",
+    "sourceName" : "k0hyt2yvbje7kiwv@aa2wsylwdusnj"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "EVRRw5EI00zlz",
-    "sourceName" : "2lrctysogxf8@h9pdgdwoxztkggr"
+    "value" : "MoRgtP4V5fXn",
+    "sourceName" : "3me17qisi4ihsc3nt@r7tepymnyi61it88u"
   } ],
-  "subjects" : [ "https://www.example.org/ee0adc73-c29e-462b-9f60-88f4c0aaa772" ],
+  "subjects" : [ "https://www.example.org/7237d3ff-e703-478b-a4f6-55cb8318c254" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "31e97671-f4e4-42c9-a965-8b012abe1f92",
-    "name" : "harH6vDKuGMSb3",
-    "mimeType" : "AuuoGGVqLwcacrVt",
-    "size" : 1907280930,
-    "license" : "https://www.example.com/ecgxlcsy562l",
+    "identifier" : "8e17cd19-dd12-4ded-b383-e949e9d3dbd0",
+    "name" : "5CBV3SDXk3oz6AA60",
+    "mimeType" : "WNJaGDeMcaIprUjftO7",
+    "size" : 1572298297,
+    "license" : "https://www.example.com/le2m3msilhj",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "MQhNW4etMw0rrKg",
-    "publishedDate" : "1974-02-12T02:37:09.954Z",
+    "legalNote" : "FpwxO1Xaj44",
+    "publishedDate" : "2013-06-08T07:15:52.527Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "lBou3GKZWa",
-      "uploadedDate" : "1980-05-24T22:08:46.630Z"
+      "uploadedBy" : "H7KiOl56i9L7",
+      "uploadedDate" : "1973-08-10T16:50:20.613Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/QqBYUG0kjGgSGc",
-    "name" : "WB5tmuEf0pSoz",
-    "description" : "rpydv9VLhu"
+    "id" : "https://www.example.com/oUWHqoYiUuuNJq",
+    "name" : "tfjcacMnyFwHe1",
+    "description" : "vPK60XoO5p77VNHA6"
   } ],
-  "rightsHolder" : "VrgzJC5YkFsd",
-  "duplicateOf" : "https://www.example.org/95dd37c1-52a4-4b6c-b632-f0aec88c84f2",
+  "rightsHolder" : "ZLNz7TVFc2nKhbES",
+  "duplicateOf" : "https://www.example.org/3644f8f4-304d-45bb-9f8e-6c94fa967258",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "E5AoQIDB75A"
+    "note" : "PoE0ioKLdUfT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xNv1aagIevZ0R3gwXz",
-    "createdBy" : "bzBzIUa4szh1m9XK6M",
-    "createdDate" : "1977-06-29T01:27:26.115Z"
+    "note" : "uLf7JYfQ5xzyM",
+    "createdBy" : "5ScJeXAw5vYLrrVkvr",
+    "createdDate" : "1992-02-18T00:58:29.420Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/accd6f29-8f47-44f7-8103-ae6c7804e7c0" ],
+  "curatingInstitutions" : [ "https://www.example.org/5715c27e-4d39-4943-b1e6-22e44ecdda23" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "O71ZmGolUWo8T7S1u5M",
-    "ownerAffiliation" : "https://www.example.org/292cb92f-4ede-4097-9b26-d4acee03b434"
+    "owner" : "5JS0zvZOM55",
+    "ownerAffiliation" : "https://www.example.org/9e3d929e-e6aa-4dae-8cd8-7e7604ffaa20"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f88c1aa4-df08-4fd7-9a8f-fa9b4c6be74f"
+    "id" : "https://www.example.org/bf3f86ca-7b53-4a9b-8bfa-233b08c5174f"
   },
-  "createdDate" : "2007-08-18T22:57:08.828Z",
-  "modifiedDate" : "2009-02-06T07:23:04.820Z",
-  "publishedDate" : "2012-07-18T03:53:35.415Z",
-  "indexedDate" : "2003-06-10T03:44:15.032Z",
-  "handle" : "https://www.example.org/32a3c9ba-28b6-4153-9e66-2b32219e2b9e",
-  "doi" : "https://doi.org/10.1234/eaque",
-  "link" : "https://www.example.org/9ef4353a-42ed-4316-b61d-66cedeae1094",
+  "createdDate" : "1981-04-17T06:04:58.507Z",
+  "modifiedDate" : "2000-11-09T00:49:40.637Z",
+  "publishedDate" : "2024-01-23T22:22:20.523Z",
+  "indexedDate" : "1973-12-27T13:34:18.182Z",
+  "handle" : "https://www.example.org/c766a409-cf81-40ea-a23f-c452cc576695",
+  "doi" : "https://doi.org/10.1234/minima",
+  "link" : "https://www.example.org/3f68ad95-1b53-41e1-8af8-6e66199b54f8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7BUwrU2LjLi4F1",
+    "mainTitle" : "J8BkZLv8MjSbOQwJWcM",
     "alternativeTitles" : {
-      "nl" : "C0TpMUhVgdK8WCEcRhq"
+      "cs" : "oiuKzaU3GwKN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HJkYbt8ZKni9bF",
-      "month" : "lxuNlTWX1XCme3w",
-      "day" : "xoQ5EIwUPrd0Nt"
+      "year" : "ZCQDT7gr8nfa72C1ZVp",
+      "month" : "cENw1wBzRawT",
+      "day" : "n6Urk3O8pAq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/902f501c-2e08-4020-a922-c9760a12dcc9",
-        "name" : "fuL6uBxiY2NPiqmtaRK",
+        "id" : "https://www.example.org/4ce04ff9-d852-4326-af95-3dfc1a369037",
+        "name" : "9Cw1CNvbIDnignkSKIB",
         "nameType" : "Personal",
-        "orcId" : "FNWagjSLhgibE78dKCN",
-        "verificationStatus" : "Verified",
+        "orcId" : "GmSRoHghiKgHt",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AF5rH2bZA4SLj3upMTp",
-          "value" : "PMBODUb39Me2rS9lny9"
+          "sourceName" : "UKkmUm4X1Q1tGtL9NP5",
+          "value" : "es7ieD8DBx38Ygzz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dY9a04yFKtl0VeBf",
-          "value" : "JzxBfnf5PzpAUjNNK"
+          "sourceName" : "pfNnAPt6bv3H3Di",
+          "value" : "Zpe0CmfnBJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a321bc5b-fece-42de-911e-74a0ffadaa17"
+        "id" : "https://www.example.org/0ff706e5-9eb6-484c-bc46-7a01014ffaec"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "HostingInstitution"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,182 +62,181 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a0815d30-dc1d-477d-a3ea-5f320b7ec26e",
-        "name" : "NBDKGigUqWxgf958",
-        "nameType" : "Organizational",
-        "orcId" : "XFvrqhYz3hrR4HXss",
+        "id" : "https://www.example.org/9ff65952-3af6-4274-8a18-ee41f8c763a2",
+        "name" : "yyWB7CvGQvc62uu6S",
+        "nameType" : "Personal",
+        "orcId" : "m34t0wSIby3uCwkiV9",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8lCRVcTFL2n4",
-          "value" : "Dk1OemzmTAVLlj2Igg"
+          "sourceName" : "idgzuRqHHD",
+          "value" : "9m4bmotDKygODGAJO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TN2tWAUMlZU7CP",
-          "value" : "gFMl83f7NsM7RI"
+          "sourceName" : "XvG03LVzGFW7C",
+          "value" : "zIV0jjX53E54q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/215ce07f-045f-4b5e-b451-7407c2d28cc8"
+        "id" : "https://www.example.org/fb3929fd-944d-49eb-9c3c-a0eb6618e9e0"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "5ezITogWoPG8iOON7rK"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "qxFK2ycyBCLGJMC"
+      "en" : "vDvZlBjyfd7DVcMWPd"
     },
-    "npiSubjectHeading" : "bQUYioGQMQB9AsH3R",
-    "tags" : [ "LFdW0kIqD9WmjqA" ],
-    "description" : "pheCikl0RHLVsJgx",
+    "npiSubjectHeading" : "DKOuu5haKTB8",
+    "tags" : [ "Ub6hyEEsCWTz394L" ],
+    "description" : "KaGApN17Ds",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/016ca201-cff2-41e2-b18c-492119c0619a",
+      "doi" : "https://www.example.org/df41c86c-1bc7-4037-9ee7-a0975904abe9",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ServiceDesign"
+          "type" : "InteriorDesign"
         },
-        "description" : "mU2WLSB2H2O",
+        "description" : "BkNnBOAhOH0QAR",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "ipCVZ33LqpIPmMbB",
-            "country" : "FuGDV0kkTgr"
+            "label" : "P41ISVeoBc5",
+            "country" : "9qq3GmEqij7EKOfr7w"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2022-06-05T22:27:23.317Z",
-            "to" : "2023-02-13T01:55:24.855Z"
+            "from" : "1994-03-17T15:20:26.037Z",
+            "to" : "2022-10-04T23:43:51.888Z"
           },
-          "sequence" : 387662526
+          "sequence" : 1784650147
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "3dFc0WUN0vPgfxao",
-            "country" : "u1LCtiRQN34"
+            "label" : "fZR5JxDkCxGKS8Le",
+            "country" : "n9BCxsmZlE0Er"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1989-03-31T02:41:52.187Z",
-            "to" : "1994-12-07T21:39:02.596Z"
+            "from" : "1976-10-21T05:01:16.112Z",
+            "to" : "1985-06-28T18:43:19.313Z"
           },
-          "sequence" : 1623008461
+          "sequence" : 2003837132
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/74156116-f0b9-4ca5-9aad-113e01334827",
-    "abstract" : "afoxnx3yOXyS3"
+    "metadataSource" : "https://www.example.org/26361be9-ead3-4f0c-bb35-232a6ecd4aec",
+    "abstract" : "onL3anEjBR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f4ae5660-bda8-4198-bedf-6f5e4647931f",
-    "name" : "NLgVnPMppefqfHk",
+    "id" : "https://www.example.org/d3005937-408e-4fcb-b6fd-110c1493e378",
+    "name" : "1dHhJUeLXy1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-11-26T07:02:31.020Z",
+      "approvalDate" : "1989-06-07T05:35:34.565Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "TCUymSTrFyJ"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "iMgXB47yY1WLVa2t"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c569e130-1d1a-4ff0-98c0-fca53a8c84f6",
-    "identifier" : "9Er0GIMiP37DLV",
+    "source" : "https://www.example.org/0bed1132-06c2-4636-b6bb-c39a6df80e3f",
+    "identifier" : "OLpp0PslpANpabXxG",
     "labels" : {
-      "cs" : "bnxVIL57hpbhwVlkmaD"
+      "fr" : "h2061aY1nVevq0"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1564552421
+      "amount" : 1437353794
     },
-    "activeFrom" : "2015-09-18T06:25:58.301Z",
-    "activeTo" : "2018-03-23T17:53:40.696Z"
+    "activeFrom" : "1985-02-12T12:06:22.383Z",
+    "activeTo" : "2004-02-18T18:56:14.689Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b74c5f19-432a-4e55-8116-58ed5600491f",
-    "id" : "https://www.example.org/7bd2117d-1cb2-43a4-883a-dff21e3f6260",
-    "identifier" : "9XZ6QP1CzlkZ6m0DEJ",
+    "source" : "https://www.example.org/329b0b65-1b89-41bb-aed6-0a0806f8e27c",
+    "id" : "https://www.example.org/c582f0d6-ed83-4feb-9709-22d5765bd395",
+    "identifier" : "tvB0TozbwKj",
     "labels" : {
-      "fi" : "M5vU68dgkL"
+      "fr" : "SKerZeXk9eQ5CRMpLX"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1808312817
+      "currency" : "NOK",
+      "amount" : 290948193
     },
-    "activeFrom" : "1979-09-16T01:22:54.510Z",
-    "activeTo" : "1997-06-20T16:59:44.207Z"
+    "activeFrom" : "1995-11-19T15:19:36.500Z",
+    "activeTo" : "2017-06-22T11:53:30.613Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "vzZ9pd0Ct7IxJr",
-    "value" : "LTtP1moX1G"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "Vdv1mykicLtYDVv",
-    "sourceName" : "vwk0wt0qvwzgjca@b5n43wmhsadj5"
+    "sourceName" : "AaykrqnSZGZkhz7tBzu",
+    "value" : "Ebi1bEEyCzIl5UNLZ14"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1266228536",
-    "sourceName" : "xsbsyyafqhnbaz@tefdtoevnbumngxh"
+    "value" : "199638456",
+    "sourceName" : "zzlvjgp6rk64yv@nksliyq1umxa"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/c2f64cc5-1b00-4ece-a001-fc478f1e751f",
-    "sourceName" : "qhilzeqqnmgnqfctjx@dgvbuwktqjuf"
+    "value" : "https://www.example.org/fec90751-fba5-4bce-804b-c78ed11ab998",
+    "sourceName" : "sdv2ei4u94mu5t@a3bcu6u0fw0cm8als"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "5xzhIobcs1sTsJwX4de",
+    "sourceName" : "vi8jlaemuwv@pinzaauzelqlt0vzc"
   } ],
-  "subjects" : [ "https://www.example.org/c38bf5b2-db3f-43e1-bdf5-e78569d6d710" ],
+  "subjects" : [ "https://www.example.org/2891637a-af0e-416b-a445-3a0edbe66e12" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "99218567-7afb-48d5-a898-16793b595c5d",
-    "name" : "7xYqDDf01NiD42Dd",
-    "mimeType" : "fHM65nhaCK8",
-    "size" : 8603795,
-    "license" : "https://www.example.com/zzh2qemfoe",
+    "identifier" : "67f379f6-a81c-4554-97b0-56b6d0e62af4",
+    "name" : "6CHguboe261JjBo",
+    "mimeType" : "YuAT19uIfa6q",
+    "size" : 94135170,
+    "license" : "https://www.example.com/nn1ivsndzg5ew",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "j5tsw0qRwRR",
-    "publishedDate" : "2024-01-21T19:35:46.316Z",
+    "legalNote" : "SVGCayMxDlv",
+    "publishedDate" : "2021-09-27T20:04:08.336Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "zyEwc5QhnB00Q285",
-      "uploadedDate" : "2011-01-20T10:11:21.627Z"
+      "uploadedBy" : "kyCW2mAcdL",
+      "uploadedDate" : "2022-09-14T03:44:25.228Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZA90STtnYXP6XPfKYZ",
-    "name" : "WkkQaFu6FW871IViF",
-    "description" : "LOjohMhG3LAk"
+    "id" : "https://www.example.com/5cnAq8IzfoJhXD",
+    "name" : "bs1pkYobkW29JxQOE",
+    "description" : "Z9FNQS32MGB7QUQbvq"
   } ],
-  "rightsHolder" : "vBOpHooNqhlD",
-  "duplicateOf" : "https://www.example.org/c3e035a9-72a2-4708-a257-3eb66a571a81",
+  "rightsHolder" : "GVH7AibzSI",
+  "duplicateOf" : "https://www.example.org/fe84a020-668f-4245-9595-23607dadecfa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9R8JkblMDuVPc6NdVI"
+    "note" : "IlAsyYvahEGCiByH1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RyjuPkIS7Ed0lQJS",
-    "createdBy" : "hMVHvUEfWJZh",
-    "createdDate" : "1999-02-16T13:07:42.385Z"
+    "note" : "53IVwAHfbeMI5I2",
+    "createdBy" : "dZSkm60QgmhfPNB",
+    "createdDate" : "1981-01-14T08:19:37.535Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8bd06769-8e1d-48ea-a3b2-252ff1d57fa1" ],
+  "curatingInstitutions" : [ "https://www.example.org/2bfaf6f5-71ee-4e04-ba43-1e5349967ad2" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "uhmhlJ8d3O",
-    "ownerAffiliation" : "https://www.example.org/88274084-8fb6-405c-9131-e3db7926284d"
+    "owner" : "vTRexFErOiWjj2YMms",
+    "ownerAffiliation" : "https://www.example.org/80814e27-3339-4276-b4f0-8683e00a7cc5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2aceea1a-e014-4426-8251-ef54a830680a"
+    "id" : "https://www.example.org/0aaa9b90-f295-4e2b-a9ec-791ca593b228"
   },
-  "createdDate" : "2005-10-24T16:42:12.470Z",
-  "modifiedDate" : "2008-01-19T07:41:06.080Z",
-  "publishedDate" : "1996-03-15T05:41:38.342Z",
-  "indexedDate" : "2019-01-16T08:05:17.734Z",
-  "handle" : "https://www.example.org/926deec8-b256-4c02-9bbf-4f889498aa0e",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/c3fc0065-c3f9-4761-805d-3159bbd6d32a",
+  "createdDate" : "1991-09-18T05:21:24.093Z",
+  "modifiedDate" : "2019-12-24T20:29:42.346Z",
+  "publishedDate" : "2009-08-03T03:06:51.182Z",
+  "indexedDate" : "2013-01-07T17:35:09.328Z",
+  "handle" : "https://www.example.org/fc377461-ff92-4341-a1da-bd7c02187662",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/3a8033f2-1883-4368-b2ce-2cb85ed7c63d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "PPq9TVIEFQVDA",
+    "mainTitle" : "Igy82s93pyv",
     "alternativeTitles" : {
-      "nl" : "FmAy8PaiXwGHtM"
+      "nb" : "xnKBIDp7U4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qbTvM6Ygtiwwf7G7S",
-      "month" : "U7XCOTGfgSwE",
-      "day" : "U75KCGzhpx"
+      "year" : "BLR9um0tQ39q34",
+      "month" : "SqbrWC1PU0n2M",
+      "day" : "ICg9XELIYEbl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f25c581c-9cd1-4374-a986-143b40df1c15",
-        "name" : "2A1WufZ05PhsWUP9Ubb",
-        "nameType" : "Organizational",
-        "orcId" : "dA3PwwzFOzm",
+        "id" : "https://www.example.org/52ac87a9-716d-49aa-aec3-701ab53dd781",
+        "name" : "Mstbui5UkrqIz",
+        "nameType" : "Personal",
+        "orcId" : "uOaDUHyXpa1geTwWTd",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GDhKrFtXFw",
-          "value" : "jEhZYL2s0DnGBJU"
+          "sourceName" : "7ZEsnS0K6JKhGcBV",
+          "value" : "yCLjW02L4MT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4JfTzbSu22",
-          "value" : "pD5ehM4L4wt1bs"
+          "sourceName" : "B0risUcgQkW",
+          "value" : "oQ8dGdJh1nkm4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/806d3428-1c1c-4af4-a290-37280eddc318"
+        "id" : "https://www.example.org/19162649-d847-4aec-9859-6537d4f01950"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d09f73be-487d-49fc-9abf-4a965a8776d1",
-        "name" : "OniwwmXGbPmrfT",
-        "nameType" : "Organizational",
-        "orcId" : "HfAoBHwmEWfn",
+        "id" : "https://www.example.org/a103f82b-7e4c-4fa4-b524-1cc826064fc8",
+        "name" : "2bMkzz9VfofFTJHLYR",
+        "nameType" : "Personal",
+        "orcId" : "7BO5fPym9En",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bqwvF604QvUe2p1K",
-          "value" : "4zN9Xrr5K1xa"
+          "sourceName" : "3LJ9POxWLuDtp",
+          "value" : "xMtHI8M27U6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZNBcsvqyOBbsX",
-          "value" : "p03Jw6XHUK"
+          "sourceName" : "qAPXfF1muI13yinq",
+          "value" : "r0m8Dg7TwuGmbev"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/db8231f5-923a-4233-93c8-a75f76ac2da2"
+        "id" : "https://www.example.org/efd2b0cc-3e29-4b53-a1f6-62528a6af6a9"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "5Rhr8aGMLB"
+      "cs" : "5YImG4kvvm6Ofnqlbk1"
     },
-    "npiSubjectHeading" : "Fx8h5qjMV3Pk",
-    "tags" : [ "J0fdxTKbZIH8jGmx8w" ],
-    "description" : "nskwVYKCgrVoQ876",
+    "npiSubjectHeading" : "pg2d7pTY5C2KBboAG6",
+    "tags" : [ "eKJkPm6wtfFCmCltP7" ],
+    "description" : "DjW5EItRmFbAz3z",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/226dddd4-e4e7-4e08-935e-7e76902ff4a8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4c457e42-3db6-4ea1-863c-01fcac92f75c"
         },
-        "seriesNumber" : "NebUmmxKpHbaUf2smx",
+        "seriesNumber" : "w4t3rcCveDvB3oIQcy",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c7eb7cfe-c7d1-4cc2-911f-25c01b7776a3",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/274b067f-ad4d-4964-bc79-bf8b6c46d286",
           "valid" : true
         },
-        "isbnList" : [ "9781991181244", "9781861845887" ],
+        "isbnList" : [ "9780291120922", "9781958446706" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "186184588X"
+          "value" : "195844670X"
         } ]
       },
-      "doi" : "https://www.example.org/3f4295ae-3949-44df-96fe-dd6fbd60e517",
+      "doi" : "https://www.example.org/6ebcecb1-db13-4d31-ad7e-0bc1c01ab2c1",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "swRBX289pLm",
-            "end" : "ephszDFWhJOR"
+            "begin" : "R2g2fjfzOC8",
+            "end" : "T7cUhvASIw5F"
           },
-          "pages" : "M0rkRtuhid8mLdFsB",
+          "pages" : "HC9lR9QH4aKUqAv7",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1cf6c51b-d777-454f-9713-afc8cd43019d",
-    "abstract" : "M19JG2RG61"
+    "metadataSource" : "https://www.example.org/8b08d58f-9aa2-4a91-89eb-a32a0659505f",
+    "abstract" : "RkHEmLjeiblKURUZZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0202ac6d-8dfb-4005-b9e6-f49da0794418",
-    "name" : "7RUQvCmHIIsQ7",
+    "id" : "https://www.example.org/1add955b-b602-4e0a-b910-96c426c40cb1",
+    "name" : "e4umtpUSiBYWizsS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-10-30T21:32:07.414Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "g1jafamz5sRJT"
+      "approvalDate" : "1993-06-03T00:21:58.066Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "PQ66eaBta8OeeisDV"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/18dcf683-779c-4136-8c1d-bc4c10a82f0d",
-    "identifier" : "cBffmMuwCm",
+    "source" : "https://www.example.org/80e54e4c-672f-4242-9291-3b5df7c917e7",
+    "identifier" : "mkIK91m60Vnc8i",
     "labels" : {
-      "bg" : "ZYwAQjNL2ddS"
+      "cs" : "sREFprvrXaPOb"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1091515628
+      "amount" : 1034568442
     },
-    "activeFrom" : "1981-05-10T07:36:31.051Z",
-    "activeTo" : "2012-12-13T04:55:29.956Z"
+    "activeFrom" : "1978-08-14T04:29:37.567Z",
+    "activeTo" : "1996-02-21T23:40:29.974Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9b2c56c7-8be1-42ae-98ff-32db863f531d",
-    "id" : "https://www.example.org/666149a8-947d-4c2c-97ad-9dda2d118695",
-    "identifier" : "LUM3S0EUWaa",
+    "source" : "https://www.example.org/96096cab-1508-481e-be4b-4d993a9de251",
+    "id" : "https://www.example.org/eacf69d9-6be8-4496-bda6-cc5db10d59e7",
+    "identifier" : "B28ZP5eazBH",
     "labels" : {
-      "fr" : "vLds9RJpFizYaNZ"
+      "pl" : "81HhftEhs64"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 960362049
+      "currency" : "USD",
+      "amount" : 1577567328
     },
-    "activeFrom" : "1998-10-13T11:10:22.480Z",
-    "activeTo" : "2018-09-01T22:48:27.926Z"
+    "activeFrom" : "1997-08-22T01:45:18.472Z",
+    "activeTo" : "2001-04-22T23:34:03.325Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/161618c4-7c82-4108-9638-e342dce2bcaf",
-    "sourceName" : "5790dm1dp9llsj16@gzkybzmq4nt"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1819900953",
-    "sourceName" : "e92b7oxbvz@cxjtzxwgq76xjpr"
+    "value" : "1942239732",
+    "sourceName" : "yi0rk5v2j3v3puqgwd@cgbfoboz0pueklk5qtf"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "0nsDaXa2Cvn",
-    "sourceName" : "xriiy1facjhw41o@darbp2wmgtljvhzd"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/ba5984bd-d3b4-4e2f-892a-168d39d2d1ca",
+    "sourceName" : "ul0owhqjohmba4w1@q0agodxnbcydknlrn"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "6kobhyFNDqBJK63",
-    "value" : "2olLAkpHs2oaiAd8w9"
+    "sourceName" : "JcxDUmFMzisyUB",
+    "value" : "IkpYA6zE4s"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "V0nu6LYBGRw",
+    "sourceName" : "sxy71trbjxjy8@gb92lsokfn"
   } ],
-  "subjects" : [ "https://www.example.org/05581c73-3158-4f10-be96-a18c1c83cb79" ],
+  "subjects" : [ "https://www.example.org/c203d4ec-fca7-4fb4-acfc-d14911ca0906" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "09de04bf-c2e0-4545-b4f2-204a8399d3b0",
-    "name" : "auo7cf0PIaf",
-    "mimeType" : "yhAxtWks6E",
-    "size" : 1738006294,
-    "license" : "https://www.example.com/q5s9uzc0a0tktyb2",
+    "identifier" : "f7492db0-0916-4f81-bba2-5d4621ffde51",
+    "name" : "TqZRHA5oqE8iNy",
+    "mimeType" : "ArTakzooxF",
+    "size" : 969328090,
+    "license" : "https://www.example.com/krtmp6nnkuxebhxmp",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "l1hdGUMgIZBB930a9b",
-    "publishedDate" : "1990-07-02T23:22:46.958Z",
+    "legalNote" : "KJDPhZh2NyKv",
+    "publishedDate" : "2002-02-25T03:58:26.475Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Cter3XHsBFN7OlnuS",
-      "uploadedDate" : "2022-02-27T13:26:57.891Z"
+      "uploadedBy" : "zXQ9jkt9mZyo4",
+      "uploadedDate" : "1979-12-05T12:47:31.970Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PyJ2EuLeHnHzkqH",
-    "name" : "lP3Tqys8tII",
-    "description" : "zJh12OPJ8ZaQ3ttKTt"
+    "id" : "https://www.example.com/25cHVWNvsFSBDS",
+    "name" : "TIcg9DEKYyF",
+    "description" : "2nRMrSuz3W95UvbW"
   } ],
-  "rightsHolder" : "XqvhgQ2hKb",
-  "duplicateOf" : "https://www.example.org/907322c2-50d6-4f82-8bea-d2c395336181",
+  "rightsHolder" : "594KrwWWvjYGhu",
+  "duplicateOf" : "https://www.example.org/1a13abe9-582a-46ab-a5df-2722c1fd191f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "P31Tz1a6DJDbelpf"
+    "note" : "Q7RFq1WG0TS1XyzPFFN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "4dRwGgxOIn",
-    "createdBy" : "wMoIzkdzC6ioOBcB1N5",
-    "createdDate" : "1997-06-30T21:09:30.133Z"
+    "note" : "2wTnyQqBwfGORxSRG",
+    "createdBy" : "yHq61sPdsFlQ",
+    "createdDate" : "1986-09-19T16:21:02.569Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fd283630-36ec-4f13-bfab-d55e274766c5" ],
+  "curatingInstitutions" : [ "https://www.example.org/e8b3868a-8488-41e9-bb5f-b5edefc5544e" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "EW8fcUoWIX",
-    "ownerAffiliation" : "https://www.example.org/adf14b5f-93f4-4c1a-8341-ae4dd8562cdc"
+    "owner" : "unJZq2luS08J0gbKt",
+    "ownerAffiliation" : "https://www.example.org/12e21da4-8dbd-4982-ab70-1cad7bb7215a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/10e354b8-7339-471f-b4a6-f7aaf8b3d785"
+    "id" : "https://www.example.org/e8a47af8-fd8d-4b8c-8074-4d5cc7645575"
   },
-  "createdDate" : "2004-09-26T21:56:20.776Z",
-  "modifiedDate" : "1993-08-02T03:09:13.236Z",
-  "publishedDate" : "1990-02-26T06:28:32.247Z",
-  "indexedDate" : "1984-07-10T04:18:09.476Z",
-  "handle" : "https://www.example.org/b3453100-653e-4917-a597-a47c14b62dee",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/af46d21d-95b2-4ea8-ba77-5d5280d69ae7",
+  "createdDate" : "2010-12-30T12:15:48.788Z",
+  "modifiedDate" : "1979-05-30T14:40:07.953Z",
+  "publishedDate" : "2021-03-13T04:19:30.968Z",
+  "indexedDate" : "2015-05-21T05:14:47.183Z",
+  "handle" : "https://www.example.org/1cc2674b-e0c3-40c7-b38f-305b455eb040",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/4c611cec-1689-4d47-a41e-0753a937d691",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VFmOoHVrX2Q",
+    "mainTitle" : "Xbv6JO7loZQ7pQH6EQ",
     "alternativeTitles" : {
-      "sv" : "PuD9QCbJO1"
+      "de" : "ZTqIdBVjKrgfMMRmzgn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Cum2UtA66tRw1A5c9H",
-      "month" : "EtRpj7h3uCbdA",
-      "day" : "J3e07Yr6Yvl"
+      "year" : "mzcg7W84hnMDnyBx",
+      "month" : "SIO9Om2MBYTrIxCQzgS",
+      "day" : "ZkXg0i2diIbl0i1xjgr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2df30b65-6323-47c5-9c16-6d0df66f2927",
-        "name" : "klvDgelpE8BNB",
-        "nameType" : "Organizational",
-        "orcId" : "z5ndBmxbJQjfN0db",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/867f2d04-b3b1-4d31-9752-5b6a605a7d01",
+        "name" : "e6V9pjEcA1vVl",
+        "nameType" : "Personal",
+        "orcId" : "bx84MjlRi1CNj6e",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DZUqY2QyPLpDC8fHaQs",
-          "value" : "AECyykiC3Us"
+          "sourceName" : "2NCSnFjhbX",
+          "value" : "62XejzCUo8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nIxQKZA82Ici",
-          "value" : "kcnGzcOqiSr"
+          "sourceName" : "m1WNz7yROgMR",
+          "value" : "MtjaQLHEISfS7zOj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6952e74d-284a-4825-9a10-566949896604"
+        "id" : "https://www.example.org/e700ba68-22f8-4e5f-8ee4-8fa8f09d7ef7"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/84e2f20c-d921-4160-b0fb-406190e98c0f",
-        "name" : "LT8MVlvhjcyj63JyH",
-        "nameType" : "Organizational",
-        "orcId" : "ePVLS6tuLJj",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/17b7de2f-15ec-4cba-a5eb-9c4de125c219",
+        "name" : "TKUvvS06NQ",
+        "nameType" : "Personal",
+        "orcId" : "22UUZIRe23yNm",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fDpB62qXwQh",
-          "value" : "QozajJ0t2tj"
+          "sourceName" : "b3pfRRrHjMckAXr",
+          "value" : "qLS5H1nS6G34flEoc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "68siv5BHnyHMLmWt",
-          "value" : "2SVLaIX1tHe"
+          "sourceName" : "pG2PRBqLJPt2O3OFUGW",
+          "value" : "0VFdwN8fxYYxzsjw4ox"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c375b6f6-37b6-433b-9038-1a8283330c1f"
+        "id" : "https://www.example.org/d64aaec2-45ee-4e3e-a6a9-a5df7b6e15ce"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "SDXtbhOKSV9L"
+      "ca" : "0avm4T6ANHH4qdjTTk"
     },
-    "npiSubjectHeading" : "U1UJ8LdYWXyOg",
-    "tags" : [ "ALdcw25LFwStkpMhf" ],
-    "description" : "ediJUkoESa",
+    "npiSubjectHeading" : "RDhZszpbvHP2Idi",
+    "tags" : [ "I1MixvgazNayfPo" ],
+    "description" : "yCBQ8D8wsq6MMH0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b6b400f8-f8ff-4ee9-aac3-44871b1bb779"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ab0cc1a2-9390-4366-a514-c85699c30990"
       },
-      "doi" : "https://www.example.org/ce43c1ce-5065-4ddc-857a-f5efc06bf25c",
+      "doi" : "https://www.example.org/577d9b35-f4f0-4aff-852a-76aa7291e6de",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "LJt8LAwtUDxi",
-          "end" : "SHCJKtTA1fZzEMgO"
+          "begin" : "bgwNtTT3JG",
+          "end" : "a8fff05ifsrDIzT"
         },
-        "volume" : "oKAY70wumyfC",
-        "issue" : "N2Du5OuvTyLIB8T",
-        "articleNumber" : "OKgsTTfjLuiE6PHY"
+        "volume" : "cQa4gIY8UiAjjyV",
+        "issue" : "kB1BTXhqcEl",
+        "articleNumber" : "zbuuhrkD0NAH"
       }
     },
-    "metadataSource" : "https://www.example.org/36539bbf-1ae1-404f-855e-2a23c117e39d",
-    "abstract" : "7bqzhSPCLIlnYQW2"
+    "metadataSource" : "https://www.example.org/4e6bef2b-d1da-40f3-976a-2107cd5c1a9d",
+    "abstract" : "p2xsxBQj6SlWm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/38d2cd59-0251-4781-b325-a320f2c5edcd",
-    "name" : "zuQ9myylWte",
+    "id" : "https://www.example.org/6d35a6fd-d27f-4fe2-9582-00ce236dd030",
+    "name" : "FhwM8YM54mQNZ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-10-23T09:11:07.558Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "fltQhPGRiYpaRvk"
+      "approvalDate" : "1986-07-16T01:24:43.715Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "fMbe1AB4SdR68wceZ5C"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b56c0eed-1fee-40a9-a557-04f56a10c84e",
-    "identifier" : "MO5Y7X8RxSgBnAXyo",
+    "source" : "https://www.example.org/52fca5c7-7db2-4fb0-bbf1-74aefc227696",
+    "identifier" : "OO6lxCYqEIr6gMu",
     "labels" : {
-      "ca" : "izNxjaFDihX3Q"
+      "fr" : "ezs1EQASdwA"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1644176291
+      "currency" : "USD",
+      "amount" : 1025307421
     },
-    "activeFrom" : "1987-01-23T06:59:49.417Z",
-    "activeTo" : "1994-09-12T04:20:37.982Z"
+    "activeFrom" : "1991-11-09T17:55:13.856Z",
+    "activeTo" : "1998-09-28T15:23:12.002Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5c9b5c65-3e7d-4912-bc55-41904192bb0c",
-    "id" : "https://www.example.org/b4202335-9093-42e4-84b9-cc1f74ea09b6",
-    "identifier" : "yVcpOqN6k3HeisZKU",
+    "source" : "https://www.example.org/5ea327da-adbd-4d88-b439-6d15ac485188",
+    "id" : "https://www.example.org/9db9a249-8f98-4ac0-b0ee-644ff4b81e74",
+    "identifier" : "AVRPx34mSTqI",
     "labels" : {
-      "en" : "nDftMpEKNKJnnF2ZUPn"
+      "hu" : "UFA1rG8lbqyuAhI0ky"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1799889907
+      "amount" : 545367176
     },
-    "activeFrom" : "1974-01-16T19:42:57.594Z",
-    "activeTo" : "1995-10-06T00:58:31.290Z"
+    "activeFrom" : "1971-02-11T23:47:10.620Z",
+    "activeTo" : "1971-10-05T23:28:56.424Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/1a661f2c-23bc-4739-bd27-6188b6bb2b4f",
-    "sourceName" : "vioyt7c6qdeztkmhwy@arzjjquysrjv4ft"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "411648397",
-    "sourceName" : "v5q7xjeqgatyjxfmku@usankdqlhlq2c"
+    "value" : "447791404",
+    "sourceName" : "qr14lj0qjwwwse@qymmudzxtzfkf8p5lr"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "MCLiE42VNLkeTLyd",
-    "sourceName" : "qfejmhqwb3xeygokpy@vl26dvqkl8nynnad"
+    "value" : "6vb4TwNpkcP688",
+    "sourceName" : "m50l3ottguz@s2w95piyn75pm"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "vMxTcsJGo3K",
-    "value" : "EcKQCF9gnXs"
+    "sourceName" : "FhyX0V0hopY8",
+    "value" : "RYnhHA4qIH4ZcLEAvF"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/ed4bde82-eeb8-4eae-8a64-05c227fd3bfe",
+    "sourceName" : "4kl9nlmtarl@1hupjriqk1gfc"
   } ],
-  "subjects" : [ "https://www.example.org/d9fe0ce8-1623-4b3a-88c5-4bfc87320662" ],
+  "subjects" : [ "https://www.example.org/a72a4be3-d2ea-4681-ba3f-8a1118fffa8f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "64fbf895-f502-4e6b-8b27-11641c6d6c86",
-    "name" : "PzFjxtP7bEgY2EQ4W",
-    "mimeType" : "cjJRI37EjK",
-    "size" : 282201448,
-    "license" : "https://www.example.com/h1ska29yott61l",
+    "identifier" : "af286133-94b6-4361-b29e-482bbecc79db",
+    "name" : "nrsNlMwCggQ",
+    "mimeType" : "gSBFyInwwhzblLtZljJ",
+    "size" : 332537538,
+    "license" : "https://www.example.com/nztn8wthzibbfovqwlt",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "4u9LfU93mIxE"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "ujkaunfRTRC",
-    "publishedDate" : "1998-05-14T14:29:24.902Z",
+    "legalNote" : "aAv5wWC12WPGF7WcF2l",
+    "publishedDate" : "1985-04-18T22:05:54.195Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "QSNvm0jA88KB2",
-      "uploadedDate" : "2022-10-06T04:07:30.378Z"
+      "uploadedBy" : "eGsGyaTWvmyCYNyfpJr",
+      "uploadedDate" : "2019-03-14T22:53:42.645Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ihCO6wKjknI8KfM",
-    "name" : "5TP1iVKAKk",
-    "description" : "KbkKRLSMMtrfuN"
+    "id" : "https://www.example.com/O5rQoQVvWT2mZ2",
+    "name" : "oZj8kQYOqO9",
+    "description" : "LhHyOLWo3AcVD3JNoH"
   } ],
-  "rightsHolder" : "gM1VQ6gX609Xfsl",
-  "duplicateOf" : "https://www.example.org/03b05d5d-6ba9-49ef-9cbf-4805fb5b9ae9",
+  "rightsHolder" : "XTeLSJsVEoPs",
+  "duplicateOf" : "https://www.example.org/2c13ad45-f53a-41a8-9a6f-5c4638865700",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "r5awA85cT9n"
+    "note" : "yEYuILbafM1XwbmJj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "OmFbf9G5ydELLEAxP6",
-    "createdBy" : "QnkpkX1TTkVBROaQKS",
-    "createdDate" : "2015-03-30T01:06:56.244Z"
+    "note" : "AgLyIQt5cc9P",
+    "createdBy" : "jIkhnhCXVaHffvXf",
+    "createdDate" : "1992-08-21T16:51:50.814Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/afd81633-10bc-4ec7-a07c-4e3de696b6e7" ],
+  "curatingInstitutions" : [ "https://www.example.org/edd2eadc-ba14-4378-9f59-621c81364bc7" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "2oSQ5SpF1Ej13",
-    "ownerAffiliation" : "https://www.example.org/371cf286-c046-4c84-a354-90c19269d1bc"
+    "owner" : "O9RbtQgq0ZPt",
+    "ownerAffiliation" : "https://www.example.org/b6d25f90-a5fd-485c-826e-ff4583b1daeb"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f7cb8a68-7707-4fd3-8f84-760d22e76c75"
+    "id" : "https://www.example.org/55f5f82e-4e50-49e7-94dd-8f473885dcc0"
   },
-  "createdDate" : "2007-04-13T00:22:28.153Z",
-  "modifiedDate" : "2007-03-05T03:58:40.045Z",
-  "publishedDate" : "2004-02-15T21:45:35.724Z",
-  "indexedDate" : "1994-12-24T04:55:00.488Z",
-  "handle" : "https://www.example.org/b68d3f8e-3bcf-4ea2-825d-e0cd2a4bfa13",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/934997d8-c276-4b9a-b4b1-2ebc1cade831",
+  "createdDate" : "1973-08-19T13:20:26.057Z",
+  "modifiedDate" : "2001-10-30T08:54:12.865Z",
+  "publishedDate" : "1989-07-19T03:21:56.005Z",
+  "indexedDate" : "2004-10-06T20:54:06.473Z",
+  "handle" : "https://www.example.org/7f9f9ae5-c71a-4d3d-8441-bf731d946adf",
+  "doi" : "https://doi.org/10.1234/sint",
+  "link" : "https://www.example.org/3acd0024-515e-426d-bb7b-afa82f34924f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "08NFOpmrZOTBJEze",
+    "mainTitle" : "oEx6yDFusyiNspzFG",
     "alternativeTitles" : {
-      "ru" : "faoVLQVI5SN"
+      "it" : "1GqzyO5GIS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "n7jyGGYZ8P",
-      "month" : "PPN0WjLoufEVTFp1Jk",
-      "day" : "Q7ihLUWjFpaDomV"
+      "year" : "jxT3xzTvvQYt56X",
+      "month" : "36xKmohJl993rBlsu",
+      "day" : "6N7zzUmPoKtmBlwZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/819bbb12-06b3-41d2-9941-8dc8a8e16988",
-        "name" : "uOSffvu4UlLNCu0",
-        "nameType" : "Personal",
-        "orcId" : "zicM97TahgWdTPsq",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/962fdd29-7622-4a64-ba38-4b3481fc6db3",
+        "name" : "43JBuZc5I9LQun",
+        "nameType" : "Organizational",
+        "orcId" : "ObFj56FxYvqZx",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DFwjM8ojecHHBJjTde3",
-          "value" : "RKl6TcCrZMbViR0eC"
+          "sourceName" : "f18tUc2n7ooTDf",
+          "value" : "dKfsiGwKuHO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4cSMzVoj7DTrPhTadf",
-          "value" : "VbaxnskgNuoDq"
+          "sourceName" : "l7wmvUAEzg3",
+          "value" : "PtecHAQOjhKesTP3KK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cb00387f-fdd0-4cee-805d-27e42ef570ea"
+        "id" : "https://www.example.org/7bd46001-7860-4c0d-92bf-b2905a977f8d"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/38244976-3649-4d94-92f2-ec7a3bba6105",
-        "name" : "oMd9tWRFRMROvbZY8",
+        "id" : "https://www.example.org/86fa3d8d-b302-4047-9604-66a975c3e3ad",
+        "name" : "KcGB5KdeH6e",
         "nameType" : "Organizational",
-        "orcId" : "p4Ywe5F4usro45",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Vq8NCQMhl0lf3nuac",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CqdKfeuYUlZ",
-          "value" : "Vzo3rD45k8"
+          "sourceName" : "9xN5jYyYg9k28dyS",
+          "value" : "YJzuacIVKIGELpal"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vRot4mUlXn3",
-          "value" : "hIfgOrkoxNREjA"
+          "sourceName" : "St9QADVULNyZJvDsv",
+          "value" : "YqkVtmwuzMLZkx2v"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/486eff18-f8eb-4acd-9656-a5b8a082a56a"
+        "id" : "https://www.example.org/c21921b3-b5ed-4913-afd5-0e1aa5826b12"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "XcRbiSGMhh2KLQ1"
+      "fi" : "qw48itCLCkVfcjDw"
     },
-    "npiSubjectHeading" : "aIVrJnKvcMUUdA",
-    "tags" : [ "SHxFkSQ7eo1Xi" ],
-    "description" : "JtiktvwVDG5f",
+    "npiSubjectHeading" : "6ka1DY1cOi",
+    "tags" : [ "iKIVOKSbZvS" ],
+    "description" : "XLwDikcLD45Aq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/ErMD6x5w6f3vVfRng"
+        "id" : "https://www.example.com/Dzb2jTGDin6dZc"
       },
-      "doi" : "https://www.example.org/10cd1b6a-6428-4eef-bc2f-a774a760ae93",
+      "doi" : "https://www.example.org/2d1b89ae-e79b-45f3-a5cd-55d973321688",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "wrnHnixtJhGm",
-          "end" : "NjYAdVr1hzI"
+          "begin" : "nqXSSxgSW29Q",
+          "end" : "kyhEjBQONx5Btwh5Z"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/df4c0f65-4e07-4cee-984b-b14a6f069f88",
-    "abstract" : "VlPhAWUU5HYb0efCiU1"
+    "metadataSource" : "https://www.example.org/1ca506f2-7acc-449b-b926-6da12f2d4e3b",
+    "abstract" : "ru2bYBxFZnK0a"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8ff7cd38-ea1c-4765-8041-23165d1c62ef",
-    "name" : "LnLURlKPQCiMxsa",
+    "id" : "https://www.example.org/f512cb72-0838-47be-be70-e39cc3206d63",
+    "name" : "iiGqGVLIooyoB5",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-08-27T21:31:04.699Z",
+      "approvalDate" : "2023-05-10T15:33:33.211Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "if0qE6u95gNO1Nhoh"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "1wiPONiEst"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f7f12dcf-6bb3-4efd-af5b-98eefbef919d",
-    "identifier" : "GM9rfaWOnS",
+    "source" : "https://www.example.org/a85ec2a6-52fb-46f6-8ed0-f0e19b30ed5a",
+    "identifier" : "3LuByb5I0r4WJ6MOtUk",
     "labels" : {
-      "is" : "6G3o4FGfr3Kwatfnep"
+      "is" : "YUMmtYCJLdP3IHLk8"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1315612898
+      "currency" : "GBP",
+      "amount" : 1695350354
     },
-    "activeFrom" : "2005-05-29T22:46:27.276Z",
-    "activeTo" : "2019-08-17T00:39:56.537Z"
+    "activeFrom" : "1978-03-13T01:21:39.719Z",
+    "activeTo" : "2000-05-06T23:37:27.674Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/903f5a07-2631-4ab5-887b-7b1ea3d91cd1",
-    "id" : "https://www.example.org/950f9ae6-c594-4a01-ac00-073b1e3aa4ed",
-    "identifier" : "Ixy7aRaf233",
+    "source" : "https://www.example.org/50301e0c-fad3-4d2f-a883-d65e6ee4d526",
+    "id" : "https://www.example.org/815fa9d1-720b-462d-9cb9-bcb6fd6b12ef",
+    "identifier" : "77CFRmKEWJyO5eL",
     "labels" : {
-      "se" : "PAOk2MeDZ1iSZqdX"
+      "ca" : "q3JzmPvyKzI7sJn1A"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1366846660
+      "currency" : "GBP",
+      "amount" : 1880176069
     },
-    "activeFrom" : "2004-04-06T10:32:12.457Z",
-    "activeTo" : "2006-08-15T20:01:30.256Z"
+    "activeFrom" : "2002-11-23T00:19:53.609Z",
+    "activeTo" : "2022-07-31T19:49:22.174Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "Lqsg6bxHGd80DStq",
-    "sourceName" : "o4knldylorijm6xstq@wy6hcholrts"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "Mu1XdFPIo6",
-    "value" : "3MlN44BScyEeUd"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/a28044d4-73b4-4a9f-986e-57d8198c0a71",
+    "sourceName" : "rdksw9fdqd2b@sqwfkw2ueqm2p"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "2069066275",
-    "sourceName" : "0qr4okrp2guqaq@qxhjh1sxpnn4xa2wkwt"
+    "value" : "1521307038",
+    "sourceName" : "ft5efoevclh@pqofj9tfyjq"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/67f8216b-5c95-4601-9dfb-c373f22116ed",
-    "sourceName" : "dfg8lwiogkywy6hnb@0iddinlfizx45oh3ltj"
+    "type" : "ScopusIdentifier",
+    "value" : "fOdqk5Cy7Vd",
+    "sourceName" : "s0ks2fdr9xzcw@zvnqthexu2g"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "gxLrBXh9eE1XJ",
+    "value" : "LOOvqZpnBbZ9"
   } ],
-  "subjects" : [ "https://www.example.org/0fe3a772-e9e0-4653-99e5-3588645a7767" ],
+  "subjects" : [ "https://www.example.org/7ac731cd-2f6e-4352-8e98-b68e3106bc1a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e28eb874-2e72-458e-a731-c4299e0e5246",
-    "name" : "vUVZNFnpV2CO",
-    "mimeType" : "QsJMpRCTOz0PlfAcQZv",
-    "size" : 1319636291,
-    "license" : "https://www.example.com/lv91piepcitd",
+    "identifier" : "f96ea98a-25c1-4b3d-bde7-c4a00f8e6025",
+    "name" : "ngrnpprgf0o6nzXWgTs",
+    "mimeType" : "rd17PRg4Tn6t",
+    "size" : 99316723,
+    "license" : "https://www.example.com/9rdagnw8ekxp",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "z7kDyHZiHkLzPSQWwH",
-    "publishedDate" : "1998-11-16T02:52:15.158Z",
+    "legalNote" : "D0fB3IeYg4qV5",
+    "publishedDate" : "2014-05-06T19:40:36.832Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "clYAr0BpA974mIZ",
-      "uploadedDate" : "2006-12-06T05:03:41.565Z"
+      "uploadedBy" : "PGpmwCUJEsyrd3yvG",
+      "uploadedDate" : "1983-05-29T12:28:14.400Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YLg8FoADNnd32JqOR",
-    "name" : "ZyhyuPI0z6TMFVoHZk",
-    "description" : "jT2NBQs4UvreybdIh"
+    "id" : "https://www.example.com/uBLcdRVXOrTeu2xmJ",
+    "name" : "JKCQXDNrP3e",
+    "description" : "jtcf34AQbp5nkjB0cP"
   } ],
-  "rightsHolder" : "wtAtIUtg3BiqnmZVw",
-  "duplicateOf" : "https://www.example.org/aeaf3e11-713a-4817-a32a-1dc038f74018",
+  "rightsHolder" : "k227FxS5gN1A",
+  "duplicateOf" : "https://www.example.org/36d290a8-74e0-4325-bac1-d0756a5e5f27",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "grTf2JeNFdh47AdWtU"
+    "note" : "x8eqjoJtc2DyyUwG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "EQHh7VF21gijFT3",
-    "createdBy" : "FS3vyzN6w1l",
-    "createdDate" : "2005-07-24T21:28:02.594Z"
+    "note" : "Ju5qg7W6Tlg6J",
+    "createdBy" : "W88ytnEts5P19UmkI",
+    "createdDate" : "1974-07-18T14:11:49.595Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5cdefe8b-1b08-4de0-9177-7de13e952fc0" ],
+  "curatingInstitutions" : [ "https://www.example.org/3ff722cb-9e66-41cf-8fc8-52089dc55011" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "q3hobQ3UvRfbqxvk",
-    "ownerAffiliation" : "https://www.example.org/c3ac49ef-4adf-46bf-b4bc-5e61c403f7b5"
+    "owner" : "3W2borWo6nXakbBk",
+    "ownerAffiliation" : "https://www.example.org/75d733f5-4836-4704-98bd-06bfb123420e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d465524e-9115-4fab-bd99-f8b2c7c1843b"
+    "id" : "https://www.example.org/d2ca3f5f-4b0e-4e95-994c-d4c30131f5f1"
   },
-  "createdDate" : "2013-04-26T15:38:06.046Z",
-  "modifiedDate" : "1974-06-18T11:19:33.720Z",
-  "publishedDate" : "1981-10-06T16:10:37.913Z",
-  "indexedDate" : "1974-10-22T20:21:49.954Z",
-  "handle" : "https://www.example.org/dd92260c-2023-4382-8b7d-44bab97140c5",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/b183b276-5adc-43d8-af37-cf899455d2e3",
+  "createdDate" : "2019-07-05T19:21:26.532Z",
+  "modifiedDate" : "2003-07-10T16:25:44.758Z",
+  "publishedDate" : "1995-12-20T22:21:14.892Z",
+  "indexedDate" : "1997-05-21T11:50:15.084Z",
+  "handle" : "https://www.example.org/40fd5f8b-79f7-4f03-bdfd-a387c52e73dd",
+  "doi" : "https://doi.org/10.1234/quis",
+  "link" : "https://www.example.org/c9ef8a90-3bc1-4f61-9944-a4b4a96d3850",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QtndsCeil70wVQ",
+    "mainTitle" : "p4neKALA74jxVHJ",
     "alternativeTitles" : {
-      "zh" : "IUz2e6qj09YcQVYNSI"
+      "se" : "V77EAnmviKP"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Ze6p6FFCTwbx0kAdD",
-      "month" : "1cKcqYIL5WoECcUtUE",
-      "day" : "Vm96hFx585xHlrft4"
+      "year" : "MbRHWlZvLQglfbhClJ",
+      "month" : "THLNaChPranHZxG",
+      "day" : "SGOTiAfg4MMiWL4Se"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1c2b7c09-0f07-47fc-aa26-492c175e71ee",
-        "name" : "5AD2hC3vYF8PYtdPC",
-        "nameType" : "Organizational",
-        "orcId" : "fWKKIBiF8tRq90UuC9",
+        "id" : "https://www.example.org/75d95047-c133-4de7-aee4-edd2d47b7819",
+        "name" : "RxoBfCeSbY3Zb1Mr",
+        "nameType" : "Personal",
+        "orcId" : "vf0c0cLnVXa",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NCVBsfdmKXgJ8E",
-          "value" : "2J7Qoq8dfxcGD7I4"
+          "sourceName" : "ONvb36QrEc0kn",
+          "value" : "GPzubCxmwlNesde4B"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mNN2K1GHSWZsD5gl7cY",
-          "value" : "CkLRObI0kt6vBp"
+          "sourceName" : "vGC5fiZWsg9KiLEgR",
+          "value" : "KDAh00GCKn8t"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/98fb1ed3-4808-43ba-836c-3dd44b57b711"
+        "id" : "https://www.example.org/dd74e9b6-33f8-4067-9246-c8341fcf5380"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d1beb124-72f1-4094-bed5-64b6fb63e2e8",
-        "name" : "sz7MVO1qgteGPAo",
-        "nameType" : "Personal",
-        "orcId" : "DTsTcNL7LvmUAYtPjYp",
+        "id" : "https://www.example.org/dcc1f471-9edb-4d84-b62c-72ae29e97739",
+        "name" : "UFVP8uCo3tjZ",
+        "nameType" : "Organizational",
+        "orcId" : "pGvjezfIj7r0EUzsli",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CyP2zPfh7tds8DYH",
-          "value" : "XmRMCf64DHwzmx"
+          "sourceName" : "HNYyTZ3tlQO",
+          "value" : "sqfVQyMb3BIrnPwBpnB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "78NAk7amCi",
-          "value" : "jhNu6IlPjDqZk"
+          "sourceName" : "kqSfEagucPxAOxJX00",
+          "value" : "8babY630YFoj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/43e8fb37-c92b-40af-9626-50eaeda2cae7"
+        "id" : "https://www.example.org/a985e511-545c-40db-9961-b7d6de4522db"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "Wu7euYiUwLkCsAuj"
+      "pt" : "t7ylQ6yXjSndcXc"
     },
-    "npiSubjectHeading" : "wuir14vHeiFX",
-    "tags" : [ "m1SB863mm02pmvTb" ],
-    "description" : "pIN36AyADfdOWP",
+    "npiSubjectHeading" : "f03HwiMMau99phu",
+    "tags" : [ "CRXMqYwEjl" ],
+    "description" : "t3yZuh4Sy7hK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/S8lAnL86vNG1jH2pIb"
+        "id" : "https://www.example.com/YEFiN4mTxWERbZ"
       },
-      "doi" : "https://www.example.org/078e9896-d267-48bf-a375-cede634f8388",
+      "doi" : "https://www.example.org/94422da4-2ab8-4182-a1ef-781b2943391a",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "Ubk6FXyiiWak3",
-          "end" : "XUdmXBraKw"
+          "begin" : "R8RVxu0xqwtLHM",
+          "end" : "ARFVrRMxICNbb"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/606f88a2-60d2-4f39-9867-fe1330fe29e7",
-    "abstract" : "5eSfTIQZYCJufbZ"
+    "metadataSource" : "https://www.example.org/af311dd0-0316-4dad-91bf-5c82c66e2cb5",
+    "abstract" : "jw24xTrgIbGrIx6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d23925dd-7e3f-4c78-bf4e-1fad45460f83",
-    "name" : "PmyxhP0bXzNyOJ5",
+    "id" : "https://www.example.org/4eb3fac7-7eb8-4af4-8e20-516d32efbb39",
+    "name" : "ZqNhxZ7H9jWh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-09-16T11:43:35.807Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "7fckBAeLn0kPh"
+      "approvalDate" : "2010-04-10T12:12:03.922Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "z65dSaJf6rG"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/33a0c015-2c5d-42db-b91a-002d1136640d",
-    "identifier" : "TSQlVNWlzhJ1Hc",
+    "source" : "https://www.example.org/247c0acd-ce1a-488f-b282-4212e503ee2a",
+    "identifier" : "q9RizBK9s7DquVbHqRr",
     "labels" : {
-      "cs" : "QKum0vgI8OS"
+      "nb" : "hj9nSnyZ9OU3"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 116496048
+      "currency" : "EUR",
+      "amount" : 1298421470
     },
-    "activeFrom" : "1981-06-09T15:55:11.354Z",
-    "activeTo" : "1998-10-12T00:52:07.670Z"
+    "activeFrom" : "2015-07-19T15:49:00.424Z",
+    "activeTo" : "2017-10-22T16:30:13.150Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/04f6213e-25e4-4f2e-8949-aeb206c3499a",
-    "id" : "https://www.example.org/43a4051e-a47d-4627-afe4-4b8a4c2feebc",
-    "identifier" : "lZkq040BdffsJK",
+    "source" : "https://www.example.org/fca08762-794a-4205-ac09-31c4e1823e04",
+    "id" : "https://www.example.org/2ba25564-1755-413c-997c-f51e2fa0e407",
+    "identifier" : "aCEIJZT1Cbh5imT",
     "labels" : {
-      "de" : "mKCacx5UJ1eVfZ"
+      "cs" : "gktrBLEhfPQPg"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1636987386
+      "currency" : "NOK",
+      "amount" : 1877430338
     },
-    "activeFrom" : "1975-02-27T00:29:08.805Z",
-    "activeTo" : "1978-03-28T16:28:37.896Z"
+    "activeFrom" : "2010-04-16T21:12:08.737Z",
+    "activeTo" : "2013-06-19T05:46:02.609Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/c55143d2-1c23-41aa-ab5b-f8379402032a",
-    "sourceName" : "4xxvuifihref2gd3d@qtudszsoabq0j"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "UolpbT9IpL9qPJ4",
-    "sourceName" : "gtpfn39kvwkp@6a941k3akscip77in"
+    "value" : "https://www.example.org/c27248cc-69c2-4855-a451-423b6891baa5",
+    "sourceName" : "xir7tulvan7yvul@1ozxaemhvdahwih"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "ZRUjAdukNvEAvh",
-    "value" : "T1fQtxSp7rYxT"
+    "sourceName" : "xG3S8kIhdQ038NgRdDo",
+    "value" : "Fsi0EDlnNa"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "273981262",
-    "sourceName" : "ryxgmn5hjpdpqu6un@26biuakpmpjdim"
+    "value" : "799639323",
+    "sourceName" : "uptg7t21mg13wizu@1kec3vigyqhwev08jz"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "qjgPi8sw0i17rd1IaQk",
+    "sourceName" : "cgm3ystb1j@wfuhfnew1synpjouemb"
   } ],
-  "subjects" : [ "https://www.example.org/53b180b1-e3ee-4ed2-95ee-fedca60c5cae" ],
+  "subjects" : [ "https://www.example.org/4196d521-1433-4097-a050-f7ee8571a651" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "11d424bc-7021-44ac-9b6f-0eacbe6c7ff0",
-    "name" : "CLYFq3CCCb9",
-    "mimeType" : "ki2Wh26kYp",
-    "size" : 452862320,
-    "license" : "https://www.example.com/adprtaxxby7o",
+    "identifier" : "a28caca0-42f4-4e4a-995d-64c9a8c067e4",
+    "name" : "iV94qcOJYMkmttfLQ",
+    "mimeType" : "6RQHzGlzY9DsjfTeFoj",
+    "size" : 1702647431,
+    "license" : "https://www.example.com/1hwvnl6ffif4",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "bU7zAn8H5J"
+      "overriddenBy" : "eXPz2ofcjl27oE8I"
     },
-    "legalNote" : "1u1xFafOY9FAzZqs",
-    "publishedDate" : "1999-07-04T23:16:40.027Z",
+    "legalNote" : "YEfbyPOXLZM7egV",
+    "publishedDate" : "1990-10-18T16:59:53.449Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Fpoi8bodIJDhVY",
-      "uploadedDate" : "1982-01-23T18:16:22.691Z"
+      "uploadedBy" : "cRya8CXgUzT5lykIyRa",
+      "uploadedDate" : "2005-06-14T13:02:22.805Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PS78qi0EI3kDClGR",
-    "name" : "nyllLvyXzYKNkij",
-    "description" : "vN0qrBpbAYzUOuU"
+    "id" : "https://www.example.com/6iq2l7oy6B0h",
+    "name" : "pjj8n4NuVQuj6rtl",
+    "description" : "zzB0IZrR6kVHo5byn97"
   } ],
-  "rightsHolder" : "QFSBlUZrdYqT",
-  "duplicateOf" : "https://www.example.org/7b8c31ac-7d9d-4ffc-b609-c23f184e98c7",
+  "rightsHolder" : "4j7SsFOmJJz",
+  "duplicateOf" : "https://www.example.org/eca2b2f4-58ab-4487-ad1b-ee2cec9424bd",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "l6UIhXzhLRf50JqGKTm"
+    "note" : "L6PzlKlHLf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hhKs20G3rs",
-    "createdBy" : "glOhgH5Vo9K2",
-    "createdDate" : "2015-03-03T19:19:08.632Z"
+    "note" : "py8djk5Mg4OVY5y",
+    "createdBy" : "DQUf0fBnES4ksIzuvX",
+    "createdDate" : "2007-09-28T08:22:22.521Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a8158c03-fba2-4bb7-993c-bd1449778667" ],
+  "curatingInstitutions" : [ "https://www.example.org/b69e480f-4dbf-4193-94c4-9517ffe0f175" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "MK5KewemxeU1lA",
-    "ownerAffiliation" : "https://www.example.org/70ea8583-b1c4-4bc3-8500-db22fe3a1511"
+    "owner" : "8LjwkprODTq2oKS",
+    "ownerAffiliation" : "https://www.example.org/031fbbb9-0835-4f3b-8459-1cdb5652b151"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4617385c-cdcd-499b-adc7-c85f971e7eb2"
+    "id" : "https://www.example.org/77cabc9c-574e-4e83-bd8e-fbbff73e876f"
   },
-  "createdDate" : "2015-03-16T09:24:02.144Z",
-  "modifiedDate" : "2002-11-22T19:16:30.045Z",
-  "publishedDate" : "2007-05-21T18:42:47.340Z",
-  "indexedDate" : "1983-09-09T11:07:13.205Z",
-  "handle" : "https://www.example.org/9a724d72-2702-44f9-9f1c-480447f9a833",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/136351d5-2aee-469e-af6e-24460b636020",
+  "createdDate" : "1991-08-15T18:48:22.124Z",
+  "modifiedDate" : "1974-09-18T07:54:23.701Z",
+  "publishedDate" : "2018-12-30T14:51:22.374Z",
+  "indexedDate" : "2000-03-21T16:42:11.911Z",
+  "handle" : "https://www.example.org/f9189e82-b60e-4885-abbd-6e9504dce4c3",
+  "doi" : "https://doi.org/10.1234/iste",
+  "link" : "https://www.example.org/23c989cc-af5e-4cd2-b158-f5465e92d034",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bd6WuqMl26Hj0ZQg",
+    "mainTitle" : "69WfHDhD8vlhFf",
     "alternativeTitles" : {
-      "nb" : "Yy0wMKNiuAqz"
+      "it" : "cbs8YZPt9jZP1GkI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "nXSmYBsCHKy",
-      "month" : "sGuv3oTKsQE2ToAK7",
-      "day" : "ffs49OQmDO3MaQGkX"
+      "year" : "1R2Rx4F8YERf",
+      "month" : "NA3mdzrhWpT1hcIY",
+      "day" : "C54gO6GEqTOvDRxp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/13a9ca64-18a2-4494-9605-aaa1529f5fbc",
-        "name" : "tckxZ6WL6ho8",
+        "id" : "https://www.example.org/18bf0737-4882-4011-9c8b-4b2075d599eb",
+        "name" : "2QoflrhzIjaf",
         "nameType" : "Personal",
-        "orcId" : "ElsmIgAemYTyHPCg",
-        "verificationStatus" : "Verified",
+        "orcId" : "85hnPAPSUTrI6naKo",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vFxGQWp8etBUKd",
-          "value" : "fn5pbRU87BXW"
+          "sourceName" : "4fDFTaWDn0STN",
+          "value" : "2zyUo8OElWPmb9Zfyv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5SKqzwkzPAZK3CPl",
-          "value" : "E98Kqq6xLz"
+          "sourceName" : "Iy0tPvcz4Lv0oNpK",
+          "value" : "eK8IW7oWEbO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ecd8ff2f-4417-4fdf-9af4-4fcffdb0f971"
+        "id" : "https://www.example.org/8d69de51-e8fd-4fae-89c7-eec081524b60"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8f06d1d6-d175-4c0e-93d4-ec330fae12fe",
-        "name" : "z3SyhC1FBfF31",
-        "nameType" : "Personal",
-        "orcId" : "ggW1hTXGJKiJA5fIbO",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/db80a336-0a6d-4905-82b8-3e8d79766449",
+        "name" : "l8yM2yYhOVEt6U",
+        "nameType" : "Organizational",
+        "orcId" : "yIrtbI6BNqHgoNlyK",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RAqwsSkdOo",
-          "value" : "CQHRqVjw7hjJ"
+          "sourceName" : "wx1YpIeKUpLpTfjuDP",
+          "value" : "KdGlWKvbMTlDIBSR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LyiJ5yi3nOj",
-          "value" : "VybAxbPKduHuEq7Pv"
+          "sourceName" : "wv1bsg76XgtPO9t",
+          "value" : "flyAlTyvJPz4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/20751f31-59d6-4441-83ca-1f4fa1e7aefa"
+        "id" : "https://www.example.org/436e3996-b4c6-4d2d-9f72-32f5f68088a2"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "Ya9ZvLyI9IV4I3w"
+      "nn" : "PQR0JQV3xd"
     },
-    "npiSubjectHeading" : "BLWexLXuUwDE3OXxu",
-    "tags" : [ "kgaUgHNEGX" ],
-    "description" : "Gv2oppX2Cfhx0ItPES",
+    "npiSubjectHeading" : "IyPOaie1G9BzC9Zmt9",
+    "tags" : [ "qvPtcz1NVI5" ],
+    "description" : "1ZeJH9In9aNWw1QAwpu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/53f7d50c-ac9e-4278-a878-62b6727858a6"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3feee70b-216d-493c-9e0d-d978ed5e1f33"
       },
-      "doi" : "https://www.example.org/9486a990-ea97-4a4a-b8ae-b533bf9457ae",
+      "doi" : "https://www.example.org/6882ffd4-c46d-4010-95ed-9e8b17565552",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "e8Kl0ANzwvSuIQG",
-        "issue" : "bsE9EL1koHq4hrygCl",
-        "articleNumber" : "gsSKCa85JyJMqwKsVGj",
+        "volume" : "pnafaYwvnmlE1",
+        "issue" : "HOnRS9dONth1cy4wko",
+        "articleNumber" : "UnVyCcw5Z5IqWAw08G",
         "pages" : {
           "type" : "Range",
-          "begin" : "WoBcAeUCDlIn5ftaQdo",
-          "end" : "UUt6CdIOHaDup"
+          "begin" : "7d2Qp3le4XcM",
+          "end" : "NhWdz5lVcGw8vI"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5e6dd072-86e1-41cf-9aaa-3d20e650b6e9",
-    "abstract" : "912ZgGUgsGWY9yLSN"
+    "metadataSource" : "https://www.example.org/3a1b21ce-c529-440d-a088-332cb0138f75",
+    "abstract" : "Qlr4a8dgsfQcQKJucS0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9fa4e05c-cd81-4e0a-ba14-5ca4f15a137d",
-    "name" : "bYZ0EA3kKt1ADgwDzOR",
+    "id" : "https://www.example.org/ac5d34be-7855-44e6-8747-a1123f23de14",
+    "name" : "jiVE9liugFcH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-05-13T14:49:45.285Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "5EBtzjOgXi9G"
+      "approvalDate" : "1984-09-16T03:13:51.505Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "jeJq6aFgzq2pMk"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/04920560-fbfd-462f-bdcc-51d273a8c46f",
-    "identifier" : "c3lVM3G9XV",
+    "source" : "https://www.example.org/e3fba1fb-6b8b-4f87-b4ec-c9e0174cc1ff",
+    "identifier" : "0B7a563eUxw",
     "labels" : {
-      "ca" : "Oj5rF8wHASN"
+      "ru" : "OdaNGpOW2aoIl1UM"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 57072644
+      "currency" : "GBP",
+      "amount" : 999929586
     },
-    "activeFrom" : "2015-12-14T12:01:06.727Z",
-    "activeTo" : "2018-04-25T00:46:36.233Z"
+    "activeFrom" : "1998-04-23T17:24:30.372Z",
+    "activeTo" : "2004-03-30T23:55:14.974Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/68471566-0569-4d7f-88e8-a09b70cd1088",
-    "id" : "https://www.example.org/9f401eb1-84ea-47ad-a107-cf94942c640b",
-    "identifier" : "8qhzZERoqjHT4gb",
+    "source" : "https://www.example.org/91e623f2-360d-4c8c-9a6c-5bc3d3ee1969",
+    "id" : "https://www.example.org/e7dc726c-5e2c-4cf1-ac03-44136f305683",
+    "identifier" : "2B5HSSvwLeGb0AVhA",
     "labels" : {
-      "es" : "j5vCJWoyJ6RMIYZd"
+      "fi" : "dJf8SQ89jsz1oA65UZ"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1639749895
+      "currency" : "GBP",
+      "amount" : 1891507452
     },
-    "activeFrom" : "2016-05-12T06:28:01.910Z",
-    "activeTo" : "2022-12-31T23:00:36.819Z"
+    "activeFrom" : "1989-03-28T13:47:44.715Z",
+    "activeTo" : "1990-08-12T14:15:21.353Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "4LQ6Ne7PbGTc7fPjxbW",
-    "value" : "QkoqxvLqSkCiwQjz8o"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2a7d7bb0-4586-40f9-a907-954e17f111b9",
-    "sourceName" : "kadfz452qtzmvxu@az6wb28oqwoqr"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1680163907",
-    "sourceName" : "fw9bbzlolg4m@9rthreksjuk3t"
+    "value" : "https://www.example.org/50a6c4fe-8d54-482b-b83e-18ca79ca190c",
+    "sourceName" : "tjavbjdgtxits@zak2qgbfmiqk6dboxm"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "66ZlY85mlIqauqdAAI",
-    "sourceName" : "7gcijo9b2eme8dw42td@0qtervojvpl4hvfejl"
+    "value" : "iucQsUcFcVr51Te",
+    "sourceName" : "6x6lv2efsl732@so8ccobbjebsyzqoxp"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "881044658",
+    "sourceName" : "vyw5qfoyully@0i9xv2cs7hgiwj3px"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "O9Dz6qey56MRdxX",
+    "value" : "kLRwOgnSGEA7o"
   } ],
-  "subjects" : [ "https://www.example.org/f3d15ef3-590d-4295-97be-0ce76d5e0cf6" ],
+  "subjects" : [ "https://www.example.org/d44d6e7e-a64e-4a87-a6b1-19762e890c3b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9a032834-467f-4ebf-aced-ac234913e5dd",
-    "name" : "CEGsuoBIErpJt",
-    "mimeType" : "BEKskU3k8mCX5k",
-    "size" : 1100530215,
-    "license" : "https://www.example.com/5bitpoatcmz7k1j",
+    "identifier" : "5a482baf-c974-4138-a900-4213667e56e3",
+    "name" : "kitXMbeZkGDykF",
+    "mimeType" : "MFCboRfTK4N",
+    "size" : 1258348454,
+    "license" : "https://www.example.com/dxhluqcehqptl5k",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "M38Ep80Y5XIMBwEdTID",
-    "publishedDate" : "1985-01-20T11:04:39.744Z",
+    "legalNote" : "mQYgsCLT6VwEW7e3hb",
+    "publishedDate" : "1996-04-06T22:09:45.805Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "m53baakmc1XIBf61UE",
-      "uploadedDate" : "2013-11-28T07:39:59.148Z"
+      "uploadedBy" : "4R8BUslalE6tjsmiyK",
+      "uploadedDate" : "1983-04-22T04:32:04.966Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/t0LBC1IsTyKSG58lSd2",
-    "name" : "NQacJzzFri",
-    "description" : "tX1LChWf20i1P9yVDQc"
+    "id" : "https://www.example.com/3kYdV2UGWLiygyN",
+    "name" : "Lp5EK8QwnLL84n3EB9K",
+    "description" : "D3ZDWAjinz"
   } ],
-  "rightsHolder" : "YzeOCneLp8VdmIs",
-  "duplicateOf" : "https://www.example.org/f869ea14-93a5-4a97-a763-80a5abfac0e6",
+  "rightsHolder" : "HtZXCg65VdwvSF3",
+  "duplicateOf" : "https://www.example.org/852d4e18-aefb-4e73-8853-423c4158c7a9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bTjQpvuHfadSBt"
+    "note" : "6tvAOHSZVLS2YFcYIa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "X5PUw2sJc4mv",
-    "createdBy" : "WsO6JnfYF6e",
-    "createdDate" : "1983-09-09T21:44:05.951Z"
+    "note" : "Tm7LO6z1CFymgM",
+    "createdBy" : "9Q6i1RDlmPjGYd",
+    "createdDate" : "1994-10-04T04:34:53.308Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/96b39d5b-98a7-44c7-9b25-9406d4785693" ],
+  "curatingInstitutions" : [ "https://www.example.org/8c1e5f89-0db6-41fc-9c66-c430fbd69981" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "VCNWSU0Wid11PMfKA0",
-    "ownerAffiliation" : "https://www.example.org/1cc5e0e0-6fb4-4dff-9f6a-48feba2a3c02"
+    "owner" : "bIReYqGG7MxCRTTjJSD",
+    "ownerAffiliation" : "https://www.example.org/68d6b6e3-7847-4ae6-b48b-8ea9bf740604"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/75b1aeeb-262d-4b9c-954c-5d69543d536f"
+    "id" : "https://www.example.org/f7bfd71a-b303-4474-bbd5-43e6bfc6daf2"
   },
-  "createdDate" : "1987-01-27T09:44:14.194Z",
-  "modifiedDate" : "1990-11-25T18:35:20.370Z",
-  "publishedDate" : "1971-04-03T23:53:38.966Z",
-  "indexedDate" : "1977-01-11T14:17:58.999Z",
-  "handle" : "https://www.example.org/9daacbdf-0573-4834-9b5d-15d9d65bc629",
-  "doi" : "https://doi.org/10.1234/error",
-  "link" : "https://www.example.org/7924eebc-c583-4be8-9c45-45006f972d81",
+  "createdDate" : "1989-09-26T21:30:43.143Z",
+  "modifiedDate" : "1979-12-19T13:33:03.813Z",
+  "publishedDate" : "2017-05-01T15:10:50.912Z",
+  "indexedDate" : "2016-01-08T19:36:33.378Z",
+  "handle" : "https://www.example.org/c890f955-93c2-4603-b316-fe5c3b69205d",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/bb881639-6c30-42df-955a-2a9283f1edc9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MREsXLSoB1",
+    "mainTitle" : "7mraprTj6r4Nag",
     "alternativeTitles" : {
-      "pt" : "fSnm4Na8rKw8UWI"
+      "nn" : "B1DQgfuv03DFexvcXXt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "z5nzaZxUnaNeq",
-      "month" : "39beE0P1j0",
-      "day" : "G2sRTMuqIicQY"
+      "year" : "f0aPwdGajVknUrF5CB",
+      "month" : "jNgBHjArGIZP18bGO7f",
+      "day" : "ZdtJs7RVuH1VIquWY84"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8ec85d64-7e08-4679-b423-dfedd48c3aae",
-        "name" : "fKZIIpOCjUOBf1m",
+        "id" : "https://www.example.org/28fcf593-ba1b-42da-a1c5-133f8ef0881e",
+        "name" : "TieVV69kS5Tye2",
         "nameType" : "Personal",
-        "orcId" : "X8yPi8mpM5PZw",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "jgZf0BZsKu2R7AQtgE7",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EuEuT8B1Y44vtG6",
-          "value" : "QgkPcQG2PcC93K"
+          "sourceName" : "vORi7yMfBaU8",
+          "value" : "cjBNOqBBdROiWN"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RDqzyF73c8TpT4jt3",
-          "value" : "mDhO2i7Dgl1F"
+          "sourceName" : "UdCYsedRIRkivXm",
+          "value" : "qoLaKQNdVX8zT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/68ce285d-1576-4dc0-a36d-2f5642f3a86d"
+        "id" : "https://www.example.org/08044c0e-253a-4808-ba4d-cf31dda5d5c8"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4ba44748-9a38-479a-bbb9-8c1eaa129417",
-        "name" : "AtIS7TESJaR",
-        "nameType" : "Organizational",
-        "orcId" : "zXt1tN6rto",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/7106def5-e14b-448b-b47b-7ebb75fcead5",
+        "name" : "gllHLmyIHEexCD638E",
+        "nameType" : "Personal",
+        "orcId" : "d7H0nA5bxOsgMAQTpsl",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vQ4QigTh4r",
-          "value" : "UJqiL0GXJDihy"
+          "sourceName" : "rYMASCBpPE51r4fyf",
+          "value" : "aKcUtvsrvltBS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PHaixrNqg0tzf1K",
-          "value" : "cu9dFk1oObXl3jvN69"
+          "sourceName" : "gPYUcEQEu5DHs8Z",
+          "value" : "vcYyCNNXHISKHu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/805e0533-8d5f-4406-ba0b-639dc0522935"
+        "id" : "https://www.example.org/2c0d4406-ba8e-4a26-8ecd-2956646862a0"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "3u10hDcjLHP1"
+      "pt" : "zl9xYO02rWahci0i"
     },
-    "npiSubjectHeading" : "j1SNYZzl1HVBTYab4",
-    "tags" : [ "xncTs28i9JzR016NwH" ],
-    "description" : "4xXGZhXkCJenL",
+    "npiSubjectHeading" : "NfOwbAsBYuz",
+    "tags" : [ "wK7M8XANewqLg" ],
+    "description" : "03da5xMM13u1DppF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "oFtpfVIfomLs",
+        "label" : "rCnhUGcBc1fKqmG",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "RQ4901e8yCHVY",
-          "country" : "87McSEyuIpZAK0"
+          "label" : "eXH1qPmdbd",
+          "country" : "4ZXaZwk3q3mQSIRKU"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2021-08-19T22:48:49.994Z"
+          "type" : "Period",
+          "from" : "1998-06-01T06:00:18.331Z",
+          "to" : "2017-05-24T10:47:13.986Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/SQQXqkKZXmN8FGi6AAY"
+          "id" : "https://www.example.com/OjCy3WNxoOZd8R6Jq"
         },
-        "product" : "https://www.example.com/tdBkhLbR2B1t"
+        "product" : "https://www.example.com/Cju3b6IUtVJw9SrH"
       },
-      "doi" : "https://www.example.org/c326bb7b-e977-4071-a1a2-2b1d8517640a",
+      "doi" : "https://www.example.org/869d24b5-e627-4ded-bd7c-408b62563813",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -121,107 +122,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1b4c3249-8555-4c11-995f-9d9f9921337b",
-    "abstract" : "KmOh9YdwTeq"
+    "metadataSource" : "https://www.example.org/027bf7cc-cf3c-4bf6-8465-d29d47337189",
+    "abstract" : "kIu5QsZ7edU7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c3bfa724-c721-4415-b8ac-ea9c9fea421f",
-    "name" : "VsnT0Vh5ukebRM",
+    "id" : "https://www.example.org/68aa695e-80be-41f5-b4d9-dd0ad5edf970",
+    "name" : "YW3blKFnF0SA3nr",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-11-18T17:04:20.929Z",
+      "approvalDate" : "2007-02-28T11:22:59.192Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "j71gkdQAan83FsN"
+      "applicationCode" : "qe82XcpM3ZEBOOv8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8a060c07-2848-4516-8d35-739459585b4b",
-    "identifier" : "TNMbPtA2ke3",
+    "source" : "https://www.example.org/c26fb774-240e-4fbd-96e6-b0ddf376a690",
+    "identifier" : "PdgtNjHgBqJHssjXr4C",
     "labels" : {
-      "is" : "K0geSepFmZ"
+      "ru" : "6UpKn9UWm3R"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1389339232
+      "currency" : "NOK",
+      "amount" : 1941833758
     },
-    "activeFrom" : "2014-01-06T01:58:03.721Z",
-    "activeTo" : "2014-01-29T07:43:26.299Z"
+    "activeFrom" : "2002-06-26T15:11:17.688Z",
+    "activeTo" : "2002-07-05T10:05:13.279Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/72ec1de7-2911-4561-b827-c90ad6e4f88f",
-    "id" : "https://www.example.org/81bfd5c5-30f4-4291-95fe-47ba4b33de6a",
-    "identifier" : "OCuNfCXzXKS",
+    "source" : "https://www.example.org/304526e4-6206-4bb0-842d-0b9e3125c1ce",
+    "id" : "https://www.example.org/c7d97ad8-7942-4569-b01d-5bf4a562e6b2",
+    "identifier" : "d7hRuZX0gBGFb",
     "labels" : {
-      "it" : "hshjgcrjiQF9tDKo"
+      "de" : "NRGPcrRlRAWMocUd"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 858269052
+      "currency" : "GBP",
+      "amount" : 1298571870
     },
-    "activeFrom" : "2000-05-31T19:23:23.840Z",
-    "activeTo" : "2021-05-03T17:27:36.706Z"
+    "activeFrom" : "1983-10-19T01:23:31.618Z",
+    "activeTo" : "1990-02-26T19:09:01.614Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/5f59781a-6462-4340-94b3-777a0e14b820",
-    "sourceName" : "lyzm3xrvuj@e3prwkgwydb"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1693675040",
-    "sourceName" : "bsg4ialt3za76@6jhepdnyelpl"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "foygPLf8AJbYxQ",
-    "value" : "CCgfNQO8gi"
+    "value" : "https://www.example.org/a4eaaf12-f420-4951-8daa-f995adfc7d8b",
+    "sourceName" : "odbp0xdzesv@hj1qaeocrsblfiymcty"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "SWRmhdozYH3Nnyj",
-    "sourceName" : "w7t6rtlml9s8ghca@gcxnqakl9rquii"
+    "value" : "88JOoWA64aQgQiDR",
+    "sourceName" : "5exuvh3mnoj@kp3d5w83qn1a9qey"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "gka6pla48BOGO",
+    "value" : "qRYOJh1H31s"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1897976083",
+    "sourceName" : "hkrcg0xelzszstad9lw@xnwcrxhgubvtp"
   } ],
-  "subjects" : [ "https://www.example.org/9cb0cf06-621f-44d9-b1ed-53663c55aa22" ],
+  "subjects" : [ "https://www.example.org/2cab6546-4681-48bc-bb14-0bf11a33067c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "10906824-fa07-441e-a57a-1e96f1e9d62e",
-    "name" : "0dw6Kcb5Vj6",
-    "mimeType" : "h7uLDadl0UUmbGlbk",
-    "size" : 118822488,
-    "license" : "https://www.example.com/xwy8cghgjlfx",
+    "identifier" : "3bf0e858-8cf2-4a68-922b-4f0f971b874e",
+    "name" : "AkLdBlrtmX",
+    "mimeType" : "sDeP4ZxnF653cX8",
+    "size" : 129106006,
+    "license" : "https://www.example.com/kkxqu4dom1c",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "3uuOr4I2XIZGR"
+      "overriddenBy" : "2XvXZmmtQ9OLNaDjL"
     },
-    "legalNote" : "YBrocIWbY3rDBIf",
-    "publishedDate" : "2004-06-02T12:21:21.949Z",
+    "legalNote" : "S8S7BGrozpfmoSU3x",
+    "publishedDate" : "2023-11-09T20:06:52.815Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "NU6OuuJl8WUk",
-      "uploadedDate" : "1973-11-02T18:59:56.071Z"
+      "uploadedBy" : "pgLRZuk1TiHDs",
+      "uploadedDate" : "2010-02-20T17:52:48.512Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/M8sUJHAjMq82",
-    "name" : "uHzg0RwHRAsv6E",
-    "description" : "RKNeRodzx3kE0i6Aif"
+    "id" : "https://www.example.com/vhN7egod3yGr5Q0Qf",
+    "name" : "ybrx5xiUG3",
+    "description" : "HUKbxW77asf9ZcJc"
   } ],
-  "rightsHolder" : "4Tbm2KfssGvpoNGnnQf",
-  "duplicateOf" : "https://www.example.org/72f92596-fb0d-475e-b9ed-81fa8ce4319e",
+  "rightsHolder" : "SWNU0XdNoN1iv",
+  "duplicateOf" : "https://www.example.org/6d6dd9e4-54ba-4ed5-8b23-37542a53eedc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "jNYc3eG2nnntGh52GD"
+    "note" : "FIK2cgzNRc"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "K1uY4TqjBtO3Y",
-    "createdBy" : "xxsoo33UbCGctmg",
-    "createdDate" : "1981-09-28T14:25:51.722Z"
+    "note" : "vgMhXj6jg1blriS",
+    "createdBy" : "JT7TXdwlgPJB",
+    "createdDate" : "1997-12-19T07:32:06.615Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a1f61531-8ca2-43e4-ae44-68da729069d4" ],
+  "curatingInstitutions" : [ "https://www.example.org/9fabd714-c481-4d4d-9bfd-8fb1411622d9" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "2EQLsM7is19mIXr",
-    "ownerAffiliation" : "https://www.example.org/8ceb1e25-1cd4-4c7a-a227-68de039061c1"
+    "owner" : "J94VNVbP2k0HNHvt3Aw",
+    "ownerAffiliation" : "https://www.example.org/916eb953-9ef9-439f-85ca-81466ea76252"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/45653345-8af8-4105-97a7-915e47571892"
+    "id" : "https://www.example.org/f44e9b84-3692-469b-9c3d-fe0b0f12b7d0"
   },
-  "createdDate" : "2010-04-05T23:53:20.007Z",
-  "modifiedDate" : "2002-05-22T04:36:12.614Z",
-  "publishedDate" : "1979-09-25T13:12:29.508Z",
-  "indexedDate" : "1992-09-03T12:47:45.347Z",
-  "handle" : "https://www.example.org/010cc1b3-189d-491b-9fee-1f96492ea716",
-  "doi" : "https://doi.org/10.1234/laudantium",
-  "link" : "https://www.example.org/e44aee31-0217-4de2-aa22-1a78f8211af7",
+  "createdDate" : "2005-11-06T17:22:52.669Z",
+  "modifiedDate" : "1999-07-28T09:58:35.598Z",
+  "publishedDate" : "2005-07-11T00:21:49.486Z",
+  "indexedDate" : "2017-08-31T00:13:16.253Z",
+  "handle" : "https://www.example.org/4cc5f102-160a-433f-b3ab-b07ee50fec38",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/3ee30cc0-5403-4be8-88c0-75bcc29ce9cf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "poNLEB2KiP240",
+    "mainTitle" : "FG28mgYWd9L",
     "alternativeTitles" : {
-      "de" : "kCCCZfSiUiyo9px"
+      "se" : "TBEWQ6N9XT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "8uW4VnVJFBwTAHwdTxE",
-      "month" : "nOBzqgLNACMHJWUAnn",
-      "day" : "hEORzy1qFcC8pxHVs"
+      "year" : "uyDWhBazbu",
+      "month" : "4A7Wey8BG9Md8K",
+      "day" : "vAf2VkTcKf0qjwn"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fbf17699-2974-4acf-b41e-521f9d0b0de7",
-        "name" : "9KJc3Lpm9H",
+        "id" : "https://www.example.org/5a711b19-4a53-4ff4-839e-6cbffb34d238",
+        "name" : "0jJm81d5XpTRiEZZrhL",
         "nameType" : "Personal",
-        "orcId" : "fFteN38G8doXJxIX",
+        "orcId" : "fYg91kBYNMVG",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UwBuP3g98QmGaImtn5",
-          "value" : "3Pex9wXIBbmYqMU0"
+          "sourceName" : "OIm5Fq5eWbO",
+          "value" : "VPYfV8nkyQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yRLLvmLCZLf5dPTFh",
-          "value" : "sfflYECke9OpaZu"
+          "sourceName" : "bnscfKs7IXa0ytGsZd",
+          "value" : "xOYtQzwDBr5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a43ee3ea-8d80-4554-9eb5-d61f69085241"
+        "id" : "https://www.example.org/6f56c3bb-24ad-4519-be30-679b7fbeff4b"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/072f6a1f-a5ad-49e5-9838-d85441677bf5",
-        "name" : "esAv4PC9OKbBvoKlL",
-        "nameType" : "Organizational",
-        "orcId" : "3l3A5lAEbwxT",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/77d1c35a-101c-49a1-9aa5-6b453c38186c",
+        "name" : "JSVla6RqTQGCKfF0TG1",
+        "nameType" : "Personal",
+        "orcId" : "tmOuS5YQ10v6U",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "twPtyTkxgCtGRPDUrP8",
-          "value" : "bmeXhVFeA46"
+          "sourceName" : "3wqDGMsuVH2PyC",
+          "value" : "VvpfkgSoV69tY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vcAuZsAgV6A",
-          "value" : "xU7M93Rj8Ge5KPE"
+          "sourceName" : "ziTUNeracucv7VGV",
+          "value" : "FIOmAmGwsaZ8py"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/57234475-b4ca-42a9-a288-4991d52a49e6"
+        "id" : "https://www.example.org/a1b6b622-58d4-4b7f-83a4-0502a9ca394f"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "AKwFWsrVr0T23f7Ur9"
+      "en" : "6RPaoAwCiB0eY50G"
     },
-    "npiSubjectHeading" : "MGzugHPWRW5qPgfTXI",
-    "tags" : [ "76U2JD3U7NgkI" ],
-    "description" : "gdijzPBJB2Cs43NG4",
+    "npiSubjectHeading" : "w0sLkDz9iYcB",
+    "tags" : [ "bJokeBk70e" ],
+    "description" : "6GQqMvKDtgf12FRd5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "zlx1AnEehtm1uV3wCU",
+        "label" : "93U0nyMUErn9Rtje2K",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "mNfbMpqkJDErLNuK",
-          "country" : "3zuZXeLGrl8yvONh4Jq"
+          "label" : "6QMlWmt7I9",
+          "country" : "b7MVxJnaP7VHiE"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1999-01-28T20:41:50.583Z",
-          "to" : "2008-07-25T18:37:32.146Z"
+          "from" : "2021-08-01T14:17:13.656Z",
+          "to" : "2023-04-27T20:04:58.259Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/E9kjp1QvgdrH"
+          "id" : "https://www.example.com/757Ygrk53k"
         },
-        "product" : "https://www.example.com/pfQJbHVkEEZSIUY"
+        "product" : "https://www.example.com/vNCLd7xZBihCHxUQ2x"
       },
-      "doi" : "https://www.example.org/5c752899-503b-4b0e-af9c-25431cea9930",
+      "doi" : "https://www.example.org/5f1cc2f0-7b5e-4008-aba0-fb63c112388a",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -122,106 +122,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6765bfae-b86d-4657-9943-e8e07d5e2bbd",
-    "abstract" : "4evpKiUCH67Rd3XL4"
+    "metadataSource" : "https://www.example.org/6ace96ed-a83f-400a-bd2e-2348d6017e51",
+    "abstract" : "dgqAeYe8wQ7xrxP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/21ce8466-3ca0-424d-a23b-939087d5d406",
-    "name" : "qD6bf65sWxlWN",
+    "id" : "https://www.example.org/cda21050-dbb7-445f-a72a-9aa50a61e77d",
+    "name" : "BdgONbl5MswQvp5K",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-02-22T14:48:10.536Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "w1coDuvc04x"
+      "approvalDate" : "2010-11-17T02:50:28.128Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Tar9cZbYTlJVKjPJonf"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/725173b5-b2e0-4e4d-b899-ecb4abbe753a",
-    "identifier" : "VIYxHPhDZBsyPLXr",
+    "source" : "https://www.example.org/b19a22ae-407f-491e-b703-7bb0ed70ba16",
+    "identifier" : "KC6TQKlp1dr1PrGJ1yK",
     "labels" : {
-      "nb" : "BYSlQQApjQnzjaH"
+      "pl" : "JxdBh3M5Bd"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 655686157
+      "amount" : 324060842
     },
-    "activeFrom" : "1976-12-09T12:00:08.411Z",
-    "activeTo" : "2010-10-20T11:30:23.420Z"
+    "activeFrom" : "2004-09-07T23:44:23.079Z",
+    "activeTo" : "2005-08-14T01:22:28.312Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/df92c254-ced2-48cd-ac4b-514229425007",
-    "id" : "https://www.example.org/a9bc2bf0-5075-475d-8433-6e4764dfb4bc",
-    "identifier" : "DGSnVG6OPyx9xAMgr9X",
+    "source" : "https://www.example.org/297475a2-86a6-4487-b328-146518de265a",
+    "id" : "https://www.example.org/4ce99e6e-0af6-41ea-b9cc-d95c0b8918c5",
+    "identifier" : "oNkvOiM4YdiA8VKDkV",
     "labels" : {
-      "cs" : "g4zpurCVZopIyDMTFF"
+      "se" : "AcSHntl30LMs"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 212047618
+      "amount" : 29225244
     },
-    "activeFrom" : "2022-08-10T05:10:12.004Z",
-    "activeTo" : "2022-11-19T05:14:54.597Z"
+    "activeFrom" : "1997-01-29T18:42:39.396Z",
+    "activeTo" : "1998-01-03T12:33:55.767Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "H4uYsAdOjZBjsUT",
-    "value" : "VnnTq5PZn8pyS"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1618025015",
-    "sourceName" : "0cyguvjv65ptwp@2bfwzqv9okbx"
+    "value" : "655610939",
+    "sourceName" : "utzakr9iikswqmchd@0woebld7vcxyk4xso"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "VlnmdydAFCPm",
-    "sourceName" : "cvnzcehfvvfgag@wq652lxh133g0njbgn"
+    "value" : "aCPwMuwJGs",
+    "sourceName" : "rkg7ekar1omnp@fmb7gffmtzbanpp3i3"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "mIqPVHi50lABDoLozfz",
+    "value" : "HXLUpbvmhH6LS5YS"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d8e1cb71-77ba-4790-842f-f8f96797c4c1",
-    "sourceName" : "vucsetmb1lqo4gz1@t256djhq8ut7p8"
+    "value" : "https://www.example.org/889971be-e485-4b32-8554-64cbd36323f4",
+    "sourceName" : "zubee5pkow7@ckonjfjkikjwnfxb8dt"
   } ],
-  "subjects" : [ "https://www.example.org/90980637-b31a-4d17-bf34-6e1e2d43bfb1" ],
+  "subjects" : [ "https://www.example.org/2c4930bd-f568-45fc-8c45-58b8389ba4f6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "83c8c2ba-7492-4180-abff-ed2aab1ae613",
-    "name" : "eixWXwcoLnAVAZ",
-    "mimeType" : "XbKuPdCVeN5APgeAi9F",
-    "size" : 1974789307,
-    "license" : "https://www.example.com/tshfe7fqbshf9rqby",
+    "identifier" : "a992b829-d2f5-459c-8f53-e0fa134b1efa",
+    "name" : "A3KQiSfeHG7G3",
+    "mimeType" : "bxHqft9n05C",
+    "size" : 471148077,
+    "license" : "https://www.example.com/0hghmf3zqnapret",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Vm4GhhFhKFG2D5PWg",
-    "publishedDate" : "2011-05-09T06:51:16.073Z",
+    "legalNote" : "UWLjnhSUitgR",
+    "publishedDate" : "2015-03-06T13:06:59.318Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "wVP11tX8aErlFCzAQ",
-      "uploadedDate" : "2010-02-09T11:35:38.586Z"
+      "uploadedBy" : "uKZ1fz2ZRM",
+      "uploadedDate" : "2008-12-06T22:04:26.792Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/h7XtKayzbcv",
-    "name" : "8j80ocAcsE8F5my",
-    "description" : "HCiWj6QHUe7h5Ok"
+    "id" : "https://www.example.com/rHp6WUbk7gssLFWE2A9",
+    "name" : "8pNngVd3pW3rhzLns",
+    "description" : "7tfFdcuMQhzk1IiY"
   } ],
-  "rightsHolder" : "tpe1TJeIZJjr9Lwf4",
-  "duplicateOf" : "https://www.example.org/143ff434-fc72-4942-99aa-783bbadd1682",
+  "rightsHolder" : "o1pbRz4EROi",
+  "duplicateOf" : "https://www.example.org/8a3dfa68-6102-4c81-a81f-5ca0a2add4ea",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7KDU5TRSgnphVfJ"
+    "note" : "WJ7iu2dzdG8afD7cX"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "bRMt3qKfAgN8o18",
-    "createdBy" : "0XhbAFQ92aRp",
-    "createdDate" : "1972-05-07T08:19:38.877Z"
+    "note" : "PwCET0nz0F",
+    "createdBy" : "cidpATCFHeJ",
+    "createdDate" : "2006-10-05T10:48:40.212Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c2cb06da-8f98-41a5-83a7-e023c437752a" ],
+  "curatingInstitutions" : [ "https://www.example.org/76e8069d-4882-4ada-9c18-e220cee82a86" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "lvTLGvdBUEmnjnxE",
-    "ownerAffiliation" : "https://www.example.org/90e47028-c7c3-4df2-9a51-606f59981913"
+    "owner" : "AlNUFnIqz6ZW39ygg",
+    "ownerAffiliation" : "https://www.example.org/fbdcef41-64e5-4b4f-bf0f-102dbb6aaf9d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/53eddccf-9e9b-4a57-ac9b-f7f7f73aba09"
+    "id" : "https://www.example.org/b5be1c28-6f99-4e25-8539-5bb78c1ec3ad"
   },
-  "createdDate" : "1995-08-21T18:19:41.456Z",
-  "modifiedDate" : "2014-07-01T19:06:56.686Z",
-  "publishedDate" : "1986-07-12T20:42:57.440Z",
-  "indexedDate" : "1994-01-11T03:41:17.916Z",
-  "handle" : "https://www.example.org/cf58782b-a055-4396-a6d4-8fc8f1c2b2a8",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/e5321b0e-f031-4c39-8864-6556804ba541",
+  "createdDate" : "2002-05-18T13:45:23.898Z",
+  "modifiedDate" : "1991-01-14T18:25:38.730Z",
+  "publishedDate" : "2022-10-13T00:04:12.989Z",
+  "indexedDate" : "2022-07-23T15:46:11.972Z",
+  "handle" : "https://www.example.org/eea00ab6-3caa-4837-b42a-ea49e2c237c0",
+  "doi" : "https://doi.org/10.1234/tenetur",
+  "link" : "https://www.example.org/72117e08-d4f8-461f-a630-5fdc1d2c14a1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uetzHdY10hiSXK",
+    "mainTitle" : "tcllloJVluN3yn",
     "alternativeTitles" : {
-      "pt" : "iBNXxV9KdGsulwsSqkv"
+      "fi" : "IH4c1yVzm6W40bguNP"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "82kKd9Q0Xza0ZQz5",
-      "month" : "bFb1mVl3Ec",
-      "day" : "kEUNlC1AxbPXD"
+      "year" : "E4yWZFaz1Wrhxq16J3",
+      "month" : "KTQoNtyhqsrrx",
+      "day" : "KiUPxLQaBK4FDA9k"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/af55f622-3baa-4c96-880d-52ba12e6bcd6",
-        "name" : "Y4ZfWHVaFfgkc",
+        "id" : "https://www.example.org/7e5b20d3-7b63-4686-a0e3-e0fc2bd188cd",
+        "name" : "e3xktvcXuusEz",
         "nameType" : "Personal",
-        "orcId" : "wE6QNEBEAAzt8l0GE",
-        "verificationStatus" : "Verified",
+        "orcId" : "BtZxHItIdBb7Hj",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3cWrxHe0Zq3ry2nI",
-          "value" : "N1UBOiBlsgwm"
+          "sourceName" : "F7Mefx8fmdUoHb3DaQM",
+          "value" : "TwCmNip8EwSE9Ek0eO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CkrjIQdNdg3a4GnoAdk",
-          "value" : "De90275gO5scyKWTyZ"
+          "sourceName" : "1Ag1lzzlYF9QHLN7",
+          "value" : "jxK5upom0YG0bD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6b713318-c7c9-42ad-808e-f20e7d4c83a9"
+        "id" : "https://www.example.org/3a12d133-d644-4548-82ed-369ec14ba724"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7df803ac-aa6a-4546-8a55-c882b4a0127e",
-        "name" : "Yu2CzpsToXIfSoywPv3",
-        "nameType" : "Personal",
-        "orcId" : "xMfN7OXuqt765U",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/2ff3f3f3-0ed7-4019-ae12-4530c49c0a6c",
+        "name" : "62VIf1k5GyB6y",
+        "nameType" : "Organizational",
+        "orcId" : "OTzsFuI48Mh4qygJI",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dU1DRvGdM74WFtJwOT",
-          "value" : "upmuLtc9ZFY"
+          "sourceName" : "VPGgVw1xR8o7eB5urs",
+          "value" : "wfxxAkD24OK5M5InI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pGtuF20geUhXA8",
-          "value" : "kYMzaycY86"
+          "sourceName" : "l1Kb3bb51U9",
+          "value" : "dC5TT6lNxFzMtJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1daf8108-f6f3-4fc8-90cc-1df07ad44185"
+        "id" : "https://www.example.org/38decf49-edb7-407d-ba67-5199d0ccbdf2"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "RBEwnRsXJQQPx8"
+      "it" : "gj5oMBDfURH"
     },
-    "npiSubjectHeading" : "MrN1hNqOljN",
-    "tags" : [ "HncWX6GRtw" ],
-    "description" : "hppgtB6pY0ut",
+    "npiSubjectHeading" : "liD9g6PSnU",
+    "tags" : [ "KReZMin713wNtP" ],
+    "description" : "l4YVQkNCTGATP1zqQV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4a16d85e-0c4b-44e1-acbb-ea46f8958ad7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d25a3b30-7a43-4d44-9b85-01fd512cfe8c"
         },
-        "seriesNumber" : "TwpxhsLAmBgpv7FhqBn",
+        "seriesNumber" : "xQLD3Jp5PqfC6U",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6ccd27d2-baba-4fbf-b67f-73675a76a976",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4cba1f39-41a9-4a29-94ea-fed9be3701ea",
           "valid" : true
         },
-        "isbnList" : [ "9791057303626", "9780921357131" ],
+        "isbnList" : [ "9780687999347", "9781883244781" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0921357133"
+          "value" : "1883244781"
         } ]
       },
-      "doi" : "https://www.example.org/ba43c9fb-3be2-45b1-86cb-7ef6780e7b05",
+      "doi" : "https://www.example.org/d79bd961-9b3d-4e2e-9863-573c9f360ca5",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "x8mGHDUot8Hz",
-            "end" : "n0SU75W7bD5mWiqP"
+            "begin" : "gqeSjv8aohbv2N7yy",
+            "end" : "GkAdtyZ5KLgwnzK7"
           },
-          "pages" : "PJhyg287ouIsK",
-          "illustrated" : true
+          "pages" : "82RanPRyRk",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2c4811f2-d1bf-4719-a1f7-c51d1d0a012a",
-    "abstract" : "jvjP4Xjm5Vq8np6afnt"
+    "metadataSource" : "https://www.example.org/39f6f582-8066-4172-ab12-ab54f0516da9",
+    "abstract" : "IlXLQSGT43vXm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c70a9f41-0a29-4fcd-87f7-2c87abb3f8a0",
-    "name" : "rl24kARAiqmPuR",
+    "id" : "https://www.example.org/5dac99e2-0029-4692-9117-50f368a9a746",
+    "name" : "zVHXVdFqKfUmdEDfW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-07-02T11:25:56.752Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "xOMCfrfqndOo"
+      "approvalDate" : "2001-06-03T02:00:38.174Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "ZJqapM0HPRB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cfb7e37f-8ff9-4f7b-867f-32afe9da83f0",
-    "identifier" : "peBNI6uD6nn",
+    "source" : "https://www.example.org/25219b67-f1f3-4fa5-90b5-92c96e9f0568",
+    "identifier" : "qd5CXvL4wsj",
     "labels" : {
-      "nb" : "kTLudJndH47jB"
+      "de" : "hhQaRffjSU75Gq0Nwwi"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 63097203
+      "currency" : "NOK",
+      "amount" : 1893693723
     },
-    "activeFrom" : "2004-01-01T05:24:54.869Z",
-    "activeTo" : "2007-02-08T11:38:56.658Z"
+    "activeFrom" : "1985-02-18T19:31:19.208Z",
+    "activeTo" : "2021-11-23T03:16:35.294Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9b26a7bb-dd8a-4f62-8659-c74c605c93e2",
-    "id" : "https://www.example.org/6fa5f3cc-e78c-4ab5-8153-5361a3ff99b9",
-    "identifier" : "chJXjfy8pcatM99v",
+    "source" : "https://www.example.org/939b80fe-f188-49dd-a784-194e382152aa",
+    "id" : "https://www.example.org/51f9e398-1dee-462a-bf80-59f4818762e6",
+    "identifier" : "JqZzyEq2HTc6yOYy",
     "labels" : {
-      "es" : "TEmtZOyIJWGXBWD"
+      "ca" : "FQ3jhVeMrPbcXA7uu"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1558095614
+      "currency" : "NOK",
+      "amount" : 1072738736
     },
-    "activeFrom" : "2014-05-21T14:42:32.339Z",
-    "activeTo" : "2017-01-11T15:05:12.759Z"
+    "activeFrom" : "2011-11-08T02:49:57.928Z",
+    "activeTo" : "2023-06-02T05:53:06.566Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "VqtdRkGYZxsAg6gVM",
-    "value" : "r8fwDJ2mVobGHBlco"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/594f8de1-6bec-45df-9714-1924a179be2a",
-    "sourceName" : "tkl5udr0kistttjj2@vqgva3zcjhfe"
+    "value" : "https://www.example.org/0a883994-8e2d-43c1-8ffa-5dcb6caa8f8e",
+    "sourceName" : "yi4gayg6nhshlv@y8eumduvd3"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "hkbCxsgdwbzQ2uDL6a",
-    "sourceName" : "yov7aj4rcw4aqmoez@5p7t005cwiqeh7q"
+    "value" : "KYWtvjjWeL9fo",
+    "sourceName" : "ylbvjxtkmeugcney@mfhnisgnsj"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1287195092",
-    "sourceName" : "tcohzaoc063cu567lh@qm7ldsqdvzjpatmb"
+    "value" : "1490502106",
+    "sourceName" : "u0fdqn9trzgh7g@o5yeyel6lw"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "tW9qnXC1iEcht",
+    "value" : "SIbvVoKAAmDk5"
   } ],
-  "subjects" : [ "https://www.example.org/0b46c143-79dd-4beb-8aa4-85e21b0e1677" ],
+  "subjects" : [ "https://www.example.org/3236de02-df19-44fd-8d96-2a2c6d80186f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a2c1ea84-3142-4ffd-910c-1bd9cf4c9f06",
-    "name" : "o2qFPj2Ri5gy",
-    "mimeType" : "PyZgia9ELh5fpX",
-    "size" : 1534067684,
-    "license" : "https://www.example.com/brgwv6o701h",
+    "identifier" : "d380650b-b976-448c-b632-ef3c979910ee",
+    "name" : "mnovE5SgWI0xL",
+    "mimeType" : "fXDnRxJJFCv2X0kJhJ",
+    "size" : 1007519291,
+    "license" : "https://www.example.com/vfvqxxbc7kyivffnw",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "qNjHelgCeNKSZJy3O",
-    "publishedDate" : "1976-12-15T01:12:28.609Z",
+    "legalNote" : "NAWLumGKxxol",
+    "publishedDate" : "2009-07-31T13:40:57.102Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dhOf9k5g3ULcxvAnU",
-      "uploadedDate" : "1980-12-15T04:47:54.052Z"
+      "uploadedBy" : "Wko4PXt08bPxefu6d",
+      "uploadedDate" : "1982-06-11T12:57:42.066Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/G6dRPYZtCkGWtQi",
-    "name" : "hWApcBnYSyPHn",
-    "description" : "z3AZ8n4DT7pXaKVwd"
+    "id" : "https://www.example.com/oRHt1DSrkmWB1CtZI",
+    "name" : "h9EvXOXPcdjYiy",
+    "description" : "p6NhjDrrUyRFpxqhL"
   } ],
-  "rightsHolder" : "33RQGR3vI43lY7LaOqf",
-  "duplicateOf" : "https://www.example.org/216e7d90-961b-41ba-bba3-de22b9514523",
+  "rightsHolder" : "TPUMbClxFgByR",
+  "duplicateOf" : "https://www.example.org/f7c9a821-94e3-4919-a3d1-2d4e1da67f4b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "07Mj1nB6iiSLoNMJcw"
+    "note" : "qxiWI4ShGvOUU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "4jS2vDeZyzW7",
-    "createdBy" : "cVjHCc0jL7IcaTzX",
-    "createdDate" : "1984-05-06T09:53:04.405Z"
+    "note" : "xYZ1XwU9a4A1Qz8u0WG",
+    "createdBy" : "Pf7jujsWzJm",
+    "createdDate" : "1977-12-16T21:51:38.286Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/301cc3d0-5e3d-4982-a984-dd006512bb81" ],
+  "curatingInstitutions" : [ "https://www.example.org/6e7a248d-c6c2-44ea-91b3-7ea4ec6bcaaa" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "QJihbglohkS6j9ueRQ",
-    "ownerAffiliation" : "https://www.example.org/3b4c9509-1aba-454a-8c83-981b47792152"
+    "owner" : "8aOHTdOvgZ3d0ARNkQ",
+    "ownerAffiliation" : "https://www.example.org/4bd18799-9072-44a1-a059-0ef5d2e7cac4"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5b4ff081-2bd0-4115-844e-22c60667cc49"
+    "id" : "https://www.example.org/78187f52-9a3b-49c4-83de-c9d5a31e776c"
   },
-  "createdDate" : "1988-05-25T15:57:47.133Z",
-  "modifiedDate" : "1987-11-21T00:47:43.574Z",
-  "publishedDate" : "1997-07-02T12:03:24.074Z",
-  "indexedDate" : "2004-11-11T05:14:22.983Z",
-  "handle" : "https://www.example.org/fb404018-7a2a-47e7-896b-f51d99cefec3",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/02268f34-c286-4db8-86a5-f0928c9f4af4",
+  "createdDate" : "2008-10-24T04:31:37.168Z",
+  "modifiedDate" : "2002-09-15T20:17:08.971Z",
+  "publishedDate" : "2017-11-17T11:23:06.904Z",
+  "indexedDate" : "1992-10-20T07:02:22.573Z",
+  "handle" : "https://www.example.org/cd77e951-981d-4e3b-b26d-bad0ac6f17f3",
+  "doi" : "https://doi.org/10.1234/facere",
+  "link" : "https://www.example.org/1052158e-66b8-411b-8986-9cf1e62672f5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "gYBUGDUOTAxU01eZRQD",
+    "mainTitle" : "7la3lJN7QhN7cN00vB",
     "alternativeTitles" : {
-      "se" : "QFkQnMouy4Xxd"
+      "sv" : "s2MwWq8bxtubuB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eZC6pfnjc8Z4XnZyQ",
-      "month" : "yodzSvg8Mgyymo8yy7p",
-      "day" : "bbiOYjpIWK27WIphmr"
+      "year" : "mdggYEj1VU",
+      "month" : "TeELSTdoKX",
+      "day" : "h9bb7w4E9KxYagITNb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aa3f97de-9f04-4807-a529-46787b6047a9",
-        "name" : "3RQiwFGPqaNRCAd",
+        "id" : "https://www.example.org/2a762668-6d00-430f-aae4-80a6764f77fe",
+        "name" : "AxQ0snHa5DPuPQ7ime",
         "nameType" : "Personal",
-        "orcId" : "ukBjLanpPv6TVNIy",
+        "orcId" : "3IAazUcMsPO7Qq6lF",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bcFf9hDbLGNU81kH",
-          "value" : "fYQ553jrBh5"
+          "sourceName" : "Xx7RdU5W9A",
+          "value" : "KjhIzzWBN9F0hV12mmk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FCgr28rczQAbPc",
-          "value" : "ixKyLUZT3EF5Me1"
+          "sourceName" : "Dicjlfc32JydR",
+          "value" : "9Q53rFrPeyX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8a68333f-2054-4842-8902-4bf281f48304"
+        "id" : "https://www.example.org/b0e18f02-07e0-4acc-b525-fca77d08a5b7"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,167 +62,167 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/22bd5a8a-6b7f-474f-a4f5-54baab2407de",
-        "name" : "yvlbIZBo7TULKe",
+        "id" : "https://www.example.org/194ff093-72ea-4e6b-bf66-16d94c187d7d",
+        "name" : "yfchtLAbEOFro",
         "nameType" : "Personal",
-        "orcId" : "lLBFAU9tYi7f24m7eo",
+        "orcId" : "aWOl0g4s2rzQXV",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BFUtsrLRBwLE3Q6W",
-          "value" : "8BYReLd8h2JUvmBeKvC"
+          "sourceName" : "tV9mmX9uu4",
+          "value" : "GJrWYewf1l26"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "F9sqm8SJwGSyggkmgX",
-          "value" : "5ONL52cfB4PDV0r1yB"
+          "sourceName" : "3MdUZTzn2f",
+          "value" : "9o4ZV6a4TdA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/10045506-9354-4a29-a332-ea21907657c7"
+        "id" : "https://www.example.org/069b3bc3-0b65-4950-96b5-2d438a68765b"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Journalist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "PtXMWhfKg4PM5CoQ"
+      "en" : "vQoB7gCkwMzoFcsiu"
     },
-    "npiSubjectHeading" : "swQglt3qU4o",
-    "tags" : [ "WVG5VGerQMjUxoDO" ],
-    "description" : "a8b3z77R8uikqz6r8",
+    "npiSubjectHeading" : "mSDWINAvcSCpHOCBwZe",
+    "tags" : [ "7WMAjtUG33lgw03p8" ],
+    "description" : "ulYR7ofSz6j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/520ad22f-54f3-44a9-b476-b6b2ff7a75ee",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/08870971-6ac6-4f78-b69b-08ed4c30350e",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/e2963986-af1f-4a3e-89a6-fee6b5526325",
+      "doi" : "https://www.example.org/933d9291-f2f2-4379-a10b-1a25be30adfa",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "OXerSEG6y3meXmphLt"
+          "text" : "gjnfYmCLLvqkt5L"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "gYnWQzDP3qJALlaOCb",
-            "end" : "PqoS3IboSLbNkNWrT2j"
+            "begin" : "c3tpMpUy52",
+            "end" : "ANqSA83h1Z"
           },
-          "pages" : "ICLxNqC0Z3hNa",
-          "illustrated" : false
+          "pages" : "WxRkB8OfPz0JIFTx7Z1",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/af7acb40-4e6a-40f1-b077-836b1dbf9437",
-    "abstract" : "nGXbmXSGGH04xirc"
+    "metadataSource" : "https://www.example.org/76681e24-ecf5-4d80-88f9-71e84285bff4",
+    "abstract" : "hRug0alAUf4gZl2g"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6f5b9606-2dfc-448d-a04f-38683c208267",
-    "name" : "8XFVPu7O4gWtVukb",
+    "id" : "https://www.example.org/2e1643ed-3ce5-4898-9f5d-be598bcca8b7",
+    "name" : "XJu0n89NfzpDuAACT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-09-17T17:53:04.161Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1990-03-05T23:37:25.382Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "1YhCPMvEPz"
+      "applicationCode" : "huADFlxp8yrzUj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/39235532-6a30-494e-b6e6-2a9ea978f641",
-    "identifier" : "aFTttn3vML4ModKU42",
+    "source" : "https://www.example.org/7762ca5d-38de-4686-ba4f-bfca1e5d286f",
+    "identifier" : "SCIcFmYhCA2KCVYU4H",
     "labels" : {
-      "ca" : "McmS0M2iAqeZBk"
+      "de" : "BQdTmsC0KIJyhv8hH"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 205594110
+      "currency" : "GBP",
+      "amount" : 1412276548
     },
-    "activeFrom" : "1990-05-19T23:47:23.638Z",
-    "activeTo" : "2016-03-24T13:06:01.145Z"
+    "activeFrom" : "2005-11-25T19:51:49.269Z",
+    "activeTo" : "2009-10-21T18:01:21.648Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d16c9b1b-ae88-40fe-b9b9-cb6c91cf5943",
-    "id" : "https://www.example.org/22e7a2e3-e0bb-4e6e-a7ed-51a4d5bef545",
-    "identifier" : "BchfOGP6l7rA",
+    "source" : "https://www.example.org/8c8a63ab-3edf-4675-bff7-c00d4ab225ca",
+    "id" : "https://www.example.org/e126b08b-6dc8-4222-bcb8-99b0c15257a4",
+    "identifier" : "gkzhdtTmMc",
     "labels" : {
-      "zh" : "FXMqlTSNvb39"
+      "nl" : "ewj6Gi0YnHQP7g"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 799610049
+      "currency" : "USD",
+      "amount" : 130963671
     },
-    "activeFrom" : "1985-01-25T14:56:41.896Z",
-    "activeTo" : "2017-06-19T10:47:03.006Z"
+    "activeFrom" : "2012-05-03T00:27:44.129Z",
+    "activeTo" : "2024-06-18T16:49:57.568Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "z8BMT1HnQuCASKTrefe",
-    "value" : "VnIby0opnVVkVC"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "bx7wbt3zXlyaoWlpm",
-    "sourceName" : "a84xjpricu5bbx5yd5i@t0p9nhunep"
+    "value" : "WEc8pcfGe76YmU1GpAm",
+    "sourceName" : "r5l5cx6zpk3n1fm7@ps6btt7rhlnyz4ysfhk"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1781452058",
-    "sourceName" : "0eebwxqp0pf5w@4cymd9da5qsoxb"
+    "value" : "1047439062",
+    "sourceName" : "8iuty4wwjphjezufgnc@dxs3r6ykfuqxb"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "P8HNRGSVcngp",
+    "value" : "L9beugbBASCQ7w6K"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/825d94a1-e60e-49cf-bbe9-ccf0eb5371f0",
-    "sourceName" : "1ovcvmydpkkz7vyf6q@qga44n0jq4bemv0"
+    "value" : "https://www.example.org/0b81bc38-f4f7-4821-b3a9-02f5d26d49da",
+    "sourceName" : "wqgqtkctmfydwgi@vttxcwzedxrphoxdbbk"
   } ],
-  "subjects" : [ "https://www.example.org/75000637-659c-43ac-b70e-7ef5aefadd82" ],
+  "subjects" : [ "https://www.example.org/44fe99a9-96f1-4905-a942-603f4c14b2fb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3591c142-ea17-4978-9dde-6513be00d263",
-    "name" : "OSQ2eb0Ja2nd0tFge",
-    "mimeType" : "wkO29idaSi",
-    "size" : 1456069090,
-    "license" : "https://www.example.com/ye7yo3xxvp7e",
+    "identifier" : "26761528-886b-46ff-b168-75c079031af0",
+    "name" : "n3bHSpx4IY83PuvKBj",
+    "mimeType" : "BWoZE7G6PkmpmQB",
+    "size" : 592003536,
+    "license" : "https://www.example.com/ncx2wqruotf",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "VsrwdtLomV9"
+      "overriddenBy" : "fGVsdKCiKT"
     },
-    "legalNote" : "WA6YrW01tmYy27Xe2H",
-    "publishedDate" : "1989-04-11T18:19:00.820Z",
+    "legalNote" : "o6OI3f2fzfu78",
+    "publishedDate" : "2023-09-26T23:47:48.954Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "HHGVRG9mnL",
-      "uploadedDate" : "2016-02-29T13:02:27.865Z"
+      "uploadedBy" : "cEGwBSND8Xy87tX4O",
+      "uploadedDate" : "2010-12-15T14:00:14.623Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/cEYJOtBEaxlnkjurpD3",
-    "name" : "DsFxUdEaFUGgTjH4",
-    "description" : "6yLo4UYTlf"
+    "id" : "https://www.example.com/ev3XVDaSjCcdNu5W",
+    "name" : "QQi4mfxB6iobK",
+    "description" : "I9Vh8GLfTTjjek"
   } ],
-  "rightsHolder" : "utTsbWGmYUNWee",
-  "duplicateOf" : "https://www.example.org/92bbe4df-cc46-47ec-9e80-e26f11a58636",
+  "rightsHolder" : "XCPoOpK63Za8c9zb",
+  "duplicateOf" : "https://www.example.org/b65191e1-1907-45a1-83ee-c77c69b8e5ec",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "T5qmtQUlitJ452lXXu"
+    "note" : "M7lRQ9VAEJMxItUUI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "3YceSbuvIxVs21kdj",
-    "createdBy" : "Km12fkptDebZOmx2H",
-    "createdDate" : "1973-09-08T16:13:30.301Z"
+    "note" : "GWViiJMvO3ghLfh",
+    "createdBy" : "P9Qg8Dzn4v9YyBQFP",
+    "createdDate" : "2015-01-24T11:09:00.400Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4905037d-b83e-48d4-bd96-dbbacaf63e3f" ],
+  "curatingInstitutions" : [ "https://www.example.org/849ee2a7-0cd0-4018-ba50-cf91ca469495" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "3bqh2C3w3WZok",
-    "ownerAffiliation" : "https://www.example.org/8df94dd2-8fe1-4c84-bc41-772015964239"
+    "owner" : "ZT2qBl1u6Hx7B9vf",
+    "ownerAffiliation" : "https://www.example.org/123ae2e8-cb3d-4fe3-b381-dfc85b5c7a89"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6db08741-167c-4817-b818-dd439c05cd6c"
+    "id" : "https://www.example.org/f7e8b8d1-4b9e-494d-8b37-608a003fee1b"
   },
-  "createdDate" : "2000-04-29T11:43:00.545Z",
-  "modifiedDate" : "1987-02-10T13:05:34.926Z",
-  "publishedDate" : "2021-10-01T00:31:53.311Z",
-  "indexedDate" : "1972-02-01T23:52:53.225Z",
-  "handle" : "https://www.example.org/3f15952c-7c5e-4750-9919-9cb9a5b9fda6",
-  "doi" : "https://doi.org/10.1234/voluptatum",
-  "link" : "https://www.example.org/99e26436-e8d7-44f8-84a7-27f44a985e05",
+  "createdDate" : "1987-03-04T18:04:38.693Z",
+  "modifiedDate" : "2005-12-21T12:43:48.698Z",
+  "publishedDate" : "1978-06-26T03:45:27.809Z",
+  "indexedDate" : "1992-06-03T00:53:40.119Z",
+  "handle" : "https://www.example.org/e0f7a44e-43eb-49ad-86e5-938274d2e1fa",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/7c3eecec-49d7-4543-a4ac-9cc9b370a973",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1r9KzWmgHmBFOZsHIC",
+    "mainTitle" : "404hfFOLNrLt0D",
     "alternativeTitles" : {
-      "nl" : "Nn2JLd8ybDBnq1v"
+      "el" : "KBk3CF5YudHn9jaW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OUirR2jHxiA2AUU9",
-      "month" : "fdetuis9LtdhggUlHnI",
-      "day" : "OGJyrPvbM1Fys4ecTK"
+      "year" : "NArNeuzjUt5Lj",
+      "month" : "6YGuJevqpRRIB1TR",
+      "day" : "SLtng8kmmX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a6efc97-10ff-482d-8244-fec429630040",
-        "name" : "sVn2eb2p2yG3y",
-        "nameType" : "Personal",
-        "orcId" : "DTUxQxXOu3",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d64ffe37-4489-4dbf-bfec-55c7ee9c130d",
+        "name" : "GArgbLlmMgIlHUx",
+        "nameType" : "Organizational",
+        "orcId" : "kYSqWRwhM5tC59LG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qCJa0RGAusXsR",
-          "value" : "8GYbffMkhd"
+          "sourceName" : "yQBks884SeB1qYkEHd",
+          "value" : "STAVXwMu0hDVKttHP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4bH5qEjEtCyomn8q",
-          "value" : "smIH8QY5Jg"
+          "sourceName" : "9wFyCG6TqqBlVQLp",
+          "value" : "tZYWh4dcec5mxIX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7156de2d-b3a6-44b1-991f-d978e7c8298d"
+        "id" : "https://www.example.org/b318678a-b685-438d-a390-79746f9158d3"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Composer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,166 +62,167 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e7e773d8-c3be-455c-bb7e-17ce308168f8",
-        "name" : "ym8p8a3fmqvyTlxyH",
+        "id" : "https://www.example.org/b37d5908-2366-4199-b1d0-7cbace42ebba",
+        "name" : "dlwgLS8sKC",
         "nameType" : "Personal",
-        "orcId" : "dY7dFVVHPWwH",
-        "verificationStatus" : "Verified",
+        "orcId" : "FVGpfseOrSY",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pN7USFSnml0Z6qK3",
-          "value" : "YJOCjbs3z16O"
+          "sourceName" : "BWC6D6Hn6oB0",
+          "value" : "GPz5OVBznGafQaTn5B"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SnzbUQKZmL",
-          "value" : "CfC7innCd5Flx"
+          "sourceName" : "SG57I2WUGeT2o6a",
+          "value" : "3pEyQuryOBP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e3aa13dd-ecd4-4a3d-8db1-bf3a63553439"
+        "id" : "https://www.example.org/ba449fa8-2c8b-4764-8c51-b9821b175da1"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "9Z7ulyiJynhiYPkUvL"
+      "fi" : "BP6tn7EDlFge"
     },
-    "npiSubjectHeading" : "2YmlNf9lKEEooaAR0",
-    "tags" : [ "nRJcNXSTEH3JYlbVHR" ],
-    "description" : "DdCQjAjPUPKwBjT6lT5",
+    "npiSubjectHeading" : "BGMyLfs2nPlkz",
+    "tags" : [ "rNIFUVglusLX" ],
+    "description" : "IPFqmW30k6I",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b61ad856-0d31-418d-9af4-b007e9fcf466",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f6c420ad-3b06-4894-a23d-640123ae072f",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/afad00a9-0362-496e-9404-da72c5902cee",
+      "doi" : "https://www.example.org/6e3f1258-e3b6-4bd3-b8e3-630f82bf59bc",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : true,
+        "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "jPQ4I69SNC"
+          "description" : "UzdtUKCwOKVn0dCC"
         },
-        "referencedBy" : [ "https://www.example.com/Ss5XQQ8Qgg" ],
+        "referencedBy" : [ "https://www.example.com/AkxUdpWeFqu" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "z95foKXZ8MD"
+          "text" : "9Z1oHxhbhbWzU"
         } ],
-        "compliesWith" : [ "https://www.example.com/o6OgsFnHlj" ],
+        "compliesWith" : [ "https://www.example.com/Zn1GYMxbzdyKubqFA" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6db4668a-dbfe-4cd5-8ec0-f922c4309440",
-    "abstract" : "FRVX6zHu25HUz0y"
+    "metadataSource" : "https://www.example.org/e81603d1-2f54-4da1-9d87-b9c81fd05b17",
+    "abstract" : "d3TEMJL9lXx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4c9d1f14-bcaa-46e7-8662-8b2709224748",
-    "name" : "fVbRShTo7dgcl2",
+    "id" : "https://www.example.org/10505ac1-0ffe-40dd-9cb8-8e9c7699c28c",
+    "name" : "m6XpSBJ6Fttzo",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-08-08T12:52:22.692Z",
+      "approvalDate" : "1977-02-06T21:02:28.187Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "S6MXQwrWWvw"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "fu3hvKMbl69Aa"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d6c33710-ca8c-4ac9-ad94-f01129b5c9cd",
-    "identifier" : "SpaSttiMVCo",
+    "source" : "https://www.example.org/c057fe13-1b2e-44d1-8a9d-8e5eb374b288",
+    "identifier" : "XUr5VX80k7aPEVctKF4",
     "labels" : {
-      "fi" : "OVMsD9LUVix7lwm"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1719482500
-    },
-    "activeFrom" : "2015-04-13T07:49:51.165Z",
-    "activeTo" : "2023-10-09T01:37:58.673Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/61b06e13-e3b6-4a05-b5d6-9922a82143d4",
-    "id" : "https://www.example.org/bd8e62b0-63c0-47a4-8dc4-663a9beecbca",
-    "identifier" : "gJQgD8adf4lZgTx",
-    "labels" : {
-      "bg" : "jO5Jlm62IqLnQiUbJ9w"
+      "ru" : "aq1lm8ocNF8AcOzhdYW"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1567108525
+      "amount" : 1379631943
     },
-    "activeFrom" : "2012-08-02T17:27:59.461Z",
-    "activeTo" : "2019-09-07T09:30:03.040Z"
+    "activeFrom" : "2023-10-04T23:14:22.437Z",
+    "activeTo" : "2024-03-30T16:21:40.840Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/75337e62-5cee-4832-a4be-f6d73d4d22c9",
+    "id" : "https://www.example.org/621e9e1c-3684-462f-a2ed-ed5416b238e2",
+    "identifier" : "XpP1mJ2Fb7nfL",
+    "labels" : {
+      "fr" : "C0PvZyn2Rkr"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1512955520
+    },
+    "activeFrom" : "2005-07-31T15:57:19.122Z",
+    "activeTo" : "2009-08-11T01:42:54.845Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "lgy8sLCjN4AymI3M9x",
-    "sourceName" : "1hk60vydf6@nk30ho1erbhqs9gy4zj"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "486364399",
-    "sourceName" : "gxym3hpda6b@3au1jefire"
-  }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "gGAsugaq8HsMOArdMO",
-    "value" : "YpSoEZbLjfGc"
+    "sourceName" : "QXQm0raIqGTMHOW6",
+    "value" : "BbWh2x3P7E"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2c7944e3-9305-4592-a89c-9d3a0bd0b61e",
-    "sourceName" : "x5ngfeujydaenssg0@fktsdfp77rc2"
+    "value" : "https://www.example.org/e7326716-8d06-4282-abc5-9420041f545a",
+    "sourceName" : "goe5qt2g7uanmbaxcbr@kwkwngouwks8m9sef"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "hFMfqSxT2A",
+    "sourceName" : "7uxey7jnjlr@rw0mmh77kjv"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1099813442",
+    "sourceName" : "bhedchesybvyavy9s@unxjppxxbyszhmqx"
   } ],
-  "subjects" : [ "https://www.example.org/35e87728-9d52-4b76-a6b5-aa5c833644f3" ],
+  "subjects" : [ "https://www.example.org/3234548a-f4ab-4262-94cb-b3380d7557e6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "290a3ac3-f8eb-4aa5-8d8a-92b629ff7d03",
-    "name" : "h3wFdixzKfe",
-    "mimeType" : "j2WKDQ2NBXK10Eh850u",
-    "size" : 808275992,
-    "license" : "https://www.example.com/nnyohpjysl",
+    "identifier" : "576718f0-5b2e-45c5-b421-af3af9ee1da5",
+    "name" : "PM6xnVGzGHG1NcNJ",
+    "mimeType" : "uZ4UTcqGgBRwYl",
+    "size" : 630333536,
+    "license" : "https://www.example.com/dlspkzpr75qvifsozw",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "IyMNYsLGtCm"
     },
-    "legalNote" : "6V2Iphj6qef",
-    "publishedDate" : "2008-02-16T00:26:00.414Z",
+    "legalNote" : "wTmE6bXQCwAVdG",
+    "publishedDate" : "2000-06-01T23:35:10.807Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "XDVA4eWhDrb4wK4q7sB",
-      "uploadedDate" : "2018-05-15T18:17:16.922Z"
+      "uploadedBy" : "vUgWZC8aT26",
+      "uploadedDate" : "1989-10-29T05:00:37.880Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/B5uhG9MmDbVseCt",
-    "name" : "YJ4EIUlG3DtMofW7xP0",
-    "description" : "zM3rtZJKEKWy"
+    "id" : "https://www.example.com/IVm1WjD5ymVkC8Xf85j",
+    "name" : "VDjSy8EPWe",
+    "description" : "OLoHCOB50rjmYyt"
   } ],
-  "rightsHolder" : "s9NIeuQH9QpS3TE",
-  "duplicateOf" : "https://www.example.org/0038c984-dc6c-4e5e-85a7-f1722cb41273",
+  "rightsHolder" : "ecr5GY0aGY",
+  "duplicateOf" : "https://www.example.org/b9e6e017-17bc-4c08-94c4-20e335b6c8fc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "f3P8shmRgw"
+    "note" : "zvBnMQRYp7KepY5rnY"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "UTClI4lJznhLBls",
-    "createdBy" : "ela2daEFHh5Sfw",
-    "createdDate" : "1992-02-28T14:01:37.827Z"
+    "note" : "P6R6sCGLZmcEyftVsj",
+    "createdBy" : "9cZ3WqQAHEwaq3k",
+    "createdDate" : "2002-07-15T19:35:02.301Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e412170f-1726-48f8-b0cc-e5edfb445bda" ],
+  "curatingInstitutions" : [ "https://www.example.org/ae34713f-5caf-4313-a4a6-8263531303ba" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "FS7szvOtTRTyqZ2gF5M",
-    "ownerAffiliation" : "https://www.example.org/8c2eef01-4cf7-4024-b024-0e94c490816b"
+    "owner" : "tA4aookF8A127lki",
+    "ownerAffiliation" : "https://www.example.org/d20caccb-c63a-466b-b26a-3e698f9e1605"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/807f9b0c-787d-4749-bc62-777c385a2c75"
+    "id" : "https://www.example.org/4af9c013-dda1-4d09-aba4-0be6abb2df46"
   },
-  "createdDate" : "2003-04-29T11:38:19.685Z",
-  "modifiedDate" : "1991-08-26T13:13:03.066Z",
-  "publishedDate" : "2001-04-13T19:54:29.061Z",
-  "indexedDate" : "2016-05-07T01:02:11.541Z",
-  "handle" : "https://www.example.org/f8a73775-3c18-4af5-9483-9e8b86bd2cdc",
-  "doi" : "https://doi.org/10.1234/consequuntur",
-  "link" : "https://www.example.org/d78477e3-511a-423e-918c-2efef0b864ee",
+  "createdDate" : "2021-11-11T16:48:33.848Z",
+  "modifiedDate" : "1996-12-03T05:07:16.979Z",
+  "publishedDate" : "2016-02-08T00:53:52.796Z",
+  "indexedDate" : "2007-02-10T21:18:19.731Z",
+  "handle" : "https://www.example.org/11987b20-1a7e-4457-804e-489518b7971f",
+  "doi" : "https://doi.org/10.1234/atque",
+  "link" : "https://www.example.org/da84c13e-fcd5-4fe2-8591-3d641bbcbf9e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eX8syCciOZ",
+    "mainTitle" : "Qcd6n3VXSW",
     "alternativeTitles" : {
-      "is" : "DMIn6D0pc8JLm1"
+      "bg" : "i5oyghU5Oa"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6DaLGQGHKt7Su4i",
-      "month" : "O7OuE1zeBYAkdwwPm",
-      "day" : "xFIB18T91JSJ5qIkyJO"
+      "year" : "HHppdtLgN0XFl",
+      "month" : "Q0dRcjn7p7Aux8",
+      "day" : "eDHopI0cy6O1sHQELz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/323e6240-c941-42c6-bc0b-679d12232266",
-        "name" : "HkALlWM3CBDv",
-        "nameType" : "Personal",
-        "orcId" : "jEb0ukAwHG6lMTn",
+        "id" : "https://www.example.org/eb1b220d-50c8-480c-9c89-4a5c3643ee9a",
+        "name" : "To4qtkSsRnnGMToXkr",
+        "nameType" : "Organizational",
+        "orcId" : "Jb5lbVPP0Y",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MMgR86A9We3w3NT",
-          "value" : "ubajCTocWIAnZ"
+          "sourceName" : "jFYabhXwWdWRI",
+          "value" : "GOOAsuz8f3NOmnd7Y"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dBDgVMuEIrkShkNKFn",
-          "value" : "whpOpyqanRDQlMHwFg"
+          "sourceName" : "khzIoEMYJWR8h9",
+          "value" : "036SVgr2WThU3Kzj2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/df236d76-e833-4ce2-ac3c-f15be4e274bb"
+        "id" : "https://www.example.org/9a836f51-61c2-415e-9a45-89e9ddc78781"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "Scenographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,184 +62,183 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f06632dc-4514-4ee3-aef1-fa38b02e2ba4",
-        "name" : "JSBn1ErCgJqjO0331A7",
+        "id" : "https://www.example.org/37975c8c-a213-4909-99af-bbad65326116",
+        "name" : "OIiy4XH0KFIskml5",
         "nameType" : "Personal",
-        "orcId" : "3zqTrFpwomjfmUh9",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "idlzsTk0Wd3N6dbJWT",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GMEsytlvjbkSzx7R",
-          "value" : "k3XA7kMwvLIhZMeoFql"
+          "sourceName" : "KXm4Uc7DhgJw",
+          "value" : "SdruXcPYJvD2GwAOsM8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BPjiNbr2KjI",
-          "value" : "WDdtXfExDKd1yL"
+          "sourceName" : "tJ3w08UbpgJgKfALQv",
+          "value" : "r0FaKbQefmv3tc4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/515351fe-3f1f-4c86-a29e-19e0c4ea0c9b"
+        "id" : "https://www.example.org/128c44e6-a058-4ffb-9de2-a23140e45278"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "Q92u4DFdsZRsgVSs"
+      "nb" : "wku7vpSipwRfLtO"
     },
-    "npiSubjectHeading" : "JkGQTiuYMzQxbnUA4JI",
-    "tags" : [ "mB9LMxsZwrkFSFu" ],
-    "description" : "qGfYTNVsZPpUaPR2Mlz",
+    "npiSubjectHeading" : "IBlBqYSivXym",
+    "tags" : [ "Y6htpkwzyRO" ],
+    "description" : "rBOLqV9asWhoNdzcOD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/02a258ac-0663-4b88-b1dc-e9ab5ce2bf2d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/770fcc1c-1c25-4e85-af81-1bf08c3cfab1"
         },
-        "seriesNumber" : "icrA3iw5amg4",
+        "seriesNumber" : "1M4ub6wB9IAfoshoj3",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f6285842-3d44-4bd8-b837-02b1e68b97f8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ce871db-9c6e-428e-af11-9b2bb3ace5a1",
           "valid" : true
         },
-        "isbnList" : [ "9790040612295", "9781920857813" ],
+        "isbnList" : [ "9780465884414", "9781600528408" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "S8lZdYowQ5lb"
+          "code" : "EHNqRj9bUvRR"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1920857818"
+          "value" : "1600528406"
         } ]
       },
-      "doi" : "https://www.example.org/3b5cc797-35d4-4dbb-a2c1-a24a7317c5d6",
+      "doi" : "https://www.example.org/dddf07b9-5d86-432b-9db2-3c02bdeab420",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "45OQ41U8CgUg",
-            "end" : "FI9483eTZ96K"
+            "begin" : "DiHvYiAPWzNK73eUWt",
+            "end" : "R8lnvw3Klc"
           },
-          "pages" : "r5pvDelPEtTzbVL",
-          "illustrated" : true
+          "pages" : "aCX7qBsft84PWC",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "hDvIbYpROetA",
-          "month" : "QLZYIstwhEBW",
-          "day" : "weQLo6N6HQ9"
+          "year" : "r2c1e7XDx3N9v",
+          "month" : "3touiyZlca0I7mCzj",
+          "day" : "QyYr98EMdB9h"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2503e0c3-9f70-4516-9ee9-84b04d8b0b0f",
-    "abstract" : "Mc52USVmwfQ"
+    "metadataSource" : "https://www.example.org/4f756a25-ccec-4541-bfb6-fedf01d3f371",
+    "abstract" : "q40NmJr1tiG2x"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/507b9bc8-b55b-4d98-a60e-62e7bc6dd293",
-    "name" : "JxYK8qKujHX",
+    "id" : "https://www.example.org/ee60636d-5d4c-45c6-b886-eaab071f7acd",
+    "name" : "2l9gvBiU9nP9lDm4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-12-23T21:54:31.868Z",
+      "approvalDate" : "1982-09-07T01:45:24.219Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "uPgKqVfJFXcx"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "hbBwbmGEqZAjTQTu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5902310e-d38b-4996-b281-3b66fc2ce6d0",
-    "identifier" : "5TAO9ttVFfUOB",
+    "source" : "https://www.example.org/fbdde2d3-4c44-48f6-b2c9-d81a3cf2103d",
+    "identifier" : "Jk0EEQAvG7Rj5UO",
     "labels" : {
-      "sv" : "OzUO3dmsDOo"
+      "se" : "AmJPv5uNSiJ5bC94"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1610008473
+    },
+    "activeFrom" : "1976-08-12T19:54:56.893Z",
+    "activeTo" : "1996-05-18T00:51:13.243Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/fa012e43-f2b2-44e7-ad11-aa765d6f231f",
+    "id" : "https://www.example.org/4f18e829-3d67-42e6-a0a6-cd45cd8b585b",
+    "identifier" : "hgrePxIsXMiNrI4gFA",
+    "labels" : {
+      "pl" : "oJjyM7wJyduCjd"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 614129302
+      "amount" : 762351413
     },
-    "activeFrom" : "1980-04-24T05:25:27.597Z",
-    "activeTo" : "2012-03-05T13:12:30.369Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/01c978ef-a785-4555-b9c1-ae7a5ef97c5a",
-    "id" : "https://www.example.org/d3cca476-6a54-4ef1-b543-1ab44b6bd433",
-    "identifier" : "uiWO6f0nNFK71",
-    "labels" : {
-      "is" : "cqjJfXpcGl9pWWxfH"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 159742983
-    },
-    "activeFrom" : "1971-12-22T10:03:52.198Z",
-    "activeTo" : "2012-10-17T01:05:40.313Z"
+    "activeFrom" : "1984-04-26T15:07:30.113Z",
+    "activeTo" : "2003-01-14T11:14:31.512Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "axj9fYfnnaiEVp",
-    "value" : "Lrh01WX2rzyMCdeXTs"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0d1a81d6-3696-46ca-8a86-c3d1b4a32e67",
-    "sourceName" : "hgmd7adyo26t@zueeiptf72qy"
+    "value" : "https://www.example.org/0253608f-15f6-491e-92d9-724abf5c1412",
+    "sourceName" : "0vz19pazud@dknpwp9hs2"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1802795195",
-    "sourceName" : "9txkzwzw5k9fxipvnj@1nthpeg6wcvbczv2"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "njAd299GYtmVF2VB",
+    "value" : "96tER6LcKy"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "KqoBLRDxFL8HRjnY6",
-    "sourceName" : "iqfundijgzmi5p9k@coz7tvc8xkvb"
+    "value" : "iDEEUdzwsxeeXxlOchv",
+    "sourceName" : "3u0zjbwh5tmy4pzl@n8pc38j75wutmrp"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1614506507",
+    "sourceName" : "yiw1a6rasobffeiyuwv@zix8jqzcc3"
   } ],
-  "subjects" : [ "https://www.example.org/f3082e7f-4072-4c95-b547-47301dc36cfa" ],
+  "subjects" : [ "https://www.example.org/cca99664-4a07-44cf-a893-6157c4e1edc5" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bd2ea321-10d3-4197-acfd-98185297695b",
-    "name" : "GzqIt7iLALCLp",
-    "mimeType" : "6v83YqXtNouLtZd",
-    "size" : 156725289,
-    "license" : "https://www.example.com/sleqrt8wygswdcoq",
+    "identifier" : "0452471a-a725-40f4-846f-ccd71197e75c",
+    "name" : "0uIRvToBbUs46fxkzqw",
+    "mimeType" : "5k1AxvO0NLQ",
+    "size" : 157534270,
+    "license" : "https://www.example.com/bqidx8actv4c",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "UV0Zn6MZKtZN2cLEU4D"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "HdIBpOyrMlMHS24Zy",
-    "publishedDate" : "1976-01-16T12:33:52.483Z",
+    "legalNote" : "D6fDazs8SM",
+    "publishedDate" : "1974-06-02T07:18:10.621Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "EyTjaQYi8Hz726Y",
-      "uploadedDate" : "1993-01-13T22:58:01.303Z"
+      "uploadedBy" : "CvAmTReF1Lu",
+      "uploadedDate" : "2012-12-20T14:01:30.037Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/jzkfDfJYmLl9Z",
-    "name" : "O78h9jqd6TH8skCYPbN",
-    "description" : "Gv66G2k9IvT"
+    "id" : "https://www.example.com/a08eWXYptmLOgdzvx",
+    "name" : "KB1mFrheTduvWuK7",
+    "description" : "qrBFi8AL3c5xOfEQD2"
   } ],
-  "rightsHolder" : "nshMyxp4z2h",
-  "duplicateOf" : "https://www.example.org/e5207f03-3b81-4082-a9db-2b084eb8181b",
+  "rightsHolder" : "3hhh6fZPgwEG5",
+  "duplicateOf" : "https://www.example.org/d598ce7d-afe8-4ccd-948d-d69ce835395d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Zc6YmSwXrF5WxZO5"
+    "note" : "4f2cFGh8Szh89hl"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "FBDI4X3YA5a",
-    "createdBy" : "HkJ9p0r40t6mHCn3",
-    "createdDate" : "1971-03-10T10:43:18.986Z"
+    "note" : "7Gqh5GQiV6",
+    "createdBy" : "Yu4WmsoUZfg4HbwHbBl",
+    "createdDate" : "2005-07-27T14:04:42.156Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4be9bca5-bd35-4e28-bafb-50e7b0d349c6" ],
+  "curatingInstitutions" : [ "https://www.example.org/0344b0f9-6908-4a2e-8c3a-c0e5d8bf6097" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "S1UfLLpjSAM",
-    "ownerAffiliation" : "https://www.example.org/4f7d5a1f-6c9e-4d14-80f6-a50fc4b1c1e8"
+    "owner" : "vq8wF6Pi3vM",
+    "ownerAffiliation" : "https://www.example.org/ae72afa0-340d-4b91-a617-b8f64350eac8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ad7a96ac-9912-4685-a781-1c2c316e0983"
+    "id" : "https://www.example.org/4fbd4d2a-ba32-4390-a437-844ab534aac4"
   },
-  "createdDate" : "2004-10-26T17:51:08.577Z",
-  "modifiedDate" : "2012-05-11T05:40:55.820Z",
-  "publishedDate" : "1992-10-13T17:42:07.569Z",
-  "indexedDate" : "2013-10-07T18:41:04.776Z",
-  "handle" : "https://www.example.org/c1e67cc2-7c0f-48b4-8a67-c17f483b1163",
-  "doi" : "https://doi.org/10.1234/vitae",
-  "link" : "https://www.example.org/2582def6-1424-4fac-a5ab-b5d4352e53b3",
+  "createdDate" : "1982-04-13T09:43:23.327Z",
+  "modifiedDate" : "1994-05-06T07:26:30.236Z",
+  "publishedDate" : "2008-01-03T03:23:25.895Z",
+  "indexedDate" : "1972-06-11T16:55:43.140Z",
+  "handle" : "https://www.example.org/0550f316-606b-47a9-b781-7e335debb805",
+  "doi" : "https://doi.org/10.1234/asperiores",
+  "link" : "https://www.example.org/3fa5114c-614a-4d98-99e3-957a0b226700",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pa55h2dEG3kMwKsaQwb",
+    "mainTitle" : "89w63oGEfejlc9tpOu",
     "alternativeTitles" : {
-      "en" : "OiEqYT9L0VGqBq"
+      "se" : "lefCZIae3YjxnJebT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "hd8d8oCsLH99X2s2Ba7",
-      "month" : "Vw1BWTZF8tD",
-      "day" : "vi3nW5edQFcf1aCi"
+      "year" : "SngTKe9gyG6",
+      "month" : "i7FyrthK9qVLCP5cC",
+      "day" : "n8zBXpJkS5MWQcNm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7d930864-75af-4cf4-8a59-374803d690f3",
-        "name" : "nb8HWECGVF36MFg2E07",
+        "id" : "https://www.example.org/abee57b4-831c-4119-8c25-46a1221f43f3",
+        "name" : "m5kTScoyWiZnTW5",
         "nameType" : "Organizational",
-        "orcId" : "NSxNROKkraKp9R",
+        "orcId" : "rmbuYI9Uys9dHXgALz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Fa3ia3ebdeLeyyvJTT",
-          "value" : "O60iwHuY6rXs"
+          "sourceName" : "Cu8wdWafROwPiu",
+          "value" : "PcT3nXzFC9n"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "A0WAQMqoAFdjtCbXQ",
-          "value" : "FZjzHaRhEVWZIgFxLY"
+          "sourceName" : "hSag3skgeTY",
+          "value" : "IMds1Wb9jBKfdmPR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/88297858-9c4c-4ec8-98ac-ff8f4dd1a6f5"
+        "id" : "https://www.example.org/f1cff554-9628-4fba-a8d0-2c43b335dd6e"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,183 +62,183 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8ce2ef4f-5fd5-42fb-a985-1468353d615c",
-        "name" : "CoqjlUxNUm",
+        "id" : "https://www.example.org/b59f05e3-c813-41eb-ab54-feadccdae8d7",
+        "name" : "sR4rDpv1n8",
         "nameType" : "Personal",
-        "orcId" : "rXunRNcVDVf",
-        "verificationStatus" : "Verified",
+        "orcId" : "44LlxzR2dZX",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fXAeJdWOM0h",
-          "value" : "Oad7DByfyQniKbMiC"
+          "sourceName" : "qgtIsmAXIccm21VpsYW",
+          "value" : "UAsCQ5YtWekjw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WnRjhXmpeItGP3LB",
-          "value" : "FKxHYPJ0XQeQ"
+          "sourceName" : "XqaKqFOqNPK8N",
+          "value" : "qME7lADUlfNI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/92c96f7f-0598-40a5-ad5b-07bf5f62bc2c"
+        "id" : "https://www.example.org/f1f17b59-941f-4a2f-9b0d-6f1dc7eb13c5"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "SoundDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "5KYAIkmsKuiiJOha"
+      "bg" : "3BvWlku6JlaE7bZ"
     },
-    "npiSubjectHeading" : "AZx0w3aIUr",
-    "tags" : [ "fUQ6lboWYgzZKMLllGk" ],
-    "description" : "E8SHEnJj6IvZ00yA9bN",
+    "npiSubjectHeading" : "CeqA0oeAgUpqkt",
+    "tags" : [ "mJDZbXXeHX0CtVWWYdN" ],
+    "description" : "Ntbn6s6kk7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/18c81d3e-9520-4352-a87d-5f464009ab46"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d62f6d96-b7ec-4d49-ae95-3e58ba93448d"
         },
-        "seriesNumber" : "KcqXyWqljqz",
+        "seriesNumber" : "1uBtXRyS5CS",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2b6e9ad8-34a9-4bd6-8c68-27ce785fc70c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/509bfc8d-d81a-4bb1-9fb4-4e772b076d8a",
           "valid" : true
         },
-        "isbnList" : [ "9781877861215", "9781018071060" ],
+        "isbnList" : [ "9791067123221", "9781023681117" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "sV6Neb3cynbfl"
+          "code" : "tPAH7S8LHpP"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1018071067"
+          "value" : "1023681110"
         } ]
       },
-      "doi" : "https://www.example.org/14ade4b7-0ea3-4ec0-830b-9763877ab874",
+      "doi" : "https://www.example.org/74391d21-52d5-4e10-9f32-970068f36901",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "bDf5kXoAlHE30GDcI",
-            "end" : "n1Q9H6hMvr6GQ9M"
+            "begin" : "apPYtKl9Oba",
+            "end" : "L4E6lYCastm3xcT"
           },
-          "pages" : "dSQ7KsYTqaIHRUIQv",
-          "illustrated" : true
+          "pages" : "q98PeGP88ab6rIPwe",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "ohk8SLo1Tnj",
-          "month" : "NIOnXc2YWq",
-          "day" : "KIk2Yj2YclxWr"
+          "year" : "4rR2qRfehohZu07gHF",
+          "month" : "w2RgcnSAJYYRTEk",
+          "day" : "UeqG8KCA3x"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/181481fd-2fd7-48f4-8e66-1ea2d30aa0c8",
-    "abstract" : "bDVa3GAFTEhv"
+    "metadataSource" : "https://www.example.org/8bdb5ff8-1642-480d-834f-530d29f05bd7",
+    "abstract" : "2eSDZTOIJTCYb8IU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e238cb35-bffd-422b-bd97-66ceafffcd5c",
-    "name" : "0Ta7Qymp557KZYlCoP",
+    "id" : "https://www.example.org/75bbe24e-68aa-4bd5-a73a-deb6cb9d8ff0",
+    "name" : "vQ0TcAimu1CvQ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-11-19T09:36:41.750Z",
+      "approvalDate" : "1976-03-21T14:32:25.678Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "dLwXUN6mT0JND"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "qSuInsPqToSNuxfgiy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/eb226266-b450-4406-83f6-9b8fc2ab7029",
-    "identifier" : "sSBRZmmaAtzQVu",
+    "source" : "https://www.example.org/c812302d-7d07-4538-bef9-d8d53c1ff457",
+    "identifier" : "94AgtCjtzVFZJ9la5E",
     "labels" : {
-      "nb" : "xhpxyD2IYss3G3T4m"
+      "bg" : "kvmHXjFzoHXv"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 44838126
+      "currency" : "NOK",
+      "amount" : 604976662
     },
-    "activeFrom" : "2004-06-14T08:27:07.770Z",
-    "activeTo" : "2015-05-09T05:51:54.188Z"
+    "activeFrom" : "1997-01-07T14:23:08.013Z",
+    "activeTo" : "1997-08-28T14:48:36.070Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8962da9e-fc9e-482a-8005-f5300db353cf",
-    "id" : "https://www.example.org/688b3779-bfef-4e59-a738-2a18e26a5e10",
-    "identifier" : "WFLPixDRK9rU",
+    "source" : "https://www.example.org/adceb592-812d-4229-bc4e-9362bcad417d",
+    "id" : "https://www.example.org/113793d0-1752-47ff-90b2-18dbe4306d6e",
+    "identifier" : "OamJQNjzQJQ3xpdMt",
     "labels" : {
-      "fi" : "74psIR20vDJxu0Ci"
+      "af" : "nyvwc1YarQ"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1715595316
+      "currency" : "GBP",
+      "amount" : 592670559
     },
-    "activeFrom" : "1997-03-19T21:22:21.794Z",
-    "activeTo" : "2023-09-23T20:57:20.203Z"
+    "activeFrom" : "2007-03-16T19:17:21.937Z",
+    "activeTo" : "2022-02-14T13:24:20.862Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "LJhyCYNFcJONF",
+    "value" : "kAUev8JlXVZAmNZcJa"
+  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/39b31eb5-4701-47dc-af37-e290d538964a",
-    "sourceName" : "p2ghilz1qj7nahywvuk@dgbg5ylvihly"
+    "value" : "https://www.example.org/8de0d6a7-255e-47b4-85b8-d1b908f8f337",
+    "sourceName" : "mgmjqhxtc6jlefhcq3@wa4yuw9gcrqfbgb2npf"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1182664404",
-    "sourceName" : "ldqyikwj6tia8ummym@fh4jgafxvclz28xeeix"
+    "value" : "307235226",
+    "sourceName" : "yff3ouplvmdckf8lk@mecnprvcr4"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "13UXUlzuSVGG",
-    "sourceName" : "egpxq4ieuehfa2xda0@rlwqxfbytvq67"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "QCzgmF1BrvImNc",
-    "value" : "fj6Pw1l175fDEW"
+    "value" : "WRvSwvOm2MtKnosei",
+    "sourceName" : "gsuz6eocowahp8uxk@2kir67vhoqtbzzjlgr"
   } ],
-  "subjects" : [ "https://www.example.org/bb4a8faf-7983-4b08-9026-06aaf99830e3" ],
+  "subjects" : [ "https://www.example.org/09bf20e6-d9a0-4057-9246-d247f188b22d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d401efbd-fa3d-4aee-b2bd-8e7f2186509a",
-    "name" : "UqLOvk6t7Nbej",
-    "mimeType" : "fP8H0xJ5joiNF",
-    "size" : 1321896791,
-    "license" : "https://www.example.com/bsqs5hbnud8n",
+    "identifier" : "ae14e0b7-c43c-4d3e-b7ba-203c08b1c1c2",
+    "name" : "97Iy93h9jUyl7",
+    "mimeType" : "Sbcis0DEE2",
+    "size" : 1188370296,
+    "license" : "https://www.example.com/sczctvds59",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "JNPTSR7Ao8qOOV",
-    "publishedDate" : "2022-10-15T06:01:37.164Z",
+    "legalNote" : "nvJnZQQEVByE0Lg1J",
+    "publishedDate" : "1977-06-01T11:52:41.983Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "j3v8JpYGFpbSa",
-      "uploadedDate" : "1983-04-27T13:20:37.161Z"
+      "uploadedBy" : "XH9Gic5Mhv",
+      "uploadedDate" : "2006-07-25T13:34:25.255Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8RQ2J0Kbg5uxDMOmR",
-    "name" : "jWpIa7HTAUBf",
-    "description" : "WsxO1xDvtqwu"
+    "id" : "https://www.example.com/cm5NniHIq1HDbdeyntq",
+    "name" : "QZGEN0UFkWjzJtcxct",
+    "description" : "g07eJpKcRkgA1"
   } ],
-  "rightsHolder" : "jiEGHzmFxyQ8w",
-  "duplicateOf" : "https://www.example.org/6d8b6313-d706-4b0e-b335-cf2e9b81e25c",
+  "rightsHolder" : "WpZV27I0bP8VTT",
+  "duplicateOf" : "https://www.example.org/6cffdaff-83e1-48ba-876b-57f2fd7d16fe",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "JUcXMz2jdgYrd"
+    "note" : "FDNpOUvjxAWhczNwSwH"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "pHiwXW0OTt9ukl",
-    "createdBy" : "zN2a5mWSrjZPPMovh2Q",
-    "createdDate" : "1971-07-19T14:48:25.207Z"
+    "note" : "RjEOUmDuThIUzZ7fCl3",
+    "createdBy" : "4CUZ1mkhqPKwT9HL",
+    "createdDate" : "1996-12-05T18:42:51.207Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/199f0458-5fc5-4041-8ef2-66012560ff91" ],
+  "curatingInstitutions" : [ "https://www.example.org/aff6eae7-e9be-4c0e-a83c-1695a41cf4e3" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "fKKeRNDsa6zBm",
-    "ownerAffiliation" : "https://www.example.org/af9134ec-33d3-453e-871b-34f303a35534"
+    "owner" : "N0UpGzkSAUXj4ue0fdH",
+    "ownerAffiliation" : "https://www.example.org/13a81acf-88e3-47c9-a46c-0e9e970c32af"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8f57e277-d7f0-4dd5-a458-f9fe071b01fe"
+    "id" : "https://www.example.org/156cd646-c7c1-49d3-84df-e23515d48ad6"
   },
-  "createdDate" : "2003-02-03T05:21:39.720Z",
-  "modifiedDate" : "2002-03-11T05:17:22.642Z",
-  "publishedDate" : "2018-05-22T01:44:36.877Z",
-  "indexedDate" : "2023-11-18T17:24:26.164Z",
-  "handle" : "https://www.example.org/021064c6-a55d-452b-84ad-053c2ae53d7c",
-  "doi" : "https://doi.org/10.1234/magnam",
-  "link" : "https://www.example.org/29905e51-5b64-49e8-9861-91a10afbdf7b",
+  "createdDate" : "1988-05-26T01:27:47.263Z",
+  "modifiedDate" : "2021-08-22T01:04:46.120Z",
+  "publishedDate" : "1992-04-27T04:07:20.435Z",
+  "indexedDate" : "1980-10-04T19:28:57.716Z",
+  "handle" : "https://www.example.org/da2c53bd-160e-4ead-b39a-433ebba5c3e0",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/8ff14b39-a830-4425-9378-c940af2c8777",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zEjyT7ozKsWeP",
+    "mainTitle" : "yhgfruqqge9nBAQCmuD",
     "alternativeTitles" : {
-      "zh" : "F4BAmENMwhul"
+      "nl" : "WDfkOCBiISxtI6PRdhr"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tHPdRjeOVNYf1L",
-      "month" : "JPpyhMCMTsZLdR",
-      "day" : "sLajgB2pqrvnEr8K"
+      "year" : "sWQ8dFSeKRAskR",
+      "month" : "bsGqxVSXj4Yy79",
+      "day" : "oXE9e0VKBSMdriagpJh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/688dc91b-d669-4ede-931d-aafe27a0393f",
-        "name" : "8CzCe1kLGT0sTks1S",
-        "nameType" : "Personal",
-        "orcId" : "Xr1YB5SHh5eLi1x",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/cc29a4d7-76ba-4979-8282-488f6f1352d9",
+        "name" : "0kyDkrSxwa",
+        "nameType" : "Organizational",
+        "orcId" : "4XEDniFkC3VvX2srO",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QHcSov21azYj7",
-          "value" : "PbfD6IJ9pVR"
+          "sourceName" : "zwquJ6wS7zwGnIUvhJ",
+          "value" : "C47ChBWjV0q"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m7l0qI4GrY5",
-          "value" : "qCwB2r9UFfKm"
+          "sourceName" : "U8unrayj0z",
+          "value" : "fFgU5Qkp5eQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/99b4c53f-752f-4dec-8311-d077a6bbeabb"
+        "id" : "https://www.example.org/c3717bb6-8b9f-439b-85d4-5ab1b309ae10"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,183 +62,183 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94e91cb9-4afa-4707-abce-74df966b93b8",
-        "name" : "pM421NFMOfx",
-        "nameType" : "Personal",
-        "orcId" : "Nu8cvb823WsWt",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/7c1add4e-6cd4-4416-92c5-664106cb4a4b",
+        "name" : "8ygbdGKtemxUQ",
+        "nameType" : "Organizational",
+        "orcId" : "Vd48xgoJH98EFhSA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4KX6XS3KeRU",
-          "value" : "k5dMcaKKaHDaSjs6R"
+          "sourceName" : "0eLeMETWsdGL",
+          "value" : "7wBtC04oCIoy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9RNt5PlsCCmnpKkN",
-          "value" : "bkcGY4VVXzDr"
+          "sourceName" : "zyp84gfo0gAAgfN0z4W",
+          "value" : "kHCw6n4FrxLpoTCU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fb6e3582-3adc-4482-ade7-4071c2d9578e"
+        "id" : "https://www.example.org/703ce3af-bcd0-4a5c-8cd4-843e4e85c1dd"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "cJhDHzew5Q0XF6mzEJT"
+      "ru" : "5idzE8hPOEuj1"
     },
-    "npiSubjectHeading" : "TBiY8Acij6lZ60",
-    "tags" : [ "ZJJD2zdtrWIEv5LUM" ],
-    "description" : "I5LobJKFLJM8BRYVf",
+    "npiSubjectHeading" : "UtN8S1s2USD0AqSm",
+    "tags" : [ "tARnf6J80zfGz" ],
+    "description" : "RDqkVE5AMdsNQD0vD2j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4cb22988-13a1-452b-923f-281d87e76bd2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b0976ab5-bb90-46a0-ae43-85bf7c6cd7b2"
         },
-        "seriesNumber" : "Ls4WzKOO8QFY80W",
+        "seriesNumber" : "P4X1xvMkxGPnaNs2JQ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3280d4b8-0a71-448f-9a05-46fb10a252d1",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/946d3ab3-cceb-4d9a-a071-0f30b5126714",
           "valid" : true
         },
-        "isbnList" : [ "9781896014609", "9781985649804" ],
+        "isbnList" : [ "9780907099833", "9780938482888" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "4fNZOPDM0SetJAp"
+          "code" : "iFT8CvUae5P"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1985649802"
+          "value" : "0938482882"
         } ]
       },
-      "doi" : "https://www.example.org/5e05d887-2400-417d-8540-ffee8a321877",
+      "doi" : "https://www.example.org/19147c5e-f22b-4364-a905-07721f91fd1f",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "RBhYXuvT6afZ18j",
-            "end" : "93pQ0Ww3MBYroTnPMs"
+            "begin" : "foKG1ND2ehE9",
+            "end" : "fKresw3sU1y01luy"
           },
-          "pages" : "Jom3AKfEoDicl2l",
+          "pages" : "T4OFQRhmNezkc",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "9N74VDbmMhF11H",
-          "month" : "aFdXWXXytkot7RAhR",
-          "day" : "Qby2V5oHuGKBAngPCq"
+          "year" : "jcKnxwAdAE",
+          "month" : "b6k4e4Rapj",
+          "day" : "chrR7WPpZK"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0fa89239-8fa4-49aa-81b1-5bf850ddc84d",
-    "abstract" : "ccqtGgbK3xUCts"
+    "metadataSource" : "https://www.example.org/52531331-b73b-4f4b-b7fc-f629fa5e1256",
+    "abstract" : "4C8vqCegHgr9m9O"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/17de0b47-1e93-4725-b594-7114c790364b",
-    "name" : "A2QR2CI5Hg7qH",
+    "id" : "https://www.example.org/2a0d5303-98fd-4d3d-a8e8-96a03bef1c2d",
+    "name" : "nEyO7nfA5R",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-11-21T08:34:38.164Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "IzHRTXPrKzu8i15R"
+      "approvalDate" : "2016-12-15T11:15:19.288Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "kx0uwnBqAZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/760fc2f1-8456-47d6-bc2e-96e5aa110174",
-    "identifier" : "bxaXkWQsTIcPPhL",
+    "source" : "https://www.example.org/e4db607d-8f4f-4be6-96d5-486e314688b3",
+    "identifier" : "re663CosM7hEdHC4skb",
     "labels" : {
-      "fr" : "snrlIB5RMt"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 740411280
-    },
-    "activeFrom" : "2012-12-02T03:38:22.332Z",
-    "activeTo" : "2022-02-15T20:51:54.627Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5d659cd0-3fb0-400c-8384-21b2f8b1b84d",
-    "id" : "https://www.example.org/40babf4a-60dc-4778-9d5d-ca338aa6a23c",
-    "identifier" : "o5ReTbPfC7ALJ3W",
-    "labels" : {
-      "it" : "MzZEjrA8nz93"
+      "pt" : "wYE7LKWHKNy4G5S"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1679728215
+      "amount" : 1258392883
     },
-    "activeFrom" : "1976-01-30T09:41:50.819Z",
-    "activeTo" : "1987-06-24T11:01:03.991Z"
+    "activeFrom" : "1978-04-07T17:53:42.631Z",
+    "activeTo" : "2012-10-19T19:52:26.492Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/605c5b2f-d65f-445f-acca-e1133323d1ea",
+    "id" : "https://www.example.org/afe0b0b3-3901-4587-bf57-8b1f6e059bfe",
+    "identifier" : "1kCgSnqIv4DNifx",
+    "labels" : {
+      "nn" : "5qnVJBr29ykIJZa"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 587256868
+    },
+    "activeFrom" : "1989-02-20T11:29:59.136Z",
+    "activeTo" : "2015-07-12T23:13:06.915Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "3wr2j7wgP9KaS",
-    "value" : "fkfuoxn90lmo"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "yBKc6ep6drhCeAHUc",
-    "sourceName" : "gfh1agtvod@crrr6qere4s8oxcjr"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1091786683",
-    "sourceName" : "l7wqbozep0c6qapkq@mj0fycohoa52oao9vq"
+    "value" : "1853405574",
+    "sourceName" : "likfv4be7jxq@0w1ridkrdgur35rb"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/017961bf-570d-4608-871d-a0016992afb1",
-    "sourceName" : "6wuswb5qbhgw8u@gzfxwomkonpuq"
+    "value" : "https://www.example.org/5d04630f-0cb6-47b4-ad86-3d8ae1ed756e",
+    "sourceName" : "xeomoxgmtkpwhiadhsb@feql708vmqllqhf"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "qyIjreXCUNQdeXVwu",
+    "sourceName" : "zkb3cggqxosh@i8fgn84ebg12yv"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "8k9QzJAshVcTF",
+    "value" : "p1DM1WdVdSnqXq"
   } ],
-  "subjects" : [ "https://www.example.org/59ca1e55-2843-4aab-ba14-6fb7d24518f4" ],
+  "subjects" : [ "https://www.example.org/c3b43044-7e10-4bbb-9b7a-4915808d9f62" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b8cdabd8-a29e-4f51-be35-7a23160a73e5",
-    "name" : "AdlFqRUMthzIT7",
-    "mimeType" : "gTmkqai3SY",
-    "size" : 2016324918,
-    "license" : "https://www.example.com/75jsbebue1",
+    "identifier" : "c693c049-35b3-4550-b665-66761d8d78c0",
+    "name" : "XQDBdVsJPPi9bJHd",
+    "mimeType" : "e7CPriEB8M26UHRsfe",
+    "size" : 2010400702,
+    "license" : "https://www.example.com/s4wb4qthpjdisu",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mG25AmoBwLgsxweaT",
-    "publishedDate" : "2008-01-20T23:35:50.973Z",
+    "legalNote" : "bf6Nv1JivsLSak",
+    "publishedDate" : "2024-08-21T06:00:14.197Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "NL6odOIgwCFllwT",
-      "uploadedDate" : "2008-02-26T10:38:57.008Z"
+      "uploadedBy" : "ERA5vimBUo",
+      "uploadedDate" : "2024-07-28T19:07:56.546Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2fmkw6T3HHu",
-    "name" : "rfjWW8kOQxaWciZp",
-    "description" : "o4I1PEearBTTcW6guPg"
+    "id" : "https://www.example.com/9phWGb4EmLIYwuP",
+    "name" : "w3ghk3ZS9vS",
+    "description" : "9l2wKAH6fNASPi4YY"
   } ],
-  "rightsHolder" : "C8DFGLNxx2ta",
-  "duplicateOf" : "https://www.example.org/6470bfeb-e7ef-402f-87b7-6de05bb28058",
+  "rightsHolder" : "4A9gkxQdzV215Hm2",
+  "duplicateOf" : "https://www.example.org/52ba528a-f56e-4264-b401-d74742c51370",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "JjMcGJ61xMpt8w"
+    "note" : "fcl5MfHhpqtNbN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "NspBz6trcm",
-    "createdBy" : "ioeHv0wyfvxK2U",
-    "createdDate" : "2019-04-04T05:10:37.992Z"
+    "note" : "J8KikYTmwJIgTjTgL",
+    "createdBy" : "2kFVGTMXKk6JuYGEZGP",
+    "createdDate" : "1987-06-24T19:17:49.795Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/803dfd1e-b0bc-42cd-9d44-e8600e37014e" ],
+  "curatingInstitutions" : [ "https://www.example.org/bfc6fa66-e6c4-4d14-8078-e074b99477f2" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "bIwBx8GFSKr8QV",
-    "ownerAffiliation" : "https://www.example.org/453d4fdf-871e-4a3e-830c-322023380c06"
+    "owner" : "Azzp2Ft9oOVsQyO08l",
+    "ownerAffiliation" : "https://www.example.org/40b3850d-b622-4954-93a9-b8f825839490"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/33c7f808-13ef-45b8-984b-8d706a376d0d"
+    "id" : "https://www.example.org/b26f4695-5fff-4d5f-9af1-b7622dd81fe4"
   },
-  "createdDate" : "1994-08-09T23:10:58.256Z",
-  "modifiedDate" : "1995-12-25T05:54:23.063Z",
-  "publishedDate" : "2011-11-14T19:29:45.897Z",
-  "indexedDate" : "2011-03-13T05:39:45.745Z",
-  "handle" : "https://www.example.org/26690ed3-5e93-48e6-8d84-7915b406103a",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/91595f38-aff8-4edb-b40a-20fc2137cb7b",
+  "createdDate" : "1995-12-22T06:24:58.887Z",
+  "modifiedDate" : "2022-07-02T10:45:48.991Z",
+  "publishedDate" : "1981-08-15T21:38:00.567Z",
+  "indexedDate" : "2000-12-26T19:26:03.503Z",
+  "handle" : "https://www.example.org/f8f6015b-8054-45cc-a521-2f73ea8cfc53",
+  "doi" : "https://doi.org/10.1234/quis",
+  "link" : "https://www.example.org/5c264aa8-8e73-4747-8cea-e0da60dd564a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "06M6NpPohw",
+    "mainTitle" : "OhWuNvRZaXm3O6J",
     "alternativeTitles" : {
-      "se" : "jfcQxROl0tYOK"
+      "se" : "4L6kWyPDhQ0qAcCaZC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6m4YDte61T9T",
-      "month" : "O146h30LfEhG2",
-      "day" : "lqAcoChbF5pvElSs"
+      "year" : "qJrFtgC6SmhWzbrjmFe",
+      "month" : "spwHjf8KkEbvIL",
+      "day" : "qo2YbLmnHFxw5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ba114d09-4816-487a-a41b-6a2e84024b62",
-        "name" : "X7shoLLB6Kbrdexb",
-        "nameType" : "Organizational",
-        "orcId" : "ZZzCLkuGzHvaM",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/91a786a3-179d-4f61-a219-d37db4d4c72f",
+        "name" : "akaZkvRt6vy",
+        "nameType" : "Personal",
+        "orcId" : "CxsEBafyUdR",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "weKC1WoMIfrnyslFz",
-          "value" : "JbcQz1iaFezJ"
+          "sourceName" : "7RZJTi7qVi8vpH",
+          "value" : "AMqWpQEknb00Y4fR9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JwtuncCh1FHZQnf6taz",
-          "value" : "43yuAEwf2i"
+          "sourceName" : "AZ9vzwjabnsQvVZ5w76",
+          "value" : "pLgOSI2du1edE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f759c57a-0ea0-40a7-93bb-c13affc29d28"
+        "id" : "https://www.example.org/a0225628-9d01-451f-918a-b1c045ba32d1"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,190 +62,190 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/44ef2c55-90cb-4c25-b8b6-ed046e6b2d58",
-        "name" : "mFeHBbiyzCJn",
-        "nameType" : "Personal",
-        "orcId" : "93PtYcnIFKAW50F",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/49798219-5328-422a-979e-d8e478007016",
+        "name" : "wprr5sCh0feEHGJI",
+        "nameType" : "Organizational",
+        "orcId" : "huyDNaaHHHf4QN",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5qRZ5Z8i1f3uNOYv",
-          "value" : "Uk2o73RTiE3n1g"
+          "sourceName" : "jiDRNzA9IbViaWy",
+          "value" : "oDttzPGgpiDBbwyvP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1GaSCpCWlJSVpn4HmV",
-          "value" : "rXQcKUloKEgLqRplE1"
+          "sourceName" : "EI6Uak5Qhm2rm8l8",
+          "value" : "taqnyUKwhkJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/36e05d7c-600d-4334-80d4-99af754481df"
+        "id" : "https://www.example.org/784e3cca-ae54-4b24-b359-43d89acc7f54"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "mh7NmtPyIZuq"
+      "is" : "3MaAECbIvEBgAI2Pld6"
     },
-    "npiSubjectHeading" : "sivLmSlRXdnV72nZJv",
-    "tags" : [ "DE03xSUaDzxOk" ],
-    "description" : "ZFJgj0cqiqWnKY",
+    "npiSubjectHeading" : "3aShwNFnGV6audzKJ",
+    "tags" : [ "J2rI6cWbft5Kuaagev" ],
+    "description" : "LEfoJ13wMYayeg8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a9f84738-d93c-441a-8640-a3a78fdb5d8d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6fb3a3c6-1bc6-4d85-8ba1-de18a307b9e2"
         },
-        "seriesNumber" : "ZBWoVp6y0C",
+        "seriesNumber" : "0NQI10ByoRieurk",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5a9accaa-b30d-48e5-b212-bd8ec6b50755",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/124b6545-9e09-42f0-956b-0f8b3d2ac3d0",
           "valid" : true
         },
-        "isbnList" : [ "9781937463151", "9780888963895" ],
+        "isbnList" : [ "9780990139751", "9781096257653" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "OMMPUJDE0PCj"
+          "code" : "UusibVphCDdqR633EvN"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0888963890"
+          "value" : "1096257653"
         } ]
       },
-      "doi" : "https://www.example.org/54d830d5-30b7-48c1-8fef-bbff7d202305",
+      "doi" : "https://www.example.org/e945a6fe-2890-418b-9727-0301e3ae8aa1",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "REIunilckDs18YdR",
-            "end" : "avH3acSkpygzmE"
+            "begin" : "JKzUJKj8hzc8JEFLZRU",
+            "end" : "Ig3uOUAmCQInFk9ZS"
           },
-          "pages" : "MmwGFIPTNnjmKdAeqLO",
-          "illustrated" : true
+          "pages" : "P8F9Juf58ttdCoSykag",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "XGgVye0w7uwkOE",
-          "month" : "cjbXML4YAaOLcmh",
-          "day" : "3JYVy9ivRpDDwoyIEV"
+          "year" : "5Wj9A8uQE2BT76",
+          "month" : "0uytzLNkIA",
+          "day" : "9iZ84REAIL16q5k"
         },
         "related" : [ {
           "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/KKrckVqG5BcQCf"
+          "identifier" : "https://www.example.com/1Xill8nBDj7YDs"
         }, {
           "type" : "UnconfirmedDocument",
-          "text" : "1mdB6oLbDs"
+          "text" : "97VMaEu3vaS0"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/2d7c77db-7922-447d-acc0-b60a4a75db48",
-    "abstract" : "F6razSbgGmzMO1OCaNl"
+    "metadataSource" : "https://www.example.org/f825f035-1115-4a42-8be5-0a95f54b4d7e",
+    "abstract" : "h0EVRMB2Dw4YOcT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/76888384-647a-4d11-9f99-87ef4fac2c67",
-    "name" : "veSWxNDWd5q",
+    "id" : "https://www.example.org/5907bf6f-f647-4d22-acf2-85fe028e0047",
+    "name" : "plrMoS9TYmDepoMo3",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-11-27T18:04:46.193Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "1GVjZdTtKNP7xV"
+      "approvalDate" : "2000-12-31T21:10:52.604Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "kRzIaWjSFohCJLEmpcj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2bf3e007-ef25-4198-9046-18d24ba78c8e",
-    "identifier" : "dkdnWgxxfRTgRF",
+    "source" : "https://www.example.org/8f39213c-5c3e-4202-bb54-870c41045a98",
+    "identifier" : "oVgRDFkJXOArk",
     "labels" : {
-      "pt" : "DMuffJduURILh58GP"
+      "nb" : "jsiJ2yXaJ4T"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2039400764
+      "currency" : "NOK",
+      "amount" : 779817299
     },
-    "activeFrom" : "1995-11-12T03:32:47.953Z",
-    "activeTo" : "2012-03-10T14:29:51.664Z"
+    "activeFrom" : "2020-11-12T15:48:04.777Z",
+    "activeTo" : "2022-04-11T19:03:14.076Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/418c1483-e9e3-48c4-bfa3-b576c3dab33c",
-    "id" : "https://www.example.org/6f7bb1b1-272d-467b-b8a4-eb1ae4ffeb1f",
-    "identifier" : "rtS6bSzk1O8Kd",
+    "source" : "https://www.example.org/6f005d2f-844e-4b8c-b601-9430a64982d2",
+    "id" : "https://www.example.org/e2fd8d94-79f7-4dd4-8333-6a73d684fdff",
+    "identifier" : "B4CFg4QONY4PWTRL",
     "labels" : {
-      "cs" : "2l3tbrAPzwrkiWvnN"
+      "se" : "WcXfU34lmKuAzbCIN"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 728484356
+      "currency" : "NOK",
+      "amount" : 437290883
     },
-    "activeFrom" : "2000-07-17T22:55:40.520Z",
-    "activeTo" : "2010-02-22T21:42:03.115Z"
+    "activeFrom" : "1983-02-11T22:23:36.287Z",
+    "activeTo" : "2016-10-31T04:50:54.175Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "rYguJ75mTr4R1I1Wt5S",
-    "sourceName" : "ciomjuu6nikgb8mt@xabvmlbmya"
+    "type" : "CristinIdentifier",
+    "value" : "2122411487",
+    "sourceName" : "z9pn4yn6hnudmwj@trfvtbhkvwk2eu"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/27a94999-4248-4106-8280-6c81e58e17e5",
-    "sourceName" : "y2eusjhnborwj5o5o@s7hdcm7lbg"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1752684311",
-    "sourceName" : "wlbrwq5hve8g8h0yd0@w8bb5am7xlrnzgks"
+    "value" : "https://www.example.org/62511e51-cdbc-464b-b9be-e141af32f015",
+    "sourceName" : "slwhmdhivm@fj60kmi0hsjmqdfvpzu"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "5JjyiPA6cC",
-    "value" : "o3azcEUaDFpHzxPz"
+    "sourceName" : "bKcEkj0W3N9Ksn",
+    "value" : "9Bw51g9yGRDFi8zgoe3"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "LA2tKey7RENoq",
+    "sourceName" : "cpqzgqqm4lmp6wjyk@1zgjthg3ekdp"
   } ],
-  "subjects" : [ "https://www.example.org/c0a868a8-5a09-4d49-a702-5fc5982689e5" ],
+  "subjects" : [ "https://www.example.org/fd3595f7-de12-405e-b15f-591989f81b46" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "17dcedc0-c4aa-4e83-a20d-7da43123d952",
-    "name" : "LGY48hVcvVK4z",
-    "mimeType" : "wuBx8k5fDR",
-    "size" : 390677760,
-    "license" : "https://www.example.com/7mbrsyyknfsnaj8c",
+    "identifier" : "fe539ecc-cdcb-4268-9c7f-8f88a89cf79b",
+    "name" : "0aj9CAfBAO",
+    "mimeType" : "pcx6M2Hl2X2SH",
+    "size" : 1101101648,
+    "license" : "https://www.example.com/0hue5l7gtfudjv",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "63l16rrGxzo0pDhVSj",
-    "publishedDate" : "2022-12-06T14:23:24.786Z",
+    "legalNote" : "Y0t9APnt1Tgo",
+    "publishedDate" : "2004-11-10T07:11:37.018Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "0akCWdKOscqSdYY",
-      "uploadedDate" : "2021-09-28T19:05:15.252Z"
+      "uploadedBy" : "Qq7y5fNKux",
+      "uploadedDate" : "2021-04-14T14:06:58.389Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/kao6gpX6GkXn7E4iVR",
-    "name" : "aMcq7qHOvsNma",
-    "description" : "iLMvWi2CgbNwngF"
+    "id" : "https://www.example.com/PqxBJ9dJNxRRl",
+    "name" : "ZFGqpnVFZFLuP1mB4ND",
+    "description" : "c3UYdZUOw7a9iEm"
   } ],
-  "rightsHolder" : "qvPOYaFMtog",
-  "duplicateOf" : "https://www.example.org/5c36cebc-4300-451b-877b-c5bdc13e273d",
+  "rightsHolder" : "zVVUVnkgyuwpsg",
+  "duplicateOf" : "https://www.example.org/e69cb147-ecd3-436c-a409-83d7160ee09e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "EArqvy2F4lmD"
+    "note" : "DgHMxI4Ak4m"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "lIu1NBcqse7JD9l",
-    "createdBy" : "uHxHiqXxHcfMQPsL",
-    "createdDate" : "1984-03-03T02:51:08.378Z"
+    "note" : "06cI5oj3OlVHHZQVl6",
+    "createdBy" : "bEOLHYHCXEW",
+    "createdDate" : "1971-10-28T15:50:01.104Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/229d41ab-639e-41e1-9d03-62fd00eacf75" ],
+  "curatingInstitutions" : [ "https://www.example.org/8a53fd56-ba92-41dc-b6b6-c4eb995a3da8" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "ogN5cKF9Qhl",
-    "ownerAffiliation" : "https://www.example.org/7ab51430-827b-47f5-8b3a-edb27ba4d09f"
+    "owner" : "vCiqwf1QJzOOD59xPnP",
+    "ownerAffiliation" : "https://www.example.org/d4bec5d8-44f6-412d-b3ed-898a99cf4fc4"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/010bc74a-f387-4cce-924e-9dbb4d63310a"
+    "id" : "https://www.example.org/34bc05ee-8240-499f-95bd-d777e994fd33"
   },
-  "createdDate" : "1998-10-22T04:53:32.581Z",
-  "modifiedDate" : "1993-11-08T03:04:02.015Z",
-  "publishedDate" : "1988-09-15T16:32:25.346Z",
-  "indexedDate" : "2011-06-30T07:43:54.829Z",
-  "handle" : "https://www.example.org/2046bed4-de4c-41d3-a311-92cb4865516c",
-  "doi" : "https://doi.org/10.1234/fugiat",
-  "link" : "https://www.example.org/96cbfb45-3c58-4451-bfee-c24f7433f512",
+  "createdDate" : "1975-07-25T11:22:26.016Z",
+  "modifiedDate" : "1992-05-25T04:42:18.444Z",
+  "publishedDate" : "2014-08-01T10:23:10.767Z",
+  "indexedDate" : "1991-01-10T18:18:24.827Z",
+  "handle" : "https://www.example.org/6c03794a-0335-4072-a0ee-e1bbd8dceee2",
+  "doi" : "https://doi.org/10.1234/debitis",
+  "link" : "https://www.example.org/c4d77ace-3879-4d24-a17e-1b36b363b93e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7NOUszYWntYU1X2",
+    "mainTitle" : "kjWd772rUfu3hldTlUv",
     "alternativeTitles" : {
-      "en" : "978e4ovGqVaWzi0r"
+      "en" : "VnwoEJldWOEaH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zpXqPfw4TrfIVxx",
-      "month" : "znzKCL4It1WU",
-      "day" : "mODLL2LYxmbB4"
+      "year" : "WwykPqJMWUUlhsirRX",
+      "month" : "bSAcFmhlus7ZSfHqJ",
+      "day" : "7HQLVsBfPo1Pyq0hzyZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ac91fd2f-189c-4ad6-9927-602fe306cfd4",
-        "name" : "OIqPkvV0lxRI1",
+        "id" : "https://www.example.org/e759d767-24de-4b95-b720-3570a49efeb8",
+        "name" : "Qpym3Htsn0HNbV",
         "nameType" : "Personal",
-        "orcId" : "CN2gkJAWp8d",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "trTpUw3zWy",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5RmYZ5S43454fz",
-          "value" : "BvDYAsibyVM"
+          "sourceName" : "yRYWKhBwup9lFZGyRPo",
+          "value" : "aUo2rAOMpcfBOl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3XskynBrkNN",
-          "value" : "RTsiDMyP9NNUFWLEM"
+          "sourceName" : "HJavBzfKIWCeSdI",
+          "value" : "lhjTpUU9ZK3mdWl5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9899a80c-ff08-4a9d-a7f1-480c239c7227"
+        "id" : "https://www.example.org/b3f85efa-afa2-422f-a063-69b01042250b"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Producer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,175 +62,175 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8f85a012-528c-488f-aeec-cc8a335bb296",
-        "name" : "Vg3JNMAzV6",
-        "nameType" : "Organizational",
-        "orcId" : "a8M5fsLMrDHeq6WqC",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/66f22163-ecf9-4f4a-88e9-247a4f5b5fe5",
+        "name" : "F7R9aolNhat4XKDn",
+        "nameType" : "Personal",
+        "orcId" : "eqDQzwMS5b",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xIIsaea2gg78QQXG",
-          "value" : "14e1nhOtylixy9cM2"
+          "sourceName" : "es0SI2bO8xJc",
+          "value" : "tibxuWZ3h8xKxPJl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kQTm1q887mTA86",
-          "value" : "BS96cP2XhSCyjr"
+          "sourceName" : "9NhX9EOQxi9FODR",
+          "value" : "vAGd7je2eTe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7be38386-5c18-45cb-800b-5a92383cc347"
+        "id" : "https://www.example.org/03e989cf-7703-4443-8dd1-d3e0adc3a899"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "HzwhDxQ1HZS8NK2AThf"
+      "fi" : "x0PCdEcrg1"
     },
-    "npiSubjectHeading" : "3bd0uWB4SkKYMlsig",
-    "tags" : [ "vvIOXiIV6xhUyc" ],
-    "description" : "iemQx4NykyZciTjl",
+    "npiSubjectHeading" : "j47SIq3YOOYSj",
+    "tags" : [ "jlrrVQODTHS" ],
+    "description" : "FX8MhRMVHJy6r1vX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0de00381-0e11-4d64-802e-c934f93510b3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/da5809b0-ae66-4cf5-98fa-d251db74a9fc"
         },
-        "seriesNumber" : "R23Hwga9uOKuYu",
+        "seriesNumber" : "3zRY1WG0Iu",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7f06224e-1e1f-4c82-9373-61f74e5c259f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b9ceea36-3f9b-493f-8659-45e587168925",
           "valid" : true
         },
-        "isbnList" : [ "9791849359350", "9781841622668" ],
+        "isbnList" : [ "9790869549413", "9780933626263" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1841622664"
+          "value" : "0933626266"
         } ]
       },
-      "doi" : "https://www.example.org/79b29a6e-85e3-4090-a1a2-e49dd4bc21f0",
+      "doi" : "https://www.example.org/22956523-477e-44d2-8320-20820ac2fe4d",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "nLN43rO8pC3QepPGab",
-            "end" : "nDn64uQwk4KSMaX2U1"
+            "begin" : "h2Trt5qRGcqh6AyNtCR",
+            "end" : "1CEcwz8CSE1gkI3W"
           },
-          "pages" : "Y3mwHoXpf0",
+          "pages" : "QGgSZ3jbTwjGQcL",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/45d0263b-c381-40a1-901e-22156decf0a0",
-    "abstract" : "WeaGtNR5oC7k"
+    "metadataSource" : "https://www.example.org/8ea0cb44-3661-4197-9f07-83c71b5fb580",
+    "abstract" : "EsNjBlQ08y2Ey"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/29b7ac74-18d8-40a3-b64b-81832648801c",
-    "name" : "d5KK69wffw4C",
+    "id" : "https://www.example.org/c99b91c6-872a-457b-a074-89ffa5f61994",
+    "name" : "gTArMfDfWI8",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-06-18T12:23:24.871Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "rYEotFv9RL3dZU8"
+      "approvalDate" : "1984-09-19T05:58:11.320Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "rfQdTtLrHEJ9u3P"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/580284c4-b4a7-416d-93e9-7f9d7bf2a522",
-    "identifier" : "pbPGS0F43N8i8yk5j",
+    "source" : "https://www.example.org/518621aa-6d3c-4af5-821f-57d301c91fbf",
+    "identifier" : "Y1E2VsEGiMM",
     "labels" : {
-      "en" : "RwPJMQeVyWgdZQ"
+      "en" : "j8ju6mN7OcGSOvBYOt"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1621616709
+      "currency" : "GBP",
+      "amount" : 183838309
     },
-    "activeFrom" : "1980-01-08T21:49:54.954Z",
-    "activeTo" : "1991-04-07T00:20:24.590Z"
+    "activeFrom" : "2024-05-14T13:46:46.205Z",
+    "activeTo" : "2024-08-02T18:12:55.018Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/59628a56-86dc-4996-bdf6-d092715a65e9",
-    "id" : "https://www.example.org/cfa631cb-9b11-452a-b6a0-9246b42505b0",
-    "identifier" : "sf6YjWYFjc3",
+    "source" : "https://www.example.org/57d09d7e-6329-4336-874d-cffce634a5c7",
+    "id" : "https://www.example.org/de2c3a01-9c35-4485-86bc-d3d205732cd7",
+    "identifier" : "4O8EGNnNl8ynRRedM7",
     "labels" : {
-      "da" : "NwDG5iuJZnBurRgVhk"
+      "zh" : "rgTMm645E0TDP5V"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 821282373
+      "currency" : "GBP",
+      "amount" : 1385924952
     },
-    "activeFrom" : "2010-10-09T19:06:54.753Z",
-    "activeTo" : "2020-05-17T20:15:31.580Z"
+    "activeFrom" : "2012-07-08T03:13:06.305Z",
+    "activeTo" : "2019-11-07T13:37:09.788Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/09b4aedf-903d-4775-baf8-b812f471004b",
-    "sourceName" : "auas64leusd@qtrpmaeycagty524guj"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "SWchMWTAW0Y2lR",
-    "sourceName" : "jfuuejknsnmmim49@ntjui7ud2yunhi"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "571943293",
-    "sourceName" : "gkrjf3cg1cgxnf@6xtnfebhfq1qxy5c7"
+    "value" : "https://www.example.org/3f842288-9b86-473c-8d61-3f70fa5cebd2",
+    "sourceName" : "lszuj4tdffyny5k@yslqaosbasjmo7hhrh1"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "vlv9JdJKZD5aB",
-    "value" : "iymftpPmDQUhOmVl"
+    "sourceName" : "YJDNBVxBlpIuds",
+    "value" : "LbyCC1M4lISXv"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "851652161",
+    "sourceName" : "sd6rckwj7ivriz6d@lw2pp6qz1jpaxqmp"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "FCnPKeRwmKTX",
+    "sourceName" : "acccvxws26of7ncctfs@9iforxgbdfh"
   } ],
-  "subjects" : [ "https://www.example.org/074da13a-5e62-4e57-828a-1ea22e169112" ],
+  "subjects" : [ "https://www.example.org/5cd2048b-c10a-477f-a29e-e1210bfed5cf" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5584b10f-fb31-4be0-9e3a-697f4b2c1890",
-    "name" : "TLlIO9tAv7ygnV",
-    "mimeType" : "DIUp4aHdMM",
-    "size" : 53075418,
-    "license" : "https://www.example.com/cexvrnnconezrcy",
+    "identifier" : "ddadd7fc-354d-4f60-939d-2c302c0fd106",
+    "name" : "NU928zBplTpHuHr7s7R",
+    "mimeType" : "Oq5l4djE8QsT4Ew5G8",
+    "size" : 2084473693,
+    "license" : "https://www.example.com/w5exeyyzfhhs76orcb7",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "Mht4k0k16edN"
+      "overriddenBy" : "JIgrDgtEJ23D6"
     },
-    "legalNote" : "elmOo4Nj4MU",
-    "publishedDate" : "1996-04-25T09:51:11.625Z",
+    "legalNote" : "Zrq9I9WQSn3GCFcTDP2",
+    "publishedDate" : "1974-07-17T02:55:13.533Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "sV5Xb8I6vZgfweHjI",
-      "uploadedDate" : "2015-06-25T23:32:39.255Z"
+      "uploadedBy" : "Fxo10pJzkwFGF08",
+      "uploadedDate" : "1984-12-04T08:20:42.375Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JANRld04JH0J",
-    "name" : "0FCGEriWnDJBwW",
-    "description" : "sagAUBZmmm"
+    "id" : "https://www.example.com/eApnbuCNcIPW9JPf",
+    "name" : "QTc077FYlnO2ej",
+    "description" : "zYunbFpuoMuAcD4"
   } ],
-  "rightsHolder" : "25i7LBnQRCxcd",
-  "duplicateOf" : "https://www.example.org/b899da0e-02e9-4209-a2ba-709c7a430b86",
+  "rightsHolder" : "k65TICRBya5gW7TxaaB",
+  "duplicateOf" : "https://www.example.org/0a58a1b6-8917-4d29-8d4a-0e555f278f47",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tOqotsgt4Q"
+    "note" : "Tdn0kiSK25OWj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2N7DYXsvxmkw7V1XSD",
-    "createdBy" : "ShLGIVraasWHN3Z",
-    "createdDate" : "1971-03-08T17:41:00.564Z"
+    "note" : "ZInbrtblCU0ebQ",
+    "createdBy" : "3iMlVrnXDlUi0K",
+    "createdDate" : "1972-02-03T08:22:35.759Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/651dc946-5371-4220-a059-42daed9fd013" ],
+  "curatingInstitutions" : [ "https://www.example.org/6f1c1a1a-29ef-4956-b810-b2352f4d8156" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "i0EV18SRSzrvWpx0z",
-    "ownerAffiliation" : "https://www.example.org/af610119-615f-446e-a62f-b677757d05ae"
+    "owner" : "Eiip9UQ1u2EW7MR2Zn7",
+    "ownerAffiliation" : "https://www.example.org/b6c1842d-af30-4f96-9b7a-af918f2d721f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ac9f1799-3d7c-44c3-89fb-bd4ccef3112c"
+    "id" : "https://www.example.org/389ded17-2e0d-4fe4-a2c4-b72cbc8c0a50"
   },
-  "createdDate" : "2010-01-15T10:29:12.097Z",
-  "modifiedDate" : "1988-08-20T22:30:13.747Z",
-  "publishedDate" : "2001-09-21T14:16:55.298Z",
-  "indexedDate" : "1992-01-07T06:34:06.933Z",
-  "handle" : "https://www.example.org/178029da-d5c5-4c26-bce7-36162d917339",
-  "doi" : "https://doi.org/10.1234/error",
-  "link" : "https://www.example.org/a63fd035-b622-44b7-8eb7-8d077e6e3577",
+  "createdDate" : "1976-08-19T23:06:07.178Z",
+  "modifiedDate" : "1980-01-15T12:54:11.748Z",
+  "publishedDate" : "1980-05-30T14:41:38.684Z",
+  "indexedDate" : "1991-02-27T09:54:23.260Z",
+  "handle" : "https://www.example.org/f5e5081a-ed1a-458f-b762-b0a973a17105",
+  "doi" : "https://doi.org/10.1234/maxime",
+  "link" : "https://www.example.org/bc389659-a4ac-4b83-90a1-1b862e23e291",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JnO6blh3qDst",
+    "mainTitle" : "hMhK6XY4lKlEmO6zm",
     "alternativeTitles" : {
-      "pl" : "1KXtHzg4KcGuday"
+      "is" : "VDIJaXRzZjK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uvoVhcBjho",
-      "month" : "P3V4zXze9L7x",
-      "day" : "lPnIRWnAMghpd2qU"
+      "year" : "xJpCTffZmxU2tsUC",
+      "month" : "V2PaHTiI4n5E",
+      "day" : "hLI3fo6EzzdMQaD0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2b286c13-9389-49ac-b79f-5071c09307bb",
-        "name" : "s4bFuxKvP0eHzZDh",
-        "nameType" : "Organizational",
-        "orcId" : "O9Ka45sA1TEc",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/52ff372e-cf94-4e9b-b664-c19b348d1947",
+        "name" : "MhE1C9IuzNooFujxuc",
+        "nameType" : "Personal",
+        "orcId" : "VnkQ4Zw3rGU6K7M",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SX1oZYZUDVw",
-          "value" : "uUXTMadlfBYG5d381N"
+          "sourceName" : "eOEfgTT4dvqByRV",
+          "value" : "afIu9Y4WsVPDlSR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wQeNMTttbZh",
-          "value" : "kwN7jl9QkXFAhDfpjj"
+          "sourceName" : "THh18lISP4MKAiaLt1",
+          "value" : "LSIDj5Axpf8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1912231f-e3b1-46bc-93bd-8e66f666dfc4"
+        "id" : "https://www.example.org/5a001476-d561-4139-b70d-ad91adf12a83"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eb5a2192-8df5-437c-bad9-92cfb96b688b",
-        "name" : "CTZVUkudR0WR",
+        "id" : "https://www.example.org/706011ca-8541-400d-b378-aafff837562b",
+        "name" : "SnncBrmELdKy",
         "nameType" : "Personal",
-        "orcId" : "BnncaeaEJTibPu",
+        "orcId" : "m2sUrTl47jLW5",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Wp6WsIQgDY7LzNMMU1n",
-          "value" : "YBvb6QC6C0uD"
+          "sourceName" : "i22QUXLAG5U",
+          "value" : "i5eakC8a9LX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "86SwbkDfvYCmbpYQFTy",
-          "value" : "rZGiz1a1V0TP8GuWqs"
+          "sourceName" : "RoUYI60BFBxsO",
+          "value" : "lG5SLsPsGJ4i9A"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9eac25d8-ef14-4039-a247-dd16f9aef993"
+        "id" : "https://www.example.org/915aaf42-f7de-447b-be92-b87b0e9ae158"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "XFyBThqQxEVW2hRRB"
+      "pl" : "QiccJiVrPM"
     },
-    "npiSubjectHeading" : "V8NhUMDGNOD1Ig1",
-    "tags" : [ "tUgxJkaVRYE40sHl" ],
-    "description" : "kjwdVIoGjH",
+    "npiSubjectHeading" : "4RmNLUIEW3a7PboVuy",
+    "tags" : [ "Ffz96iQ5p1pBEFQ6" ],
+    "description" : "fMUsKEOnIvREEl",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/flHSifYLrrye9uDU"
+        "id" : "https://www.example.com/ZaK9rn1nWDVu"
       },
-      "doi" : "https://www.example.org/02bf2033-cb34-407e-8a30-b269fd640cbf",
+      "doi" : "https://www.example.org/e0d01c03-7c1a-4790-bea3-14cc72322871",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "gqkUblmKrcEEkfLYU",
-          "end" : "9ksESOgDwPifJ3"
+          "begin" : "MrVQ961jrRkANJeagX",
+          "end" : "YQSyAJpxaj5oz"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/922d12cd-5746-4aa9-a3cd-de812d74c837",
-    "abstract" : "ixRwsBYNg2"
+    "metadataSource" : "https://www.example.org/0f51b754-d67a-4330-9b54-a8f76e03c53d",
+    "abstract" : "57PuhBFOrgz3wVcK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d15fdd61-a921-481e-9acc-5cb76d4e5106",
-    "name" : "O9zSQPQUkj",
+    "id" : "https://www.example.org/a55aff4a-772c-4e51-99ad-dccf41d5133d",
+    "name" : "6Csl4jCWlrtUO",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-04-14T11:14:34.314Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "C0yySdQtaMd"
+      "approvalDate" : "2004-01-06T17:09:42.961Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "e87yKh5TdZwmMpmb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6d8bfe4f-b14e-430b-ab52-2491274ab2d7",
-    "identifier" : "JSqUm6nD7xe",
+    "source" : "https://www.example.org/aff83993-0d2a-42f1-b703-ba94d791a156",
+    "identifier" : "jgErByDJtrWWha",
     "labels" : {
-      "bg" : "BcxPvOuZZZRKOIaV"
+      "hu" : "9BQWlv5y6HQin4dFmNt"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 239968832
+      "currency" : "USD",
+      "amount" : 1036001180
     },
-    "activeFrom" : "1979-06-07T00:50:35.309Z",
-    "activeTo" : "2006-08-23T18:55:04.854Z"
+    "activeFrom" : "1984-12-08T02:42:40.366Z",
+    "activeTo" : "1989-06-11T05:10:37.843Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2616cab8-af3b-450c-b3c6-4371faa669e6",
-    "id" : "https://www.example.org/182679d3-d749-47fd-9fab-b0f30b599118",
-    "identifier" : "etQNscmaOzKOlk",
+    "source" : "https://www.example.org/6c0a42bf-261a-42f8-880d-0a2302706d5e",
+    "id" : "https://www.example.org/d3c99d5f-5c46-445a-ab84-81149326e27d",
+    "identifier" : "skLHnJPyy2fAymOw",
     "labels" : {
-      "nb" : "zHWwb8BF7rSQpNQimK"
+      "pl" : "9NUjAI2vvF1"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 208959299
+      "amount" : 1723625523
     },
-    "activeFrom" : "2021-02-28T12:57:55.476Z",
-    "activeTo" : "2023-06-02T15:03:29.654Z"
+    "activeFrom" : "1993-01-27T18:53:54.281Z",
+    "activeTo" : "2014-06-11T11:30:30.355Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/6c74fee5-45d5-45d6-9567-9a38d1fc971a",
-    "sourceName" : "z0yh5p4y077o@oycoqpfokl"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1397778435",
-    "sourceName" : "bydwci2ufbkegvbwosn@sm8ao4fdq2o2fy9mwpu"
+    "value" : "400763059",
+    "sourceName" : "xljcrn0rft@xxbm2gzafwbfb"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "zQpnjh2SQv1AhYr5oE",
-    "sourceName" : "6t6e06xgdzgqcl@tkn3fzcpzcbuh1h"
+    "value" : "y5dvJautiuVhBagRwo",
+    "sourceName" : "brsutvtbtkn911ot@olh3lpxdbr"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/2e4dbb82-3e2e-4fee-8f19-e3498623cb79",
+    "sourceName" : "g81nzvdxnt4y0fhau@itd4src1fgglufx9ie"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "N9eGddkp4L",
-    "value" : "ReR1tGa6bTj1C4d"
+    "sourceName" : "CH8HvkOApENUXCgFud6",
+    "value" : "3t1NrEJvUbx"
   } ],
-  "subjects" : [ "https://www.example.org/dabea65b-1cad-4852-8a3a-60d166ff5977" ],
+  "subjects" : [ "https://www.example.org/16b6bc1b-17a2-401c-a265-6d267bf8e564" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "cd3f0d5a-6e86-469f-92a0-c11ea3db1dc1",
-    "name" : "Emh8v83DNSsC6D4D",
-    "mimeType" : "Xf8YHR6TrfiSR",
-    "size" : 1919683652,
-    "license" : "https://www.example.com/4paj0wxxkz7vlqokokx",
+    "identifier" : "03f4516f-f6da-4b3c-822a-bd0bd81a6963",
+    "name" : "9ECnGzToEYDkoj75WPg",
+    "mimeType" : "b7rZa080kUlqpDl",
+    "size" : 237326011,
+    "license" : "https://www.example.com/ah2scriunnqektb6st",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "zQgWuLbo5TnF"
     },
-    "legalNote" : "T3X5Mn8LlODPdTgXjq4",
-    "publishedDate" : "2002-11-17T03:41:41.100Z",
+    "legalNote" : "7zXeLHIu2BS4yk91",
+    "publishedDate" : "1984-06-22T12:24:53.429Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "rowhRYRtWi4fWakY5Qa",
-      "uploadedDate" : "1988-02-16T17:07:39.168Z"
+      "uploadedBy" : "jaKVfRyICRI",
+      "uploadedDate" : "2014-06-24T16:34:08.054Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tRy7W4IPNBnnTwXT",
-    "name" : "0RWP5Cfgf3UoZ",
-    "description" : "jnU96KmjG2qHToL"
+    "id" : "https://www.example.com/c8bqwpbKxD2uurG",
+    "name" : "i9hpQ2hxJubWUXQPW",
+    "description" : "ZHxUpjsGepN8hS"
   } ],
-  "rightsHolder" : "gkcsYwTbqGzVeXyk",
-  "duplicateOf" : "https://www.example.org/35e13343-e4a9-472c-850e-a1962556f30c",
+  "rightsHolder" : "cuGYlblGDH6x1",
+  "duplicateOf" : "https://www.example.org/4bdbf32e-1ba0-40ae-b418-eeae78597507",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "fLaRfpHRa2T8"
+    "note" : "zwnWOG3eUU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "but66vHXxuyaJd",
-    "createdBy" : "5GWoPuEHhXVAUWo",
-    "createdDate" : "2017-08-05T06:40:54.790Z"
+    "note" : "KN7j3QQZ9jmlGx51i8",
+    "createdBy" : "k4oGBzlvIiNiO",
+    "createdDate" : "1995-08-09T00:01:37.866Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ff8c094b-1608-4959-9ade-2fa96d15894c" ],
+  "curatingInstitutions" : [ "https://www.example.org/f628c0f6-db38-493c-bafa-39cb1e738ba2" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "CJ09S6YVWfZzc",
-    "ownerAffiliation" : "https://www.example.org/f48e99c7-23ae-4652-9860-331a561cb16e"
+    "owner" : "OABYTJ5QWhVV",
+    "ownerAffiliation" : "https://www.example.org/e084692a-18ad-4de5-8174-18aa05ec1701"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b3b4eb89-0d8a-4b80-a192-e736a30432af"
+    "id" : "https://www.example.org/c5f4c0aa-94a2-4cd8-a813-fde8e2525b53"
   },
-  "createdDate" : "2023-07-31T00:02:58.952Z",
-  "modifiedDate" : "1990-06-13T22:05:40.231Z",
-  "publishedDate" : "2016-08-23T16:11:09.033Z",
-  "indexedDate" : "1999-08-10T10:50:43.943Z",
-  "handle" : "https://www.example.org/ef5ae422-683f-4f49-a1be-97dcecb0c2d9",
-  "doi" : "https://doi.org/10.1234/doloribus",
-  "link" : "https://www.example.org/b3a01ee4-f3ba-484c-9717-d29973ba08c3",
+  "createdDate" : "1975-02-15T07:46:14.575Z",
+  "modifiedDate" : "1984-09-26T19:27:41.259Z",
+  "publishedDate" : "1985-04-09T01:18:40.836Z",
+  "indexedDate" : "1988-04-11T12:09:19.208Z",
+  "handle" : "https://www.example.org/e736607a-87b1-4e28-b02d-ba58143cfcab",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/2069285b-6e04-4aea-8fe7-0da98d88170f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ug65AbAvrkbMvRFh",
+    "mainTitle" : "qrhP1FuM3nStWVfk",
     "alternativeTitles" : {
-      "ca" : "k8Pd0JKWwcoS"
+      "se" : "vWilt4XVLTWmlxtwmX0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "8ldmWvdbhHvitHCn6S3",
-      "month" : "xeQLUypKTqvFMqMB",
-      "day" : "gyTdLU9Mz6jeIitbkP"
+      "year" : "e6GS1bfJNfpmFWdZ",
+      "month" : "OslbrGsRsJdl",
+      "day" : "wKlPHBNOpOpKBddK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e52de1e-727f-4afa-9a12-a8de3a300ca4",
-        "name" : "A7TRZtu4tprC4KL1",
+        "id" : "https://www.example.org/3a63dd6f-1ef6-48ad-988e-fb0ee49677b5",
+        "name" : "pAWqdUGMfrjKyOwE",
         "nameType" : "Personal",
-        "orcId" : "yUNEFYrx8UPkXUtU",
-        "verificationStatus" : "Verified",
+        "orcId" : "WLHWElZv9RQ6Na",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VeQYtLuojnr93N",
-          "value" : "YjxuGsIZn3mryST"
+          "sourceName" : "t3NvVYsFTTUI3uzsd",
+          "value" : "upz8LQzrKq8zjHnmy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kPCEd6Ur37mcKYAQ",
-          "value" : "i5VviRAboUae10vS"
+          "sourceName" : "yjgsDSyeuuGUg",
+          "value" : "7YOBJFwbkf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e2754df4-a4c1-4b65-9456-69931d612721"
+        "id" : "https://www.example.org/ca9864b1-8fc4-4d36-b5e9-1c115e17b80b"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,175 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a2191bea-4237-4df5-a6de-a1e3ebab71a6",
-        "name" : "UBDfPM0fmrltNOGn6D",
-        "nameType" : "Organizational",
-        "orcId" : "F72jrAaen5WIwZdG",
+        "id" : "https://www.example.org/b586327a-7124-4155-98f3-7eefbe8b860f",
+        "name" : "u9CL0dvOkAv7IH8Y2",
+        "nameType" : "Personal",
+        "orcId" : "aOvTOcEn7U0vgdzMjF",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KFx1M6vpCYKQSWk857",
-          "value" : "i7joivg2dOLNaOaYV"
+          "sourceName" : "2NBVeErzbd3pet68zmK",
+          "value" : "F7KPMv0RR26CU4ka"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Yu4CbrfARj",
-          "value" : "ZbujK3ngyG"
+          "sourceName" : "Na3LohMhYHRSs0",
+          "value" : "fQxSjcrNZHQtlae0Yi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3eba6ecb-1664-42ee-bfeb-a1bf3c314884"
+        "id" : "https://www.example.org/c861b5d4-01db-46b0-9a7c-7a3b03c1ed5c"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "9ekzjd1IVBf"
+      "zh" : "Y6Vx0EtQQqB"
     },
-    "npiSubjectHeading" : "rB1Wcp45quXZmy9CYFz",
-    "tags" : [ "5YlaRp0xkvgrr5vqHU" ],
-    "description" : "oapDIspnzXzyIPxK6qZ",
+    "npiSubjectHeading" : "0rA99cKsend7FB83H",
+    "tags" : [ "6yhVXoVo7m7uPt4" ],
+    "description" : "E4OYMwvse4wUOVlIe",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e45fc291-ae51-44ab-8780-c2a85a452183"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e95e6e7f-d3ab-48a9-b0bf-a9596db17e33"
         },
-        "seriesNumber" : "3Kh4qe1Wwgin87v0C",
+        "seriesNumber" : "nLII736Na4u",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2b98bdb2-0942-4104-9847-bdeb1fb9ee5a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b6bb6570-7d63-4f68-b981-caa09960ce00",
           "valid" : true
         },
-        "isbnList" : [ "9781096770732", "9780503145811" ],
+        "isbnList" : [ "9780987695260", "9781826607970" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0503145815"
+          "value" : "1826607978"
         } ]
       },
-      "doi" : "https://www.example.org/99bb03a0-c0aa-46e5-98f6-d65add501a0c",
+      "doi" : "https://www.example.org/ee2b1891-a2c7-4cd4-b5d5-0e33e7d7d456",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "l51idRcvSsZ8H",
-            "end" : "76joe12irY"
+            "begin" : "6HK8iB8cCM",
+            "end" : "OP4FWn56N9jfbl"
           },
-          "pages" : "MyflBy4qLnaL7jVqz",
-          "illustrated" : true
+          "pages" : "UDqgW4u7rFXCT",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/15a5d91c-5a17-4989-815a-18af341945ca",
-    "abstract" : "IfsLRtv9TmAOa4J"
+    "metadataSource" : "https://www.example.org/2c39f09c-9e50-4ade-9032-256f65287471",
+    "abstract" : "dbNjmfQbboOIm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f7ffe02d-f1a5-491a-8846-0b3a0832d4f8",
-    "name" : "3iyT8yFifKagMXn",
+    "id" : "https://www.example.org/b938d32f-00e9-443d-9122-c0e505f19ab4",
+    "name" : "aBlw0FLXzS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-12-20T23:21:43.635Z",
+      "approvalDate" : "1992-10-24T23:50:46.261Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "9r5ODaxbcMSIpWt"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "mN0rmh9hAUqfjc25"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/148e215c-9bb6-42cd-bd11-ed135e3301bb",
-    "identifier" : "8hZEastJ9sGwuzVa2v",
+    "source" : "https://www.example.org/a6e0f020-5c22-454f-a6a4-67d1972e7d00",
+    "identifier" : "pws3A2XaPHPHPM",
     "labels" : {
-      "nb" : "aGR8C0Udgrp"
+      "en" : "OgV7xYBxNWX94L"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 483272876
+      "currency" : "EUR",
+      "amount" : 49273617
     },
-    "activeFrom" : "1990-01-08T04:12:41.585Z",
-    "activeTo" : "2003-03-31T09:34:54.784Z"
+    "activeFrom" : "1997-09-28T04:23:08.527Z",
+    "activeTo" : "2017-02-05T12:36:41.533Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e4f99883-538e-44bc-8fd7-f88d3c0c2719",
-    "id" : "https://www.example.org/26f1a174-32b8-4771-9f67-b801fffb4a10",
-    "identifier" : "xtmIDkzc8WK1WTRBQZW",
+    "source" : "https://www.example.org/c858b08a-9e6e-482a-8edd-af61e06a441a",
+    "id" : "https://www.example.org/b1a39701-1742-4656-9bd7-688970d16849",
+    "identifier" : "wyCUrbNWXJWT",
     "labels" : {
-      "zh" : "3CNIITgiwxw39u"
+      "nn" : "MP7U7lVWgkfh1kj4c"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1295180205
+      "currency" : "EUR",
+      "amount" : 556887641
     },
-    "activeFrom" : "2023-12-04T08:26:56.294Z",
-    "activeTo" : "2024-06-09T06:53:18.406Z"
+    "activeFrom" : "2021-02-10T14:28:07.228Z",
+    "activeTo" : "2021-05-21T15:54:48.747Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "c754lZMVjyTpVMI",
+    "value" : "5NJLvjtB2Ss"
+  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/587e77d2-61d1-4650-86a4-776f1d34438f",
-    "sourceName" : "7sjyo5kh1dsx3xy4ecn@zfc8xolae4"
+    "value" : "https://www.example.org/b51acea3-7f44-490f-9e83-44eee2f0211d",
+    "sourceName" : "ywgkfkutymmqkmi92lp@7d9kz3j4ywz"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1002715947",
-    "sourceName" : "3p8u00sszaakydcy9s@w8u4ggkdko3utqa8wn"
+    "value" : "721451634",
+    "sourceName" : "1xrrdjdepxygnl1is@yov26kn2zq"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "Sfdjk1JxVLBER",
-    "sourceName" : "4xcpnsbws9gvaxmmnb@skyi1qlch9xz3ury"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "q8UDsW49KMW",
-    "value" : "zXKCUwqtzTFnjyVt"
+    "value" : "8Ec64P1OhN",
+    "sourceName" : "h9acewciswy@ca42mfeok6"
   } ],
-  "subjects" : [ "https://www.example.org/c8b8c462-ebaa-47f3-9958-b42435f3f9af" ],
+  "subjects" : [ "https://www.example.org/a0635c51-3b3b-434a-98b1-029ca8b3025e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b16248f5-0c38-44bc-aa61-d351463ba80f",
-    "name" : "BVqgF76CxF2UeMgr",
-    "mimeType" : "QXRK4TcHamp",
-    "size" : 116470329,
-    "license" : "https://www.example.com/rby6fisadw2mg89bg",
+    "identifier" : "6dad0e2e-189d-44fb-a392-b6896d44b159",
+    "name" : "SYJfeJtF6pS",
+    "mimeType" : "jGC2fvg0LD2AFJ889i",
+    "size" : 207293445,
+    "license" : "https://www.example.com/tsbsdnnkri",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "yP3OwRF8Hj0bb0Tlvf"
     },
-    "legalNote" : "H1KHyNOl8ty9qutGr",
-    "publishedDate" : "1977-10-19T09:09:48.154Z",
+    "legalNote" : "ChNSO2H7QHGXit",
+    "publishedDate" : "2023-08-10T07:30:25.086Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "198mKFC27Bp",
-      "uploadedDate" : "2011-01-31T20:07:47.422Z"
+      "uploadedBy" : "CSiuWRM7WHRjRTzIgYH",
+      "uploadedDate" : "1999-12-18T00:14:15.778Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZC9ZLLv5EvcMKOW",
-    "name" : "r47NCjaoQZbofIgnYt",
-    "description" : "JvnOByZh6xS"
+    "id" : "https://www.example.com/7K3RZvCi1LTQ",
+    "name" : "wscXFPyA69Zw7y6",
+    "description" : "KOkjCYUtnVa8nA5E"
   } ],
-  "rightsHolder" : "4mjSB21bTw3ZM17OyI5",
-  "duplicateOf" : "https://www.example.org/fee06f58-08c3-4912-ac6b-ff4c5049af7e",
+  "rightsHolder" : "ndTqjpakdMOS9Js",
+  "duplicateOf" : "https://www.example.org/2f1fe140-c05c-4d89-ab27-37505e4e7e39",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "uW7wpLnNFPnu3LO"
+    "note" : "nCzJ4uFn1C361"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ADoS04R5pYu7xEP9Da",
-    "createdBy" : "rbrWqu3B3n",
-    "createdDate" : "1972-07-27T02:24:07.362Z"
+    "note" : "aa1Zx3FcxBvMGpkPhxt",
+    "createdBy" : "azxW4kfQithxbEvtNK1",
+    "createdDate" : "1982-11-13T00:52:51.302Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e7b92381-6f6a-4904-84cf-5dd0271a4294" ],
+  "curatingInstitutions" : [ "https://www.example.org/b866aff1-ae26-4409-9ece-3436f416cf93" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "jANRmDLT2jhFF4kFy",
-    "ownerAffiliation" : "https://www.example.org/5822bbe8-f527-457e-bba4-972ff8b90ff4"
+    "owner" : "BljguXLly32c7",
+    "ownerAffiliation" : "https://www.example.org/75b80228-0684-4ee3-8041-d59396733bbc"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9159d367-4be5-47d5-be41-fe0616d54c90"
+    "id" : "https://www.example.org/e3650a74-0ab2-4880-afaa-40211808a647"
   },
-  "createdDate" : "1976-12-31T17:03:57.453Z",
-  "modifiedDate" : "2006-03-08T20:05:58.073Z",
-  "publishedDate" : "2021-06-10T08:12:46.981Z",
-  "indexedDate" : "2004-11-29T10:07:30.051Z",
-  "handle" : "https://www.example.org/d8f25f70-ad64-429a-bbef-fefb94aa8134",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/2c72a2ef-92ef-4a72-816a-8867b76242db",
+  "createdDate" : "1979-07-18T10:45:57.674Z",
+  "modifiedDate" : "1988-04-19T10:12:43.606Z",
+  "publishedDate" : "1977-05-11T22:28:32.135Z",
+  "indexedDate" : "1999-08-09T08:59:37.955Z",
+  "handle" : "https://www.example.org/64ddbd78-afca-49e1-a29f-fe8fdccecd93",
+  "doi" : "https://doi.org/10.1234/praesentium",
+  "link" : "https://www.example.org/44bd0c6f-6577-4fa1-9564-0c6fed0596dc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hkcAkayvEf",
+    "mainTitle" : "GFjODpBbhwxw4GFwI",
     "alternativeTitles" : {
-      "ru" : "1wDu5zazKd9W3q"
+      "bg" : "oFvcbxCoFyzf1tOxi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ypxB7mO0Bmz",
-      "month" : "pH7ZQXTSGNoimJI7pt",
-      "day" : "mMN5daaS5RKgnBoH6e"
+      "year" : "ZVKx3GT9hLk8Nm14kU",
+      "month" : "NChwTAOkV8cNx",
+      "day" : "GEKXtDouBZqM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e538da21-16f9-4abb-84ff-e9349c1660bd",
-        "name" : "oir0q3kP3xbhC1",
+        "id" : "https://www.example.org/0c588923-909e-4b3e-8996-85f818c5b805",
+        "name" : "IFqMZlmLPSGLGgw2om",
         "nameType" : "Organizational",
-        "orcId" : "fRBfzlSgJWbG7FT9",
+        "orcId" : "lGdpnuryEZWr7PI65",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QKYns7daTAbAqf0hRk",
-          "value" : "nbNtLjl2LyZSgt1y"
+          "sourceName" : "IewJWbHgzQDrC",
+          "value" : "Co61xuvHhXpK5kHV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1dFJRN5jV4FotYyHi",
-          "value" : "XbRhEcqcpJ7Zts"
+          "sourceName" : "8riiKd1aDPP2RIy",
+          "value" : "j8raiCnMXg51eLGon"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f8a0b1f1-4eb3-40e6-bdd8-22a331061629"
+        "id" : "https://www.example.org/2835e5f1-708c-4aae-b329-740cc9ddad0b"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ca64fbef-964d-45f0-be67-96d3f1d70562",
-        "name" : "KCOORyUc6apuz",
-        "nameType" : "Personal",
-        "orcId" : "sA57KDW6VJdKUNpNlh",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/101ace23-84c9-4ae5-8209-94cc30eeed9e",
+        "name" : "oX8oYou9bSanG0",
+        "nameType" : "Organizational",
+        "orcId" : "Ei8JQ16I4cFPFW5z",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "86pxrX2wrne8J1",
-          "value" : "rtEFBp5rLft"
+          "sourceName" : "loXI6nCDvmu74ST",
+          "value" : "7z4FcjOR6DbD0WixZM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5Ag5R45tZLWY",
-          "value" : "Kiis1qZNMQCKUKN7b8"
+          "sourceName" : "uFd9yNm7QKyccenXfqr",
+          "value" : "YHuh3oSGt6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/142c1369-c227-4717-85c9-2513a1446419"
+        "id" : "https://www.example.org/00a441e0-e29c-4924-bf71-77c9c950364e"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "Librettist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "FMbCwZv0lbp0"
+      "pl" : "vQUN5FY7hIga9vbUZa"
     },
-    "npiSubjectHeading" : "9RWkeBRUyfCC6q",
-    "tags" : [ "8S30zEAKRytFRgq4u" ],
-    "description" : "RrQSBOkjVMsOS8ufM",
+    "npiSubjectHeading" : "vVbL4VWSil80jEAR",
+    "tags" : [ "AuK6shVpYGRQRfBb6y" ],
+    "description" : "vTDEvAEIOX3ZGe2LY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/WyHDl7YPGz"
+        "id" : "https://www.example.com/nIoNcpeUKqgrwNX"
       },
-      "doi" : "https://www.example.org/f63ce895-f253-40da-b407-08c246d2ab79",
+      "doi" : "https://www.example.org/7b874100-9e5c-40e1-bfac-4d6ada815bbc",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "w8gwk8Oe7eUV",
-          "end" : "AJLetyyw3IpQ5J2t"
+          "begin" : "9P9h8PYd6RLzE",
+          "end" : "6Q4yrgrAJbaEyxdg"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/470ee985-3233-4e5f-84c8-9094c4697e27",
-    "abstract" : "ng00P3bGPugWpnP8Lw"
+    "metadataSource" : "https://www.example.org/0d57ea4e-1952-45cb-888e-27d8ae23cd08",
+    "abstract" : "ohtTjWvLZVcMS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d4ddbfab-59a9-4ff1-b4fd-5fdc2835a5f8",
-    "name" : "Uij0cNalBvAm",
+    "id" : "https://www.example.org/c9f95d66-c687-44a8-ac7c-be7b79594643",
+    "name" : "dYrD4caz70",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-12-14T11:07:58.251Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "vziw6lZNB540TSXKf3V"
+      "approvalDate" : "1973-09-25T04:25:29.286Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "W87v4meFh2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/74db733a-ebb8-4bd4-a789-41a9f544300f",
-    "identifier" : "cLeMCPjZt3USY4yuM",
+    "source" : "https://www.example.org/4230a206-dd74-4a1d-a584-e108b70e3826",
+    "identifier" : "lZ7WVYjAR9DTp0vM",
     "labels" : {
-      "ru" : "Cnba7Lf344LwCOFRK"
+      "pt" : "Z2MxbP8CwNDRg7W"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 622921866
+      "currency" : "USD",
+      "amount" : 142027619
     },
-    "activeFrom" : "1988-02-14T20:26:24.703Z",
-    "activeTo" : "1992-04-04T23:49:51.258Z"
+    "activeFrom" : "1988-01-24T14:58:29.907Z",
+    "activeTo" : "1999-07-05T09:34:25.768Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9d77ff1c-2b73-4a78-a60e-3ae12bdcb4fc",
-    "id" : "https://www.example.org/db445f89-3056-4c3f-b960-2181cbd119f1",
-    "identifier" : "nP2qRArXMc",
+    "source" : "https://www.example.org/b83faa5a-cf8b-4c38-8b26-61522dd02867",
+    "id" : "https://www.example.org/5013d514-a5c6-44fd-9857-85147b820601",
+    "identifier" : "WJciJT5NrSmI4lwNRI",
     "labels" : {
-      "nn" : "gq5QzzYkEeHJ8lY"
+      "zh" : "nK9tjn3Tdws"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 752056624
+      "currency" : "NOK",
+      "amount" : 574957217
     },
-    "activeFrom" : "1985-05-26T14:07:41.253Z",
-    "activeTo" : "2018-07-07T15:09:42.377Z"
+    "activeFrom" : "2016-09-17T21:26:57.202Z",
+    "activeTo" : "2023-05-14T08:16:24.993Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "VnoZaZDkFkm7O4plnB",
-    "sourceName" : "hhitfomyvqchvs@ud0cvgfgjvykvm"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2997dfbc-1212-474f-aef1-4254e54e4188",
-    "sourceName" : "ni1snefsipd20gd@vxosen591owsrd"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1590003362",
-    "sourceName" : "b1px3w2i1gbn6n@sfxazagfkmc3"
+    "value" : "https://www.example.org/861e5327-5b85-440d-a0d6-9159957fc746",
+    "sourceName" : "7ee3cc900ik@wx1k4tdmys95pww"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "xSA4YoCEzns",
-    "value" : "UPNySTSY7WZ"
+    "sourceName" : "n654Z894dPi9g2",
+    "value" : "Tc9gC164vuWVfj5ZXBW"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "ksbswQadIaHwK4S",
+    "sourceName" : "116mrrhgxy3odk3@iuu0aowlxewj"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1638613688",
+    "sourceName" : "2bqpxgjdxxw@fgrcgi93lpb3g"
   } ],
-  "subjects" : [ "https://www.example.org/88ca1f80-9323-4088-9262-9ab7e325e8bc" ],
+  "subjects" : [ "https://www.example.org/09642924-76e0-4460-9592-e8e8f53be671" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bc8e18e7-4849-48ab-b694-2fb188dbbf9e",
-    "name" : "yNGFYhaqraVI5yHs",
-    "mimeType" : "Ucby1gH3jgye",
-    "size" : 926520642,
-    "license" : "https://www.example.com/hwzn1bhw7quvmqtng",
+    "identifier" : "2f1fb13a-be8c-4ca3-909c-a3e6846325c9",
+    "name" : "cdCEDKWnhsktgP",
+    "mimeType" : "CHYpi6B5tqRb",
+    "size" : 339365734,
+    "license" : "https://www.example.com/pe2ndbuboq",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "REet7LM1TSGL",
-    "publishedDate" : "1976-10-16T10:43:16.744Z",
+    "legalNote" : "L5qCUQYab5",
+    "publishedDate" : "2006-01-18T20:10:12.590Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "AcHJdam3Cxv",
-      "uploadedDate" : "1986-04-27T23:44:22.681Z"
+      "uploadedBy" : "CVWE4g2wf746P1",
+      "uploadedDate" : "2005-09-15T18:13:57.465Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Fm4WmFbpoP",
-    "name" : "7YbkdTnWynTHxO9H",
-    "description" : "ztx7WLiTyM7gkCGQw0q"
+    "id" : "https://www.example.com/l55tGAUGWVils6J4",
+    "name" : "dYmEgvyWlLVUyz5p",
+    "description" : "WEHEnPFoh5sX5c1"
   } ],
-  "rightsHolder" : "W7Ym2WdrQ1U",
-  "duplicateOf" : "https://www.example.org/6bf4dcd6-461d-4990-bbc8-93e61feb9962",
+  "rightsHolder" : "iXWshP7KkWNsd6o",
+  "duplicateOf" : "https://www.example.org/9cbae5d7-104d-49c7-b7d6-c5705d7bcf68",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "s8kKibThjC9A1YrX"
+    "note" : "3UjEqw60pEMJq5F"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "yWQAkT1GeLpL",
-    "createdBy" : "08HPwYmKemtu",
-    "createdDate" : "1977-10-18T04:52:29.804Z"
+    "note" : "yI658sOApnS8BcJJ",
+    "createdBy" : "rYJ8rdWCJPIq",
+    "createdDate" : "2007-04-18T20:45:11.753Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4b41d385-00b5-41a7-b6dc-a9d65674a865" ],
+  "curatingInstitutions" : [ "https://www.example.org/d15b224f-d1b6-4272-9e74-91d243a1ad50" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "pv7LRKJiJVJ",
-    "ownerAffiliation" : "https://www.example.org/b2b55beb-e780-48a0-b5fa-0d63cc60f529"
+    "owner" : "714U0Xiz2fvh",
+    "ownerAffiliation" : "https://www.example.org/2e8c83b4-30b9-4635-ab65-0df5bab78f15"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1d4c8024-c95e-4bfe-ba1a-a329c0e4cb45"
+    "id" : "https://www.example.org/52cf72dd-5e1e-4ce2-874a-3409e8bb61ae"
   },
-  "createdDate" : "1998-09-25T17:27:23.800Z",
-  "modifiedDate" : "2019-12-25T06:35:36.549Z",
-  "publishedDate" : "1998-11-21T10:15:33.896Z",
-  "indexedDate" : "2019-03-02T01:16:50.696Z",
-  "handle" : "https://www.example.org/733723f1-8ccd-4fda-b168-c751acfceef3",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/c4cd30dc-b2bb-4a4b-8624-678648cba39a",
+  "createdDate" : "1987-08-31T16:58:35.655Z",
+  "modifiedDate" : "1991-02-27T17:51:54.506Z",
+  "publishedDate" : "1996-06-20T06:51:28.108Z",
+  "indexedDate" : "1989-11-02T03:27:19.787Z",
+  "handle" : "https://www.example.org/bf1f391b-53f7-40a7-bf8d-0d15ee088466",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/08f62d58-4b3c-48a7-9cac-0089c52d77c1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bfDdrcuOSDd",
+    "mainTitle" : "zIZqinKTL1tf0",
     "alternativeTitles" : {
-      "nn" : "kztMDJwc1INDEk"
+      "is" : "BHBdWEuQGGVka"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UiKGw2jw1cBE",
-      "month" : "fRHTdhRWqVP89UTs",
-      "day" : "1mUx1ZSzWhB0ls80T"
+      "year" : "AUoRnK23MZqW",
+      "month" : "dfSs6lWmBmHz",
+      "day" : "xOfxQf2Yg4o5DvQLD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/53042e84-7dd0-487b-b2b2-c5d39cc83bd1",
-        "name" : "0GX3I0VYLmxzX10icj",
+        "id" : "https://www.example.org/050b0f50-ebeb-4468-ad2c-b5aca43df6b3",
+        "name" : "vWsy7LZFZulM",
         "nameType" : "Organizational",
-        "orcId" : "I8cgQluKHljr",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "dm5PJIy258GpL",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QfjVS6TpGm0lZYvMc",
-          "value" : "a20GFDBuez9G"
+          "sourceName" : "GW8xJeY5Ux",
+          "value" : "FKQTCUzYCwBQrixF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ejOsMVsQ1Y",
-          "value" : "6qfB2ShuEZL5nzLK"
+          "sourceName" : "6cKqy9fEN89tJfnfzJ",
+          "value" : "AKIeCWKfkD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/769f7770-bafd-4019-b54e-8dbf456404c9"
+        "id" : "https://www.example.org/41f26f9b-f40b-4f3d-8659-c805d6eb64db"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Musician"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,94 +62,94 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ed1722f5-1080-45c6-ae5e-bb20484005d2",
-        "name" : "u3B5zVfTkMqyo1MX",
+        "id" : "https://www.example.org/cdc6d1a8-856e-4b90-98e5-a2ee3069bfd6",
+        "name" : "pSwvTnovlBgkb5QFsDA",
         "nameType" : "Organizational",
-        "orcId" : "if4OcpPkyfa",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "ppCvUja8BkcRlx",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QM2I4cIFL2lH8",
-          "value" : "YRRzVrpPj5YL1"
+          "sourceName" : "jSQrk1ZdYYCEh2U2",
+          "value" : "BJDvaipAVh0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fR1QAJrN3re6PoNDC",
-          "value" : "hb9keRw4D6n"
+          "sourceName" : "w7tBlR65JOda",
+          "value" : "GKPqxgysFt1XPWNM02"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/549f0163-5a59-4d38-8d99-4c299e342fc1"
+        "id" : "https://www.example.org/1335a383-864b-40f7-a620-fff66c85a30c"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "2zd3iW8uz81BcNfVI"
+      "zh" : "uzOux4odhlSTQMpY8O8"
     },
-    "npiSubjectHeading" : "abrkbNn9uT",
-    "tags" : [ "0C2lbyZVlaZoviw8R" ],
-    "description" : "rkXXmoi3jcz19nnT",
+    "npiSubjectHeading" : "H5u9SDASY8FR0UTUml",
+    "tags" : [ "xVqMD9JCpKh7FZszCG" ],
+    "description" : "8jbOYRba68",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/32230eaa-c932-40a5-98fa-883e73f62577",
+      "doi" : "https://www.example.org/0679da29-9ba7-4d6d-9356-0d1860b8a394",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "PopupExhibition"
+          "type" : "BasicExhibition"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/tr2GuqUEmBzBmfl9Zu"
+          "id" : "https://www.example.com/VQCFIv5jbMA35"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "T3h6wu4pVPnNKrhm1S"
+            "name" : "wNVKEoCLrMg9GHm8"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "i9R3WIDOPbX5wy85",
-            "country" : "L6yCQU3ImaLF"
+            "label" : "fHbkNWHVHqoHBpBJ",
+            "country" : "hPfwwM6EeWtDmEHU8X"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2012-08-16T21:11:39.221Z",
-            "to" : "2013-07-21T07:31:33.618Z"
+            "from" : "2000-06-10T08:31:27.338Z",
+            "to" : "2020-02-09T18:54:30.026Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "hd16vzqwXDX",
-          "issue" : "KKaT9DmmPa3dNYN",
-          "pages" : "45CmhFyukC7Ony3f",
+          "title" : "yNT4AhX5J7KjRf",
+          "issue" : "CqT39PqZM9w1FqsLiC",
+          "pages" : "J7EvBMBRPO",
           "date" : {
             "type" : "Instant",
-            "value" : "1974-09-13T09:36:49.267Z"
+            "value" : "1986-06-23T19:49:27.886Z"
           },
-          "otherInformation" : "GDxoSeplgmCD"
+          "otherInformation" : "fFGk1W2YAq5VqUdhn"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "EJ56pMsIgW",
-          "description" : "Io6KCcqKowcg",
+          "typeDescription" : "PAMHLCAcUe3",
+          "description" : "mxuMEpTqRMMVjBmoZ",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "i2Q2TjvExpJk28w",
-            "country" : "1p9FxaCoErMQ"
+            "label" : "OB4igKezn3VfEZvr",
+            "country" : "lwaRI59S0xjdRZ7"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "kqS770GJhsqlIx2sg3",
+            "name" : "vutWkBvgjL0K4iA",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2006-07-29T08:32:01.273Z"
+            "value" : "1999-09-09T22:04:23.272Z"
           }
         } ],
         "pages" : {
@@ -157,106 +157,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/25fe9989-3a1a-4091-af65-edc1b19bb20c",
-    "abstract" : "UPsZuyoeKl"
+    "metadataSource" : "https://www.example.org/bfa11c0b-8509-4165-a7fa-8d220930fe22",
+    "abstract" : "VKLWRq9YM5gdEa"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7b7e5dc5-4eb4-4fe1-aa3f-5eeb21306680",
-    "name" : "QZ86allHTeuh4J",
+    "id" : "https://www.example.org/59c426ef-e495-43ec-bfb3-8fbd4cd38f93",
+    "name" : "nkByYderndPnzkp7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-08-16T19:42:36.057Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2005-01-28T14:29:03.557Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "ozsJwswOgREb4Q"
+      "applicationCode" : "UQ7g1KdJTPUy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/457ef634-24f7-44b4-b0bc-5e47cf0e8395",
-    "identifier" : "Kk296SXg7OJmfHgOCu",
+    "source" : "https://www.example.org/3ef0cc1d-2f50-46e2-9669-74cd87debeea",
+    "identifier" : "xyrPlCCVigNZBY",
     "labels" : {
-      "is" : "VO0Bo7g2VWKs2Ue14UR"
+      "hu" : "nEUubMg60LrlV7"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2125251780
+      "currency" : "NOK",
+      "amount" : 1506753815
     },
-    "activeFrom" : "1999-06-04T12:27:31.906Z",
-    "activeTo" : "2001-06-29T09:10:06.086Z"
+    "activeFrom" : "1987-03-11T11:00:32.166Z",
+    "activeTo" : "1998-11-04T17:36:23.881Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4cb94471-a00b-47cc-b573-e4d88a8c12e9",
-    "id" : "https://www.example.org/14ee0063-825e-4e5f-99b7-316e0b252524",
-    "identifier" : "bKLsQ9qYFhwuRP7c3pG",
+    "source" : "https://www.example.org/9119c82f-9297-4e2e-9a68-d62507acf209",
+    "id" : "https://www.example.org/b7bae701-e9fd-4521-8dc3-8e1e51d31d0b",
+    "identifier" : "7x4jokFNwYo3iPE",
     "labels" : {
-      "es" : "lm2CRJCaaUfIlpngmM"
+      "is" : "uDuEre5UOXi"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2028741757
+      "currency" : "NOK",
+      "amount" : 629521257
     },
-    "activeFrom" : "1999-04-03T04:55:36.052Z",
-    "activeTo" : "2015-12-25T12:53:21.391Z"
+    "activeFrom" : "1997-01-30T21:53:53.593Z",
+    "activeTo" : "1999-05-16T21:37:54.004Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "TqOQ9iQE3yt76Zx",
-    "sourceName" : "md1oipnne4syi@6fk6aebozur8"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "Y0r7dqzovAkVdmveU",
-    "value" : "Wr7uZ5a0fJwuivQOR"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "827941917",
-    "sourceName" : "c7toccjienmrqjgltsg@lissdvjzqq"
+    "value" : "107256450",
+    "sourceName" : "olrrcsojhavb@b7n60u6e3tunwdpynmi"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "fseDgaPhJW",
+    "sourceName" : "hx6jrjgula7e5@eirfou1fobzzkqx4sna"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/60ca5fd8-5e74-434c-9e15-3e2425b7c23a",
-    "sourceName" : "xy1tg4pbat@l0wlpnp9w2p0"
+    "value" : "https://www.example.org/a78e756a-9e8f-4ef6-8ad8-d5f6853e99ea",
+    "sourceName" : "e6zbzhgdr0tanifcdxj@sapx8bqkl6v"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "OtL4UkMPCyuLH",
+    "value" : "HuBJucW9JfUQnEb4"
   } ],
-  "subjects" : [ "https://www.example.org/5c8fb389-fc68-4016-9179-43fc96c2e8a2" ],
+  "subjects" : [ "https://www.example.org/c4efb843-2e20-425a-830e-ba0a7ed23be7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c58e095e-c5ac-4ff3-a1da-dac3fb13dc16",
-    "name" : "Lto4UQbSKLM7xNEd78T",
-    "mimeType" : "1VkGTC5y9OHVQEcuDhU",
-    "size" : 1227181461,
-    "license" : "https://www.example.com/b1aphrofs89yuw",
+    "identifier" : "ec80c6ca-2364-408e-abb6-38717ef21003",
+    "name" : "w3UhYwlBTPsjiXi6",
+    "mimeType" : "tD0PhFPpMd",
+    "size" : 1785176675,
+    "license" : "https://www.example.com/vttblwhuhgqlbwy2f",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "nUWlQ7VQpB3",
-    "publishedDate" : "2022-03-02T07:48:06.808Z",
+    "legalNote" : "1PWykAV1qYJqTG2o4q",
+    "publishedDate" : "1977-03-12T03:33:34.802Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ec4SnUVY31rYKV19Z",
-      "uploadedDate" : "1972-01-02T12:18:41.103Z"
+      "uploadedBy" : "61CaF7JBWb5",
+      "uploadedDate" : "1993-04-13T12:19:06.721Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/z5bwNWvEZq7",
-    "name" : "CBiGoJzj6uQMAl6YE",
-    "description" : "frYJYtOPwDy1mePV0M"
+    "id" : "https://www.example.com/msXNwP4D2nUhu",
+    "name" : "Lb6pMwLDVol",
+    "description" : "apyeeAY6kA8"
   } ],
-  "rightsHolder" : "WF2YiDc4CpQtPjTnM",
-  "duplicateOf" : "https://www.example.org/38dc94c8-77b3-426c-a6cf-9f5b1c9216e0",
+  "rightsHolder" : "I56dynUdLJNPy",
+  "duplicateOf" : "https://www.example.org/ce81c1d2-f0ad-4cac-bbdc-8cb055d359ab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Qt39vnn8xin"
+    "note" : "hneR8NUSzbqZIzr4g"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "UNCpkcwbVS",
-    "createdBy" : "YD548Vc4yKYO46AfrLP",
-    "createdDate" : "1988-05-31T16:31:50.124Z"
+    "note" : "iIB0gCjXUH4lvyZYwJ",
+    "createdBy" : "cXCKGZyD21Fo",
+    "createdDate" : "2016-02-08T20:09:32.398Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6d2bbb0a-5e99-440c-8cc0-4b4f3ad33f92" ],
+  "curatingInstitutions" : [ "https://www.example.org/bcb30545-9e2c-415e-9bed-f0ddd0ba424c" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Niq5eG1CMboUZgNleL1",
-    "ownerAffiliation" : "https://www.example.org/b8d5dd2c-191a-46bf-a30e-f1af230c8b22"
+    "owner" : "cqaMQOKer18",
+    "ownerAffiliation" : "https://www.example.org/a6a7c1a1-1c71-4d47-a9ee-d4349995fc22"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ca308f3a-5f32-43a6-ab4f-d75a5685a84c"
+    "id" : "https://www.example.org/9e221ebb-b0b3-4e4f-95b8-acf6244864c6"
   },
-  "createdDate" : "2017-09-22T10:18:40.384Z",
-  "modifiedDate" : "2000-01-23T02:13:59.772Z",
-  "publishedDate" : "1972-11-30T12:23:50.413Z",
-  "indexedDate" : "1978-04-03T20:26:56.159Z",
-  "handle" : "https://www.example.org/2e7a758e-1aaf-41bb-b88e-7b4acde9443d",
-  "doi" : "https://doi.org/10.1234/rerum",
-  "link" : "https://www.example.org/a36dd077-df4b-4077-b0c5-de3f5e83dc26",
+  "createdDate" : "1984-11-25T16:48:34.065Z",
+  "modifiedDate" : "2004-09-10T06:13:52.260Z",
+  "publishedDate" : "1978-05-17T23:29:49.277Z",
+  "indexedDate" : "2002-06-26T04:25:17.727Z",
+  "handle" : "https://www.example.org/f9a7cdda-4cd6-434e-81be-c8fb36ce6c9f",
+  "doi" : "https://doi.org/10.1234/fugit",
+  "link" : "https://www.example.org/2db927d5-9636-484e-836d-beea17f47f7b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xKhFZqxESN3g4vh2lV",
+    "mainTitle" : "DQj7sMbRFPJ2jY",
     "alternativeTitles" : {
-      "ru" : "EU48dM88XLy"
+      "el" : "ETR3N7iYbigDzF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AtdibT8z4hDMOWacMs",
-      "month" : "Dx7EPjxaTJwZGPlp",
-      "day" : "dh0pSLugGza4MVu44vA"
+      "year" : "jFbycYdh874a",
+      "month" : "yXOLSW7IIy",
+      "day" : "5z2uxqk61oMZ2b"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fb6a1e18-4b39-4e5f-8cc1-a1b49075739f",
-        "name" : "ce9Gh9BJGoryGJPVeB",
+        "id" : "https://www.example.org/0202e0be-d05f-4fa0-b79d-0f4d7518612d",
+        "name" : "l97Ew8iadY7J3u6",
         "nameType" : "Personal",
-        "orcId" : "MClRC1Vo8q3KrE",
-        "verificationStatus" : "Verified",
+        "orcId" : "fLIlEYavm21pqCLH0qT",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YiDRSuz0fBjRYj",
-          "value" : "tXaLPCVNfTDy"
+          "sourceName" : "Zvp4hKWJx3r1",
+          "value" : "anmCBeIYk1h3hO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RiZcjcvWPKrHqRDx",
-          "value" : "mDTZVBusulGXH3BY"
+          "sourceName" : "Lc9YBjvMxL3HIP",
+          "value" : "N4XuQE4M1Egs2TPnU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6d13a317-0682-4021-ad82-2b5e315891a2"
+        "id" : "https://www.example.org/f7ac2a1f-49bb-4247-8f39-13c35a09c46b"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e7dfe66-ab44-4380-a0a3-fe035ea9bc61",
-        "name" : "j0K1Gns7iG7MxKF",
+        "id" : "https://www.example.org/d68e5132-3c72-4874-835e-17aa40bf7372",
+        "name" : "wL2KMfavIT5FruLfIX",
         "nameType" : "Personal",
-        "orcId" : "TDXBVUvIGeePzQD5EJo",
-        "verificationStatus" : "Verified",
+        "orcId" : "PIJO2eLd55TK6r3",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ql19n5z0meZ",
-          "value" : "XOY9nxtSP6TAz3iGHX8"
+          "sourceName" : "vVfgB3L9WrFNuI3",
+          "value" : "BuKRXGt17qA5qseo0B"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VxNP9afL3dq5O3ja",
-          "value" : "0DmNwv4Na1FnZ"
+          "sourceName" : "HBo84JBiQDBg",
+          "value" : "Unoo6EJbwTthOvRc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cb1803ab-c71f-4a97-8e57-ea54d4432b38"
+        "id" : "https://www.example.org/cdd563ac-63a1-4f48-8710-c9504ce5bc4b"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "ctAoSzo49t6Rd"
+      "de" : "InPB96puXt6Z1Er"
     },
-    "npiSubjectHeading" : "tJU1TJAi58tkgxeVdy",
-    "tags" : [ "1lsaaSsxBe" ],
-    "description" : "E93RpfKc3tyeM6p",
+    "npiSubjectHeading" : "qAoMydBr6jK",
+    "tags" : [ "RokZxGjB8rPcpsLe7xr" ],
+    "description" : "yhQREQ4FaEusqT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/h9Pyi6wpdJ4HnlwMbl"
+        "id" : "https://www.example.com/fG8NcCdyuttkPdsTjW6"
       },
-      "doi" : "https://www.example.org/e9e0e7ec-b69a-41b9-8284-13b12749a330",
+      "doi" : "https://www.example.org/c17f57b2-e369-4bbb-bed3-3c57404fc107",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "Sch1p7KQQM5",
-          "end" : "xuSIOEAo3MHJjeA"
+          "begin" : "2Xhx1bCuuvbRmEWs",
+          "end" : "rJOqsRBKcxcDWmrWT7"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3dabdc9b-f297-442e-a09d-d24e7a96e365",
-    "abstract" : "baO5OdOQJlUF2r4Ir"
+    "metadataSource" : "https://www.example.org/a29d0b29-5d51-4009-96cf-932c35fd6d1d",
+    "abstract" : "IDBfOnVCAjC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5f4787f7-146f-49d3-a640-ba51b38564b1",
-    "name" : "kpT3CANqIQpsd",
+    "id" : "https://www.example.org/dc8547b3-0ff5-4b58-96a7-43e9053d217b",
+    "name" : "9dGy1oCPS4OkXmCJB",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-01-10T03:24:04.258Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "WI7tuH8PoGr0Qbj18w5"
+      "approvalDate" : "2014-02-12T16:46:22.869Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "IVKnCcJlgLvMgwU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e56ed899-868d-4606-9685-be4044bce1ed",
-    "identifier" : "aDZF9AuUa11xeQX7tE",
+    "source" : "https://www.example.org/80957717-ff20-44f1-9f57-d34a5b309551",
+    "identifier" : "SUD885mTueH",
     "labels" : {
-      "da" : "0dqHIhVgY5"
+      "bg" : "NPRLpQ1gKXi18jjJph"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1198460809
+      "currency" : "EUR",
+      "amount" : 1692175427
     },
-    "activeFrom" : "1972-10-14T20:26:54.254Z",
-    "activeTo" : "2020-12-26T17:17:16.140Z"
+    "activeFrom" : "1992-02-03T14:30:15.905Z",
+    "activeTo" : "1992-04-12T18:59:59.859Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e9778b43-d0ca-4166-ac06-8b3b5feff269",
-    "id" : "https://www.example.org/e26f3b40-fdb9-44fb-bbda-064df36d13d6",
-    "identifier" : "IC8H4ynbA0BIyDBetL9",
+    "source" : "https://www.example.org/da69f733-b4e9-4c2d-86b6-7b0f2bca7e10",
+    "id" : "https://www.example.org/cdc41aa9-e619-470d-8391-aabe0f60623e",
+    "identifier" : "592QrEhZFzxOq2jI3xB",
     "labels" : {
-      "fi" : "egKbFVBXGDs"
+      "fi" : "S0HNaoGWPIg"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1942837141
+      "amount" : 429785662
     },
-    "activeFrom" : "1997-07-07T01:10:49.465Z",
-    "activeTo" : "2007-04-25T23:05:44.232Z"
+    "activeFrom" : "2014-02-27T20:56:44.966Z",
+    "activeTo" : "2023-03-30T11:42:45.728Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "lCI2pswCSYukS8Zh3O",
-    "value" : "7iiIBzJkYksA"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/af0cc7de-352b-4090-9a4b-2f5c9d475bb8",
-    "sourceName" : "r1ugbqf8rxk5p@0cscgqugcfuzjo"
+    "value" : "https://www.example.org/eff794dd-ad35-43f1-9f0f-63894bd15c01",
+    "sourceName" : "e4ym7fzpzs@4klobamu3ox8l2"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "rW10Q6HeYUG",
-    "sourceName" : "bdvjonkkyz@poosltgfoympbaqq"
+    "value" : "pAJxfdWMRkQ",
+    "sourceName" : "wasiodriy6evw@cfuvtoxcm6fk4hbc"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "TbMuaBkG9j9UH",
+    "value" : "3FLCkSJFSwRL"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1459643327",
-    "sourceName" : "ydytkddhqsbz0m@ztdeugs7jgrw78l1za"
+    "value" : "237766099",
+    "sourceName" : "8qfaglwzkjx2duxh@8blmjladloucs"
   } ],
-  "subjects" : [ "https://www.example.org/89c85e7a-220e-4f8b-905f-3b752a1e9161" ],
+  "subjects" : [ "https://www.example.org/371dbe4f-8dad-4dcf-9ec7-6477eaaab8bd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "536a6df7-acbe-44c6-90de-8f56b51d49dc",
-    "name" : "IAXfE6avPtH0i1",
-    "mimeType" : "ngh6YWq4oj4MTKvWE2y",
-    "size" : 2074892391,
-    "license" : "https://www.example.com/9evbh2k2lry8pi",
+    "identifier" : "119d4da3-d3b8-4076-a7fd-760e4e300ead",
+    "name" : "pCCfNaqbRo33",
+    "mimeType" : "M2ou8cSjDhND64nU9g",
+    "size" : 1698772121,
+    "license" : "https://www.example.com/lmi9e3st87az",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "gkmxl3goz0W"
+      "overriddenBy" : "KEmRzrfr3ccF3mAB"
     },
-    "legalNote" : "06WLq2iO0S",
-    "publishedDate" : "2022-07-04T06:28:56.948Z",
+    "legalNote" : "1BDaNssEsdj9dhHjG9A",
+    "publishedDate" : "2023-02-11T06:37:03.987Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DE93FbWfXZlH0e1",
-      "uploadedDate" : "1983-11-27T06:42:06.933Z"
+      "uploadedBy" : "oKzPHrDBMhQVgVSrnX",
+      "uploadedDate" : "2023-02-27T14:03:44.815Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/1rbKCfBAtT25",
-    "name" : "iBXmWpTHKITnxcge8W",
-    "description" : "jgvKwZHczuqC2"
+    "id" : "https://www.example.com/KSUcxaNsM81p",
+    "name" : "U0vLzyGv5e",
+    "description" : "pKtvooe579HY"
   } ],
-  "rightsHolder" : "It3tBO8wy11F",
-  "duplicateOf" : "https://www.example.org/02ade6b5-365e-407a-9213-72b7a1b06574",
+  "rightsHolder" : "WumyBLXZOYcTImK",
+  "duplicateOf" : "https://www.example.org/3b2949c3-3883-4566-8d1e-ee1a913e7ba1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "HGBF8CZJZA"
+    "note" : "17Ac3j6BVUCr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "EtFwPsvcOO",
-    "createdBy" : "BJ93Ip5ZUnc6skGz",
-    "createdDate" : "1996-10-02T03:15:41.834Z"
+    "note" : "dXcNa2fOnw1",
+    "createdBy" : "GAOVAfWq6vOx0jjhoL3",
+    "createdDate" : "1999-04-05T17:34:48.850Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/cc8c46a0-ea13-4367-9e6d-39651fcb0195" ],
+  "curatingInstitutions" : [ "https://www.example.org/d8779d59-ddfc-4d52-866d-16ed6770023d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "g4FuEZj5BwNorAEd",
-    "ownerAffiliation" : "https://www.example.org/ce2fd9a3-34ef-4920-a07a-953412fe26bd"
+    "owner" : "Yw9mL1hgtQxM",
+    "ownerAffiliation" : "https://www.example.org/65d74972-8401-4896-84bc-033cdeabf2b5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9a9b9f1b-806c-4bc9-af27-a7c3c521f1f9"
+    "id" : "https://www.example.org/ece2cc0e-71f7-4102-919f-2c389bd19268"
   },
-  "createdDate" : "1973-12-26T16:55:41.698Z",
-  "modifiedDate" : "1971-10-17T22:32:54.831Z",
-  "publishedDate" : "2012-07-15T09:23:40.005Z",
-  "indexedDate" : "2004-04-27T03:44:17.804Z",
-  "handle" : "https://www.example.org/9655b648-a2ef-4f63-b324-80b81a1ece2b",
-  "doi" : "https://doi.org/10.1234/inventore",
-  "link" : "https://www.example.org/6985e169-e2ba-4fe9-81d4-c372fd4bff30",
+  "createdDate" : "2011-10-20T03:50:20.827Z",
+  "modifiedDate" : "2023-03-14T21:43:17.309Z",
+  "publishedDate" : "1975-09-08T10:01:08.224Z",
+  "indexedDate" : "2012-03-04T21:56:25.583Z",
+  "handle" : "https://www.example.org/c3d85f8e-4644-42f3-af38-4d1308ea2ced",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/43cc98a1-811e-46d1-96ec-300741297a54",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "PChqcUj6gwKt",
+    "mainTitle" : "sBtTVO5U9EeE",
     "alternativeTitles" : {
-      "is" : "A4S3sXp7sM"
+      "bg" : "airkprQKGm2HDJN7gK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zHK7NkK6wxb",
-      "month" : "uow4h0sVnU0rJdVAqEr",
-      "day" : "KyGRSOuBSnaCSteLIN"
+      "year" : "LVEF08bfLlhPDnd",
+      "month" : "nWeYWAXWydXr3lcg",
+      "day" : "w48BzDBSlVVeN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c0f3b9e7-4799-4917-a165-515cbff824f0",
-        "name" : "M5X9ImH14C",
+        "id" : "https://www.example.org/8ff31ca8-5fa3-4955-91b0-052ea583d399",
+        "name" : "VHVrKWzgCw6UDa06sz",
         "nameType" : "Organizational",
-        "orcId" : "7yiBmavtOrq3qNTrlxn",
+        "orcId" : "Fvv74oa6sKjaj",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ndKcjcU1e4gfj",
-          "value" : "KzkkJ7mIZY"
+          "sourceName" : "cAY1juokczDjVBpe",
+          "value" : "Rf9anOV5vacVAXG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lSzne938yHzGEKYb",
-          "value" : "myxh7DsDevAFK6qGwq"
+          "sourceName" : "fO4oewxdCs",
+          "value" : "L3VKvFr4NhfGYBgem"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f4c8af5-c9a6-4792-828f-e800394f2b06"
+        "id" : "https://www.example.org/a02c4d8b-88c9-4356-ba7a-55555864117f"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,158 +62,158 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e4189c81-852b-4c04-ab32-ba92c97ffda2",
-        "name" : "WvWoB8fJF1b",
-        "nameType" : "Organizational",
-        "orcId" : "YqCp2TFFMP2X9q",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/5cf29037-2fcf-4d3a-bf74-4bc209dd802f",
+        "name" : "ettIFufh5ur7Nv5",
+        "nameType" : "Personal",
+        "orcId" : "AbCUAFIkCd6WEpl",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7Iq20b78cRLAx",
-          "value" : "FJvyRqdxz3Jdat5rk"
+          "sourceName" : "4MtArarRPwJWX2",
+          "value" : "cf4iXkRFnIc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Dz0uATq8P6YyD",
-          "value" : "sBvHuBJxCZr"
+          "sourceName" : "AwZIXZhSxdHdlFgBGR",
+          "value" : "b0m3WlY8daT3aiyCVo5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5899f008-8fc7-4617-849b-395a2d37d249"
+        "id" : "https://www.example.org/87d4888f-403e-463d-ae27-5cd4b37f5771"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "wP6lGlMIQG1TLsNsG"
+      "bg" : "ts5Uys2Ml44LVj"
     },
-    "npiSubjectHeading" : "7yN0BEEHbdodXFzyIoF",
-    "tags" : [ "dVdYVPNoNijyu8aiIC" ],
-    "description" : "ySiiY1i3QXb",
+    "npiSubjectHeading" : "0bNOWL51rg1GFPmsznW",
+    "tags" : [ "ml5zHZEQelU9SNlr7Wi" ],
+    "description" : "z4GYhnpraO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a6e82f65-d472-4fc7-b6be-1148ad040216"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/43fd4c87-3a51-407e-a816-c70d3e2ce771"
       },
-      "doi" : "https://www.example.org/a7f7e476-6cda-4b67-b35d-08f2f777f2fd",
+      "doi" : "https://www.example.org/3e24776d-8d98-442e-aaf5-4bde861e9efb",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "eBSrruV44n5XnSs",
-        "issue" : "Al41KVslzIaCZ8sdpy",
-        "articleNumber" : "HbHOFyblB7grqUh",
+        "volume" : "hqOcmmgT1CGN",
+        "issue" : "AWn22FxfU2PCc7b43RA",
+        "articleNumber" : "vYMLd0WBupfsCPE",
         "pages" : {
           "type" : "Range",
-          "begin" : "UMq1gBG7eTPbv",
-          "end" : "YxhW2gfgBXgNAz0"
+          "begin" : "Wi0FmItJzoJ2DNN",
+          "end" : "ubiL6pGa0Wsqbl6xuZ"
         },
-        "corrigendumFor" : "https://www.example.com/2AF52Van8hWSnaN1mC"
+        "corrigendumFor" : "https://www.example.com/UgkK51biVg"
       }
     },
-    "metadataSource" : "https://www.example.org/4d3b587e-53a9-4f23-a5fd-4510cc72657a",
-    "abstract" : "2TBB1ZAS5X2od76Pc"
+    "metadataSource" : "https://www.example.org/f18b08b3-1dcb-4f11-8869-86b53fda4566",
+    "abstract" : "mKknrmAs77E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/96fb3871-d095-455d-a0dd-321091eb80d6",
-    "name" : "wSkkwt5zm86AoyY4",
+    "id" : "https://www.example.org/dec1e8fa-8387-413b-93c0-a9d25ed89303",
+    "name" : "BXGvRU7i67jkL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-02-01T02:21:12.483Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "8dujDk3iKr7xgg"
+      "approvalDate" : "1997-12-28T07:28:42.410Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "7wdJIjfYnKIc67hSblt"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7b3107d7-b86f-4a1b-8546-327edc306397",
-    "identifier" : "uwLyVHt5pHMT4DVW",
+    "source" : "https://www.example.org/8fd6a21d-104f-4d7f-8997-7bf8e994bd65",
+    "identifier" : "f0lA7TJw5r1CvZt",
     "labels" : {
-      "cs" : "DzqXIwa5Vt8L"
+      "is" : "ekECA3tAQxH1hqdsWO"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 159100434
+    },
+    "activeFrom" : "2019-01-19T09:50:58.397Z",
+    "activeTo" : "2022-11-15T05:24:48.611Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/93fd3665-3ae9-4f61-82dd-da9694fbc448",
+    "id" : "https://www.example.org/1a5f275d-b56a-4632-8e68-7e598b4951d1",
+    "identifier" : "Ns9REEQ83Q9lsSxjy",
+    "labels" : {
+      "pt" : "ljNupquwyu4O"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1290651490
+      "amount" : 1958141648
     },
-    "activeFrom" : "2015-06-16T23:50:29.274Z",
-    "activeTo" : "2022-04-07T09:46:05.708Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/64f8e810-b0c3-4fe2-9065-1e5f288488ac",
-    "id" : "https://www.example.org/5cf53c0d-221e-44c9-91d9-e5c85fd5924b",
-    "identifier" : "F7sm9zABOBXZwWMHRiY",
-    "labels" : {
-      "fr" : "CZGcscsCp6vKR8OG"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 724487226
-    },
-    "activeFrom" : "1976-08-04T15:44:19.459Z",
-    "activeTo" : "2022-01-15T14:58:43.955Z"
+    "activeFrom" : "1992-08-30T02:39:06.202Z",
+    "activeTo" : "2005-06-28T09:31:34.392Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "y9o0hDUMXpfEMx",
-    "sourceName" : "aiwl3vpozvm0urdrh@tc7wmf5aem"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/8a964405-8840-4c8e-a05f-1ccef7006979",
-    "sourceName" : "5bx9uerlbd@o8g8lkymh2tvqy0at8c"
+    "value" : "https://www.example.org/bb014200-cd3c-4e7f-9548-6cfc538e0ba5",
+    "sourceName" : "wksnu1yqebh1x5htmw@mpvmi5hgs768"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "yRBwy8Gj9g09XUrB0",
-    "value" : "GYKOXUwTxX4"
+    "sourceName" : "iv5OnC1QvqFN4TIuy62",
+    "value" : "yBjSv1WsXNxlwyM"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "6wJRGXEHf9WmhsZ",
+    "sourceName" : "gr5p2uiy21a6vszipi@uigxifnqmgx0hlt34vj"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "678511666",
-    "sourceName" : "grjppuaqzkexxkkinak@uzeip2uwhder6fjkgx9"
+    "value" : "870521503",
+    "sourceName" : "7kss4rdoel5@mz3xdik3hybv2rvv"
   } ],
-  "subjects" : [ "https://www.example.org/8da480d8-e3ca-4c7a-867a-47e5fee2bbe7" ],
+  "subjects" : [ "https://www.example.org/0ad8eaea-8057-48a0-b268-0302be2c3b1a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e7dfb1fd-0517-4b52-9640-312ced73eba9",
-    "name" : "GHuDVcSRWOWCC",
-    "mimeType" : "LyQAPTpUkm3sd",
-    "size" : 499096544,
-    "license" : "https://www.example.com/47dulrvn2jih5",
+    "identifier" : "a94e2b4c-19d2-4ba9-ab0d-3264fbe9a38a",
+    "name" : "sOZoKgiOoEu4zSHFN",
+    "mimeType" : "J2naLBN5K5Sek",
+    "size" : 569283860,
+    "license" : "https://www.example.com/7t2bfk6jqf",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "q2dWIMGuKHJDDSwbb"
+      "overriddenBy" : "XkkOmOuThq3B8NxekF"
     },
-    "legalNote" : "PO9KGRx8mDDWrIr8fDH",
-    "publishedDate" : "1994-09-10T07:15:36.855Z",
+    "legalNote" : "bZ0eR5ZpVpXg",
+    "publishedDate" : "1993-08-16T05:31:13.162Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "YxWH3QVciambVb",
-      "uploadedDate" : "2022-03-21T10:10:25.832Z"
+      "uploadedBy" : "A557evFajALy8",
+      "uploadedDate" : "1984-09-07T01:09:19.564Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XMU9bzyvGL",
-    "name" : "0t6uXVXVJdo6uVzgdCF",
-    "description" : "y26RYZeyfcCa0IWF"
+    "id" : "https://www.example.com/F5jwjNI0XC3EZ",
+    "name" : "WgaXrC94dcJTBx",
+    "description" : "aBBTmVxa2XWmiOybfg"
   } ],
-  "rightsHolder" : "snrlZCZs7ySoF",
-  "duplicateOf" : "https://www.example.org/724292b8-091f-4260-ace2-4adda3d3b3dc",
+  "rightsHolder" : "SMPMoiy58ZngVK0",
+  "duplicateOf" : "https://www.example.org/f91c9a50-982f-40a1-a0b4-a407e524c19e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "99AQlgyEonwBG013"
+    "note" : "4xCTzAT3HOAI9ik"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "b8bMIndnn6",
-    "createdBy" : "ViEsYW76OOG5y8AG",
-    "createdDate" : "1978-06-28T23:17:49.274Z"
+    "note" : "hdX2czJo1K",
+    "createdBy" : "raEXgZaXsnyZqPWdEUZ",
+    "createdDate" : "2001-07-10T10:58:17.303Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/56e5dc29-ecc1-46cb-a817-8a8e34e904d0" ],
+  "curatingInstitutions" : [ "https://www.example.org/c8a29087-939b-4744-95c2-4c163698ff78" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "rcHklsp5uOO",
-    "ownerAffiliation" : "https://www.example.org/ed8c7a47-8c3a-47a0-af6d-2c2050a573f6"
+    "owner" : "zTjoQRgCK0ID8UA",
+    "ownerAffiliation" : "https://www.example.org/337b9804-0a83-4064-961d-b262472aeba5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d132fd95-ad0d-4a2a-809c-2004019d8570"
+    "id" : "https://www.example.org/129fd47a-291e-4c7b-8391-027b84d8817d"
   },
-  "createdDate" : "2015-07-31T04:44:15.072Z",
-  "modifiedDate" : "2022-06-07T04:44:37.575Z",
-  "publishedDate" : "2015-10-26T12:49:16.451Z",
-  "indexedDate" : "1992-07-15T13:23:50.179Z",
-  "handle" : "https://www.example.org/4f0db96a-ed22-43db-9a93-ffdf73ee5394",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/2d20ac06-4af1-4b36-8004-03edad389168",
+  "createdDate" : "1995-02-02T21:29:25.774Z",
+  "modifiedDate" : "1981-02-12T22:33:13.963Z",
+  "publishedDate" : "1993-04-01T17:55:38.349Z",
+  "indexedDate" : "1979-05-03T02:51:13.243Z",
+  "handle" : "https://www.example.org/4dd92d53-8a88-4f08-ae3d-6bf9409b39dc",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/66144d47-2825-4b42-be15-75a3913fbd89",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9OjWUp2unUjm",
+    "mainTitle" : "UV8WXBr4r2n7FqoU",
     "alternativeTitles" : {
-      "bg" : "EUQd5XNiC95MqYirkkG"
+      "se" : "9pcBAlLYSMC5xdNoV"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Syt9ogJvfW9I8JME",
-      "month" : "VGrg52P6L2",
-      "day" : "xXdGbkMU8a9p"
+      "year" : "MxBcPz34EHvgY9H4lSA",
+      "month" : "Ygss1HJvXuxowT",
+      "day" : "0Sp2sHrZv32"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d2042b7e-971b-464a-9f8d-16faf87e8168",
-        "name" : "Lu1g8yGZZ9k6tLy8Fl",
-        "nameType" : "Organizational",
-        "orcId" : "B3NdJRanGA1ozCWh",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/6f8db062-6339-4ff3-887d-0ef6c9e9ebd5",
+        "name" : "H9jlNUvISZWTbJwY",
+        "nameType" : "Personal",
+        "orcId" : "WI2Pf5XluOlhee",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eA3rCdt73Q5aMYL",
-          "value" : "krMiaAPF1c2HcQ2u0j"
+          "sourceName" : "jnROfymwcevhSH",
+          "value" : "U1fzgfKyQhOqm04SRJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z4KAO3fNLfY2micug82",
-          "value" : "VInLAqCD71JP"
+          "sourceName" : "e81Ctb6yXMWXj",
+          "value" : "lfIWiTlahnS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d421a86a-ec2e-44a3-9a98-b71b8685cc29"
+        "id" : "https://www.example.org/c6dde1ba-0ad0-4d35-bd8f-b3cb6346749b"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/be4b9447-6460-4191-90c8-f5c30d7b0cf6",
-        "name" : "YHdpqgTB9O3tC",
-        "nameType" : "Organizational",
-        "orcId" : "8FJobYFqt2J",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ebf74eb8-07d9-449c-8cf9-0d47978fb7fe",
+        "name" : "8WhOaGhPXh",
+        "nameType" : "Personal",
+        "orcId" : "QwJvX0NH7woJOVNv",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "plDUHhoW5njzcfL",
-          "value" : "k9hDTAVNzI34"
+          "sourceName" : "Aifjrmv1YIyVTpWNqQ",
+          "value" : "6kh90Cv4qY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CT3e7VDM6Gq",
-          "value" : "fvA1LwBCyPgS6cHnZ"
+          "sourceName" : "sJv7gjl4cFa",
+          "value" : "dQS3TZcrKZEh6DN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/53dafa0e-1bc7-4dea-8b92-f2a2cc80ecb7"
+        "id" : "https://www.example.org/1799c5ad-4722-48bb-8c11-a21fae507f7c"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "Cv7AlnLUr6hykiKG"
+      "se" : "dAqgnNw1HAMfnzK2a"
     },
-    "npiSubjectHeading" : "kBi9QkD6ezBHQ1",
-    "tags" : [ "cx3wxB1L3X9" ],
-    "description" : "Mu9DD0IqKQyVdg",
+    "npiSubjectHeading" : "qYKqX9uoffbPBXAF",
+    "tags" : [ "BLDfJu6TIYFt" ],
+    "description" : "PAl2rPL8oq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eede6c84-793c-4187-bfc6-5816796e91a3"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8243864c-9bf0-4287-93cd-1cbc3acad86b"
       },
-      "doi" : "https://www.example.org/bdd6050d-f415-4003-8823-07a3fe974c3f",
+      "doi" : "https://www.example.org/6ce2319b-cbe2-4694-84b0-76631f85c5f2",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "Do4TrbHq0N2uXir6Ga",
-        "issue" : "JIvKSCCHPSt7kpp6P",
-        "articleNumber" : "kdtpNDUiVCExDX",
+        "volume" : "dr6JFnDQC5v8vpIjAr6",
+        "issue" : "5WKxIJlA7i",
+        "articleNumber" : "T1gIrm3zVGJzxGJn9IL",
         "pages" : {
           "type" : "Range",
-          "begin" : "NzKCD4YDlzhTadw",
-          "end" : "ZP3AZSHEuIhwl"
+          "begin" : "wyBZXNBWv71",
+          "end" : "WBhGqEDBYvS"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f7721466-ef84-43a1-ac6a-bff5fc1fc3d9",
-    "abstract" : "CwjbX9jOrZsN5U"
+    "metadataSource" : "https://www.example.org/f977de1e-fda1-4c57-bdf4-cc23c42a18d1",
+    "abstract" : "v3s22u9nhLVjCg6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6050bbe2-304d-4c9f-aee3-b8b4f8be2fd3",
-    "name" : "CWxJeN8iZrxI2Xhu",
+    "id" : "https://www.example.org/1d85ac5d-5dae-4a6a-af40-6cb4d9a91713",
+    "name" : "Rc0ic6gUg7EOLh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-08-04T11:03:37.273Z",
+      "approvalDate" : "1993-05-21T09:56:08.768Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "0mqDE9OUEIVkuDVvz5"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "6X0h06CD1zY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/532170d0-29fa-4576-8ecb-8aeb654f9fdb",
-    "identifier" : "NmPh46WqI64kkyTSj",
+    "source" : "https://www.example.org/d44ada4e-d8d2-4607-8ad0-3ac011f711bd",
+    "identifier" : "F75p90pcSCXIW",
     "labels" : {
-      "is" : "mDmQ2cASDxiYM3"
+      "pl" : "41BIz6qrp8Dcl"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 513810591
+      "currency" : "NOK",
+      "amount" : 1462825701
     },
-    "activeFrom" : "2007-09-18T10:09:54.301Z",
-    "activeTo" : "2016-05-17T12:50:35.462Z"
+    "activeFrom" : "2017-02-06T21:08:45.890Z",
+    "activeTo" : "2019-07-28T08:54:52.914Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/645e2811-6fde-4c8d-b68a-0c5d677ba688",
-    "id" : "https://www.example.org/0af6edcf-ef59-4522-9a83-116a292c42ca",
-    "identifier" : "RNqFVzsMDEw9",
+    "source" : "https://www.example.org/6d2a40bb-db7c-487e-9bd0-df55efbf068c",
+    "id" : "https://www.example.org/852cc71a-9721-4a0c-81ea-7a587a29892a",
+    "identifier" : "LdSBnI8JlSBJ85PyR9",
     "labels" : {
-      "fr" : "OMfP3dm7c4sm"
+      "fi" : "VUj1pnc60bLL7"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 699965327
+      "amount" : 656644884
     },
-    "activeFrom" : "2021-04-07T01:00:07.658Z",
-    "activeTo" : "2024-06-22T21:27:53.087Z"
+    "activeFrom" : "2014-06-19T04:52:15.186Z",
+    "activeTo" : "2022-01-09T07:06:45.067Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "CristinIdentifier",
-    "value" : "1856287777",
-    "sourceName" : "cbpidnouq1tua@sap0cnwa47ist"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "7Q9XbNIOWJhQtG9A8",
-    "sourceName" : "mv1ecv0dfc@sldt0rvi9t7cexg4"
+    "value" : "600221285",
+    "sourceName" : "aevevb8c0s@xpuylakhelasny6"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/4afebdb2-2941-4845-b3e0-74230ca906e0",
-    "sourceName" : "o89tuag3rwyiyku@86ivhmpkalxtb"
+    "value" : "https://www.example.org/ca160bf1-e40a-4900-a9a9-12d7b5e9cc65",
+    "sourceName" : "3kmtqsqs6pbus@zflltimg39qaxwdkqqh"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "XnXuWF0bAsio",
+    "sourceName" : "ogg0pyhikln9ksg@evmiv7ronjkodg5v9"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "CWaNJJxML86k",
-    "value" : "Mn63vptaCSq"
+    "sourceName" : "5ZP3Be7k7N0aayDw",
+    "value" : "vnNWurJh0OeFQ9hp"
   } ],
-  "subjects" : [ "https://www.example.org/ea983c04-e60d-47c2-8659-c147c5cc0bfe" ],
+  "subjects" : [ "https://www.example.org/773b65c2-d606-455a-9571-7ff1510076a2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bd2c9517-bb92-4709-9256-d66ac0cf670a",
-    "name" : "z6CMCY7arUFW9gShB",
-    "mimeType" : "kFCUyYvgINljsU9o",
-    "size" : 1612035675,
-    "license" : "https://www.example.com/xgze68aq6ylrfb8jv",
+    "identifier" : "a5b4317e-041e-44df-b054-d8278f9df945",
+    "name" : "mbD1yqNdgXvj3C9Ix",
+    "mimeType" : "KMTXopnGBfiUa",
+    "size" : 1429374543,
+    "license" : "https://www.example.com/rq2ekeypne",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "DWvfIL0DM2",
-    "publishedDate" : "1980-08-16T12:32:19.580Z",
+    "legalNote" : "6vXCaTmjBaCQ",
+    "publishedDate" : "2022-04-21T03:13:33.992Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "IEFvUIbD7HxPu",
-      "uploadedDate" : "2013-07-02T07:55:18.002Z"
+      "uploadedBy" : "XJP509RhNC684jucH9",
+      "uploadedDate" : "2000-01-23T13:05:00.543Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/567hmgYCtkPK1rv7Nq",
-    "name" : "65r77LqohHdbxGFkna",
-    "description" : "fKLIEAlc5t7au29T"
+    "id" : "https://www.example.com/jLuX9HIFe2yvQ",
+    "name" : "30fQNoAcWa",
+    "description" : "nSTyhq1B8U5E8TvP"
   } ],
-  "rightsHolder" : "5JwlTlprg3xJ",
-  "duplicateOf" : "https://www.example.org/6b768de2-dc22-4500-9297-0b0e9d3b5e06",
+  "rightsHolder" : "6mjVZuwKrqtlxrO",
+  "duplicateOf" : "https://www.example.org/e22e2d11-765c-4dbc-b90c-2f261056b24b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dgaMKBrFoFNj"
+    "note" : "rFrdi7YuLIm7aeoqhVX"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GvsQVMr4n72c9",
-    "createdBy" : "mPTpk29AGB108LgZ",
-    "createdDate" : "2012-12-09T19:05:56.736Z"
+    "note" : "AlcggrUODgkTBQn0LJ",
+    "createdBy" : "Y6cZEjNXi3BN8v5h",
+    "createdDate" : "1988-10-10T14:46:06.165Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/06a49244-0b0c-4d4d-8e24-04583fca6d05" ],
+  "curatingInstitutions" : [ "https://www.example.org/24ee0d04-f92d-4ec6-8982-e244de3afaef" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "tB2dzMQQDM",
-    "ownerAffiliation" : "https://www.example.org/3f3531fb-4336-49ed-a97c-6854a35b5430"
+    "owner" : "rhPNVNzfNuZONQb5ua",
+    "ownerAffiliation" : "https://www.example.org/24d8bcd5-db2b-4ed7-a424-4ec60f4cfa77"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0d4a727e-a9ad-4307-80dc-6bd593699c3e"
+    "id" : "https://www.example.org/02be404c-62f8-45cf-9e8b-0062417d55d4"
   },
-  "createdDate" : "1996-10-10T13:26:45.821Z",
-  "modifiedDate" : "1993-11-24T06:11:11.569Z",
-  "publishedDate" : "2007-04-04T11:26:41.634Z",
-  "indexedDate" : "2018-02-21T18:50:24.298Z",
-  "handle" : "https://www.example.org/54016e88-3cbc-4edb-818d-6d3414d9db24",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/eb430de8-5add-4a30-bac6-79c23baf9be6",
+  "createdDate" : "2020-11-07T17:06:49.257Z",
+  "modifiedDate" : "1986-11-11T19:50:23.071Z",
+  "publishedDate" : "1994-06-04T00:03:31.013Z",
+  "indexedDate" : "1973-08-12T12:38:42.385Z",
+  "handle" : "https://www.example.org/34408f3c-4811-4147-8266-5bd8a8a441d2",
+  "doi" : "https://doi.org/10.1234/molestias",
+  "link" : "https://www.example.org/5cc651aa-363b-441f-93f1-ea8d596c685b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "o2TPGWTAMpN",
+    "mainTitle" : "zbc6f7iaZLMt",
     "alternativeTitles" : {
-      "af" : "bQoPAxtqVnAUnqQmr"
+      "sv" : "SleEgmG7j21l8ekwp4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BDXstm458MqlYAo5",
-      "month" : "mtUIElO5q7400qpk",
-      "day" : "TFcKZnTxRlACQY36J6y"
+      "year" : "FQSH2NewaQe",
+      "month" : "2raBnR0VsbMcwp8",
+      "day" : "WOjOblbQNjL7Vd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/220984e8-5094-4b6a-8274-16a13e9bbb70",
-        "name" : "a5SmlHilSPBh9FFsRg",
-        "nameType" : "Personal",
-        "orcId" : "rQbYySSkxhdj4p6CxM",
+        "id" : "https://www.example.org/2b3bd0f3-7782-4126-ac0b-4472e2906059",
+        "name" : "gu6HifJW10xP6x",
+        "nameType" : "Organizational",
+        "orcId" : "57KOizK6SwUOw5wW",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eXKlsUCO2sM6U8Yh0",
-          "value" : "EKMcut2vtE2LwwS"
+          "sourceName" : "lizmRHcraDbixX",
+          "value" : "huILIM23DZFX4lH"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AdXdjrGkXQRFS",
-          "value" : "KJXaWZ8h9kJ"
+          "sourceName" : "xzNPldhyyFEoMeBB6",
+          "value" : "QOh3XwR0MM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ba2140d6-36ec-4e5b-987a-b50c4b80a295"
+        "id" : "https://www.example.org/af679976-07dc-4948-948a-40151cfb38f4"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bff7caf4-a43e-4bd1-b59f-3366ad0cbb65",
-        "name" : "p4eSgYqTYGcg",
-        "nameType" : "Personal",
-        "orcId" : "qVuHxxzFevtL2iNVzQF",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/1cbb5cc4-a814-4aad-baed-0cbdc405b65e",
+        "name" : "ioslfiynIBMDxl8eXpj",
+        "nameType" : "Organizational",
+        "orcId" : "oqvIVQfxSaj5GZtZ9",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sWywZIqhCjAMC3",
-          "value" : "7lJg9HnQP9zssmMs0wU"
+          "sourceName" : "OKkIN4K8AOrF4Nppc1M",
+          "value" : "ntH2YiWzpYFVqgmY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RZ9e6SsktJg",
-          "value" : "lbrLuROXS2LN"
+          "sourceName" : "DTntbeiCsVqcDDe",
+          "value" : "tfOnnxFUZuuPnAB7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0bc87a29-1914-4b35-ba37-17f7c4bda59c"
+        "id" : "https://www.example.org/381c569b-374c-4cbb-bf2e-b6de4aff576a"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "szIvVt58QJmWfeW3lt"
+      "es" : "HeZ9d4tcwrM3hj7"
     },
-    "npiSubjectHeading" : "jxH7C9Cbl5r5WtPPi",
-    "tags" : [ "MtsqMrlWThcKCFuUxU" ],
-    "description" : "LjBusEziHDnHr",
+    "npiSubjectHeading" : "1Dm9Thc2Iq",
+    "tags" : [ "AqriW72bC7" ],
+    "description" : "aKlKnmvhWSOLf73a",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ac2adc3c-d7e5-481d-882d-38f4bf424092"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/55cdf40a-260a-4c67-aa92-51a934d5b56d"
       },
-      "doi" : "https://www.example.org/dd905826-d426-48ae-a9fa-1bfe60e403e7",
+      "doi" : "https://www.example.org/bbd78fbb-322b-437d-93d1-e87066557939",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "fLT75kOO03N1ReC",
-        "issue" : "ABzgwUwjomLz",
-        "articleNumber" : "TCobTnNVKepxSsp6HmQ",
+        "volume" : "msUo0OnH5nMOK4",
+        "issue" : "8gv2ardxEh91Zaxqh",
+        "articleNumber" : "dC4IVQz8Es4z8KomJQP",
         "pages" : {
           "type" : "Range",
-          "begin" : "GKa8SmvI1JUQkR4N4b",
-          "end" : "eKpAsVXvpZ5DYPzN"
+          "begin" : "PgTMnPPE1sev",
+          "end" : "Lo45e1GH7vl5Sa"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0cf4effa-a337-4f1f-bf8b-b927739036a0",
-    "abstract" : "rh3WDQbDOBKwTGzVWk"
+    "metadataSource" : "https://www.example.org/dc00214f-fc12-4562-96f8-fe759cdff0ef",
+    "abstract" : "yOPp1Rhtegkh2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/96ec4b23-cf0f-490a-bc72-6f0657976a06",
-    "name" : "BEPU3S1fYfzMVO84yi",
+    "id" : "https://www.example.org/40d4134b-6b96-4ab0-856d-501cd727efc2",
+    "name" : "3DD4TjzGnO9pZFgQ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-06-30T22:14:59.047Z",
+      "approvalDate" : "2017-04-04T18:00:15.732Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "4cBSrpdJ7S3So2Gli"
+      "applicationCode" : "K9ynT6UKn8CxVI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b2e4a2f2-cd40-4e83-b08b-c3c51ad16eb3",
-    "identifier" : "9GHXIosF9o0p",
+    "source" : "https://www.example.org/10cec052-c2fa-4a56-b3ea-5e94ebcbea96",
+    "identifier" : "MonZVM4rTQuWx4xf6",
     "labels" : {
-      "sv" : "fphp56uICthFRIb6e"
+      "zh" : "FYknh0nHUYFk9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1024206134
+      "currency" : "GBP",
+      "amount" : 1116612852
     },
-    "activeFrom" : "2011-07-09T07:13:33.708Z",
-    "activeTo" : "2020-10-17T08:26:10.996Z"
+    "activeFrom" : "2010-10-22T08:07:38.603Z",
+    "activeTo" : "2014-12-12T13:28:24.848Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/019e4b64-7364-462e-8608-94eae9639af9",
-    "id" : "https://www.example.org/6d492b05-7f7f-4a89-bd1f-d35db04972ba",
-    "identifier" : "tldMEZ3GfP",
+    "source" : "https://www.example.org/ee1919d9-fce7-4907-a5d6-33030d0c312d",
+    "id" : "https://www.example.org/62169f2f-02f8-48f5-a1c3-d875e8ffc7e9",
+    "identifier" : "yDzJGi0BYTO1",
     "labels" : {
-      "cs" : "uv6r3tvutaCS"
+      "af" : "pJ2ZK9gHVZ1C"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1791263173
+      "amount" : 26189189
     },
-    "activeFrom" : "1985-06-28T20:43:11.548Z",
-    "activeTo" : "1992-02-10T06:47:44.713Z"
+    "activeFrom" : "2002-11-08T07:34:38.251Z",
+    "activeTo" : "2005-12-25T00:53:40.961Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1995485492",
-    "sourceName" : "qcvh8ni8rz@fhsidrv2jp0tccf"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/51007e5b-83b1-46cb-b2cd-9e7218f5ed1e",
+    "sourceName" : "3dpctudfdg5ok@ik56bjarrx7zkq"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "AIurWPVyQ2UtwqFqJ5F",
-    "sourceName" : "75u7vms0dg0@g1ojkfw312qxike"
+    "value" : "fZJw1ag0rJQ",
+    "sourceName" : "ictvclquhmcoapukoy@u8koq0or8tm2gk"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "1AQqEzKWXdUx7osd6Jk",
-    "value" : "Gn2sCLJTFAMZ"
+    "sourceName" : "VxQq6qL6P4Fy",
+    "value" : "vEW3KE6QZS9"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/27d12cca-a0cc-4de8-9abd-391e1ad7ed3a",
-    "sourceName" : "h3ycc75wzehcvzdmvki@wdotau2dqtif8u"
+    "type" : "CristinIdentifier",
+    "value" : "806947743",
+    "sourceName" : "hoqia84s2mexr@cilmowygrdhw"
   } ],
-  "subjects" : [ "https://www.example.org/caba43b9-170e-4777-8a0f-d81a4a2070fe" ],
+  "subjects" : [ "https://www.example.org/25df3af7-4b61-4bf3-b4ca-1b11d5268b20" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c8ec94fa-7b82-446a-b2f2-caa3c2573ddd",
-    "name" : "BvcjB7Kd886AllZ",
-    "mimeType" : "aFR8I9z8mbUEm",
-    "size" : 137105917,
-    "license" : "https://www.example.com/kdw5guniwujmwb3azk",
+    "identifier" : "aad105f7-7dfc-45fc-8b40-7686cb4a59c8",
+    "name" : "tZr0qntRSA1gGU3aEc",
+    "mimeType" : "XlsJT8ZYlozWq",
+    "size" : 1156797743,
+    "license" : "https://www.example.com/mvjuabwqz41ma4mzi0",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "2qrvIUmzyURJXHf",
-    "publishedDate" : "1997-12-18T10:24:45.410Z",
+    "legalNote" : "bKT3FHndKefvDl1hlzF",
+    "publishedDate" : "1998-07-26T02:52:39.867Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "tBvUOoTikr1",
-      "uploadedDate" : "1997-12-17T07:05:47.367Z"
+      "uploadedBy" : "Bvp90n8c9OjEPR6yR",
+      "uploadedDate" : "1982-02-04T17:34:05.459Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/uvqrGzjeZnbiUHbM",
-    "name" : "mjRvOeh4tTzxY",
-    "description" : "H3S0L8TKBLqUT1wCEXG"
+    "id" : "https://www.example.com/N4lzyoVEBL0",
+    "name" : "Md6ehyE4iW",
+    "description" : "wbvmCZxlR2qzip7nfvj"
   } ],
-  "rightsHolder" : "V6hKoPfo0BarHGyL",
-  "duplicateOf" : "https://www.example.org/37fb0bbe-4c6e-41a8-9bec-2df04ae53f8d",
+  "rightsHolder" : "dH7mYBDsbMoASZeo888",
+  "duplicateOf" : "https://www.example.org/fc88c88a-b862-4223-a592-f433b8506766",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TlQ4HyWw48Wj3zdNH"
+    "note" : "89qWHEgyne"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "TqDh12FuGVAC",
-    "createdBy" : "6uP0DNgjtb4bR2Xb4i",
-    "createdDate" : "2002-08-28T18:04:34.422Z"
+    "note" : "fvCPu9ZcUPHmS2Jh5",
+    "createdBy" : "O9Y1und7AY4",
+    "createdDate" : "2012-06-27T07:20:55.207Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/50ed7636-e760-432d-9c51-b9960a3b5bde" ],
+  "curatingInstitutions" : [ "https://www.example.org/7ab669e0-2b72-414d-b301-3be067919282" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "7rOhaY82W6oSf",
-    "ownerAffiliation" : "https://www.example.org/8e88a280-cbc8-417f-822a-26e52b1508a6"
+    "owner" : "0wDePRBpWs5sn",
+    "ownerAffiliation" : "https://www.example.org/22d0422a-6f77-49ca-96f4-0e6bf0136e0c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/14aa84d6-1c1d-4638-a407-bd5b197d9929"
+    "id" : "https://www.example.org/a625dbf6-1834-420a-bc7f-c3c215ad3976"
   },
-  "createdDate" : "1995-02-09T02:03:18.119Z",
-  "modifiedDate" : "2002-04-01T23:20:20.689Z",
-  "publishedDate" : "2019-03-15T11:54:42.894Z",
-  "indexedDate" : "2005-07-19T23:57:35.578Z",
-  "handle" : "https://www.example.org/8befc3e6-3d3c-488c-b221-da522d2d89fa",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/3e9bbbe0-48ad-445d-8524-cd5083e94ca2",
+  "createdDate" : "1980-10-20T13:20:47.422Z",
+  "modifiedDate" : "1986-08-07T04:10:35.051Z",
+  "publishedDate" : "1994-11-16T22:05:19.881Z",
+  "indexedDate" : "2020-05-05T09:00:47.670Z",
+  "handle" : "https://www.example.org/bc2bc254-bfda-4081-bcaf-e51b191d93df",
+  "doi" : "https://doi.org/10.1234/expedita",
+  "link" : "https://www.example.org/050e693f-2f61-4a9c-b5a3-08f2d3bad404",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mW2jczh3kqapl",
+    "mainTitle" : "mziaVrnHoLKGo",
     "alternativeTitles" : {
-      "sv" : "32JTKGr2jMdzChcy8IM"
+      "cs" : "C0qzgPsMQMdP4uQ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UfH7nArZO645c81wY",
-      "month" : "IlgCk8JmifrNG9z4",
-      "day" : "yNRBcyMfIGgjOUHa"
+      "year" : "JoFSmyqvHwk6Hi9VHC",
+      "month" : "bQEUv4AD91eSKH9sUmp",
+      "day" : "mNSmoYCsQOymEDsjA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b1859107-17be-4615-a69a-a419c619c3d3",
-        "name" : "5PoEKHUXYQVu",
-        "nameType" : "Personal",
-        "orcId" : "UF1WKUPTNyFuWkHB4r",
+        "id" : "https://www.example.org/dcac6a87-6ca1-4608-955f-221cb9a46931",
+        "name" : "wusABjIQrq9dXrWbom",
+        "nameType" : "Organizational",
+        "orcId" : "JLFZrR4fANo9116pF",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lDazlzgT5My",
-          "value" : "91cRdlAGGfdp"
+          "sourceName" : "Eo5wCNZ6rBRuC",
+          "value" : "3j8guVeyk7Pw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "C7RKGG0hhFOo9fv",
-          "value" : "y7UoLGtfuRKGla67"
+          "sourceName" : "VurjYiOSxiCUhj",
+          "value" : "Cx9gB5NracN66"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9ccd110f-eae3-41be-941d-3ff076425891"
+        "id" : "https://www.example.org/7464da13-7c57-4dc2-a05c-f37cb07f3d7e"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/36c3cb2d-58eb-4f4b-93d0-ac963c9883a6",
-        "name" : "XSeqgRKFmwdrc",
-        "nameType" : "Organizational",
-        "orcId" : "KS4E4dsibfUxDM",
+        "id" : "https://www.example.org/c0e6ae46-2bfd-4640-bbeb-45950f14e521",
+        "name" : "tGjdcphpG7",
+        "nameType" : "Personal",
+        "orcId" : "uQaQ1n0hU3LBFOGKJk",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cPOONaxajQUzTvcgEB",
-          "value" : "ZeCVQrTNLV0"
+          "sourceName" : "Y2HIqy9wScIEohF",
+          "value" : "DynPdEsp2z70vo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "33MS2l2ccDIP",
-          "value" : "WhGK51xm7KJs3K"
+          "sourceName" : "uMSGCxP0v2",
+          "value" : "JSuSEf00lazuEIEX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1444ca7d-a681-4221-b9ec-fe31ca054eac"
+        "id" : "https://www.example.org/80ee9a7c-5de5-4336-a7b2-03daf08a4812"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "z2F3o1dShj3AdjC"
+      "ru" : "QDq6rLkPTMkZYJgYtW"
     },
-    "npiSubjectHeading" : "LBUgSSmEKtmIGRw",
-    "tags" : [ "4np4WuX0mbUA" ],
-    "description" : "EMxMSSlqjMpnEb8a6",
+    "npiSubjectHeading" : "0kcFiMomPI",
+    "tags" : [ "8F4jwoPRCcLDTrqTk" ],
+    "description" : "YEcvzvTSnHMhk1G9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1df3c00a-2641-4e2e-ba0e-3823aa091431"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fbec631a-4051-415a-a741-52030fbfe6a2"
       },
-      "doi" : "https://www.example.org/bce6efb9-9ed1-4dd8-b5f5-878948dd5344",
+      "doi" : "https://www.example.org/4e6200c8-f5b7-4c87-906c-93591b12b7dc",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "9FpJ9gl9thxOwiwsc",
-        "issue" : "TTi7H7k1ndeXpCPlt",
-        "articleNumber" : "wOKP3SMv7aUW4KTYWHS",
+        "volume" : "YJUsxEurjjPKyTY",
+        "issue" : "fm7qoda8JuTBr81yn",
+        "articleNumber" : "ek6LDIimtrDf4K56",
         "pages" : {
           "type" : "Range",
-          "begin" : "9AIXEHr52aqxfmTR",
-          "end" : "G5Zz9ZZ5ORC"
+          "begin" : "XjKzRiZx5CFw",
+          "end" : "T2MOgccOWKzrqkfoHz3"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/01b19f79-e3bb-48aa-b25c-6c7407575417",
-    "abstract" : "k9TA7Lj6Ygmi"
+    "metadataSource" : "https://www.example.org/8fd0aa62-56ba-4546-98d9-2985477e6cd1",
+    "abstract" : "mDw27vvlzWvqq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/364a659f-97b5-4a03-ac1f-92cecba3e9bc",
-    "name" : "D94KC8APQxetGe",
+    "id" : "https://www.example.org/ecc7aad4-1648-4d06-9ca1-114a2f8fe37a",
+    "name" : "6mATyIxhKl8UFWYmHTq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-01-16T12:31:42.701Z",
+      "approvalDate" : "2015-03-15T02:58:55.850Z",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "PdN9UW27UC"
+      "applicationCode" : "YkLanT5M6OiLEnRS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6c28115c-2f7b-40d5-9cd3-40dd12e41e37",
-    "identifier" : "x8myMp5pQt",
+    "source" : "https://www.example.org/bc7893ab-cb8f-4483-95e0-54290bade1c9",
+    "identifier" : "JuHcreTQXZlLt2Oc",
     "labels" : {
-      "bg" : "Mj0hsdkKUA"
+      "pl" : "OuwhK0D2X3TTeO"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1057698698
+      "amount" : 974246682
     },
-    "activeFrom" : "2021-05-30T17:43:12.236Z",
-    "activeTo" : "2021-10-01T01:30:35.127Z"
+    "activeFrom" : "2016-03-20T22:34:15.812Z",
+    "activeTo" : "2017-11-29T17:47:23.741Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ecf93f3a-1366-4a43-a4a7-90595ce91693",
-    "id" : "https://www.example.org/90ea21d0-e0f0-453b-b8fd-a08bc5f8a94c",
-    "identifier" : "LGB9xlpnU7vay",
+    "source" : "https://www.example.org/1262440f-439d-4bc2-a31f-14e8cfc9211c",
+    "id" : "https://www.example.org/f67bc029-7964-4f0d-a0a9-a4fd376569b2",
+    "identifier" : "Jsn9qqxZxHcBvNFfRPF",
     "labels" : {
-      "nn" : "5T3l8NlCgpl3aJ"
+      "ru" : "F1AJ1uoAENfSYPyPS"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1223548987
+      "amount" : 2004423118
     },
-    "activeFrom" : "2002-03-09T15:52:03.968Z",
-    "activeTo" : "2019-09-17T09:46:31.496Z"
+    "activeFrom" : "2012-08-31T17:09:59.994Z",
+    "activeTo" : "2018-11-15T15:13:53.733Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "Gzrt3yeWs6UW7",
-    "sourceName" : "xcbmnkzkyc@d4snfmvlihmnp6oncas"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/30b16855-a397-4edb-9f2d-4b74bdf4913b",
-    "sourceName" : "d13kfah7hysfn@qm4wy7nlqav"
+    "value" : "https://www.example.org/940681a2-0256-4523-969a-95a4a6f34604",
+    "sourceName" : "fg0arauibbh@ifbap449mstkrhlms3"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "PoOVlfX2L6KtD7LHPMn",
-    "value" : "bPK7tPSK67c4cBtHaLI"
+    "sourceName" : "Z3Iksqnpgd",
+    "value" : "b9JPjJiemQS"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "zIgpEdrl8Eha",
+    "sourceName" : "xhz86pulnqtwwdymxu@zaa5ykwf9tky9ux"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "114883615",
-    "sourceName" : "gt1mi63kokh8qdrliuy@qfksos3pa7lwapliv8b"
+    "value" : "817875553",
+    "sourceName" : "en4surjnkxixx0@tcufz96kkchzntulj"
   } ],
-  "subjects" : [ "https://www.example.org/006255ec-a1d3-4d70-8ddc-21ff5cd06c1e" ],
+  "subjects" : [ "https://www.example.org/4889b6b2-04a0-4026-afb7-f5468ae09a6f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "28ebd4de-df4f-4056-b26d-30e40ed611c0",
-    "name" : "p3uv9GyiZeEBa",
-    "mimeType" : "gW6HvJUpz4Z9",
-    "size" : 1044541852,
-    "license" : "https://www.example.com/ldrdwjjvsqtrdx",
+    "identifier" : "a25a5ab8-e5b4-46d2-a241-e2a8d87add92",
+    "name" : "yXiiBjk6qF72J0yHxX",
+    "mimeType" : "tvLtaROSAF",
+    "size" : 1481398674,
+    "license" : "https://www.example.com/wu8byegtwvho5",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "UMh0Zuazmg"
+      "overriddenBy" : "PrAGpHKaVT"
     },
-    "legalNote" : "2qnmKozGeSZG",
-    "publishedDate" : "1980-05-24T07:32:37.081Z",
+    "legalNote" : "P49N51f5XnrL6vi",
+    "publishedDate" : "2014-01-10T11:01:06.629Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "wRoy9J9qSWNutpKhC",
-      "uploadedDate" : "2001-04-19T03:52:06.928Z"
+      "uploadedBy" : "KlEJ3IisGy3TXYGvvq",
+      "uploadedDate" : "1999-08-12T04:59:55.891Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/pNCqoHtLgVHokY9yRZ",
-    "name" : "WBhBcm4lBziGWbCKdr",
-    "description" : "jrCaEmdPCCs"
+    "id" : "https://www.example.com/pSiJlNeNSYheZND",
+    "name" : "MMNkSIEWVoEPUT",
+    "description" : "UTozW01jjaL2LWmi"
   } ],
-  "rightsHolder" : "c8EQV6MjXS4ikD3lGZ",
-  "duplicateOf" : "https://www.example.org/c6da48a5-5875-440d-ab0b-bec466fce30d",
+  "rightsHolder" : "TsTvw8pygSbS0LfY",
+  "duplicateOf" : "https://www.example.org/1ce3b925-cb35-4911-a4f5-1cb445e00e9b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "oXzS003x6xxDS"
+    "note" : "pVNEBayO3OGb"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fmzSsYYhvZBj",
-    "createdBy" : "DxY3VwvI9Ewes53mLL7",
-    "createdDate" : "2014-09-17T11:07:13.845Z"
+    "note" : "RVBF6Pubp5s",
+    "createdBy" : "DNfXnyEuVuBneqKH",
+    "createdDate" : "1987-01-24T02:42:29.621Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b8d6a9b0-a55a-4f43-b334-61427797837b" ],
+  "curatingInstitutions" : [ "https://www.example.org/029f1c83-5b90-4a03-bd9e-5c4487a87ae9" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "jJ0JRbRkvY",
-    "ownerAffiliation" : "https://www.example.org/bd30e785-d7e4-41f1-99c1-50f30e7593cd"
+    "owner" : "1mpRnyxeouvR73TvJdj",
+    "ownerAffiliation" : "https://www.example.org/83316a89-f838-4827-8be4-2be74c43235d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/af56da43-74cd-4377-938f-b26ab8f20d18"
+    "id" : "https://www.example.org/d3096517-32b2-4d93-92d3-dc8c67cf26c2"
   },
-  "createdDate" : "1996-11-22T19:13:24.594Z",
-  "modifiedDate" : "2010-11-29T04:24:46.045Z",
-  "publishedDate" : "1976-10-01T01:59:37.482Z",
-  "indexedDate" : "2010-10-09T19:58:51.128Z",
-  "handle" : "https://www.example.org/d56a18ff-5dc5-4a7e-9519-63a5be3a9efc",
-  "doi" : "https://doi.org/10.1234/natus",
-  "link" : "https://www.example.org/5cc76395-9e73-4ac6-bcd0-7a10a9639305",
+  "createdDate" : "2005-05-07T08:16:09.968Z",
+  "modifiedDate" : "2024-01-25T18:29:18.167Z",
+  "publishedDate" : "1992-08-11T23:26:38.292Z",
+  "indexedDate" : "1989-11-05T06:25:05.902Z",
+  "handle" : "https://www.example.org/ced1395a-472f-4b90-b57b-4bcd4bafb660",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/a9241287-9ca2-4acc-a2bd-ed8b450a1727",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xRjRfRMoFn3QCz",
+    "mainTitle" : "JExAuw5MUCK5yGDE",
     "alternativeTitles" : {
-      "da" : "DxYO7M3gXG"
+      "it" : "pHpdO0wFjLlAPqAPQoz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tlhvd0UIN0XkptN8g4",
-      "month" : "G9s9FmvzbYnTW7d",
-      "day" : "Ne04ioW0EG7WaPwmB"
+      "year" : "ke6f6O3ga8qhqvpCd",
+      "month" : "TsV4OgnUdW0k7",
+      "day" : "LehHajW4UBmdI5T3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4d7bfe6e-59a0-4294-8a21-8d6db8173460",
-        "name" : "JM99z5vXc5lpuvkGC",
+        "id" : "https://www.example.org/3835c4de-4016-480d-ba4a-1326718eeae1",
+        "name" : "gUcXo7N7toZ",
         "nameType" : "Personal",
-        "orcId" : "BHoZVs4jtTWXwoO6UDH",
+        "orcId" : "49CgBQG9gAMZtlhTy",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "75zBo7cWEQVZhN",
-          "value" : "66zJQdDEUkyihyXg"
+          "sourceName" : "codjQqCiXXB",
+          "value" : "CNsUlRbbw0yuHU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SRgvEesNCLjmN7Jyfb",
-          "value" : "uBFNiT1wW2M2tw6Ihf"
+          "sourceName" : "bLgrtzS9BGR09148",
+          "value" : "0URshd8C2qSZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ac7d636c-7bb3-4906-9463-73c8d7d283c3"
+        "id" : "https://www.example.org/585ae89b-b0f9-46dd-b4fa-ce8b1d6fa7ec"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e71172f3-5ff0-497b-a941-09b8000755d8",
-        "name" : "2RybLHMBSCm",
+        "id" : "https://www.example.org/ffa94525-687a-4b07-8090-692ffe1c7729",
+        "name" : "Dd3uE2T9oZ6O6bVHRo",
         "nameType" : "Personal",
-        "orcId" : "W7q3akbJSYY6AIXO",
+        "orcId" : "ULaV6uIvgRaoTxW3Zw",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tmb5gdZsCtDSbO",
-          "value" : "fS2SH4NnFN"
+          "sourceName" : "8F7MFDAILLe0j8m",
+          "value" : "6336rJOQF7PO2nt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GsrAsRt9LzGYR3kD1m",
-          "value" : "qRmqRl5BlkbuMiUrTV"
+          "sourceName" : "9W0NgivsLxK4W",
+          "value" : "KSh9n6j9eGijfnPiIsc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cf1fd5be-8786-420a-a008-3651c9b45a34"
+        "id" : "https://www.example.org/c964a7d8-655e-4882-8763-ac2b0b3de0ec"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "Vut5DOUr6GFvmK"
+      "es" : "9N8uBFQaD7qFZgDI"
     },
-    "npiSubjectHeading" : "59XnVBG83CQkexKa",
-    "tags" : [ "hz1Ey5Q3GDECXVx7GcE" ],
-    "description" : "g9advguiVKtpSMuCS",
+    "npiSubjectHeading" : "vje8lLeTsV3X",
+    "tags" : [ "DFAIQJNx2cgbGZK" ],
+    "description" : "jgGhYGKWNvoKtfcQYKk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/01973905-0f8e-4958-aebd-7e7e4c663aee"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8255dc36-249f-4148-90e0-3a48be77bd4f"
       },
-      "doi" : "https://www.example.org/29975b09-f0f4-4d24-8e94-b2f56c85ca1e",
+      "doi" : "https://www.example.org/bd97b027-b783-4732-9758-a3de65e86dae",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "WlXuSFWUGTKHxg",
-        "issue" : "p0l0fLBqWvKpV7F0c",
-        "articleNumber" : "2jfIpqcRe3Dn",
+        "volume" : "sM55OrNAM1gtt",
+        "issue" : "ucfDXwZDvPtm",
+        "articleNumber" : "h3dBdWLS3JAQk",
         "pages" : {
           "type" : "Range",
-          "begin" : "3RaucTQPWn4DyHh",
-          "end" : "CP13AbrvDzkR"
+          "begin" : "P7SNcJCluv",
+          "end" : "qO0sYmW25HZXNJ"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c55a06f2-13af-4d5a-a941-9719d43264ef",
-    "abstract" : "cpA9ekFPl0"
+    "metadataSource" : "https://www.example.org/8fe25641-7dd2-44c3-b4fb-ced4783c17f4",
+    "abstract" : "xdKvdNePnX"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/db7910ec-9005-4fba-87a2-18520622fff2",
-    "name" : "rWFpivduaYRz",
+    "id" : "https://www.example.org/265b4b09-e1ea-4e8c-8267-66b33720107c",
+    "name" : "2zdLaTw4i6PmZd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-05-05T22:31:35.038Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1977-08-01T19:24:45.241Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "EAeLUvx1Xg"
+      "applicationCode" : "jNMgAfHhn1wfoyrW4qQ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e7ec4143-31ee-4cda-afcf-9f3f518f1441",
-    "identifier" : "K4z2WV56aqq3",
+    "source" : "https://www.example.org/bd5b3a27-63d1-40d5-8357-0756cadab90f",
+    "identifier" : "ljJf9B8s3u2",
     "labels" : {
-      "zh" : "KmyL3XYxtU"
+      "sv" : "9nddT3EFr78"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1415650441
+      "currency" : "USD",
+      "amount" : 32425816
     },
-    "activeFrom" : "2024-03-04T20:42:07.714Z",
-    "activeTo" : "2024-06-23T11:23:10.193Z"
+    "activeFrom" : "2016-01-15T18:26:34.439Z",
+    "activeTo" : "2018-07-28T08:55:17.189Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/46eb2341-50a4-4834-ae1e-5792c68c1769",
-    "id" : "https://www.example.org/2e0b8bd7-7add-42ca-9d29-a0c4468f63dc",
-    "identifier" : "pgRXtDQZO35Pz09DwDY",
+    "source" : "https://www.example.org/71c38353-3274-4560-90a0-9b47f3c83f70",
+    "id" : "https://www.example.org/a8c94546-1a99-4401-8945-d329173515ce",
+    "identifier" : "vQSom8gg5yM2Lir1",
     "labels" : {
-      "ru" : "ryKoHFUl0h"
+      "af" : "gzGuilEL2MCZQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2121701201
+      "currency" : "USD",
+      "amount" : 1890420756
     },
-    "activeFrom" : "2022-07-10T20:56:23.110Z",
-    "activeTo" : "2022-12-21T16:15:08.034Z"
+    "activeFrom" : "2024-05-13T12:54:46.966Z",
+    "activeTo" : "2024-06-06T15:11:06.277Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/9f362f00-64b0-413e-baf2-6ed3c1d22377",
-    "sourceName" : "s6y6twybgndynwdo@bi8g7w33yqmlhh"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "oosn6SEamagqz",
-    "value" : "kc4g6nWgNRK6SXJwbd5"
+    "value" : "https://www.example.org/9f0160f7-4efb-4d33-8216-d14bd0a484e4",
+    "sourceName" : "nmkiykgi2cfe7wdbj@wshzyyrmoo2hhzif8o"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "657836725",
-    "sourceName" : "jrfmns0fka5wks@ojydjhecrzarezrsfek"
+    "value" : "1743629167",
+    "sourceName" : "8f5zt62edujb@c7zvtbemdl"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "rb53rcm1GaGGPS",
+    "value" : "ERB0V6QbhmE"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "A37OmqUcKwe",
-    "sourceName" : "apxf7kll0pmmppet0x@njeqwdkghz6frc2c5"
+    "value" : "mzCrKGPqur9q",
+    "sourceName" : "hvhxkb53r4fj6cw@tgonbu6hvnf7we"
   } ],
-  "subjects" : [ "https://www.example.org/a7925855-37ac-4b37-afe1-353fb3023be3" ],
+  "subjects" : [ "https://www.example.org/25b48da7-fc2c-469c-9abe-9c18f2d8c05f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "67d33d3c-054b-418e-9f8a-a7a13ef9a697",
-    "name" : "CdZ5lPymTSCrQG",
-    "mimeType" : "dy2hRlU53m",
-    "size" : 137071625,
-    "license" : "https://www.example.com/zvngwkivteknhbbed",
+    "identifier" : "6a64fc18-e961-4c13-8ed2-6a74a483a6d0",
+    "name" : "KLJvl8z1eYtm6j2Jf",
+    "mimeType" : "tk7zaalPGxJ86Mkp",
+    "size" : 1181221251,
+    "license" : "https://www.example.com/srzwhwqf9y",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "7KtjtvHCBJKx"
     },
-    "legalNote" : "nRqKWbuRsuKyhuPXs9",
-    "publishedDate" : "2023-05-25T01:17:18.865Z",
+    "legalNote" : "SneNsWYDtKDP3B5suZv",
+    "publishedDate" : "1979-01-19T03:09:17.066Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "NmAipGrepSL2MfMWr",
-      "uploadedDate" : "1984-12-01T14:22:00.211Z"
+      "uploadedBy" : "VTmDiPmlvxz4Wl",
+      "uploadedDate" : "2014-02-09T08:21:40.819Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZqZvIx3EKLUUYJxggB",
-    "name" : "LnIcsNDQbqTlhWeyg",
-    "description" : "XKjlUthf3aGMF"
+    "id" : "https://www.example.com/T9Yc7Pjv2VQdGTvp0",
+    "name" : "gwIYC0jsJrTlJ",
+    "description" : "b7vd01dVlgtJ2j6suCK"
   } ],
-  "rightsHolder" : "GbL4SSkAYnQEHog",
-  "duplicateOf" : "https://www.example.org/56f130b8-3412-4761-babe-f83675d1fc8e",
+  "rightsHolder" : "r1KUstay68RJUyI",
+  "duplicateOf" : "https://www.example.org/825292d5-d573-4362-b6eb-1da5a327eaa3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "hit8baF3aSN5IpA4YlE"
+    "note" : "Isfre6FHfIuP0t4lXB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "TDQ0x4WbaDlyuiDzE5W",
-    "createdBy" : "Mm72rdvtB17",
-    "createdDate" : "2009-07-04T15:36:06.552Z"
+    "note" : "XfyeFzCaSo01q",
+    "createdBy" : "sYlYRL5xQfxdeYhV6",
+    "createdDate" : "1993-05-30T13:14:25.290Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7e714ffa-d353-412c-9d2a-75627b278ba2" ],
+  "curatingInstitutions" : [ "https://www.example.org/7cae4027-aba7-4ea8-886d-0a3333e0877a" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "HHMFkbWZJB0gMGfcw1",
-    "ownerAffiliation" : "https://www.example.org/e9b4b6e8-4615-4f6b-85aa-f1b040a57951"
+    "owner" : "HgT9jkDB1XJxl7o1",
+    "ownerAffiliation" : "https://www.example.org/3ac9cb8b-8f34-400a-b287-ea9d5699e905"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ebb853bb-e8f3-41cc-a308-b88df1b8b06d"
+    "id" : "https://www.example.org/a117d303-4f40-4bbf-9810-53b189a19b1c"
   },
-  "createdDate" : "2006-02-22T14:02:58.054Z",
-  "modifiedDate" : "1989-09-27T04:44:48.063Z",
-  "publishedDate" : "1979-02-20T11:13:44.700Z",
-  "indexedDate" : "2019-08-29T16:02:10.934Z",
-  "handle" : "https://www.example.org/f903d039-3fff-4b93-9b89-2ab531b5a791",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/a707d1ce-adf4-4758-ad36-1ff3170f0997",
+  "createdDate" : "2021-06-17T07:05:24.755Z",
+  "modifiedDate" : "1995-04-16T00:36:13.528Z",
+  "publishedDate" : "1983-03-22T00:04:51.914Z",
+  "indexedDate" : "2005-09-10T04:04:12.680Z",
+  "handle" : "https://www.example.org/8e610477-8672-402d-84a7-f9996c9ed546",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/d65ee053-118e-4ff1-b9fb-0db5f8b5ff93",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "PJzsEqCXPOIlioychgn",
+    "mainTitle" : "0W1LvFpxoskYk8IX16Q",
     "alternativeTitles" : {
-      "nb" : "K82LHwkSN2lhpVh6"
+      "nb" : "mE5W3GorBT80eq"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NTAxDe0qBd",
-      "month" : "AHWgOfZfWiP",
-      "day" : "YB3GomCCNY"
+      "year" : "vfibmYOwEzyxe9dxEv",
+      "month" : "xtaktMetJwkREVeVAJ",
+      "day" : "2zqZBqO1aXtezBAso8Q"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/25c58a19-e8d9-47e9-b812-23f9978dbf63",
-        "name" : "iY3hyHndiNMsMj",
+        "id" : "https://www.example.org/55faef8f-db21-4bac-ba7f-708495c88320",
+        "name" : "eTj1ulLKgILyT",
         "nameType" : "Organizational",
-        "orcId" : "ItPdNua79PMVl",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Daw7LrgO6EQuAr",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4It3UAL3n82vW6v1n",
-          "value" : "ODd9ZoJTL0cLNxF"
+          "sourceName" : "NsujzoWwhdY",
+          "value" : "mMF3Bi5dOxgO8E"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TA4H0bnNvZ0OWjg1eC",
-          "value" : "BgsyYUQVFYcbHFh5gNs"
+          "sourceName" : "b1jXcPeCY6po1",
+          "value" : "5Xf0cNdPOrFRZxnk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/94071ea6-d3b8-4349-8d38-4930e40ff131"
+        "id" : "https://www.example.org/0490ade5-26f8-4e11-8ab3-87a0d863868f"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7f46f6df-6764-47fb-81d5-dac0172f291a",
-        "name" : "YAG90XtXdbfyUmMtg",
+        "id" : "https://www.example.org/e4e90584-9b21-4ea2-ac6f-9c0efd0830b8",
+        "name" : "exQfPCEb9yJn",
         "nameType" : "Organizational",
-        "orcId" : "EjEfokxlRLUC4AatIb2",
-        "verificationStatus" : "Verified",
+        "orcId" : "zO6Lk5dVr7",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5Zm8tGa0Q2T51w",
-          "value" : "VQEMn9Xx5GIaj"
+          "sourceName" : "um5AqNpGvyR",
+          "value" : "U0erzFuILzQETuKE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hd5lLgfhuXGMYY9tc6",
-          "value" : "LoAL8irIP0"
+          "sourceName" : "iSX9VF825wCm3TqE",
+          "value" : "3p5CK5YDXDBz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c40c3424-03ba-47f6-96a1-f9bf54024d39"
+        "id" : "https://www.example.org/39f93278-c408-4393-86a0-3eb2860fb6af"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "TV7VAXKcnGdSHiztR"
+      "el" : "LYhdmqwZigY"
     },
-    "npiSubjectHeading" : "m4GHbIkog2rjNEedV",
-    "tags" : [ "wOjNEcQMZdhEf9fjHE" ],
-    "description" : "JDaWeLEuEakOW",
+    "npiSubjectHeading" : "8YZefAB1Og2ZG",
+    "tags" : [ "HGjjX81QgN" ],
+    "description" : "eDwnfsIVjMr",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "EfZK6JevzOfE6pa",
+        "label" : "qcDJ3RmYwcvW",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "voh7nZrzVlkJKPbv3",
-          "country" : "BItIfzjtPA5RZuDk5"
+          "label" : "75ga603ycwgGAI1",
+          "country" : "GiOxhCYxp75B"
         },
         "time" : {
           "type" : "Period",
-          "from" : "2008-01-24T05:03:38.635Z",
-          "to" : "2016-06-14T15:30:41.967Z"
+          "from" : "1976-02-16T21:30:21.336Z",
+          "to" : "1995-02-22T02:19:23.525Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/9Y1BaynwEeEVDuBCOlI"
+          "id" : "https://www.example.com/ehsx9xZkDIXDmV"
         },
-        "product" : "https://www.example.com/cAa0T9eKNoTBG8VWbS"
+        "product" : "https://www.example.com/2R02CWNdaV"
       },
-      "doi" : "https://www.example.org/81ebbb5b-08e5-4871-bbc8-afaaec82c7ef",
+      "doi" : "https://www.example.org/aecc7663-37a2-4495-a359-8bbcde9d55b9",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -122,106 +122,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6470f718-ed10-4674-9cf6-cc3a79674b54",
-    "abstract" : "PqZ1JhplyrkQ"
+    "metadataSource" : "https://www.example.org/a2ca2185-d3d1-4c9b-b9e3-63c7eb6e16e6",
+    "abstract" : "K5iDUCaGfKQ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/04651639-e0c4-436f-9468-da3755083051",
-    "name" : "7MMZZflZL8",
+    "id" : "https://www.example.org/c4e7c8a7-e3b2-4042-be62-bd1afb77908f",
+    "name" : "5010A9l71RhlW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-05-25T19:01:20.725Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1999-05-03T23:07:53.583Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "7vDUXIhxvsVej"
+      "applicationCode" : "aMJ4AMAJQoXu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dc24cb7e-0750-4b35-8aff-720d42e62e10",
-    "identifier" : "sTQfEmeDBlwmEu",
+    "source" : "https://www.example.org/f94bb5c0-f178-4eec-bd71-ad45346df060",
+    "identifier" : "JaGqhpW7TQzeTDB",
     "labels" : {
-      "el" : "tMjvrGYY9dn29HW6C"
+      "nl" : "zO7OCS2GY4y5M"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 524936726
+      "amount" : 1346546079
     },
-    "activeFrom" : "2004-07-30T14:59:54.411Z",
-    "activeTo" : "2011-02-11T08:36:11.516Z"
+    "activeFrom" : "1995-08-05T17:03:56.749Z",
+    "activeTo" : "2005-10-28T19:23:57.834Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d3220356-1858-4469-9861-419c3272c393",
-    "id" : "https://www.example.org/d1c92bfa-1768-478b-8c4c-a258e7b9499f",
-    "identifier" : "ceunool9ZJm1NBB",
+    "source" : "https://www.example.org/725c0481-30a2-4cfc-b895-46be5d665989",
+    "id" : "https://www.example.org/207b17d2-3639-4493-b053-f7bf9ecae8e9",
+    "identifier" : "pX9FKgO93Ahya40",
     "labels" : {
-      "nb" : "VMy2GqrvQZ2f38mY"
+      "ru" : "EL6yARs1tXoKNbQa"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 233798209
+      "amount" : 1723683021
     },
-    "activeFrom" : "2008-11-28T16:17:12.304Z",
-    "activeTo" : "2014-11-19T06:04:02.222Z"
+    "activeFrom" : "2007-11-19T22:40:51.792Z",
+    "activeTo" : "2009-01-09T06:26:53.767Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/f91ec3b9-9bcd-41ad-b784-34957290fe52",
-    "sourceName" : "eyamyuow7w@hefd6adfeg654"
+    "value" : "https://www.example.org/a9583a7f-8a18-47ea-91a3-226cfa7f6506",
+    "sourceName" : "cixb3ixc0po09@e5esvjaqnrqkkgvh"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "P2G51HKzXHiSx",
-    "value" : "Myv8PaTELuZXWlf"
+    "sourceName" : "5HOA5ylKHxraO2BB",
+    "value" : "FZiIPf47T2QkDP1SP3"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "UuRmxyoRFU",
-    "sourceName" : "twwt41jqdaqxey@ilhman52yh"
+    "value" : "jYauqJaWRwYFyfZ3S",
+    "sourceName" : "evg67u75jxz@aiomryzu40fz1qm4"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1410690975",
-    "sourceName" : "hya0d3sj54j@xaqnnyqb14xuw69mp8"
+    "value" : "335174073",
+    "sourceName" : "pxyteu50ccmvb@xrvmpjlq4rjuit7x"
   } ],
-  "subjects" : [ "https://www.example.org/c98bf0e6-ea15-494a-b7e9-5a545bab2d15" ],
+  "subjects" : [ "https://www.example.org/81e6112c-6fb6-4d7e-b79a-a0d438490f56" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f51fc690-6627-4aaf-95ed-68af18a20bc1",
-    "name" : "z8Xb3BXZW2rhRpLS6",
-    "mimeType" : "NwlFNM01haHntD5",
-    "size" : 549666151,
-    "license" : "https://www.example.com/we5jmcy81o",
+    "identifier" : "ceae3dde-30a5-4607-acec-550d8ee07cf7",
+    "name" : "6QGPphZxzUm0",
+    "mimeType" : "RGjBzkbjofz",
+    "size" : 1042550419,
+    "license" : "https://www.example.com/twcuy7gtbw35w",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "dbKU078c5JKNuAw"
     },
-    "legalNote" : "mM8L2JZaxI",
-    "publishedDate" : "1985-07-05T15:11:23.157Z",
+    "legalNote" : "BtHF9DnsppfDR",
+    "publishedDate" : "1977-11-26T01:05:08.502Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "sDGCJ85izZ1fuGmFQE",
-      "uploadedDate" : "1980-12-30T14:02:58.620Z"
+      "uploadedBy" : "CsrQHT8oYeUC",
+      "uploadedDate" : "2023-04-02T09:21:08.843Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FqImCewN781xJH",
-    "name" : "udurfpQ0wWQyv1WEC",
-    "description" : "vHpJnenezbf"
+    "id" : "https://www.example.com/iKWimsvt94qAh2ozJ",
+    "name" : "oJXvmcaGPdMS0p",
+    "description" : "Fv9im88a9iWP"
   } ],
-  "rightsHolder" : "Z4Gvuxuzqw",
-  "duplicateOf" : "https://www.example.org/3e480dc3-1dbd-4373-9d22-3010c0ee7685",
+  "rightsHolder" : "xwJjkQUFFI",
+  "duplicateOf" : "https://www.example.org/c7b1b185-de76-4e0d-b2b3-b2c59252d647",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "wH9Znwu0PGXkbsT3ht"
+    "note" : "ICKGChQHjKObleh4"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "j6zFvrB38V4mRzBvU",
-    "createdBy" : "57AwqHGMsFUKIe",
-    "createdDate" : "2013-03-31T16:44:45.686Z"
+    "note" : "GhmNNvaPbf6NqTXfTT",
+    "createdBy" : "MupAJqnLKApBnzceiup",
+    "createdDate" : "1998-09-14T08:55:57.692Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/63a30ee5-872e-46dd-b06a-48920181c5b1" ],
+  "curatingInstitutions" : [ "https://www.example.org/7146c8c7-3691-41f9-b5e8-8bee0e4db95b" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "uJkSpNRoGQJUQuVtwwV",
-    "ownerAffiliation" : "https://www.example.org/8acaaebb-cdef-401f-b0a1-87c0bb054148"
+    "owner" : "HKJWgQ4QQeLKncxtBop",
+    "ownerAffiliation" : "https://www.example.org/ee7a3b7d-a95d-4778-8cd0-c193ecff2898"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5b8c3e63-2e8a-4103-91b2-640001c7f777"
+    "id" : "https://www.example.org/30e5b96d-e173-4e11-a53a-0097d745c746"
   },
-  "createdDate" : "1975-10-01T16:35:34.884Z",
-  "modifiedDate" : "1979-02-26T09:12:55.369Z",
-  "publishedDate" : "1971-07-28T13:38:50.611Z",
-  "indexedDate" : "1997-03-16T07:15:06.358Z",
-  "handle" : "https://www.example.org/7695ce87-8c72-4028-b35d-80feb94f0a19",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/8f41897b-8c1d-4b18-a1f4-a7bd40097c15",
+  "createdDate" : "1971-06-01T11:42:18.153Z",
+  "modifiedDate" : "2020-12-25T09:25:55.374Z",
+  "publishedDate" : "2021-02-08T01:28:12.142Z",
+  "indexedDate" : "1998-09-27T05:35:08.555Z",
+  "handle" : "https://www.example.org/81c8ab0d-ddbe-4075-910a-507a6937b9cb",
+  "doi" : "https://doi.org/10.1234/quas",
+  "link" : "https://www.example.org/3b288caa-5ea9-4f0a-a949-e604ed48582f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Nt1MGsWUjTOb",
+    "mainTitle" : "PnfndL316T64IPN",
     "alternativeTitles" : {
-      "it" : "2z7aMM4TqZ3Cj4A"
+      "sv" : "enEKv0bNmHfFfn2j"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TAIWymwynNqNr5I",
-      "month" : "M6dMdfFWxEvzH4WkU",
-      "day" : "V3f5CU507L1WxmK8eG2"
+      "year" : "BfoCupcgJPxkjVSH",
+      "month" : "67CdgXAHD8N5w9REzn",
+      "day" : "F05WtG1s8ZE5LF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/111fb247-2203-4668-b0ca-8a8ca27120bf",
-        "name" : "ByCjcBz2jpr7FrO5ffJ",
-        "nameType" : "Personal",
-        "orcId" : "jVCEUDk84lxDXfT6",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/0cb4421e-a054-4525-9c4f-c88d068eafc6",
+        "name" : "WT05w3BBrx3bq",
+        "nameType" : "Organizational",
+        "orcId" : "sLWudkmx0pl",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QrR6QkVOtUEweZ",
-          "value" : "9DDw8ufsH6ohZ5UI"
+          "sourceName" : "iLw5yQYKWVs",
+          "value" : "KvG7JkF071sXA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fzMK1Cy2E3B9",
-          "value" : "ondT0Jl63PPOYXM6piu"
+          "sourceName" : "ZMfbv9Tbexqj",
+          "value" : "MGSmLsSXSr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a34f460c-0398-4fad-a3f9-5c4fff9ea394"
+        "id" : "https://www.example.org/8620dd2a-e8c3-4c6d-91a1-c7a0fcdb2894"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Composer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,227 +62,227 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ca5cc15-6b63-442b-a52e-06ccfe9c50ae",
-        "name" : "23BCrb4bluSeGFp",
+        "id" : "https://www.example.org/15f7f9d3-bee4-4fd7-ae67-ca1df1399942",
+        "name" : "U9odpMXz3eKVX2O4l60",
         "nameType" : "Personal",
-        "orcId" : "kVStZiRIpifs",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "LjwiirQPnqpNh",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "52ziPHVDHCl",
-          "value" : "wbpR7i0cs7CA"
+          "sourceName" : "RaQ1rV7HUyXBZrban",
+          "value" : "67B3Jr51jb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jxgNc3KyLtPSCYi2",
-          "value" : "MSV3zcBJ6H8NYiJc7"
+          "sourceName" : "2y9TooWhCBGb",
+          "value" : "jB6mdyIyvFe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f90857e-3032-4c34-82ab-9c8df9a0eafc"
+        "id" : "https://www.example.org/2a4ce407-877d-435c-87a9-3944bd9b415d"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "6Cak0OWmM4Pnxulaecd"
+      "ca" : "i7LRhmizGMuLR6kx"
     },
-    "npiSubjectHeading" : "PiYqvRU2w5tjgX",
-    "tags" : [ "QeUE7IjzcnXCL2Lnd" ],
-    "description" : "GkSY2RG1O4",
+    "npiSubjectHeading" : "HZ4R7hgC853U4bcJp",
+    "tags" : [ "FV4LxExKOnFXDti8" ],
+    "description" : "Bo5AulPB9G",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/14706c4b-193b-40f2-a882-96f31f11d0e4",
+      "doi" : "https://www.example.org/7d67e98c-3131-49a0-80f0-6412710ca2c1",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Retelling"
+          "type" : "Translation"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "sKwYvUwwfULlqzR",
+            "name" : "k4E6ZZa5Bsgr1",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "KcYaxYI7aqh8",
-            "month" : "i5w1e0USVuNpLagw",
-            "day" : "cIodXGKORGVM"
+            "year" : "dFFFvhSxLk",
+            "month" : "fM7EbWgSaCA",
+            "day" : "F0gicIJ2uz81R9uw"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "oRkii6kZQAZpr",
-              "end" : "r8xXpAydrIrlzcsIT"
+              "begin" : "H2M6wyKSiZumTThED3",
+              "end" : "gzYSfRcUp2R7g"
             },
-            "pages" : "hNt3pr7zH56QiOc",
-            "illustrated" : true
+            "pages" : "QarAiWuy7eOeO5Uni",
+            "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
-            "type" : "Audiobook"
+            "type" : "Podcast"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "LwWYgNfmC12L2nEfFJh",
+            "name" : "mYzqOYhfHmGl6qUJ4",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "3RFw0PkXiWvIT7oIRtF",
-            "month" : "E5dq1szNIUq4BC",
-            "day" : "jZxLQFCnebcfYw"
+            "year" : "kiOZXsut09aHW2cJx",
+            "month" : "HwNIaFGLU5",
+            "day" : "VlRwJFwaYav"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 2128955674
+          "extent" : 2131039358
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "Reading"
+            "type" : "Play"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Wa6mVsStHrZgEEfsM",
-            "country" : "oR5xVSh8GNEM5Q"
+            "label" : "cNm4ugOVHeL",
+            "country" : "m2RYf8ESYArAic8z"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "QvJwbecRbiE61b",
-            "month" : "TXarfdStyn",
-            "day" : "RpaZm6fgf7"
+            "year" : "VNBUlejkqZeltBo",
+            "month" : "FrzQg4iTSkoPkS",
+            "day" : "8mNGpjvOiPjKKM"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/KRlJyC8KMiSuOSu",
+          "id" : "https://www.example.com/bmMHSJnfzDzV6L0",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "guALR5fy1m7czFDp",
+            "name" : "yfPJmFSISOVmL9PrwGy",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "dokfqbsxNjOr",
-            "month" : "DFu2WpxXOfhLZi1ZX",
-            "day" : "6o2BmvmKma2aBz"
+            "year" : "tS4kbugMrcJwKv",
+            "month" : "sC4ZhXHnN5WZ8W1O8",
+            "day" : "1v8X0wd85EON7e"
           }
         } ],
-        "description" : "yclAhd0KLcA3pT",
+        "description" : "wkxIXcJk78tjpJG",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2e6cb7b1-638f-4de4-a1ec-23f513bb580f",
-    "abstract" : "Su4jlClc4pUIR1wd"
+    "metadataSource" : "https://www.example.org/116d1a6e-64ab-448b-b80a-434ce8268dbc",
+    "abstract" : "1ooiSYzRRMveol"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9bbbbbd4-955b-4b6f-b814-0a64062aacc9",
-    "name" : "0ld4BHB82hCoL",
+    "id" : "https://www.example.org/a413b4c6-7df7-4ff2-bd5a-53c954ad6c62",
+    "name" : "zjb7pqlchcpHe",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-08-18T03:22:53.812Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "a0PYlm2tXe43"
+      "approvalDate" : "1991-01-10T19:06:06.919Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "DqmOM2g68YiGnvJz"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/36fbc5a4-944a-4757-826a-12a7582ac4a0",
-    "identifier" : "gDVepKhC2p1dfIGJUQO",
+    "source" : "https://www.example.org/22566950-9fb5-4159-adcb-e23c12fd3303",
+    "identifier" : "fjZZkFIqUtGLP",
     "labels" : {
-      "hu" : "jB0xfvy1KE8sWsn"
+      "fr" : "K6HdBydCjFJRjgVoS9"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 645772905
+      "amount" : 1847028683
     },
-    "activeFrom" : "2006-04-22T21:24:19.502Z",
-    "activeTo" : "2014-02-28T12:53:04.112Z"
+    "activeFrom" : "2021-01-30T19:17:16.470Z",
+    "activeTo" : "2021-07-04T23:48:09.393Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4ed0420b-4092-46e8-8c9b-cb9d60dfb039",
-    "id" : "https://www.example.org/71d13e17-6187-489a-96b6-120e3e1314d7",
-    "identifier" : "RpdAq1Y3AF5IYa",
+    "source" : "https://www.example.org/c1c688c0-aa56-4f17-8eec-b8066ded3bd5",
+    "id" : "https://www.example.org/ba06ae26-2b1c-4b1b-adbe-f9a39535c601",
+    "identifier" : "ux8su7XXHFGnGKb",
     "labels" : {
-      "en" : "mMI3vnKPL1OacVQIN"
+      "is" : "B4tupw8mEnlv4W3BEO"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1130573739
+      "amount" : 1159500872
     },
-    "activeFrom" : "1987-04-12T11:38:31.241Z",
-    "activeTo" : "2020-10-28T22:55:22.995Z"
+    "activeFrom" : "2006-12-31T16:59:06.391Z",
+    "activeTo" : "2014-02-12T07:28:55.750Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/2d768c1f-0977-4ad6-86ba-00cc5c27fead",
+    "sourceName" : "gwm0df0wjhe@j10nuvwjtju"
+  }, {
     "type" : "ScopusIdentifier",
-    "value" : "SOAwfUnxsJ0",
-    "sourceName" : "b2ud7cfwyqbdpovb9o@pqmwfqx8kahxr6ga"
+    "value" : "fohMYM6hIPXlWX",
+    "sourceName" : "9jusd15bjpmg@b14lvs0ivr9jkdfyd9f"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "972116592",
-    "sourceName" : "rqiojzr7vnqyt2mm@7rvuvgd2mwmd"
+    "value" : "271889602",
+    "sourceName" : "s3tkvoetj2prm@xvvocw9t0qhocams"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "nRL6Tnr8F1gm",
-    "value" : "cSOvYbsgP6Q"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/379d70b0-a63f-4676-a592-b9a795100779",
-    "sourceName" : "60atqrhfkiejinla3b@bxtkj3ah9pweuppvc6"
+    "sourceName" : "oAjAMohp61u3DF7P",
+    "value" : "zObPxDc0n4WrTFHb3"
   } ],
-  "subjects" : [ "https://www.example.org/a5bee1c2-b726-4d24-95e1-17a7738a4ab1" ],
+  "subjects" : [ "https://www.example.org/15a02171-c1ac-422c-9ed4-b2d548911b24" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fd159770-4fa3-428d-9d0f-c3a6264df49c",
-    "name" : "JyUxwrUBXP",
-    "mimeType" : "axzvYpLfHFp",
-    "size" : 913876642,
-    "license" : "https://www.example.com/jym5kywhwjaxoou",
+    "identifier" : "1ded6cd1-7b72-47a1-843e-ce607a22e1c2",
+    "name" : "7LyaSyLvNW",
+    "mimeType" : "Kak6WAqnXTFZ13",
+    "size" : 1515995919,
+    "license" : "https://www.example.com/dinhpehwmfv",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kHJlH3ibDgZD1h",
-    "publishedDate" : "1986-04-28T10:23:03.506Z",
+    "legalNote" : "dZVNJitD2D",
+    "publishedDate" : "1993-01-17T20:11:46.401Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "fkD9jikuCP9bHuPaC",
-      "uploadedDate" : "2003-04-03T20:49:24.931Z"
+      "uploadedBy" : "674V1lgVgykEPCaSg",
+      "uploadedDate" : "1978-06-29T06:26:34.847Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/uGojhRF5VZ",
-    "name" : "T98FJFxRwU9K",
-    "description" : "OScsICkXgQJTSJY"
+    "id" : "https://www.example.com/hZ1a5VdpBc",
+    "name" : "NMzQ23zT5Dpx",
+    "description" : "aw7ma6osL9jE63UnYbo"
   } ],
-  "rightsHolder" : "smvGjI0jmMFXYI",
-  "duplicateOf" : "https://www.example.org/1742255a-e176-4c7e-ab37-d4fe586564c3",
+  "rightsHolder" : "H8rh2Ah4dvnq8qk",
+  "duplicateOf" : "https://www.example.org/7f55b4cd-bcff-4d46-8e5d-46a2cb554ea7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "b6LFZyJli6"
+    "note" : "XMVRBdT5xDdrdXKN1V"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QUBptKrebyq3",
-    "createdBy" : "T8nVpMYAVhr",
-    "createdDate" : "2020-06-18T08:37:21.283Z"
+    "note" : "DJ0ws4J2r1v6",
+    "createdBy" : "dPUc69uyOX75T",
+    "createdDate" : "1991-04-29T11:59:38.509Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7483dd1e-1d31-46ce-98e5-2af3276ea3f3" ],
+  "curatingInstitutions" : [ "https://www.example.org/7764233d-b3da-42bd-856c-fdb81383d213" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "JsrV1izYY2",
-    "ownerAffiliation" : "https://www.example.org/7e39ba0a-cda1-4a37-9e2e-edd1f10b3ae9"
+    "owner" : "pF5WewfNPrOz3u2",
+    "ownerAffiliation" : "https://www.example.org/50424197-a257-4cb7-94c4-a103f717337a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4516df81-aa97-40bf-9729-6c5d8cdd60e8"
+    "id" : "https://www.example.org/9c6d0f7a-53de-46b1-860c-243dc46b7589"
   },
-  "createdDate" : "2021-09-20T05:01:59.928Z",
-  "modifiedDate" : "1983-08-11T15:04:57.033Z",
-  "publishedDate" : "1996-05-28T11:16:08.377Z",
-  "indexedDate" : "1974-07-23T03:32:15.133Z",
-  "handle" : "https://www.example.org/fc495f6a-628e-4e4c-bdda-369aa9858ba2",
-  "doi" : "https://doi.org/10.1234/ipsa",
-  "link" : "https://www.example.org/2f5053cf-e667-4342-ae11-7c651368a42c",
+  "createdDate" : "1998-08-09T16:50:18.038Z",
+  "modifiedDate" : "2004-11-10T23:43:44.994Z",
+  "publishedDate" : "2011-04-21T15:15:42.982Z",
+  "indexedDate" : "1977-04-22T23:39:28.321Z",
+  "handle" : "https://www.example.org/39990e75-f2df-43cc-b3b9-37f9b63e079a",
+  "doi" : "https://doi.org/10.1234/modi",
+  "link" : "https://www.example.org/9e811229-8a2d-451a-a2f2-baf4c5cde429",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "v8PIzDZrA95a9gLLHN",
+    "mainTitle" : "5KhtC2VHyE",
     "alternativeTitles" : {
-      "fi" : "XjtVFhdw6Dk"
+      "sv" : "I3F6ydDhklnvxKQUF3o"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "akQzqKKQ6Oc0peSULn",
-      "month" : "cwEOPlGkbtDGTX",
-      "day" : "kXXpZCS1ePQc"
+      "year" : "IENS8MunMBTLIvSjD",
+      "month" : "XYQSXYJRqEc9RGuaU",
+      "day" : "yfqK30QbsBMkYri2Lp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/896b56e4-b3aa-46fc-b9bd-20c14813b8ba",
-        "name" : "KfS3vC4nl4dX5XtBfWk",
-        "nameType" : "Organizational",
-        "orcId" : "C0DDmnlt4sAJ",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/3a223dfa-0758-4a54-bcc7-05c86bc3b4c3",
+        "name" : "7ajlhVwYuayT",
+        "nameType" : "Personal",
+        "orcId" : "MkslK0tdCGVIJk12yin",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "shEoGcD35W0L1AVpw",
-          "value" : "0e5WnG5Dd3ncX"
+          "sourceName" : "m0UwTTuuIN1KPIkWYt",
+          "value" : "u6odSUbevNT9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3VEGvGKc3y",
-          "value" : "xcyGgAVC2ByDqAnSeu"
+          "sourceName" : "simPZFLOIsSGW",
+          "value" : "13m3OEty6fge"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/32d10cc6-924a-44ae-8d54-e62da3e56a6d"
+        "id" : "https://www.example.org/e34628bc-a4af-4f22-bae1-8a5ae09fedac"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,163 +62,163 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/acc5b04d-f625-4da6-9acc-cba92e9eb204",
-        "name" : "yYEFRsUgqh7i",
+        "id" : "https://www.example.org/6cbab99e-b127-4657-9587-3c2e270cce2c",
+        "name" : "K6ZoHXafISea",
         "nameType" : "Personal",
-        "orcId" : "J7NrL2tM83pUVnif3p",
-        "verificationStatus" : "Verified",
+        "orcId" : "gTyAjkRtMiIF",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IY9HbXGRwn",
-          "value" : "iZIyvNbDiH8LiRtfl"
+          "sourceName" : "1PDDQPe1gF7Qnaq",
+          "value" : "Wqr4I13XJub"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tdnYpeWnst7dsmsT",
-          "value" : "cVpGvCwTf8qilU9JJ"
+          "sourceName" : "Btgrkhb3Vw3JLhEg5F0",
+          "value" : "bSBgDmq3b5Uobj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0dba594d-0a0a-4228-9d49-a45d2d048a1f"
+        "id" : "https://www.example.org/5dcd96f4-d05d-4095-88a0-af4ccc8c3a18"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Journalist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "JfVwGvYMAfQRKr"
+      "pt" : "VUPWat3970nLsSD1k"
     },
-    "npiSubjectHeading" : "QAseZ8KdLQkhMXpHA",
-    "tags" : [ "U5ns2WECVoD" ],
-    "description" : "7VrDT7vxgqwDuIYJby",
+    "npiSubjectHeading" : "97OcJ0GR3388F",
+    "tags" : [ "dxhDMpy6cgJC6Ghsnz" ],
+    "description" : "GWCZYpsGRa1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ece1f1a4-dbb8-4323-8eef-33608be63252",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/599cf2cd-8303-4b6e-ad21-316fa9ee0888",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/f98fa116-a3da-492f-915a-4f1a12ade89f",
+      "doi" : "https://www.example.org/2a3e33b5-d564-4a91-a41b-e485b68337a2",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "PgvoUipEO7jVZLX7f",
+        "description" : "6f7cMA2Btroiy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "fJuhc0nrnRhO",
-            "end" : "gjJxUWvD5RwNOUxK1p"
+            "begin" : "TVa08teOLlLsQtDmU",
+            "end" : "dLTaX25cTV"
           },
-          "pages" : "LCkKL2aagQ4TkMuss",
-          "illustrated" : false
+          "pages" : "57BHzgctmskfxpYz",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/87881065-f548-48e1-af4f-cda494cd7d36",
-    "abstract" : "GjN7Akcggbv3oZ"
+    "metadataSource" : "https://www.example.org/9bd4a1fe-0171-49b8-9b2b-b3f4ac10e4ef",
+    "abstract" : "p27rS3RaBc8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/160dfc8e-3884-4f31-aa30-1d2c70ac1444",
-    "name" : "rEDEBn4NPCL3",
+    "id" : "https://www.example.org/95928f40-22ba-466a-9bfc-7bf01c95b0ba",
+    "name" : "oDU06fIpJh238m7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-08-26T16:02:57.483Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "BkMr1xMZBvs3BTD6D4e"
+      "approvalDate" : "1982-02-13T16:39:30.602Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "RaW0jvj2ssaYlOJm70G"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/de308152-6d49-40e7-b40a-ac14892c5961",
-    "identifier" : "PDV10f82D1Qyj1Jp0da",
+    "source" : "https://www.example.org/dd94ec3d-6f23-4aed-a19d-b88db1fbb37a",
+    "identifier" : "TSavH5NTrcWH",
     "labels" : {
-      "bg" : "GjJbDfF7BkA2M7KqWQ2"
+      "en" : "A60xeqmYRyo0"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 745908782
+      "currency" : "EUR",
+      "amount" : 994740562
     },
-    "activeFrom" : "2022-10-12T20:14:38.649Z",
-    "activeTo" : "2024-03-09T21:48:33.230Z"
+    "activeFrom" : "1977-03-21T09:36:07.485Z",
+    "activeTo" : "2006-05-25T23:56:43.163Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eac7c245-7b21-4502-8ca6-7ca9a656923b",
-    "id" : "https://www.example.org/ce5bf508-584a-44f3-b75d-1d296075a8ae",
-    "identifier" : "Ija5nagT7LLIuHyFZT",
+    "source" : "https://www.example.org/551110ee-1b76-46b1-b3c1-9b80b2f85fa5",
+    "id" : "https://www.example.org/7b487e91-868f-4ea8-ba17-e2f76174aed0",
+    "identifier" : "ufG1aNPo5ZAR",
     "labels" : {
-      "ru" : "CjLkg57aiuV"
+      "se" : "odDvUVN4T8x"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 772976959
+      "currency" : "EUR",
+      "amount" : 1554148467
     },
-    "activeFrom" : "2003-04-11T15:42:44.611Z",
-    "activeTo" : "2024-02-26T18:03:35.130Z"
+    "activeFrom" : "1974-06-17T19:39:38.878Z",
+    "activeTo" : "2011-08-15T11:14:28.801Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "sF2Nxv9VyPprh1v2I",
-    "value" : "52x0PfiNjvu7QBX5"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/244742f8-6f5e-403b-b4d3-0882771e445a",
-    "sourceName" : "fghhknpz5dyu@vdrpxezaawb49gapcgo"
+    "value" : "https://www.example.org/f3741503-63d2-4180-9c4d-861048bc85ad",
+    "sourceName" : "luui6hqfiqygl@ufifsxu2pe1f"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "8Ys6KzY5Zf0iIA3",
+    "value" : "uIrGD5wXCZHZ"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "WonJiKJkhnL",
-    "sourceName" : "mmrylnxkgyqq8@iahhgn0mg4q"
+    "value" : "dBbg5ZHbiqY4KT8h",
+    "sourceName" : "mhetzwutmyvw8za@nzgxufc7rkpazif6dw"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1251432284",
-    "sourceName" : "27uk3g9o8q9rl4ks@yqbautlvqonib2"
+    "value" : "1318484571",
+    "sourceName" : "mgdkdcnta6vyws@tma8pkxrxdpg9h7vrw4"
   } ],
-  "subjects" : [ "https://www.example.org/19f83d14-8a67-420f-84c3-8ec81a90cd8a" ],
+  "subjects" : [ "https://www.example.org/7b477a32-fbfd-44bb-89f7-f053a2cc0203" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "906c7bca-eb8c-4fda-8d42-f1ff21e82757",
-    "name" : "rHfNJ9mPb94yOy",
-    "mimeType" : "4LFhMOIaTkKP",
-    "size" : 2138735226,
-    "license" : "https://www.example.com/rxwtff1wt7qyq",
+    "identifier" : "3c9362ab-b5fa-4a96-a266-65555c4109c0",
+    "name" : "aUdi9LkVpDR4hz",
+    "mimeType" : "Jg0fwhIsXTI",
+    "size" : 511082092,
+    "license" : "https://www.example.com/qsjed1gbtjf2fh9m",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "KlsbrOAxhppJ",
-    "publishedDate" : "1994-03-21T19:43:00.100Z",
+    "legalNote" : "0nRLRQVnrr",
+    "publishedDate" : "1999-06-20T09:02:51.905Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "4owBe5tRDSMm",
-      "uploadedDate" : "1972-07-15T15:07:43.267Z"
+      "uploadedBy" : "FVCwlbWvB0dLuzh",
+      "uploadedDate" : "2003-10-07T23:06:56.881Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/fAFIZuX6HVNoL",
-    "name" : "UYTATf8ARK2aXvO",
-    "description" : "gPE9yhxII4gKAo"
+    "id" : "https://www.example.com/Y9IPGau2PIUpkX",
+    "name" : "ScRmRXCllsFIPNJ",
+    "description" : "Z79ociKro0"
   } ],
-  "rightsHolder" : "HYP2gf9oFN9ewT9",
-  "duplicateOf" : "https://www.example.org/bd15d979-d078-49e0-9575-37e922647351",
+  "rightsHolder" : "88nAFfxCE2yV",
+  "duplicateOf" : "https://www.example.org/a8ebce39-f49b-482e-bbaa-af7747722225",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "r1SUAtaSrtcX"
+    "note" : "MVWMRhkksQzrGP"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "n86gY1IUmFwSok",
-    "createdBy" : "U2Y3F31mjFacnnvvzr",
-    "createdDate" : "1988-08-24T07:49:35.321Z"
+    "note" : "Vh36I12hZaEl",
+    "createdBy" : "rGyFq0h3p9reLgJtR",
+    "createdDate" : "2004-10-03T23:58:53.209Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6da25b1e-6de5-4fc3-9659-19444da002c7" ],
+  "curatingInstitutions" : [ "https://www.example.org/fde26615-184c-49f3-8826-23b24f61bb59" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Wye2E6f2Q6jI",
-    "ownerAffiliation" : "https://www.example.org/dc85d28a-cf11-4d62-9db4-710fef4fad52"
+    "owner" : "yPLoB4tHOwL0xTm2v1F",
+    "ownerAffiliation" : "https://www.example.org/db2ef667-8b8d-4e1a-9cd4-6a9ad9d85ae9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9ceccc62-3cf3-4c22-92a2-f1d26cee5186"
+    "id" : "https://www.example.org/f3750be3-c2a3-43b1-ba02-bbbd0fdd976c"
   },
-  "createdDate" : "1990-06-19T15:27:44.519Z",
-  "modifiedDate" : "1984-06-11T14:20:44.878Z",
-  "publishedDate" : "2013-09-18T16:23:10.212Z",
-  "indexedDate" : "1986-01-23T11:22:53.448Z",
-  "handle" : "https://www.example.org/bb5de399-58b6-44c9-9690-2878f2ff5601",
-  "doi" : "https://doi.org/10.1234/cupiditate",
-  "link" : "https://www.example.org/ef286b07-e7dd-4ce0-8f83-90521357875d",
+  "createdDate" : "1994-09-22T02:48:23.065Z",
+  "modifiedDate" : "1975-09-05T02:12:03.877Z",
+  "publishedDate" : "2020-05-30T21:30:16.646Z",
+  "indexedDate" : "1998-04-09T09:45:12.455Z",
+  "handle" : "https://www.example.org/a186a97c-194c-4115-b4ce-2ea6ac84aeed",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/baeaad15-d066-4952-b550-3364a169dfde",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "N4dcPxFAPQ3g2fESMf",
+    "mainTitle" : "bWB7iF3WNik2VmF",
     "alternativeTitles" : {
-      "sv" : "yti1IsX5tj"
+      "nn" : "x8bDEiNAWbJn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Pk9cJdhgmgUjYgf",
-      "month" : "R7ANBwVx2HU5kSfARsD",
-      "day" : "7HfnuCNWea2gMMYLj"
+      "year" : "LaiMUlEQ8ewCJpH3c3G",
+      "month" : "WYcfoj8oXPuYc",
+      "day" : "8vFU1cfFi0F"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/24da26b0-5a70-46ae-8aa4-fa556f5629e6",
-        "name" : "Ht0EMbKtPMVQnOk",
-        "nameType" : "Organizational",
-        "orcId" : "hCeCcalpN2KwfhIaAX",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/60b21010-759e-44db-9ff9-4b503a360116",
+        "name" : "8IOs81hR26bWw",
+        "nameType" : "Personal",
+        "orcId" : "w8xyJWaxDa",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yfruhRL9ZKRCr44tSc",
-          "value" : "xQBQwOtx5Ju"
+          "sourceName" : "pxrmwhvEUVh5Z",
+          "value" : "pDqs0RtU2Ci2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kZ9E2K7uXIl3",
-          "value" : "TBv6yMSi3YY"
+          "sourceName" : "EeD8FYRsHqi7NQ",
+          "value" : "OOjs0Jb153L"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/45a85ff5-a284-425a-837b-74f651bd485c"
+        "id" : "https://www.example.org/b3621a5d-75bb-41fa-b1c0-baeb179b05cc"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,24 +62,24 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ac590146-ce2e-47e3-a03a-4fb7555a45ab",
-        "name" : "M0XZYX4TG818",
+        "id" : "https://www.example.org/2cbedd16-77c6-4fe6-b997-c427872062a1",
+        "name" : "Ls6UNXpjvvOK",
         "nameType" : "Personal",
-        "orcId" : "1GpFGGCdMP",
-        "verificationStatus" : "Verified",
+        "orcId" : "GKvKcnC2ezO5S",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FCoK2lt1GCP4Al1m",
-          "value" : "69ID3uM44utL"
+          "sourceName" : "HQilmBAPSahjSasBI",
+          "value" : "wsJ9rTSAGVs3uEb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "97V0GKB2UA0eZ3BCG7Q",
-          "value" : "T9lQL40V6mxBpgexATo"
+          "sourceName" : "iYZJL8y1o5tCBo0J",
+          "value" : "HXY2HHAR611G8Gkcq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e260f530-344c-4056-8442-8ab16ad2581b"
+        "id" : "https://www.example.org/2894bafc-9705-4909-9694-fb67ab3a25a6"
       } ],
       "role" : {
         "type" : "TranslatorAdapter"
@@ -88,27 +88,27 @@
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "JVMumwRein"
+      "da" : "hSKFMBxBp0McS"
     },
-    "npiSubjectHeading" : "znXayk0xshVMoKH3",
-    "tags" : [ "ev8JHH0irUIFTWPhNv" ],
-    "description" : "Od7NohPjYW17NVi",
+    "npiSubjectHeading" : "ZSZ7FZa31laF3PIER2Q",
+    "tags" : [ "QlNzv3NI0W" ],
+    "description" : "HBqHa0PEkH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Internet"
+          "type" : "Radio"
         },
-        "format" : "Video",
-        "disseminationChannel" : "e9EjgmLDNVWbbfNQ2i",
+        "format" : "Sound",
+        "disseminationChannel" : "ZiiuLWIlQNfihjh",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "LDqYZEOuXSu",
-          "seriesPart" : "lGUBMnO32TQP"
+          "seriesName" : "9A4ldoJwgxxl",
+          "seriesPart" : "8ZWwK0RGr8UC"
         }
       },
-      "doi" : "https://www.example.org/de79e3ad-8633-4b5b-a5ef-d8b684791580",
+      "doi" : "https://www.example.org/d4624ceb-564e-4f24-b07b-0b361cce0192",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -116,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/17864424-4020-4793-8bf7-01a4fdf750bb",
-    "abstract" : "TIWafpjHvrSf"
+    "metadataSource" : "https://www.example.org/b7519af3-7b9e-4c4a-8068-93ae2e261ec9",
+    "abstract" : "njmqlBGOqL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/78a0cb34-c6cd-4d5c-842c-449655e55599",
-    "name" : "BRANB2GVwGmNr",
+    "id" : "https://www.example.org/a44d5b33-7b6f-43c6-bf8c-f4a48b30664b",
+    "name" : "on2W7gA9WBBQh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-01-11T21:29:22.094Z",
+      "approvalDate" : "1971-08-21T23:20:48.604Z",
       "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "2B33T5PSNJt"
+      "applicationCode" : "ply6WCMPtGablRgeos"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0ff829d3-b3d1-4402-9240-ca8462765c1e",
-    "identifier" : "DYhj2ypAb9nPcs1gs",
+    "source" : "https://www.example.org/dff4507b-7b33-471e-88d8-359a3d98a959",
+    "identifier" : "HDF1GWJlHV9",
     "labels" : {
-      "fi" : "1mFvPB7xcMAH1K33At"
+      "zh" : "HApzpNrzQgRCK5cE"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1149758513
+      "currency" : "USD",
+      "amount" : 766481393
     },
-    "activeFrom" : "2013-03-27T22:27:22.012Z",
-    "activeTo" : "2022-11-16T18:06:57.480Z"
+    "activeFrom" : "1989-05-17T05:28:55.667Z",
+    "activeTo" : "2019-09-01T22:15:12.295Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/69f2435f-6591-4cee-8393-e3d0e672535d",
-    "id" : "https://www.example.org/7096010a-d33d-4c76-af21-69b8a56fd0f4",
-    "identifier" : "Br7oMHRMFIi8yv3L7Y",
+    "source" : "https://www.example.org/2f992320-7111-4555-86ba-40489fe7c91a",
+    "id" : "https://www.example.org/9d708d52-8059-4741-80d2-35c3d41d2f0f",
+    "identifier" : "P08ZGitqpKLAB",
     "labels" : {
-      "nn" : "ZGEodn9qE5GcqljL6qd"
+      "it" : "N5hsRSIN3yRsd7"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 86723911
+      "currency" : "NOK",
+      "amount" : 1169124079
     },
-    "activeFrom" : "2018-07-13T07:09:06.697Z",
-    "activeTo" : "2020-09-13T13:34:26.279Z"
+    "activeFrom" : "1992-12-06T08:31:31.922Z",
+    "activeTo" : "2007-07-08T14:22:07.456Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1180571119",
-    "sourceName" : "uou8kygurds@0qwvgae4scxo"
-  }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "m2Dcf1qfeoJ",
-    "value" : "YQ2kLMRl0JEuMc"
+    "sourceName" : "WBpKPEOj61mS61F2R",
+    "value" : "S7Z6dhexnkh"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "UU0wm5Qe3bEe6cdN",
-    "sourceName" : "wubksk6colr@2asuyvjf6p"
+    "type" : "CristinIdentifier",
+    "value" : "1420834559",
+    "sourceName" : "1sgz3tuywb@wokjwz3zft"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/b8c56cd3-50c4-4cc2-9c2b-de7a4df60df1",
-    "sourceName" : "kovsnlrj8yx@5ipxe6ptd4xu4t"
+    "value" : "https://www.example.org/0f1546bf-cdbb-40c5-81d4-4cbbbb2636ef",
+    "sourceName" : "3xpxi4sns0g@lzgorbblpwvmt5jhpmk"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "DEnT5wkF2wdGZo",
+    "sourceName" : "fvvvnq293wpgl@hqabzvepkzu2"
   } ],
-  "subjects" : [ "https://www.example.org/9ee1b093-fdd9-406d-97a9-3da0bff774cc" ],
+  "subjects" : [ "https://www.example.org/25d8635a-2cdb-4d9b-92ce-a5bd48822d3e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "245456c1-8ad6-4f10-8e67-b1db87ed7f7e",
-    "name" : "IinbwCYjBjDtg",
-    "mimeType" : "G7V1oocYBrFDE10c9CN",
-    "size" : 487507688,
-    "license" : "https://www.example.com/glmrdxm5ktk",
+    "identifier" : "2be4758e-b1c7-410b-9807-e945a03f20c8",
+    "name" : "LGhmnS5jEzRwipi",
+    "mimeType" : "dkgRLZO9lHIeqlBh",
+    "size" : 1312098763,
+    "license" : "https://www.example.com/maqubcjm0prn",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "dXFC8928LVqoH4B",
-    "publishedDate" : "1991-07-09T11:34:41.244Z",
+    "legalNote" : "FEmIa8UAsW6vJ",
+    "publishedDate" : "2012-07-17T06:34:56.324Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dfjUsJXqGW42tTNtMs7",
-      "uploadedDate" : "2002-01-06T00:30:34.198Z"
+      "uploadedBy" : "UYbgr5kL2McyXtY",
+      "uploadedDate" : "1992-10-08T21:24:45.650Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zkbbPqpuHn",
-    "name" : "8Tn9KrMbdJwsEwz",
-    "description" : "ey9oh7BgcFOhe30"
+    "id" : "https://www.example.com/TIlTEJq4AJ3aCt",
+    "name" : "ItLWXxJLF8TE4H",
+    "description" : "s5ttpX7DLR"
   } ],
-  "rightsHolder" : "HQ7oju8fIQxA04",
-  "duplicateOf" : "https://www.example.org/49dbf2f9-5902-4ea0-87c3-8f7bbfa38328",
+  "rightsHolder" : "mOC7xO8DDdIBCE2t78",
+  "duplicateOf" : "https://www.example.org/e06f6725-218b-4c46-a6ca-963c11196a54",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZVDrBgACpW7S"
+    "note" : "isIYrimFN37q2"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "tTEq9tI68gPqXb",
-    "createdBy" : "zR1wnBlD71Ho",
-    "createdDate" : "1983-08-16T15:34:53.277Z"
+    "note" : "pKPCZVuYebsX",
+    "createdBy" : "yt33raeDunPp7kI",
+    "createdDate" : "2010-12-19T09:58:30.185Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c64c1bff-b7e0-40d1-bc7a-2c133692a107" ],
+  "curatingInstitutions" : [ "https://www.example.org/95517014-eaf2-424a-a3dd-3e79be819353" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "1lsqIApcIw7I",
-    "ownerAffiliation" : "https://www.example.org/e85f8d0c-92c4-4b7c-9442-2824a66dbdcd"
+    "owner" : "HUviZcUZvK2X8sa",
+    "ownerAffiliation" : "https://www.example.org/181bd89f-63e2-4ecd-a010-b9c89f9e5871"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8878bbef-41f7-45fc-916e-308b82f3d504"
+    "id" : "https://www.example.org/bfa94e60-5a3f-41e4-9b4a-db572686da6e"
   },
-  "createdDate" : "2011-09-20T20:07:46.841Z",
-  "modifiedDate" : "1974-02-27T20:51:27.435Z",
-  "publishedDate" : "2013-11-22T22:45:54.435Z",
-  "indexedDate" : "2015-12-01T04:10:35.686Z",
-  "handle" : "https://www.example.org/f190cd1d-f2ef-4b54-8c1b-eadb56e7927f",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/34fa9abe-05e5-4ebe-bb5b-e878ead7456a",
+  "createdDate" : "2017-03-10T00:12:45.522Z",
+  "modifiedDate" : "2021-06-21T00:45:08.755Z",
+  "publishedDate" : "2010-07-29T05:31:25.345Z",
+  "indexedDate" : "1986-05-02T06:33:27.251Z",
+  "handle" : "https://www.example.org/2e556b4f-6f51-4572-aa8d-78c9c05163fc",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/f0319c7b-fea1-4d46-a50e-1b5b9ec539c5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YRVrpaEyVh3iwHv",
+    "mainTitle" : "Psrd1ocHH0DzJV",
     "alternativeTitles" : {
-      "ru" : "aeRA2PWvZLap1Qns"
+      "fi" : "ySIEF8XnfPxdO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dcXfm2ZSdKWhY",
-      "month" : "xzxNdzZxFUq1hG2MZnN",
-      "day" : "qUAY17LWdKm"
+      "year" : "SFot18X8v4",
+      "month" : "uyOBZCeimZJ6fHC",
+      "day" : "Qy0RZ2Sobv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2247f432-a78b-43ef-9d1b-fbd5801b02a8",
-        "name" : "IJXTF2BE7m2gG3",
-        "nameType" : "Personal",
-        "orcId" : "8w3LrO77orMPD",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/907702a9-01dc-409a-a9d8-5dd5ac072b40",
+        "name" : "lk5ZpDSvs25sv",
+        "nameType" : "Organizational",
+        "orcId" : "ZFC569S9P6",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9w4n8vlEkra",
-          "value" : "1rZqHyOMG3P01U1"
+          "sourceName" : "JKtRYNr4naX5D4x",
+          "value" : "CeBveIVuOYcfMupB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w2VIvCDmBq",
-          "value" : "35j4JJXf8EKgVL"
+          "sourceName" : "6MpDmJXJmF9HF",
+          "value" : "NNcxSZRAfdv20qNy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c230f051-8071-4dc5-b398-e600c4a33ba2"
+        "id" : "https://www.example.org/9da3599f-a304-4db6-9713-d1f6b66cc71a"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9fe3c18f-1893-43a0-924e-c7a58a4fa26a",
-        "name" : "54IjK5PY456C9V87rza",
-        "nameType" : "Personal",
-        "orcId" : "FT5u5pHl76mar03",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/c76e4a39-ee8b-4cd5-a5cc-7177d4c8d53e",
+        "name" : "GbO7nPWQbEHHUwext",
+        "nameType" : "Organizational",
+        "orcId" : "FUSTMfk5HzOh",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hwntPHSJb0JKJiyAx",
-          "value" : "81v1tp8RV6"
+          "sourceName" : "iMQ0RZLPQcI8",
+          "value" : "gz8PsyILrxpSPmd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hVYntMTId6N7qd",
-          "value" : "rnjZxZjSAh"
+          "sourceName" : "dMkLLPFZ2zAuL",
+          "value" : "Fv3ix71NBDU3BD30"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6bc51f4a-73a6-4eb2-bbeb-5a3ad6bcb7cd"
+        "id" : "https://www.example.org/7c3d4ce9-760b-4418-b127-74fe1adc6181"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Journalist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "cW3cZvMlukOJIqAUyr"
+      "nb" : "OXutFyEtzQW02Vg"
     },
-    "npiSubjectHeading" : "DmE5P3nPrcBkPF2",
-    "tags" : [ "uoxYOEjvZwRLyzOHZAA" ],
-    "description" : "E9M6IhX9Sg",
+    "npiSubjectHeading" : "WM23s2KA3dmc",
+    "tags" : [ "hnClQzhWRuwkD" ],
+    "description" : "WjgK5MMZLa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/183a6b93-f38d-4a4d-9223-68f44f7f2785"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f7c64669-6854-4c06-a81f-dcde9dc93f37"
       },
-      "doi" : "https://www.example.org/95c9526e-5c1d-4378-9908-fb35ef58a635",
+      "doi" : "https://www.example.org/8ff8f7a7-00b1-435d-98b7-542f2d7b20b3",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "asYDVC3CzLAs",
-        "issue" : "nZGm6vcPEEd",
-        "articleNumber" : "HakF8WYh8lqn",
+        "volume" : "rYoFgyLhLrYbBELccB",
+        "issue" : "rduPJTIfwZF",
+        "articleNumber" : "asxCjyeOAk",
         "pages" : {
           "type" : "Range",
-          "begin" : "smhWn3iEnk",
-          "end" : "0HkZw5LZH8nc"
+          "begin" : "mf1dapyTLUALskBtcbF",
+          "end" : "bbDK2ZcFw6bmbd0oj"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/262ee69e-5e47-48be-9bc2-1ad193bebde3",
-    "abstract" : "FN4tqj76w7WJPgYE"
+    "metadataSource" : "https://www.example.org/5e6f7e74-d490-489b-99d2-54986fe4182d",
+    "abstract" : "6iZwOJi79OVv3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/48e2e51f-2283-42a0-a8e9-a97263b93e56",
-    "name" : "ucNGwmgVsmGlYd4hemt",
+    "id" : "https://www.example.org/260283f0-fb4f-475a-a4cc-314568405dbd",
+    "name" : "VigKhl9fxoUU9FuCY",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-08-08T09:20:44.190Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "PhEBEKtTkYe0VUZc"
+      "approvalDate" : "2013-03-04T10:09:33.797Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "LXOoVfzXbTCgf7Lo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/84e8b950-2c71-4b94-bd93-7f866fdd2f02",
-    "identifier" : "GU6XQ84Q9Wm",
+    "source" : "https://www.example.org/690a0933-1adc-43de-8c37-cbf519d48314",
+    "identifier" : "rG2w7NseLJ",
     "labels" : {
-      "da" : "crk3bFLR36"
+      "is" : "6nmIqJSdgC47"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 598913882
+      "currency" : "USD",
+      "amount" : 929919649
     },
-    "activeFrom" : "1996-11-19T14:49:00.445Z",
-    "activeTo" : "2008-09-27T06:00:25.598Z"
+    "activeFrom" : "1980-01-04T12:06:17.223Z",
+    "activeTo" : "2000-06-04T04:36:49.981Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0446feff-d817-4e73-868f-18fd1df82ba7",
-    "id" : "https://www.example.org/8184f92b-918f-46ef-875e-9210f7910d90",
-    "identifier" : "p8FKT6w2HcjQ0vwaI",
+    "source" : "https://www.example.org/a4702b49-d806-465d-990e-0194023b1e27",
+    "id" : "https://www.example.org/8ba40dd1-64bf-46d4-98a3-ee4b5c088bb4",
+    "identifier" : "vQBvHJMIjm",
     "labels" : {
-      "ca" : "0w0V5aekTV9"
+      "hu" : "TfKVbAnNb8kEaraO"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2046050093
+      "amount" : 145751577
     },
-    "activeFrom" : "2009-02-02T00:20:45.137Z",
-    "activeTo" : "2022-10-07T00:28:00.936Z"
+    "activeFrom" : "1984-07-31T22:40:57.237Z",
+    "activeTo" : "1993-12-17T17:32:03.536Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "621400556",
-    "sourceName" : "84qapntvogvummk1u@h4rjit4b6y"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/545c6b14-2991-4159-beca-5a70746fe6b8",
-    "sourceName" : "twofvjhliz3@pbiqm36ztfp"
+    "value" : "https://www.example.org/a1da7563-df48-4bf2-b1c5-c3ebdca0dd05",
+    "sourceName" : "cm95xe0dcrconp@uzp8zftvvlgp5zqmxm1"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "IGbXBNmRQH",
-    "sourceName" : "wrcr49vv99wmagoocc@eevcnocdeady9osasxa"
+    "value" : "YdUJKbUbgWCMvDcJ6pE",
+    "sourceName" : "w5jigbsq7rz4@585liqou4joe"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "735886254",
+    "sourceName" : "cnr9oyubdvfvwo1me8@k8ssag33zgos7gx9hol"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "YRk6NJro0Ra88",
-    "value" : "jFhTmR1NY7gl47q7"
+    "sourceName" : "hUOjLu8m7q6OXT9r",
+    "value" : "flfVr0iaCuUIKHrAQJ6"
   } ],
-  "subjects" : [ "https://www.example.org/e8789caf-92e6-42ea-8738-4747157bbc33" ],
+  "subjects" : [ "https://www.example.org/7d86a874-b143-4f3d-ac26-1389fbfbcbf8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fe454e36-e6a5-4ecb-9ab3-1029e3eb7f4a",
-    "name" : "OTTDIKN4KEG",
-    "mimeType" : "nPng1iOU0JmdKcvu6t",
-    "size" : 158944100,
-    "license" : "https://www.example.com/nsjz6bi6i8t7",
+    "identifier" : "72136f08-861f-444f-9884-54973134e85c",
+    "name" : "e12fxPFaUfua",
+    "mimeType" : "pFYdswX6AVFTnfKwXP",
+    "size" : 1428047315,
+    "license" : "https://www.example.com/let7min5dag6",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "8ebHtDuuwOHU8",
-    "publishedDate" : "2023-11-07T23:02:19.485Z",
+    "legalNote" : "frOT5eUULBY",
+    "publishedDate" : "1986-12-03T21:46:32.771Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "CfBxlkd4Onl",
-      "uploadedDate" : "1987-03-08T14:19:45.985Z"
+      "uploadedBy" : "NwT7bihu9yE",
+      "uploadedDate" : "2014-12-24T20:56:18.424Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zkcBpvtTBe",
-    "name" : "s4JpVwDk23RSTe",
-    "description" : "oNtykbhhTKa"
+    "id" : "https://www.example.com/d9kzzs5XMVmK",
+    "name" : "A8JTlI7t1CmQ4qlFrk",
+    "description" : "kOWrsMcyAyY"
   } ],
-  "rightsHolder" : "IzUaYKGgl42Q",
-  "duplicateOf" : "https://www.example.org/d90a61c3-9266-42cc-9f81-5fd1e65ce395",
+  "rightsHolder" : "Nbeb9H0yLzPbp",
+  "duplicateOf" : "https://www.example.org/476b9d83-8c1d-41dd-990e-0ebd6c2d3c27",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9I1ADAsCrFa"
+    "note" : "RBX3Ldz7EXkzs3z"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "f1TkUyWyIZITGnVooW",
-    "createdBy" : "gLOdyUND6CDbk",
-    "createdDate" : "1986-05-07T08:19:42.742Z"
+    "note" : "JY7hAICDxaMaAAdowk",
+    "createdBy" : "oNsE0nCN0s",
+    "createdDate" : "1974-04-26T16:22:44.030Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f51db81e-c1d4-4070-8ba7-3490f0d22306" ],
+  "curatingInstitutions" : [ "https://www.example.org/b203b067-4296-4f1e-9d5b-d62f40afe02e" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "CL6i7gadml5iV3v84",
-    "ownerAffiliation" : "https://www.example.org/bde28040-761b-467e-8afb-e4be7197b008"
+    "owner" : "Kan5upie1MfYUVyE",
+    "ownerAffiliation" : "https://www.example.org/32a8cfe4-58d1-4a4b-8e47-0a4a3cacadec"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/de21a8a3-46a3-4c3d-b06a-ba544f5eea4e"
+    "id" : "https://www.example.org/d43bc2ad-c02b-42cf-afea-5311901d4b3c"
   },
-  "createdDate" : "2018-04-16T04:45:15.372Z",
-  "modifiedDate" : "1999-08-06T10:16:50.045Z",
-  "publishedDate" : "1983-06-11T20:11:45.518Z",
-  "indexedDate" : "1978-07-06T06:53:55.061Z",
-  "handle" : "https://www.example.org/1c2d5106-367b-4622-aba1-436cc27e1d50",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/db3e35a7-238a-4d7d-9933-2e44ef132780",
+  "createdDate" : "2010-09-24T23:59:43.951Z",
+  "modifiedDate" : "1986-06-12T23:08:15.066Z",
+  "publishedDate" : "1990-08-10T22:30:24.190Z",
+  "indexedDate" : "2014-06-17T22:02:04.680Z",
+  "handle" : "https://www.example.org/6a5f612b-f695-4e9f-baff-203cc760f607",
+  "doi" : "https://doi.org/10.1234/quisquam",
+  "link" : "https://www.example.org/fe66cbc5-565c-495c-806e-37c0412e456a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Bsufwg8kVOHtCfEa",
+    "mainTitle" : "US0KYL9RhuSHDCJmIz",
     "alternativeTitles" : {
-      "it" : "7RW9IAdY99ib"
+      "es" : "FJEkyTtMzBPDjBd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "15qxlgqlCR",
-      "month" : "QxhfDPBl7szFY",
-      "day" : "ethHcdBAs0nhkT"
+      "year" : "HCfv4FX7Xsd",
+      "month" : "iP5IYZeQf7TaVjmAWQv",
+      "day" : "iJduP53muM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/576321bc-a38e-4cd7-8ee6-8ed58259d600",
-        "name" : "uHUdLHo1ogk",
+        "id" : "https://www.example.org/520e5e0c-971a-4e94-ada7-0847a7577d7d",
+        "name" : "4hzVyLOLYcbneaWK",
         "nameType" : "Personal",
-        "orcId" : "kgpf8golEg",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "r1EiBdDPZgXTVXG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lTSkhKfajx",
-          "value" : "sVCqe7xquFodOwgJ"
+          "sourceName" : "GcN3VVO91zk",
+          "value" : "CbwZHeXOwaSWKT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gh1FwYtWqf",
-          "value" : "f6H0X2o10HU"
+          "sourceName" : "qI5D2gxzA9WAq",
+          "value" : "lrEA6EaVtZXp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/827adfff-42a7-4797-ab6a-db79df05d081"
+        "id" : "https://www.example.org/3be20b2e-7bce-45f0-8267-ef932df72f89"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Architect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/14b19228-b687-4df7-9dd0-69b4d325e935",
-        "name" : "JDaRzDzrMD30Zdo8W",
-        "nameType" : "Organizational",
-        "orcId" : "ZbMzK1TMPc8Ev1",
+        "id" : "https://www.example.org/3d857ee9-e509-406b-be5e-cd9049cea68f",
+        "name" : "Bo6cbjGH90JmBxgHfM2",
+        "nameType" : "Personal",
+        "orcId" : "xKaa5c8rkL",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eTBtllP60O2O",
-          "value" : "2OxkgmkBj1kunKmP0"
+          "sourceName" : "LboUiDWvgR62ec9pr",
+          "value" : "IS1laq44gUfDUKodJo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eIMxPaEDK5m7",
-          "value" : "AVTw76jNK5xcUiOc"
+          "sourceName" : "YNj1W7AAg6YJWN",
+          "value" : "33DddZH8FgqxjL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f71bba92-e3fe-46cc-97e5-b5743a6a598a"
+        "id" : "https://www.example.org/9bf2d409-498a-4a9d-81fe-8fedf3fc1db0"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "igi5NyJRobIwkI"
+      "fi" : "6Hrz6lUtJOiQpGy"
     },
-    "npiSubjectHeading" : "PH1yoLxb5BW",
-    "tags" : [ "MnUnpYDKCd" ],
-    "description" : "jQ5kj3ynh4y8du",
+    "npiSubjectHeading" : "CfZaM0hOyjRqXypN",
+    "tags" : [ "FgPW8MuNN8" ],
+    "description" : "PmHbKchiKFi6LA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -101,14 +101,14 @@
           "type" : "Internet"
         },
         "format" : "Text",
-        "disseminationChannel" : "g9pxGIFABG9g5",
+        "disseminationChannel" : "MNLUlNHzYRIHiu8",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "jXqm75n2cfoUuSSAicq",
-          "seriesPart" : "PY5ZrOYHpePnrWmx"
+          "seriesName" : "kL6V9ITZPGzDVaUre8T",
+          "seriesPart" : "vp4I57nojv"
         }
       },
-      "doi" : "https://www.example.org/6a8f21f0-2981-406c-9670-28625d548631",
+      "doi" : "https://www.example.org/eb3e83c9-24f6-48b9-96b8-99ddff69cea4",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,107 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7ea72239-2c9f-417a-949a-50eb51465d6d",
-    "abstract" : "4yqZ5ywMJ3Brvwq"
+    "metadataSource" : "https://www.example.org/084275d2-193a-4529-adc7-303d72a9a6e2",
+    "abstract" : "AaX4z8OmRbavyOfy"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/84267fb6-0d61-41db-9413-b4b9aa9a41b6",
-    "name" : "tub0ryntgu",
+    "id" : "https://www.example.org/189e2a62-d7d1-456a-82ba-6bfccbb4410d",
+    "name" : "g9rcBpObLE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-02-15T03:18:01.620Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "yRQuoSKIq6IKZ"
+      "approvalDate" : "2016-10-22T17:09:04.506Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Ci7DMDxDpf"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/83e6d932-bcf2-4d09-83f6-d1ea7506422d",
-    "identifier" : "xlyhjobSCB7i",
+    "source" : "https://www.example.org/ac268570-1026-49e3-9461-a4d8a16a053e",
+    "identifier" : "3TD2zVxG0hb",
     "labels" : {
-      "zh" : "lUNAKKNM974pzd"
+      "pl" : "fCvzRtCksHZM"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1734052748
+      "currency" : "EUR",
+      "amount" : 1229364822
     },
-    "activeFrom" : "1996-12-24T15:23:41.901Z",
-    "activeTo" : "2015-01-26T17:49:54.287Z"
+    "activeFrom" : "2002-01-28T09:08:56.703Z",
+    "activeTo" : "2006-05-18T02:29:59.095Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/507795cc-f3a3-4dc4-98f4-6e9f9ac70cd9",
-    "id" : "https://www.example.org/fcd5c330-bb92-4480-b1d8-4e6bffe306cf",
-    "identifier" : "tysX3ytQy96wDmOXQ",
+    "source" : "https://www.example.org/006cce13-c656-410a-acb1-e124dab43b11",
+    "id" : "https://www.example.org/da28a4f9-013b-47cc-bc62-caf15a6a1298",
+    "identifier" : "0Padu1AQqeN8",
     "labels" : {
-      "fi" : "xBh7rXFFugE"
+      "es" : "Azmse9JXhQYX7qw"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1007425854
+      "currency" : "GBP",
+      "amount" : 1728416125
     },
-    "activeFrom" : "2019-12-28T01:20:03.207Z",
-    "activeTo" : "2020-11-06T10:38:06.412Z"
+    "activeFrom" : "2015-11-14T17:14:17.250Z",
+    "activeTo" : "2021-07-12T01:34:32.379Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/876c2764-7f4d-4790-8eac-0d69b52ba0a8",
-    "sourceName" : "uvh2vxzdy8y3z8p@p3tbwaejkn"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "7gDjnWmt3T42",
+    "value" : "BdcQH2GY8mv"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "407181380",
-    "sourceName" : "gfw8ztiggfjte8v@gillphhpbbyduq"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/de74bfc8-3488-49b7-b97c-35911c63dc87",
+    "sourceName" : "umlqsf9x4bz@ebhnr1zmkowovx"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "xWSqk0pgP9kx",
-    "sourceName" : "t4rqvdsndos@mltgdqstgejjbjxrza9"
+    "value" : "9Vd6Edm5FH",
+    "sourceName" : "pv85tgr4xm@hvrikerfaynbcdq"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "3GlYuQByxwF84KXsE",
-    "value" : "Kc22Irv7CqEoBOaT"
+    "type" : "CristinIdentifier",
+    "value" : "540868280",
+    "sourceName" : "ptrftvxuzzu4uvtluj@pgdg8vj5p8x"
   } ],
-  "subjects" : [ "https://www.example.org/d9385dc4-964e-4501-9b71-3cf906aedc70" ],
+  "subjects" : [ "https://www.example.org/8b19e45d-b18e-4a81-acfe-d1925f609e75" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2324df50-466a-4d08-8445-a7e11876de60",
-    "name" : "IqN3JFpEkUYIozjIKt",
-    "mimeType" : "7cVfNop58Gi",
-    "size" : 1547930611,
-    "license" : "https://www.example.com/8cnzjrrprr5m",
+    "identifier" : "b77a7043-82cf-481b-815b-f9aa160364ad",
+    "name" : "dhFXx7ewpAhgeuUR8LI",
+    "mimeType" : "jJVU8NmgSZt",
+    "size" : 2064957798,
+    "license" : "https://www.example.com/48epbdxombrux7c",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "JMtbYLnNn52NV9Aj7u"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "mUaF9h6yxPqhC",
-    "publishedDate" : "1979-01-08T07:42:10.862Z",
+    "legalNote" : "MI1i4CJMBS0jqrCAZJa",
+    "publishedDate" : "1973-07-30T11:49:09.490Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Lng58y170Of4ZCMEHW",
-      "uploadedDate" : "1979-07-11T23:04:56.640Z"
+      "uploadedBy" : "kNujeQ4ShnjV2lW",
+      "uploadedDate" : "2007-05-26T01:42:22.038Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/BzlVjdW1cCexVNe9N",
-    "name" : "9gBEcG5ZLpnnbk4",
-    "description" : "3vMIY71vBKPSxfQ"
+    "id" : "https://www.example.com/BK132bOXzxHht",
+    "name" : "rVvDQabb6QflUllH",
+    "description" : "eqzV95Mvy5959hNUcpf"
   } ],
-  "rightsHolder" : "KOLO0l1mQWxG5QBt8Du",
-  "duplicateOf" : "https://www.example.org/f8eef0f3-a144-4595-bf9f-aa3b08378817",
+  "rightsHolder" : "S7Bnyl8RETNKLNI",
+  "duplicateOf" : "https://www.example.org/615d2783-7c85-4b99-8e00-e77339b8583a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "NKkOs4da1qD2C"
+    "note" : "wRQL0vsL8ZHHf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "mxKYbtAUkF",
-    "createdBy" : "RG6DevfpP69",
-    "createdDate" : "1980-07-20T20:15:44.726Z"
+    "note" : "4T6D717LYtbs",
+    "createdBy" : "wIqoRlaAQGAPYTl",
+    "createdDate" : "1995-01-29T15:16:27.148Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/38bd1bcf-5f94-4b57-9e1d-7c5cd9a46b96" ],
+  "curatingInstitutions" : [ "https://www.example.org/3a5149e9-3c3a-4706-9aad-c23ca38214ca" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "tF77IjDW8e",
-    "ownerAffiliation" : "https://www.example.org/fd20d1e6-f654-4ac8-9de2-8cf48cbfa0cf"
+    "owner" : "xqbHRNhcHfDzc6vT",
+    "ownerAffiliation" : "https://www.example.org/61a1acd2-3357-492c-b158-a83322eb7fc8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f8b44604-1d4b-4610-8dce-d76f0949edc2"
+    "id" : "https://www.example.org/ea64aa0e-737c-4d9d-86f3-b949ca9c1234"
   },
-  "createdDate" : "1994-08-09T10:14:29.610Z",
-  "modifiedDate" : "2013-09-08T22:04:54.162Z",
-  "publishedDate" : "1996-04-10T01:08:18.120Z",
-  "indexedDate" : "2022-06-09T14:36:35.536Z",
-  "handle" : "https://www.example.org/3e53abca-9608-42e0-96d1-976c7169b682",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/0aad3a85-9957-4faf-8c87-7121b56a8f13",
+  "createdDate" : "2019-03-10T11:34:16.645Z",
+  "modifiedDate" : "2013-10-27T23:57:24.535Z",
+  "publishedDate" : "2002-07-07T20:36:39.146Z",
+  "indexedDate" : "1986-12-07T08:21:20.714Z",
+  "handle" : "https://www.example.org/0968f592-81ea-4eb8-ad6c-f74e78dcb550",
+  "doi" : "https://doi.org/10.1234/assumenda",
+  "link" : "https://www.example.org/54d19fd3-0c76-4e56-8ac3-8541c7b58e7d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "E0e5dLxSxH",
+    "mainTitle" : "Tbxf77KVl6o0D",
     "alternativeTitles" : {
-      "de" : "6fvyFWdBydsPvsQ5"
+      "da" : "I1PhXxkDAV2iQhl"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KPQ32Fdrgtrbw50JRi",
-      "month" : "20cid7r5ai3FtWcedv",
-      "day" : "CmwJoV8OwXp"
+      "year" : "m40YTOgt8WeipdfnSd",
+      "month" : "1SuGmsnZQ3qyHUDaI",
+      "day" : "gOpz3CTwSNL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/01152e7f-bebe-45f7-83f9-b476a6d49173",
-        "name" : "0oUpL65SqOlYisQL6fA",
-        "nameType" : "Organizational",
-        "orcId" : "xI9FAy9TQWKSAn",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/4667dc61-1e5b-4df0-ab7f-86f44ca1187c",
+        "name" : "O7T8aoGfZ1",
+        "nameType" : "Personal",
+        "orcId" : "OV1AAZh8pjtlEBEaK",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "x7tAFn9E0Wk",
-          "value" : "gOocqQEFoPKIHQZby"
+          "sourceName" : "G4kyahb4kHcyCy",
+          "value" : "KhBaUGa09mGVZu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BaRgonuX0F2Fn1V",
-          "value" : "dmezoEkoaKRn3"
+          "sourceName" : "OoTuf6aJ88",
+          "value" : "m9yy3VLNzDB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5fb63607-4adc-44a1-acf9-81ea7a2965c8"
+        "id" : "https://www.example.org/700a5ba3-49de-416c-887e-75f590fb4e5b"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/28895e40-cf2b-4c80-865e-94398efab358",
-        "name" : "SqBjPfyFC1pqgb6",
-        "nameType" : "Organizational",
-        "orcId" : "q94mKgEhmw",
+        "id" : "https://www.example.org/b1a9a76c-6a01-4058-b2d6-94bf9b553e10",
+        "name" : "UR9YdR7KkYxYL",
+        "nameType" : "Personal",
+        "orcId" : "MrdYznNZuRefvQ",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9j1BcgyjqHUWzTFUVJ",
-          "value" : "OirMjAMNLzhkrAp"
+          "sourceName" : "XqpwOL4HcVNR1URELof",
+          "value" : "bMYzykoD2oWli99oEMb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "G4MlZVZnPvj47WGK",
-          "value" : "ihp4wiMpWgwXJdKRdFT"
+          "sourceName" : "VTYa9FqPT9GrooYIsHk",
+          "value" : "hWxV3ihEJNCS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3e64ca01-6897-436f-aa27-af7a387076cf"
+        "id" : "https://www.example.org/214d0352-a996-4093-a299-ef3c296292de"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "fUC0qf5ltd"
+      "nn" : "JIdBxjpJRk"
     },
-    "npiSubjectHeading" : "po5G1hEiSmvDg",
-    "tags" : [ "XEvlQ4ywfhEFKFS6M1i" ],
-    "description" : "ESICbrn3x8wWD",
+    "npiSubjectHeading" : "OLNOysuNbttaQJUKP",
+    "tags" : [ "hPm67QkdeW" ],
+    "description" : "W7tD1aKm5R",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Radio"
         },
-        "format" : "Text",
-        "disseminationChannel" : "o8lh4ZdeyAfGO71OZ",
+        "format" : "Sound",
+        "disseminationChannel" : "4ViJQDhON6xnRY2w7Dy",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "EivQ97Tsg278MgOIb",
-          "seriesPart" : "6Vtna0fxS92AX"
+          "seriesName" : "fmAVfidz2hB80K",
+          "seriesPart" : "ecYFjjkckSYR"
         }
       },
-      "doi" : "https://www.example.org/6b656b72-0876-4f7d-b7c4-47dc0b164377",
+      "doi" : "https://www.example.org/321946ca-a310-4b15-a7f9-d85ccdf92168",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6b4c21fb-c113-4458-a8fb-94bb08544cb1",
-    "abstract" : "ER3xz5izXU2rnGQ"
+    "metadataSource" : "https://www.example.org/08dca61e-f19c-40d6-a812-3610220c15f7",
+    "abstract" : "Mcl9MWmXY0bzhzR9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7d687687-c811-42a7-82bc-7178aa81ed1b",
-    "name" : "vyg6GkmcBubPEjT",
+    "id" : "https://www.example.org/1b84f5db-6e9a-4694-92f9-2dab376835a0",
+    "name" : "PdAmdZxpMcno7BLk1iy",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-04-10T18:12:46.569Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "sJL1Z5IoGfB"
+      "approvalDate" : "1978-11-03T16:51:18.583Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "aCdFt62PT1CdcVWpMGP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/71bd927a-267a-4b8e-8c74-f11e71d52ee2",
-    "identifier" : "lAkic4qE0pDpycA8bj9",
+    "source" : "https://www.example.org/fff64255-7bf3-40a6-b2d2-7ddf19948d92",
+    "identifier" : "rvfupoLo35A",
     "labels" : {
-      "se" : "S0XFU2LnUQfAgOK34E"
+      "se" : "QTJ0Z30hxBKa1"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 854842690
+      "currency" : "GBP",
+      "amount" : 591904685
     },
-    "activeFrom" : "2022-01-29T01:17:53.416Z",
-    "activeTo" : "2022-11-30T22:59:38.348Z"
+    "activeFrom" : "2007-02-22T12:34:26.925Z",
+    "activeTo" : "2018-06-12T22:06:55.407Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a1abeefa-ccb1-4a24-b388-41ada514ac09",
-    "id" : "https://www.example.org/6382e65a-9581-4f52-81d7-cb8f2b962e42",
-    "identifier" : "OlBrPonFR2",
+    "source" : "https://www.example.org/c2621de2-59f8-4b77-8d20-e96877bcfad0",
+    "id" : "https://www.example.org/087705cf-c902-4d79-a31e-8476b74deaf4",
+    "identifier" : "DwYtiY1b1YRppf",
     "labels" : {
-      "fi" : "WOKNj6C0Aqh1Aqh"
+      "af" : "P7vT82r0bJGVT1Jqf"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2013455388
+      "amount" : 1629084237
     },
-    "activeFrom" : "2013-10-12T00:56:24.337Z",
-    "activeTo" : "2023-05-06T14:01:06.004Z"
+    "activeFrom" : "1989-12-19T20:12:05.528Z",
+    "activeTo" : "2016-09-20T13:53:39.598Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "u5tGtsfGeu0WUW06ae",
-    "value" : "hyoIkJI7YpMu8a"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "go3vjX6kdV3",
-    "sourceName" : "obss1xpzpga@qzknitqdecgggwbr"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1496028599",
-    "sourceName" : "ssst5nhbubdqflqy@iynhuxrrbknwhbbzw"
+    "sourceName" : "jUoXLaNwxFYkoeWZ",
+    "value" : "eDHruLZa30O4FeafUC"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/8f667057-ebd8-40d9-aec7-92f9d40c8d07",
-    "sourceName" : "xzy9spwluq@vail0pirzhlppyz1"
+    "value" : "https://www.example.org/e61aab7d-071a-4c73-b1f7-ab6407abd661",
+    "sourceName" : "h67ekf9kxwntf@wpj71fzvmocq"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "427471470",
+    "sourceName" : "q25ujuhxcsxmva@mh1xehft1dr2muyw"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "zyy5fenLvrOdsM",
+    "sourceName" : "qix9pyg191jofuosbo@jdwkfuapbudrdur2j"
   } ],
-  "subjects" : [ "https://www.example.org/6cab773f-f248-440e-b32b-271f21835fa3" ],
+  "subjects" : [ "https://www.example.org/6ca38991-8154-4e18-a2c5-b8a66a29fd54" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0eb4748c-34a7-4bc4-b894-ed5dd1d2dfec",
-    "name" : "pnwFS3szYX6JoolM",
-    "mimeType" : "98RtcQtzS7PGtRuR",
-    "size" : 885310618,
-    "license" : "https://www.example.com/7muuwbsa4mwvjzkorar",
+    "identifier" : "a33b72ee-5683-479e-8c64-f820e24ae7a2",
+    "name" : "WPn63gsGNiTHTi2Ci",
+    "mimeType" : "2BsqYjfGWgWhbA1M",
+    "size" : 1451726233,
+    "license" : "https://www.example.com/rwbo8so0nhdeg",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "eUe1rRGsUW",
-    "publishedDate" : "2012-03-28T02:32:17.340Z",
+    "legalNote" : "3FmEKlz7jTMKV7kzlZ1",
+    "publishedDate" : "1976-12-18T06:00:42.679Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "s05ZBxhbSL3",
-      "uploadedDate" : "1983-01-03T04:10:36.385Z"
+      "uploadedBy" : "oLxYVR1UbAn6",
+      "uploadedDate" : "1992-08-08T12:33:24.651Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wH3z42tFqKm",
-    "name" : "HPguz2n0hMPlXj",
-    "description" : "NPoFb6X1GStc"
+    "id" : "https://www.example.com/2OwTK1eJ3rDfVHJmn2",
+    "name" : "Yg18EOBxHrdUNM4C9",
+    "description" : "uaDCpQ5kn287L7HJO42"
   } ],
-  "rightsHolder" : "zsz11kWFCiqhZ2sJ",
-  "duplicateOf" : "https://www.example.org/47ba7f89-288b-4851-938c-82f27e6d08d2",
+  "rightsHolder" : "KFOQQqn73TYc9T1aVm",
+  "duplicateOf" : "https://www.example.org/a66336af-2480-42c0-8886-bf88b4b1227a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "opXp8QANCMhhM"
+    "note" : "ghU09Kn7RYEC0QJqb"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fpinpsNsMjYn8CK2zz",
-    "createdBy" : "MRvbEZMAG6cU",
-    "createdDate" : "2010-01-29T01:35:15.111Z"
+    "note" : "norpyljAOZkFCqdh",
+    "createdBy" : "NXbYbiKPMOm",
+    "createdDate" : "2003-09-09T14:27:02.023Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e62d4678-4f61-4540-99c9-26ce5f7d646f" ],
+  "curatingInstitutions" : [ "https://www.example.org/4e95a9bb-53a7-44ff-b91b-3a3a99ba9320" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "c3UthzqcDGq96",
-    "ownerAffiliation" : "https://www.example.org/be036fff-fdc5-4180-a371-21045a85a169"
+    "owner" : "dpaEOIbU7o",
+    "ownerAffiliation" : "https://www.example.org/42cac895-3334-49dd-b229-40b699edfb06"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2fde9656-a449-400d-bfc0-ba6fbad88a71"
+    "id" : "https://www.example.org/2d606f83-f413-4880-92b8-310021668758"
   },
-  "createdDate" : "2018-12-03T15:33:27.076Z",
-  "modifiedDate" : "2011-12-15T23:51:59.369Z",
-  "publishedDate" : "1972-06-28T19:44:38.998Z",
-  "indexedDate" : "2022-09-09T07:26:22.913Z",
-  "handle" : "https://www.example.org/a6fc28c4-38e6-45cf-b512-cc94848ff227",
-  "doi" : "https://doi.org/10.1234/eius",
-  "link" : "https://www.example.org/c661fc80-5b59-4693-aa89-4d8552c8c5bc",
+  "createdDate" : "1993-11-15T16:13:02.858Z",
+  "modifiedDate" : "2004-01-10T05:10:10.479Z",
+  "publishedDate" : "2019-08-04T14:39:56.168Z",
+  "indexedDate" : "2011-01-28T15:39:37.925Z",
+  "handle" : "https://www.example.org/36175700-360a-45fb-8b42-aee0db82ddb0",
+  "doi" : "https://doi.org/10.1234/quae",
+  "link" : "https://www.example.org/ee93ca44-e11c-464a-9826-2c59dd09a8bb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tRB38WyYL1TNS2",
+    "mainTitle" : "cCZlDhHHkdKhcyl",
     "alternativeTitles" : {
-      "af" : "VaF16jn5f4BX"
+      "fi" : "yWEPRMUckmy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "t3BymOPoZVtloR9r",
-      "month" : "Ye004IlwV7P",
-      "day" : "pQO3KbLUhzds59z"
+      "year" : "dsoEXK3NPVQFo20vnI",
+      "month" : "tr6f4P56JOc8C",
+      "day" : "Ko16jenYDicbs8NVjcw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e3ec798-f5b3-4548-8787-3faad6706b39",
-        "name" : "q84zQl76xJt",
+        "id" : "https://www.example.org/3b8b21be-61ff-4ca1-8fc0-fd24930ff0e7",
+        "name" : "L3CZ2hYVfgh7c9",
         "nameType" : "Organizational",
-        "orcId" : "MMAsg3pSo4jt",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "lxDnFqvX0ZWcN2uoJ4",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yEMtK5ZBLdIxVwGU",
-          "value" : "Zxv0AdNDdmCYE0fXuZ"
+          "sourceName" : "qB1g1yW5FmdPgZDgKN",
+          "value" : "0WyBivXKWx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IKT80KIlDSo5c",
-          "value" : "Qmkv8PddwzqXraIPIvH"
+          "sourceName" : "jgZU2Dlm9Kn",
+          "value" : "W1GO2Hza9ziabBui"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c4ffbfbd-3ba2-4c3a-b48c-d3dcc80e8740"
+        "id" : "https://www.example.org/8eec7e38-e240-4f3d-b5f3-638a8780dd39"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "LightDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,54 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/03f7fa27-67c0-4908-9d0c-df33237c192a",
-        "name" : "9xzQG3M9TSGF",
+        "id" : "https://www.example.org/95ba6c6f-8565-4344-ab18-9ef1e621b1ed",
+        "name" : "hShCHHzt5wKiHpbZE9",
         "nameType" : "Organizational",
-        "orcId" : "VtwKXIC3Qb9zQ1ZSA",
-        "verificationStatus" : "Verified",
+        "orcId" : "Mp5J22DdlM",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l4QGiRHGic",
-          "value" : "YISYVtq6UiEC9Lo"
+          "sourceName" : "hlTkpooQve3urOz",
+          "value" : "6Z1QQKda69"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lqPzqWFoJK0il0N",
-          "value" : "OArKVT6AKk7hNem4Qa"
+          "sourceName" : "ty2Hbv25WEu",
+          "value" : "CIzNUu8SloArK7hQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2b1003d8-4d7c-48f4-9e74-12ee812d61d6"
+        "id" : "https://www.example.org/5e07a23c-847f-475d-a07e-523999be090e"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "Whzv2T5Xpd1h"
+      "se" : "rWLLFGNvi6v"
     },
-    "npiSubjectHeading" : "ipdkdxisXwY5J06Zu",
-    "tags" : [ "FxeXrTLyOw8EFTc" ],
-    "description" : "85LixfVUFD",
+    "npiSubjectHeading" : "CAdaQ2tl02zLTBd45i",
+    "tags" : [ "BClnX4hGzF" ],
+    "description" : "SCqDhcI2vmv8mxD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "MediaTypeOther",
-          "description" : "oV5PDocDX8en"
+          "type" : "Journal"
         },
         "format" : "Video",
-        "disseminationChannel" : "ynU1IQXrYxZQ0m",
+        "disseminationChannel" : "qJdxllq8Di",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "yLSrF0XksFkK",
-          "seriesPart" : "T7SS117SBQ15KkDoywE"
+          "seriesName" : "vfcZDgl01RtQ",
+          "seriesPart" : "ITtcfqe30alT06"
         }
       },
-      "doi" : "https://www.example.org/12249fd2-8ff8-4d2d-8898-90ba6c7fbf47",
+      "doi" : "https://www.example.org/f4555c49-fa5b-49c1-8ae8-3fa9381a9c33",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -117,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7275363e-ad4b-4d93-a8e6-e7de36bfd4c8",
-    "abstract" : "8pR37J6wtL"
+    "metadataSource" : "https://www.example.org/134d0458-f95a-4253-a272-046c7cf0a270",
+    "abstract" : "lkelmEo06P"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/72802860-64c6-4ebb-843b-693f6bc3dc81",
-    "name" : "wm2HY12NuOgcS",
+    "id" : "https://www.example.org/c9886dca-22bc-49db-bdf4-c4dbbf8661f9",
+    "name" : "nC4MPXT3FuaONe2",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-08-01T04:34:19.165Z",
+      "approvalDate" : "1992-10-12T07:25:07.225Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "KOMyC7I3SoQi8"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "aLKmXNkvpb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d36d47ef-9c98-4273-b88b-9ea2dd441ba2",
-    "identifier" : "7zF4pCd3OdA",
+    "source" : "https://www.example.org/f1ebe6f4-7654-4885-a014-46020ad8178e",
+    "identifier" : "6y6KhBBswexOQ4Hyrz",
     "labels" : {
-      "da" : "yFP35h8wtSmlZ8Tlr4"
+      "da" : "8dKEW7GuqOTGF"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 426122722
+      "currency" : "NOK",
+      "amount" : 936390333
     },
-    "activeFrom" : "1993-11-14T04:00:00.052Z",
-    "activeTo" : "2008-05-09T05:42:55.904Z"
+    "activeFrom" : "1987-09-03T11:05:54.431Z",
+    "activeTo" : "2017-07-09T05:19:59.453Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/58217597-0cdf-4765-80bd-131af6828b01",
-    "id" : "https://www.example.org/8a51c85b-0df0-44f5-86a7-25848085c289",
-    "identifier" : "0DhnXFNiUikywT",
+    "source" : "https://www.example.org/ebe5f25f-d065-47cb-bd22-fbd3d45d2401",
+    "id" : "https://www.example.org/a91f3410-7909-4575-96ba-70f4d13c8b7d",
+    "identifier" : "hkOERA1mhDY5HT",
     "labels" : {
-      "cs" : "gxGUGoUn1BUIh1"
+      "cs" : "4UUPjpCRxjYMVi7SB"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1234599466
+      "currency" : "GBP",
+      "amount" : 667281186
     },
-    "activeFrom" : "1980-04-01T23:42:17.469Z",
-    "activeTo" : "2017-01-24T20:54:44.618Z"
+    "activeFrom" : "1995-11-26T10:59:21.540Z",
+    "activeTo" : "2017-01-13T23:27:48.674Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "z7GzgyUSAhnUfCdbatH",
-    "value" : "MjI8ZJszht"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "704650456",
-    "sourceName" : "y2nqigmxkok@ojad0pb98w5buuuros1"
+    "value" : "675450221",
+    "sourceName" : "rif1bpbezjq@hadmijb7hhtbp0"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "gs0Ck7USONF7t",
-    "sourceName" : "pmatlmiqac@ysz1hckga1qso"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "EJCdN7r9AiZWWVq",
+    "value" : "KlwdhjVOT3KPkXAuJGW"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/ffb10d6e-6d0c-47c6-add6-1cdc0b71f48a",
-    "sourceName" : "ek3pnaco4q@zbvy3417etdcosza"
+    "value" : "https://www.example.org/0940f0e0-9de5-420f-9896-2ec518fce1ac",
+    "sourceName" : "jtvngjwoam@mppes3w4jptczbq"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "hBZZTuWTfZQFOFI",
+    "sourceName" : "kzujfjpqxqa@wchfrxjls1xcpj"
   } ],
-  "subjects" : [ "https://www.example.org/b08698d6-6112-439d-84c5-f330e3bcb7e9" ],
+  "subjects" : [ "https://www.example.org/0d46dcf6-fc85-414d-a5fd-7a9c4797c336" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "045cba15-9193-4370-a9f7-6fdec2d6c5ac",
-    "name" : "86Xk2AqaFU",
-    "mimeType" : "2CNMvFh1AgN",
-    "size" : 122983987,
-    "license" : "https://www.example.com/kk5mcral398el",
+    "identifier" : "cd8062e0-b5c7-4660-99b3-699fd48620c7",
+    "name" : "eXvdTGhqyWo",
+    "mimeType" : "OuvWM17TCf8UZRVWV",
+    "size" : 772781375,
+    "license" : "https://www.example.com/q8aozj0kv4fk",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "For29THplAWJkmX",
-    "publishedDate" : "1998-10-29T12:36:45.346Z",
+    "legalNote" : "Z2bIv85qZ1EO7guAA",
+    "publishedDate" : "2016-01-24T08:05:15.801Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "xI2kW4K0XI53TNBoON",
-      "uploadedDate" : "1995-02-26T06:17:37.185Z"
+      "uploadedBy" : "CdWEzUqNPp0a8k4",
+      "uploadedDate" : "1975-01-10T09:14:48.411Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/UlXQf94p2ZpmAIei7",
-    "name" : "9WGtOYFGNizpUfQLY",
-    "description" : "3NHoZjeeeZgCFD8Ek"
+    "id" : "https://www.example.com/yYjdb4snSbrwz",
+    "name" : "nmaOb3AJ4ldh",
+    "description" : "Yp6ABjmfTN"
   } ],
-  "rightsHolder" : "8ClrvldCPQWb",
-  "duplicateOf" : "https://www.example.org/d41bba77-1124-4285-ab13-42d98cf876f2",
+  "rightsHolder" : "3EoXalGNOcLsGE",
+  "duplicateOf" : "https://www.example.org/c3b5a8b2-0670-44e4-8300-49965cb59be5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "4AGnI4KgHh9dzw3ydKL"
+    "note" : "DVGGvuWNJ6OWg"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Rim1y1vZxh",
-    "createdBy" : "gltjrxmmJQz",
-    "createdDate" : "2011-04-12T07:52:25.883Z"
+    "note" : "iwlr9dR4w1JLo",
+    "createdBy" : "34wzGnqLJSfo2IqWYD",
+    "createdDate" : "1998-01-20T12:57:22.090Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0cf41d98-e7b2-49b5-9bcd-067f9ddb2fe5" ],
+  "curatingInstitutions" : [ "https://www.example.org/ec6ef319-d024-4a2d-a520-d4d20b2c3b3f" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Zjizi1AujGXs0IcpF7",
-    "ownerAffiliation" : "https://www.example.org/54463a33-5d4d-42c6-aedd-a3ba41b38976"
+    "owner" : "5v8l22kgLKV5p",
+    "ownerAffiliation" : "https://www.example.org/d7bde554-2401-4d31-98ea-1b4127ce7925"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ec49ac0f-20d8-4f77-a569-47ff75d48954"
+    "id" : "https://www.example.org/daa819dd-0de3-47e8-9c15-04c8c238dc8d"
   },
-  "createdDate" : "2002-07-05T02:58:03.908Z",
-  "modifiedDate" : "1974-11-18T22:52:36.613Z",
-  "publishedDate" : "1980-04-21T05:29:10.163Z",
-  "indexedDate" : "2020-01-16T13:49:56.294Z",
-  "handle" : "https://www.example.org/d889dd78-6fa0-4c0f-9ed4-00f05ab0e68e",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/da6bbc26-c0ec-4ef2-bdd0-1356bd25be41",
+  "createdDate" : "2017-09-12T02:56:09.370Z",
+  "modifiedDate" : "1975-06-30T12:46:50.906Z",
+  "publishedDate" : "2023-07-07T08:14:56.354Z",
+  "indexedDate" : "2009-12-10T07:18:27.073Z",
+  "handle" : "https://www.example.org/a68e0249-846d-478b-9a04-d4cc1bc6bfe4",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/b96fc4fe-ec6f-4614-b7be-0625dc44ea5b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ry0VneGe5APRw",
+    "mainTitle" : "xcVxTEqsFMRrVJ",
     "alternativeTitles" : {
-      "es" : "sLPbt8WU2nC"
+      "zh" : "pVgsh33QfMoP"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eCRPyGBB51wX",
-      "month" : "z4AlamOngxUvH",
-      "day" : "FzSjyzzp1KaMCmI"
+      "year" : "k3Co1hM2iaRDUQ1x",
+      "month" : "bnDSnbzRcPhIUZZy9Bn",
+      "day" : "6hn41nvjNnjfAh0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d564d025-4843-4410-86e4-5c4f6a21b969",
-        "name" : "DKEaPdWVR7C",
+        "id" : "https://www.example.org/1b69b2b9-242f-4ff4-84d9-d4919e4fef95",
+        "name" : "ooDzpUcHVuOUaCPAPh2",
         "nameType" : "Organizational",
-        "orcId" : "JmLbKAga2P8j",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "rcLiedFccxLyvF",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bSdkJm6noExVn",
-          "value" : "o2yhY9yHc3zAI3xsr"
+          "sourceName" : "fxnscNBAVMuGX",
+          "value" : "bKMyHlwX6LBwU7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QcFUW4RwLJQ",
-          "value" : "9ryRBe07I1kGmBK"
+          "sourceName" : "aPQTnauJ9pfeYG",
+          "value" : "HFikmkrzUZAmbOFiKGu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/aaeaec8b-2315-400b-a297-7bf070cdab19"
+        "id" : "https://www.example.org/78a47ca0-874f-486f-9e37-c0db1ecef43e"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,158 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9ed30c08-6cc5-4eb4-8d4b-c9cb91fdc6e7",
-        "name" : "Mc9sTSVlA7tdYBN",
+        "id" : "https://www.example.org/0f589005-23e5-4cb4-bd08-f952b7d2b818",
+        "name" : "hTl0IxHn09I2UwVGjYN",
         "nameType" : "Personal",
-        "orcId" : "aKEBwi5F7K",
-        "verificationStatus" : "Verified",
+        "orcId" : "1q7ALvQEDGQx",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Dznu1vDsAQ7mWq",
-          "value" : "AQqypmviiqR"
+          "sourceName" : "UL0O4PeCWbGxQPOH",
+          "value" : "gxLCYCx717"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ykk2AI44hFDXFf",
-          "value" : "rPo3XfhjVD8blS6Pj"
+          "sourceName" : "x08TDDtWaLbvr",
+          "value" : "RlxCPOi30SL8bMl0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d7d022ff-300c-4634-aa0a-7750062a6306"
+        "id" : "https://www.example.org/b8e8f8fb-3cd1-4008-bb56-b42f83509b1f"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "LightDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "RBIS7oSWCv"
+      "da" : "BH6BgEY47Lp"
     },
-    "npiSubjectHeading" : "tV25YFY86adqkenT",
-    "tags" : [ "mSDtIoNi4K" ],
-    "description" : "f5AtlsdTYrcD8T",
+    "npiSubjectHeading" : "tZgwrKM5Xd",
+    "tags" : [ "1yvO8SW84lmV1E" ],
+    "description" : "jATWUf8YScX6t3T",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/342c0f9d-7b2e-4453-a968-17b626a445f3"
+        "type" : "UnconfirmedMediaContributionPeriodical",
+        "title" : "Sv93nBko6q2g",
+        "printIssn" : "4374-8619",
+        "onlineIssn" : "3388-8035"
       },
-      "doi" : "https://www.example.org/7bf313c4-92bb-48a2-b4b1-daa2284a2cab",
+      "doi" : "https://www.example.org/e2bd0ccf-29e7-4c2d-bed0-cbec5ec78c58",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "umWXrixHVPsT3bSHdra",
-        "issue" : "ih9QjCDZX9m",
-        "articleNumber" : "nc2bOXgSqQSrRke",
+        "volume" : "1uErsImW07vzKybYS30",
+        "issue" : "sqw2DGOJ4D63wj1d",
+        "articleNumber" : "JQzxMcJGTp",
         "pages" : {
           "type" : "Range",
-          "begin" : "IEkt1BeBNRAtS",
-          "end" : "uT5JKmzewz3Ge15"
+          "begin" : "5zdv1KG8tCbbKQGcXa",
+          "end" : "6rgeU84idjpCz4DbA"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/296f2bec-184a-41a3-83e1-8ba26e16c0d7",
-    "abstract" : "pHHK6CuwbcQohcE"
+    "metadataSource" : "https://www.example.org/49e8be0c-1b5e-493c-9d08-471e7bc1cfda",
+    "abstract" : "2xo9fyowrBV4MZKprnC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4b39f87f-b0e9-4290-ba23-a1f95a0c223a",
-    "name" : "aCpWt00hLZDIni0",
+    "id" : "https://www.example.org/e903434d-c7d0-4e66-8ef6-d133de589bb3",
+    "name" : "qjI8fFu6W7x3L",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-08-09T00:23:54.568Z",
+      "approvalDate" : "1979-11-19T18:44:44.794Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "YILaYnLi8hR3GDb"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "dgGpw7QEIY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7361c7b2-f7b1-4063-bf2a-a9366c68b9e4",
-    "identifier" : "VRYUGYDUeYuJfcMno6E",
+    "source" : "https://www.example.org/dd3c4929-fd49-499d-81f7-80d0e84bd80d",
+    "identifier" : "Cg6CudCBdt8GExFazdx",
     "labels" : {
-      "nn" : "VMEswsOMhaD"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1700133659
-    },
-    "activeFrom" : "2009-09-28T09:10:44.134Z",
-    "activeTo" : "2017-05-14T04:24:42.898Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/acc3eb72-09bc-42e4-830d-d614fe9d12dc",
-    "id" : "https://www.example.org/59491b04-0f4a-4638-aa07-0e83342ee52f",
-    "identifier" : "Tjg6f3DQWtEBKs7Y",
-    "labels" : {
-      "ru" : "yBodaFZz2K4JkqzwRs"
+      "zh" : "5YhXjO4pMF8JZQ8TC7s"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 520493463
+      "amount" : 1748937572
     },
-    "activeFrom" : "1990-04-29T13:46:33.613Z",
-    "activeTo" : "2007-10-07T19:58:50.631Z"
+    "activeFrom" : "2013-01-29T08:01:03.895Z",
+    "activeTo" : "2016-03-30T12:55:46.551Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/db235211-aa08-4785-babe-ce9b70ae125a",
+    "id" : "https://www.example.org/ad6034dc-2502-40de-91f3-4e29f607f7bc",
+    "identifier" : "f15Vobp7jhEH7mQnovh",
+    "labels" : {
+      "fi" : "K2fVcuWVls4R"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 128713736
+    },
+    "activeFrom" : "1971-05-10T22:52:02.313Z",
+    "activeTo" : "1981-07-03T16:15:38.468Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "cwI04PpFVh",
-    "value" : "ct4ipapzqlIGFDfh"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "17075946",
-    "sourceName" : "gttim2c262jckgib@o204doxwqqdzsrnr"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "MZnlTCcvLxtRrgT",
-    "sourceName" : "wcrgozohclrb@w5i77ozb0vhrc0mfe2"
+    "value" : "577437393",
+    "sourceName" : "ynbwlbcjdk5@iieabmapzgaqrkgon"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/96f79690-78ad-43c5-b409-6ab9a538e93c",
-    "sourceName" : "t6n9kktsur7@4ozumepalb4f18wd52"
+    "value" : "https://www.example.org/19d66758-c046-441a-9174-d348d5beb80d",
+    "sourceName" : "0ak7egkpchuh@cqfw7h1yg8l"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "89CK26Se70HLl8c",
+    "value" : "IvxqRIVcgM"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "zzMd4p6UVUd4Qv",
+    "sourceName" : "witlctg7gshsmybvk3x@1vt9sbmfx8qq"
   } ],
-  "subjects" : [ "https://www.example.org/3bac5e35-41c6-4b62-a1ee-1ebe6429a8e4" ],
+  "subjects" : [ "https://www.example.org/0e81c659-f4bd-48d1-91ff-c0af3ffdbc09" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8bd27b6e-0f95-481c-9784-5b842d399c6e",
-    "name" : "VluoASVepEbLXn",
-    "mimeType" : "8N9FfWrLJZD5172",
-    "size" : 1949705233,
-    "license" : "https://www.example.com/jvgyktocerwkva",
+    "identifier" : "85d2cd80-69c6-4c07-8f67-90aa107cf82e",
+    "name" : "bo4S5iTMXyn9Wu",
+    "mimeType" : "IF2fuVWF8qxDb",
+    "size" : 2052781204,
+    "license" : "https://www.example.com/mtm2uprcqprklmmlx",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "SNiSdmluQI"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "7824fHl7fZu1h7yVmB",
-    "publishedDate" : "2009-11-14T00:37:31.225Z",
+    "legalNote" : "XCQSnZ7Nm8gDQp",
+    "publishedDate" : "2021-05-09T13:12:12.092Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3s3wuAqsaXI89F",
-      "uploadedDate" : "2009-09-08T10:18:56.055Z"
+      "uploadedBy" : "zWEsYcJvz3XPFyf",
+      "uploadedDate" : "2006-11-05T16:24:22.971Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/dQA0YEptDNOt3",
-    "name" : "LqU5VwGTz1d",
-    "description" : "rMK7UYy0s9"
+    "id" : "https://www.example.com/eGz57LJG3sns",
+    "name" : "dmZemwU0LX",
+    "description" : "NTcL3bMMI0lV"
   } ],
-  "rightsHolder" : "NCzRjpFYDKy5",
-  "duplicateOf" : "https://www.example.org/682fe210-c4fc-489e-b27b-c7765b3aac9e",
+  "rightsHolder" : "7jlmybDZqoYuvBIa",
+  "duplicateOf" : "https://www.example.org/f52d7e4b-bde8-4095-bc66-f9e81024de47",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "8KIW7JLEsb"
+    "note" : "ORnQuwlBwawdKQTXsS"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "nsCb7dIWi1QEoLclVgo",
-    "createdBy" : "T9PCSBBs8TrZSLBQ",
-    "createdDate" : "1972-01-11T00:17:15.812Z"
+    "note" : "5Sv8tCz8glZ1bCoK",
+    "createdBy" : "oEy5toOdZRAhyTEPt",
+    "createdDate" : "2015-06-29T05:09:38.129Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2f3a3e81-ed07-43bd-9dbf-e4f5408308b9" ],
+  "curatingInstitutions" : [ "https://www.example.org/1a90fe16-16f7-44cf-b9d4-f290694a21e1" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "krhvYgRKlxj",
-    "ownerAffiliation" : "https://www.example.org/9de18db3-4129-4a59-a499-6bd163a94dd8"
+    "owner" : "pRuKGXBlcfd099nawO",
+    "ownerAffiliation" : "https://www.example.org/9700d188-4a47-4a7a-a73d-f668dda771f0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ef7e2669-5bb1-4b6c-98c6-bb8516c5d8f5"
+    "id" : "https://www.example.org/d3635487-fc05-41a5-a0a1-075ea4d4ebb3"
   },
-  "createdDate" : "1974-12-16T15:44:36.602Z",
-  "modifiedDate" : "2000-09-24T19:40:29.982Z",
-  "publishedDate" : "1986-05-01T09:56:33.213Z",
-  "indexedDate" : "2019-04-20T19:00:16.387Z",
-  "handle" : "https://www.example.org/51790ec9-f5f3-4841-b638-bd55b05ed772",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/da9d0f6c-3e63-4bf1-8813-61b20505f995",
+  "createdDate" : "1984-10-13T19:18:10.555Z",
+  "modifiedDate" : "2006-08-07T17:51:41.785Z",
+  "publishedDate" : "1984-05-22T09:51:16.633Z",
+  "indexedDate" : "2010-01-24T03:33:42.936Z",
+  "handle" : "https://www.example.org/da4d8391-d252-460d-8f80-33ea84c49929",
+  "doi" : "https://doi.org/10.1234/error",
+  "link" : "https://www.example.org/4aae972d-4ba2-4b81-a3a7-2c6f0fcddf2d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cRSwvIwR1Mb",
+    "mainTitle" : "nsDvuYKlsCib7REcTu",
     "alternativeTitles" : {
-      "fr" : "koXGTx2Tqfu4uhD"
+      "el" : "DDMEw1WyRaBli"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xRPLf0fm3uU0Ro",
-      "month" : "zwa7Nn88S5qxNyn",
-      "day" : "syqFMAwBSGuXWtA2mls"
+      "year" : "4E0psGxFM262wGCYJLo",
+      "month" : "FJpecSXNIvn9RJp",
+      "day" : "EolUhUOmIV5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dfe2ecf8-ffa9-4973-830f-051c4afe74f6",
-        "name" : "6NyaZ8W6LslEQQ",
+        "id" : "https://www.example.org/e241a88e-3919-4691-a150-a5df5d33af1b",
+        "name" : "tfK5XjCIjFMZfo25A0",
         "nameType" : "Organizational",
-        "orcId" : "mmPm1cuttiGwhF",
-        "verificationStatus" : "Verified",
+        "orcId" : "INzkKVAXPdwy",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TpzQtq4Wqg",
-          "value" : "ZJKr9Oomgu3z4TtRrx"
+          "sourceName" : "Gs9ETPHmF7EOubUA",
+          "value" : "bwhQbUAMkB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rkOUO0WGQKS",
-          "value" : "5LNvEhnrcmVG"
+          "sourceName" : "v8rtAmZ8KJKKMZkH",
+          "value" : "JH9juVMMjPk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/47334114-7267-4783-a2c3-c01b54d7fae0"
+        "id" : "https://www.example.org/9ffca535-e00d-436b-aeb3-9dca79d89bea"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,91 +62,91 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0cf4f7bc-e49a-43a6-bdce-cf864dcb6d41",
-        "name" : "oQzhJsSesw1",
-        "nameType" : "Organizational",
-        "orcId" : "I8OIGNRN3cM45wc",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2dca918d-e89c-4487-8761-75dcfa66aad4",
+        "name" : "dF0fLu69bv6MHha",
+        "nameType" : "Personal",
+        "orcId" : "jwFQZklQnoDt0DDiN",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bemF8FQDGZ1awF",
-          "value" : "zDUkFoq53I"
+          "sourceName" : "5AA3AazatfF8c",
+          "value" : "zdf4xmpOoFg7lwUZi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e1GVjb1vlvsfCV7xigT",
-          "value" : "4ZES6yuM5AwUb0kN"
+          "sourceName" : "ngq3Gdxr4UsMzb",
+          "value" : "QQwgX3h8hw7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8fd93dc8-1e90-4c62-9e68-3856abdf61da"
+        "id" : "https://www.example.org/da0d3d54-62b9-4231-ba35-f49582cb37a2"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "iHkzxTFOJPgWCiZFo"
+      "sv" : "9BMmMIshxSLQFk"
     },
-    "npiSubjectHeading" : "qlYhg2DCExVVU1",
-    "tags" : [ "7OORU7L8od2" ],
-    "description" : "ScKNcotjMp7w",
+    "npiSubjectHeading" : "nY0odneq7z60rC",
+    "tags" : [ "DVZeXAw1GbWsiT0o" ],
+    "description" : "Qjk4MmuzhgMw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/5a858dee-c42c-444d-ade6-86fb97ca9297",
+      "doi" : "https://www.example.org/132e75bf-3fce-4eeb-9324-605eb012bcbb",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Film"
+          "type" : "ShortFilm"
         },
-        "description" : "AdsxPpSvQhiWy",
+        "description" : "zehjcT3Gh37gwZ6em6",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "dgk2rxiP3lu4s",
+            "name" : "AXjQTgdfuIfXH",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2021-04-14T04:46:50.518Z"
+            "value" : "2023-06-04T07:00:23.216Z"
           },
-          "sequence" : 1921814748
+          "sequence" : 2054085819
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "q3KMVOr6xFSJGIwkj",
-            "country" : "KWs8xK7jsC"
+            "label" : "CCBCn2AwIxkcVjHcN",
+            "country" : "0pXoMowlIsUw6oEc"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2002-09-16T21:20:45.567Z"
+            "value" : "1992-10-28T09:39:42.631Z"
           },
-          "sequence" : 32144976
+          "sequence" : 968244626
         }, {
           "type" : "OtherRelease",
-          "description" : "yGWI0eySQCzt",
+          "description" : "7jp0bABoe2C5d6iwUzF",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "gwtYDJDT82A8em",
-            "country" : "qS7ftweoo6K1dQreEg"
+            "label" : "1bH9F2mMmXDmcG",
+            "country" : "EjsWvMOlLHXqw"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "YEzbnSM0NZ33",
+            "name" : "b477TxPZqEoZF8cYg",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1973-12-01T06:52:53.650Z"
+            "value" : "2002-10-24T14:13:55.391Z"
           },
-          "sequence" : 108752632
+          "sequence" : 1081347280
         } ],
         "duration" : {
           "type" : "NullDuration"
@@ -156,106 +156,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3904b760-2a00-42f8-89e0-756c6236f557",
-    "abstract" : "Uu4MoCZ6EAz"
+    "metadataSource" : "https://www.example.org/2b506734-c811-45ef-8662-fe2ad6ede28f",
+    "abstract" : "PxW30SvXEZmpTcevXGK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2022eea0-4dad-41ac-9073-55e9c62334b0",
-    "name" : "ymm9jgODFCsqy",
+    "id" : "https://www.example.org/e89f0d18-a07c-42c1-af6f-b7bb1389495d",
+    "name" : "se3jN9903Nv627FJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-06-22T23:27:14.709Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "wb2Fc0F5rx"
+      "approvalDate" : "2011-10-24T10:35:18.353Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "MZFeMmAuPopDx7opSzF"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8e4404aa-7dce-4320-8cdf-65d3ce1e02a8",
-    "identifier" : "Dwui9CT4aWVRv",
+    "source" : "https://www.example.org/15115b03-8396-47bd-806d-0e8a17c2953d",
+    "identifier" : "UffABUcMmh",
     "labels" : {
-      "nn" : "QtB315sz61GNPI0"
+      "nb" : "gvZTMxVi62f0"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1700258288
+      "amount" : 59289893
     },
-    "activeFrom" : "1998-10-21T12:54:03.634Z",
-    "activeTo" : "2004-05-03T20:23:02.242Z"
+    "activeFrom" : "1972-11-23T04:35:51.055Z",
+    "activeTo" : "2013-12-14T16:15:52.067Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f26bdcba-3b0b-45b7-8344-39d724730c16",
-    "id" : "https://www.example.org/f3ca9c56-5efc-4ab9-9f37-4900ce367a56",
-    "identifier" : "CN2k0eIWFCe70",
+    "source" : "https://www.example.org/605b8c9c-2677-48a0-a7f3-515e04877e13",
+    "id" : "https://www.example.org/937571bc-8d95-4624-895b-ecedf6a9b204",
+    "identifier" : "5PKp4jmkjc1",
     "labels" : {
-      "ru" : "WmBcxZdcs7O6On6R"
+      "pt" : "6vyPF8nbMIL"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 13466963
+      "currency" : "NOK",
+      "amount" : 1320971636
     },
-    "activeFrom" : "2011-08-01T01:01:57.757Z",
-    "activeTo" : "2011-12-15T20:40:36.777Z"
+    "activeFrom" : "1997-01-24T02:20:22.961Z",
+    "activeTo" : "2000-05-06T16:14:24.897Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "CristinIdentifier",
-    "value" : "1545474204",
-    "sourceName" : "b761mxc2f8frp0z6h@9u3si1wjgou8ep8n"
+    "value" : "1743526825",
+    "sourceName" : "biw1gctbi3v@wivjk0bhhad1h"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "eAs96sDfG4",
-    "sourceName" : "ass8menotwtgs814@xmjrkorbkn"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "TWlTNqWCscjZL",
-    "value" : "t8sFoLaTe5SYlMiGJf"
+    "value" : "vBVOGfcu1T78Au",
+    "sourceName" : "55nysw7zwvlkdtj5wp@39mro6abk1foeg93y"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0e88d278-0c0c-4660-9c4f-7735aa432992",
-    "sourceName" : "et4xoqphd75@fomwa3renbshtofkzd"
+    "value" : "https://www.example.org/103e4889-d5ea-4a66-b7c5-c4e09afa4ddd",
+    "sourceName" : "nrybnpdvp7rssl4@wkryt1xhgpxdnnumzf"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "qO5TOeUifW4g0",
+    "value" : "0vMs0xAcgQwiCY"
   } ],
-  "subjects" : [ "https://www.example.org/68ed97de-51a5-48c2-a7e1-e8d92188703f" ],
+  "subjects" : [ "https://www.example.org/fc389d0a-706e-4f98-bed7-aea3bbe3fab9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a44208ee-895a-4043-8a66-058bf2998149",
-    "name" : "rxt8RSvq4RGdO",
-    "mimeType" : "uS6cO642OE",
-    "size" : 97041633,
-    "license" : "https://www.example.com/7hede42hgd4rhxtal",
+    "identifier" : "5c4b73b6-aab1-440b-9969-0c13ec8c53bb",
+    "name" : "9XZLRNWJ1ZAX",
+    "mimeType" : "B6ffKwc5wet",
+    "size" : 1967494256,
+    "license" : "https://www.example.com/rp5vogr9c0mvoj2b46",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "cDuoSP88t0"
     },
-    "legalNote" : "wvGqjWeFxuW0nJ",
-    "publishedDate" : "1995-04-24T21:41:05.404Z",
+    "legalNote" : "9WTnJYaNDznz",
+    "publishedDate" : "2014-12-14T06:56:50.826Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TKHHoR5ekuWTREt1Q2A",
-      "uploadedDate" : "2009-06-08T12:45:59.460Z"
+      "uploadedBy" : "vdDCEeDrt5zDub",
+      "uploadedDate" : "1991-09-20T21:49:16.174Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/MBHlxiL5Ln",
-    "name" : "43O89gGDUufcimPGRp",
-    "description" : "5y9ziOX9SP"
+    "id" : "https://www.example.com/kmA0lPdQbB7vlop3tLC",
+    "name" : "Yi3wvfDJUlE",
+    "description" : "VO7Yx9GUa2T5QGCb"
   } ],
-  "rightsHolder" : "3UETDDxZcCV102S2",
-  "duplicateOf" : "https://www.example.org/7918ae2b-7a7a-41f5-b8f6-cdcf03c29671",
+  "rightsHolder" : "cccclOj9FDnpp",
+  "duplicateOf" : "https://www.example.org/8c8186ca-d992-4b87-a789-4cdb2c0eaf4d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kslY8uKJESJ6N2Mgjz"
+    "note" : "QjCDe15TB9bS"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SY1XjLimC7U0h",
-    "createdBy" : "gCrVWzM30oDH",
-    "createdDate" : "1987-09-06T01:41:18.709Z"
+    "note" : "eEiN4Z4XcLmrjKS7Wlf",
+    "createdBy" : "uMdOPJcCKlZfF3zp",
+    "createdDate" : "1993-04-14T23:02:29.949Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/be571292-4efe-4398-a09b-ec714ffc31b9" ],
+  "curatingInstitutions" : [ "https://www.example.org/8be48bce-090e-409e-bcdb-11cb8fbb66d9" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "c82rCMuTjbFUuSLE9iK",
-    "ownerAffiliation" : "https://www.example.org/2971c07c-abd0-4789-8dcf-e91fbb1c0e6f"
+    "owner" : "ihGnWwTKPZ",
+    "ownerAffiliation" : "https://www.example.org/2395659e-4a9c-4b7a-a22f-a1ef41b2ca4f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fe583b23-7cc4-4f7a-8a50-44d16e143700"
+    "id" : "https://www.example.org/a327a20f-7d8d-4579-afac-c0a405ceb6a8"
   },
-  "createdDate" : "2018-02-07T00:25:12.690Z",
-  "modifiedDate" : "1989-01-29T04:22:37.990Z",
-  "publishedDate" : "1987-08-25T15:17:31.377Z",
-  "indexedDate" : "1978-06-24T13:14:49.237Z",
-  "handle" : "https://www.example.org/d08ed32f-5680-4299-a093-58b5b004dfc8",
-  "doi" : "https://doi.org/10.1234/cupiditate",
-  "link" : "https://www.example.org/5faee6c4-e5fb-4300-b05e-115e99db877a",
+  "createdDate" : "2011-03-24T22:26:44.138Z",
+  "modifiedDate" : "1976-12-20T12:06:27.535Z",
+  "publishedDate" : "2017-04-04T03:41:53.870Z",
+  "indexedDate" : "1992-02-02T18:18:59.548Z",
+  "handle" : "https://www.example.org/c7b5117a-936c-4a85-abe1-561d31f89cc1",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/a69ff19b-9f83-4a77-bc0a-a389dd01751b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iPjUdSKqzHlUmP5xH",
+    "mainTitle" : "jyCfhQD7QXbjAdsJ",
     "alternativeTitles" : {
-      "is" : "orODNIP99ecw2Ydvqqe"
+      "is" : "SW5LKOJnRx"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "I7HixESBYH1ICY39cm",
-      "month" : "ZLB95iAIuuaALfu1OY",
-      "day" : "2QUiDdkr5Kkm0acUYv1"
+      "year" : "cfrXZ10bkfYrqu",
+      "month" : "2YV0v5mAp9tOqMS1a",
+      "day" : "2blFMVQYAGE9B1AxE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5177b057-4afa-4a25-8baf-b8df2b14a144",
-        "name" : "iva94i9hyn1Ce2C",
-        "nameType" : "Organizational",
-        "orcId" : "oGWesvIlXV0u5Zco76",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c518d02c-ef8a-47e3-9f28-8a09500286fb",
+        "name" : "in3FKUCfxlOV8",
+        "nameType" : "Personal",
+        "orcId" : "d3nmzWNN5VK",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kTQt7CDXgFIt",
-          "value" : "V0AcP0IN6sPNTZFVdom"
+          "sourceName" : "r7VwL4tH28Krv",
+          "value" : "IxGvDOaICKlf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "F7Wv4Dzmy71lTGAM",
-          "value" : "11AMhOqbbi6G9"
+          "sourceName" : "acsDr6nokMVgrHZMYA8",
+          "value" : "I6AZMkkHnnf3xSuR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8a44fe0d-c5e1-4b1c-adcf-69d4a11f68a0"
+        "id" : "https://www.example.org/5ba8e670-82f5-4e94-9312-96ba2257eecf"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,61 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/86bbe12a-6469-4b92-bc95-9e6f58ab44a0",
-        "name" : "dBAVjQ2QW7I8",
+        "id" : "https://www.example.org/603b2a28-3343-4b76-88a6-4d1182ed50b0",
+        "name" : "J69gzjW8K8bxvfOCG",
         "nameType" : "Organizational",
-        "orcId" : "jJwOq0Av8kl0sp",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "SyK6g7mHuhvLF6NRyd",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sOZ4vtGHU9Q2NSqn",
-          "value" : "mScFfAAyccRztK"
+          "sourceName" : "OHACCgMJpqLv6miBz",
+          "value" : "27kYsq7aEptL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HzfUtad1aFcV4E",
-          "value" : "W5BUL96IX7c8Cq"
+          "sourceName" : "jwDyiPt8qrzxVQ4",
+          "value" : "YTMVj9XyE4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6b2a96da-c455-424b-9303-4cbd16ce7529"
+        "id" : "https://www.example.org/5313c31c-fd84-4d5d-bb3e-0b559c5d8d28"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "4zUKbGskcGrBYr"
+      "bg" : "Cwu0NVjgOQ4NN"
     },
-    "npiSubjectHeading" : "OmBBAfRSQC6bAtAiPa",
-    "tags" : [ "is3mkW74Pvf" ],
-    "description" : "YEy7bLCvea2rw",
+    "npiSubjectHeading" : "j1Cbyvzys7kS3",
+    "tags" : [ "HaUIjGGQLA3Wh73b" ],
+    "description" : "XsM31jmIDGpiCrbHh4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/e18f3074-6553-42db-b427-82a3de44518f",
+      "doi" : "https://www.example.org/f0eb12db-1f77-4897-af26-8ea464c7979e",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "Streaming"
+            "type" : "DVD"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "RWLuFsJF4FwaWINvR",
+            "name" : "he8JHiNWlJWrl3y8ey",
             "valid" : true
           },
-          "catalogueNumber" : "J8Q7eMzfyOrE",
+          "catalogueNumber" : "ugEyN8xdO59NOeC7d",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "lGDvN36iBO",
-            "composer" : "j7tfoI3mnt3pifi",
-            "extent" : "3QpQjsm2CS"
+            "title" : "d8ABiV3mEj9GA",
+            "composer" : "PufVjpXHQkRK",
+            "extent" : "Uqn1gLPj3thA1fxerM"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,50 +126,50 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "VgBg99YXIMd",
-            "country" : "GCU5S0M6qJemXPj5y95"
+            "label" : "D8p3ieZCFce2pxAF",
+            "country" : "ypMuYitBlVmqRbDDB"
           },
           "time" : {
             "type" : "Period",
-            "from" : "2022-04-09T01:46:39.726Z",
-            "to" : "2023-10-30T07:52:29.298Z"
+            "from" : "1990-02-23T17:58:28.271Z",
+            "to" : "2007-05-02T13:51:21.995Z"
           },
-          "extent" : "GJNqdvdwIwnYT8Ns5H",
+          "extent" : "erOO7trjFkJLNDp",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "XxrQYsiUKHLZNqi4",
-            "composer" : "dYU7Zvy900l9B0bS52",
-            "premiere" : true
+            "title" : "IqaPmM5nxmYEkZdRuV",
+            "composer" : "bKrRRxdbTpf2aGwk",
+            "premiere" : false
           } ],
-          "concertSeries" : "Sy3mLuF2Z3iDCKa"
+          "concertSeries" : "akRx7gAfEfKsX0"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "FoVKYWSfBjN3",
-          "movements" : "hIq7UnB3qr",
-          "extent" : "0neDX8k71n12l",
+          "ensemble" : "qXwOxll5yZ4bP9y8",
+          "movements" : "98vVMvIlVU",
+          "extent" : "p5qfL1Win1Wq6qnTU",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "3v81BdknTwXmD4J",
+            "name" : "rrz9xhhZqG1",
             "valid" : true
           },
           "ismn" : {
             "type" : "Ismn",
-            "value" : "M230671187",
-            "formatted" : "M-2306-7118-7"
+            "value" : "9790901679177",
+            "formatted" : "979-0-9016791-7-7"
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "TW5J8mbImIx",
+          "performanceType" : "xWjx8iuYspCb",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "yThJG13LByD30AP88Vr",
-            "country" : "2p6q3wg6taSC8QczxKI"
+            "label" : "CR9AOmCVvomYX",
+            "country" : "nhZuvzrjr3n4"
           },
-          "extent" : "DAmE5rAnqKKmEd8uR",
+          "extent" : "4PpLQAo1DGqcU36aT5",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "OzdD84vw65WP8j",
-            "composer" : "52ZCUBHSSd1"
+            "title" : "JBKlijPlgX5pnGy",
+            "composer" : "ZDLvfo0KCuuDRX"
           } ]
         } ],
         "duration" : {
@@ -180,106 +180,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e9f62d8b-c6f4-4042-ab0e-8720c8f43d37",
-    "abstract" : "Kuyx2gSYaGkcx84MU29"
+    "metadataSource" : "https://www.example.org/6277c54a-3936-4d59-b379-77df9e5d7bc0",
+    "abstract" : "5SAEBJXioGM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1b7ce648-e0c9-4faf-acbb-843a2a975897",
-    "name" : "ulS1JDElhdpJZ5",
+    "id" : "https://www.example.org/6d888cca-29c6-42db-bb3b-519eefe406c9",
+    "name" : "m96TQ5K0Rj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-07-10T02:05:46.557Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "pQ1YBNDyIw6M1G"
+      "approvalDate" : "1977-02-09T09:50:16.695Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "XKcVWdwAn8gVS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c1724df9-7dbf-4000-b644-b7849015fa50",
-    "identifier" : "y3KyMCJ02dNFxa",
+    "source" : "https://www.example.org/8608aad7-2198-4676-8096-df202709d8f5",
+    "identifier" : "ZfPyvsa2Od",
     "labels" : {
-      "de" : "IR7s6IwNK9rvzm"
+      "ca" : "p0Jqv9HcpF"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1336821493
+      "amount" : 531422826
     },
-    "activeFrom" : "2004-05-01T16:45:18.402Z",
-    "activeTo" : "2004-10-26T02:12:24.862Z"
+    "activeFrom" : "1975-11-01T20:55:22.876Z",
+    "activeTo" : "1998-09-08T20:28:26.386Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ae0823c2-3301-4f48-971c-d0ff7f1d06a7",
-    "id" : "https://www.example.org/a897e4db-6a5a-48df-96e7-ecf72a925fdb",
-    "identifier" : "CUyLk4MLQL102LwC3E5",
+    "source" : "https://www.example.org/a49f1f2c-f0e8-40ff-92c9-09faa4c1bfae",
+    "id" : "https://www.example.org/0b36bae5-b2a4-44d7-b56d-ee0dcf2a5941",
+    "identifier" : "zO4hoRsFXuPb29h",
     "labels" : {
-      "el" : "2Q1brVh2YsVcTzb"
+      "da" : "vGOjYMfYwjX9ARVJ6o"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1754122983
+      "currency" : "EUR",
+      "amount" : 522250866
     },
-    "activeFrom" : "1991-02-16T11:22:40.071Z",
-    "activeTo" : "1994-12-28T06:39:31.468Z"
+    "activeFrom" : "1983-12-20T21:43:03.699Z",
+    "activeTo" : "2005-01-27T23:59:30.754Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "U8FJcO1pZLyq7uDC",
-    "value" : "pE0pfiEdydrJ2uY"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0a0def12-a619-488d-92bb-65d03fb1412f",
-    "sourceName" : "piaaegyhqss@zcd8rpoebnjnnpim"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "xaPaDF7j2oT7tk",
-    "sourceName" : "jcq1z8thqh@8nwxezs5fwvmbfn5"
+    "value" : "https://www.example.org/8989f8bb-3a14-4eac-9c65-ff7921010416",
+    "sourceName" : "zcrm87srjgjfmms2mwk@tt9bty2qbtxargszud6"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "2052772475",
-    "sourceName" : "ofqcumsfylsfx2@vydw5f9zizogp8m"
+    "value" : "416985132",
+    "sourceName" : "qeskgxw0ogocof@npbeg8q4p3setwaokm"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "UFwluXXUK6B",
+    "sourceName" : "ppwyszcqewlwkju@ui7s64sqje6szn64gp"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "pH1rfKoTcMEZS",
+    "value" : "n2pSIPdaMSu"
   } ],
-  "subjects" : [ "https://www.example.org/20f2efd0-7424-4dcd-93b2-05dad0e86106" ],
+  "subjects" : [ "https://www.example.org/c723261c-dcfb-4728-afbf-c3fc100565f0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c5928b43-b1e2-4465-baaa-45723697b44d",
-    "name" : "qoTYd1dAvdRK7xG",
-    "mimeType" : "trKxUPFE2XTp",
-    "size" : 2030589610,
-    "license" : "https://www.example.com/fllic6uzsvzromezt",
+    "identifier" : "d286d6c3-37a9-4968-91d8-294eebfa707e",
+    "name" : "mRmxfgZ6LOt",
+    "mimeType" : "wnc3W282vAB",
+    "size" : 834818086,
+    "license" : "https://www.example.com/8bhtftbnkbw",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "6IIGh46ExyHZmX5aTeW",
-    "publishedDate" : "1976-03-23T16:53:59.301Z",
+    "legalNote" : "hd8LVv94TqRN5b7I",
+    "publishedDate" : "1988-05-03T20:42:05.629Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "OJCjFfb7Y8zji",
-      "uploadedDate" : "2003-04-23T10:56:47.658Z"
+      "uploadedBy" : "niDKBPlW67cQ",
+      "uploadedDate" : "2018-09-29T12:38:03.873Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/35sY2SKttQEghx",
-    "name" : "4OsLbEEMJ7",
-    "description" : "YjJKaWcIKF8Nx0B"
+    "id" : "https://www.example.com/Tm44WvKBMVS0GLm9yj",
+    "name" : "RpGx94TPTSbrBZcG",
+    "description" : "12LZN9is4TH3oCi"
   } ],
-  "rightsHolder" : "4L3nkfL8vJp",
-  "duplicateOf" : "https://www.example.org/cd0ff452-0bd9-4426-92e1-503d35fb43a4",
+  "rightsHolder" : "5A2bDrjgybKH2JUaRb9",
+  "duplicateOf" : "https://www.example.org/1f3f3ee6-3362-464b-93b9-19db05ead85b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "VkgjUQSDgDR"
+    "note" : "SSBrmp9O5QfNZf6"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oYMo27XxjmeaVQ8Gmh",
-    "createdBy" : "6GDHQ1JlOPWX",
-    "createdDate" : "1981-11-09T16:35:07.965Z"
+    "note" : "PdQj8zjd9Y",
+    "createdBy" : "E7XmTCnsJPy",
+    "createdDate" : "1976-02-29T01:43:26.365Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/750b4ebb-fb03-48ac-99d0-0a4abc3569dc" ],
+  "curatingInstitutions" : [ "https://www.example.org/9acc590d-7f86-4f7f-9928-f80ac9dba49d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "XnfoAmaxopscWRL3dAE",
-    "ownerAffiliation" : "https://www.example.org/9b041934-70d5-424f-aa6f-3a3eb0d85d5d"
+    "owner" : "Fo7TWaMgi7zn",
+    "ownerAffiliation" : "https://www.example.org/b4185b4f-6ab2-431c-b14f-af6cf685c4d7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/296fbbf6-dd04-4369-a2d7-9db987991184"
+    "id" : "https://www.example.org/9ed6118c-2646-4bfc-8dc5-6f56bca8b747"
   },
-  "createdDate" : "1987-08-20T23:15:12.875Z",
-  "modifiedDate" : "2014-12-10T23:41:15.560Z",
-  "publishedDate" : "1985-05-19T11:54:18.518Z",
-  "indexedDate" : "1975-12-23T15:34:52.632Z",
-  "handle" : "https://www.example.org/b28a300d-1fa0-4c13-91c6-4f2407130988",
-  "doi" : "https://doi.org/10.1234/amet",
-  "link" : "https://www.example.org/fc018372-e1db-4a5d-9b42-d0dc4f9758df",
+  "createdDate" : "2014-07-10T23:08:13.916Z",
+  "modifiedDate" : "1996-09-14T16:06:03.444Z",
+  "publishedDate" : "1974-01-31T03:29:09.177Z",
+  "indexedDate" : "1977-08-22T22:27:18.912Z",
+  "handle" : "https://www.example.org/7f6be5ae-78bb-4ac3-8ffb-d92d82fed2ea",
+  "doi" : "https://doi.org/10.1234/nulla",
+  "link" : "https://www.example.org/d13419b9-436c-434b-a21f-0d9ce90afa78",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ILS0hFWOil9LGPRWLSR",
+    "mainTitle" : "jXNrSHwhbQORQi",
     "alternativeTitles" : {
-      "nn" : "ACnnwTrUDzhdHefzVWI"
+      "ca" : "r7zwFlkQPFXqxzLib"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eO9g37t9YbiuPX",
-      "month" : "VO86uD8rMDjX3MWH0M",
-      "day" : "CyW65gMQwCpAmvb0VRi"
+      "year" : "m68zJvPJF7fq8Ot6r",
+      "month" : "3q8shhB4TR",
+      "day" : "yUDhNBpQFBNHqkqMB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cef44d37-8977-430e-9968-8146d98fee79",
-        "name" : "L4AUysaVv8x",
-        "nameType" : "Organizational",
-        "orcId" : "lFdzGriFH7EhH30",
+        "id" : "https://www.example.org/64c336ac-4e55-4850-8dd3-ff5f7caae898",
+        "name" : "DR6Xcl7aEqTo9wFh",
+        "nameType" : "Personal",
+        "orcId" : "Do9Hvjp6Fziwqdqz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7JhKWd0PzJt3tkpq9i",
-          "value" : "KPG0PLpbrVE5sN9VrF"
+          "sourceName" : "zCCYgQAHJQqvf",
+          "value" : "zA8aGEssNHfqP9wox"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SM3j7EcFNPh",
-          "value" : "DIqFxovkIAWxgFHUz"
+          "sourceName" : "9U9XldmjW3BKVuXoJ",
+          "value" : "qFdioq2gq3NG1ZAKid"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/42e83085-824f-404f-af1c-45dc958547d8"
+        "id" : "https://www.example.org/47f582af-06a7-4b93-a7ea-d994726ba634"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "Dancer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a5f3c8d6-bc93-47f6-b836-e08657f57eea",
-        "name" : "YxVujt24A5EDUr",
-        "nameType" : "Personal",
-        "orcId" : "pRjSDUbi2rnh8Fq",
+        "id" : "https://www.example.org/49b30fae-afa7-41a7-8151-76e27e23f8b3",
+        "name" : "GRiW3pGV4IQx",
+        "nameType" : "Organizational",
+        "orcId" : "hWxwez1ci2RG23PB",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "F7giWLxmDDrrQ5lqZ",
-          "value" : "QZZCehhWIaUc8E4"
+          "sourceName" : "ZwurNZCdLdRzZwmXX",
+          "value" : "boScCfWRlmZAQoTC3D"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wkgDdpEj8uW14",
-          "value" : "1sf2kkAEtheYhir9d"
+          "sourceName" : "jfwgpfhqLtR7ZstyUn",
+          "value" : "2Jsy1khqPBSF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/83078f21-4c8f-4e1d-a055-2c929f0815d7"
+        "id" : "https://www.example.org/d00ca13b-5d10-4d2e-84ac-8ccd69b5507d"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "hppHF7qyZz"
+      "da" : "UYn42mEymXUzc3"
     },
-    "npiSubjectHeading" : "lRz0OVfLnEAj",
-    "tags" : [ "LeQBzSuabcKpxeU" ],
-    "description" : "5QtzUAsbL0mgflNgar",
+    "npiSubjectHeading" : "m4HCK79dFmfCdAK",
+    "tags" : [ "fI5tpH2hakA" ],
+    "description" : "TVyJYx6DT9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/T0djCXvn3UW8wanFC0"
+        "id" : "https://www.example.com/Me9FBKJzMBanr3FhyS"
       },
-      "doi" : "https://www.example.org/f2d38080-1645-460f-a9c4-e8fe98a5b68c",
+      "doi" : "https://www.example.org/5e2dbf68-2a0a-41a2-b90e-ce5d871729fe",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "u9jXRNQmG8HR",
-          "end" : "VwKPZsYwou"
+          "begin" : "5sUAGPsfVG",
+          "end" : "TlgY1HEMYPJpHMnz8au"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/de582b5c-bc97-4d90-95b4-e3b7473948ee",
-    "abstract" : "fzYTI5xJJ7OCuJs"
+    "metadataSource" : "https://www.example.org/b1ee847d-0b76-4e08-a635-093634eb8398",
+    "abstract" : "36pGVRARqPw6ibVZs3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f502afa5-70b8-4b90-b9f2-3c00a3ec6e9d",
-    "name" : "I7DjQhgSbygU9Y95y",
+    "id" : "https://www.example.org/0358b4d2-cf26-4e6d-af65-44ab051d11b2",
+    "name" : "XukMJ5f0sY4c4MGI",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-07-25T00:22:25.697Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "gzsYGAPaFiXt0Nm6B7"
+      "approvalDate" : "1998-04-16T19:45:45.246Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Lm3vG6oT6Sdxd"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2a90c39f-4470-4722-8570-176ba46ebd0f",
-    "identifier" : "Bdgg9Mosfwc8IT8TFJ",
+    "source" : "https://www.example.org/25688c6f-8016-49bc-a506-45aca8bfb528",
+    "identifier" : "P9AIyNYKH2GQMXWzg",
     "labels" : {
-      "nl" : "WVwRZKkE4KlM"
+      "cs" : "8mlMBFFIewRqFw0Y"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1837639593
+      "currency" : "USD",
+      "amount" : 177795984
     },
-    "activeFrom" : "2007-04-03T20:14:17.032Z",
-    "activeTo" : "2022-01-17T21:18:23.676Z"
+    "activeFrom" : "2011-09-30T20:46:46.703Z",
+    "activeTo" : "2017-07-10T05:23:12.621Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4f4518fb-491a-486b-aac6-7442ddec5ac6",
-    "id" : "https://www.example.org/6bae5d95-3094-42a5-8fc3-b40b8af43a91",
-    "identifier" : "INQwfDafFdn7",
+    "source" : "https://www.example.org/6a1a4c2d-aed0-4033-8eee-56f3016cef76",
+    "id" : "https://www.example.org/a232731d-b196-4fb1-92a4-e2c695722029",
+    "identifier" : "8Qq21oXYoluX0sOGP",
     "labels" : {
-      "bg" : "W0gADMDNIz55Mrc"
+      "de" : "4cFBcLdMNwAgTo8PY5"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1346689644
+      "currency" : "EUR",
+      "amount" : 142288606
     },
-    "activeFrom" : "2005-05-11T14:46:13.998Z",
-    "activeTo" : "2008-03-13T09:19:22.301Z"
+    "activeFrom" : "2011-01-07T23:46:12.161Z",
+    "activeTo" : "2015-06-05T01:36:45.270Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "g9rXJ3CvuBkf6bdT",
-    "sourceName" : "ubbmlppozfm38q@7ll2uuhtaaehtmks"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/e40c035f-3564-4757-9a54-a4afd63c7774",
+    "sourceName" : "fulxpjk13blb06gc@dxf3n02rte4ngs"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1467653663",
-    "sourceName" : "3zdijb21kyh2gof@jkuavunukl"
+    "type" : "ScopusIdentifier",
+    "value" : "2w0yo2uybsaotn",
+    "sourceName" : "ahkd0ed4bxdpjy@l2dcdttqaiw2ul84"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Fw6Quz2qyOo15pWn2S",
-    "value" : "qhQB98uEPUO"
+    "sourceName" : "jGxPiDGtF1CPwi",
+    "value" : "jddVpNOCKS66G2tV41C"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/535aeba6-d76d-40a7-9d25-c2a575df0df0",
-    "sourceName" : "8p7pknl4rb@0b2ettmovmd1a"
+    "type" : "CristinIdentifier",
+    "value" : "344716625",
+    "sourceName" : "jp2s2fuhxphvxp@yyvsgcep3no2vqonjq"
   } ],
-  "subjects" : [ "https://www.example.org/0a825b1e-ba9f-4720-b1f3-b16b099703fb" ],
+  "subjects" : [ "https://www.example.org/3977887e-06c4-4dbf-8839-5c88974ed276" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "43f3495d-edbf-4323-bac1-d258c4589fa2",
-    "name" : "0mWBcvnIyrPPzB",
-    "mimeType" : "3ce9A6XjSwk5",
-    "size" : 750867486,
-    "license" : "https://www.example.com/w2aolr9gpjtuw5fre0",
+    "identifier" : "4e169f3f-b647-4f8e-98a6-150f52236ce1",
+    "name" : "KZCm1coyAN3Vq1",
+    "mimeType" : "VufRpGm3I21INxBS6Uo",
+    "size" : 350749833,
+    "license" : "https://www.example.com/j7ojtaobxqmb9fy",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "nZky00qe1d9L6",
-    "publishedDate" : "1996-12-04T23:48:35.683Z",
+    "legalNote" : "HOiqCufnMC9K9EAa",
+    "publishedDate" : "1990-12-08T17:47:25.341Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Akpf39QebCmm1r",
-      "uploadedDate" : "1988-08-20T14:10:49.618Z"
+      "uploadedBy" : "RY8MwXLPlzrQrLa",
+      "uploadedDate" : "2017-08-10T03:01:07.757Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Is5DoKuYZT",
-    "name" : "nBK4LFI0ZYNre",
-    "description" : "3Ii4b19gB6"
+    "id" : "https://www.example.com/tcA8MuWJxSOKRj3",
+    "name" : "zmwmrzK9La3oGGZ17W",
+    "description" : "9XEzcujZkHGH7hL00"
   } ],
-  "rightsHolder" : "p9Na8IsnR3DkVGgOs",
-  "duplicateOf" : "https://www.example.org/d5016662-34ba-4ed3-9170-d536ca664d4d",
+  "rightsHolder" : "UeMBrZm19qanZ8Q",
+  "duplicateOf" : "https://www.example.org/a8109716-cc7e-4524-a8e8-ac88bd9bf308",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "hiefqTni5ZpyJ3YI0"
+    "note" : "n8rMgDioQ3Bebp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "XZuJnLjLWxeWoy9L5YC",
-    "createdBy" : "qdMtGkzN1c5g2Kn1xJN",
-    "createdDate" : "2011-06-15T23:53:09.536Z"
+    "note" : "kFxrtTrmuxkFIGC3u1",
+    "createdBy" : "QKsHYDuyy9",
+    "createdDate" : "2022-11-09T05:59:08.290Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1128413b-cd07-4dd7-a553-2cd4e54e31bd" ],
+  "curatingInstitutions" : [ "https://www.example.org/6c22909a-83bd-45ba-9d70-e1d7f03e5fb2" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "l2y32hfwsREppBijeA",
-    "ownerAffiliation" : "https://www.example.org/4a4953f6-5a3f-4800-b3ba-ba10d92f82da"
+    "owner" : "STdqSbmtJZbJj0wcZ",
+    "ownerAffiliation" : "https://www.example.org/74e16b36-d9fd-4c06-af0e-74257df682ce"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/bea7ad6b-fbf5-48bf-aad9-697caa908632"
+    "id" : "https://www.example.org/97832a7b-0b0a-47a5-a377-e32eb2e5b6c1"
   },
-  "createdDate" : "1992-02-21T17:18:30.933Z",
-  "modifiedDate" : "2010-10-11T00:22:06.288Z",
-  "publishedDate" : "2018-09-21T11:59:21.019Z",
-  "indexedDate" : "1984-10-23T10:47:23.247Z",
-  "handle" : "https://www.example.org/22efb263-92f3-44ab-9792-64b0514c2df1",
-  "doi" : "https://doi.org/10.1234/in",
-  "link" : "https://www.example.org/64193f9f-9d35-499d-9918-729401b99e03",
+  "createdDate" : "1981-09-27T11:56:33.035Z",
+  "modifiedDate" : "1974-10-19T20:37:09.139Z",
+  "publishedDate" : "1987-07-11T01:14:11.461Z",
+  "indexedDate" : "1981-04-28T01:43:12.214Z",
+  "handle" : "https://www.example.org/c24bd4bd-f9b9-4a51-9e55-54472ffb97bb",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/6975a404-131d-47b6-9562-6b464a4c1957",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QdJwPTsJGV",
+    "mainTitle" : "CO2SbZRr0h8BbjX4Efw",
     "alternativeTitles" : {
-      "el" : "gIkiKfpqOkIBNraCsQ"
+      "bg" : "KU3SfFE3vCBap8t0h7"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NNAU8GyN8l9HMveonn",
-      "month" : "2Ecb1fMNyvgcM6DK5g",
-      "day" : "r7opNm5w4uOWsmcU"
+      "year" : "4zf0E4xvcMCJ4wGxp9R",
+      "month" : "b2msWCE65d9vGM3R6bw",
+      "day" : "wKpYeejFRLe16gql"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/57141b06-0524-4086-97da-b5314e6614bf",
-        "name" : "RXcESSzEM0uSo",
+        "id" : "https://www.example.org/3fc3da8d-aeb4-40bd-9322-542ae8fcb8c4",
+        "name" : "i3aHDDJXRAnSXFFu1HC",
         "nameType" : "Organizational",
-        "orcId" : "zjidj1c2U9ZHUE",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Rf4Ihlx7N4PtCIely32",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VsQ2SvFPEetrp",
-          "value" : "sOkyJppyuUSPzxB2P"
+          "sourceName" : "Hq4OKPY0l9neJ",
+          "value" : "4yhQnoIY4BkYsFq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xc1oZjiRQp5OcGRWHD",
-          "value" : "2IBiH2mnYzq5"
+          "sourceName" : "gyGELqWY0ROGm6",
+          "value" : "Lf0trPMaY1D2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/88e437c8-1068-4fb1-9c41-b5f388d79295"
+        "id" : "https://www.example.org/4523dd03-478e-49d7-a2d7-6b0b768598ca"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "RoleOther",
+        "description" : "U4PID4ND4yhyEp"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,175 +63,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0ad42474-8b2f-4a95-9a00-30fdd4998a1f",
-        "name" : "0yeCrJGspm7k",
+        "id" : "https://www.example.org/3bac79d5-d95f-43fe-ba95-dcd256d4c41d",
+        "name" : "IHzCtmZycb",
         "nameType" : "Organizational",
-        "orcId" : "ZNKZ1dHYG31cDzEjw",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "c9n1jzhlHn9eYkm",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Cmy9sWiHMYSDbdkEIY",
-          "value" : "aAEyn3KnhKlFrqXWJJ"
+          "sourceName" : "Ol2iFS2uogQ9BnzP",
+          "value" : "sLAxwVBM4v"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JJ7rKTIzttUp1E7",
-          "value" : "Oy1cIsJFKvjYPDjQ"
+          "sourceName" : "l6iW0hLhBxlg",
+          "value" : "dEzM45Z3gwBDUoCW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4c05dcf9-2121-4558-bc23-746badb54db1"
+        "id" : "https://www.example.org/13a2673e-0c87-40cd-adfe-43c36429301c"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "g7KxUvcrT6wIA"
+      "bg" : "KKelJWLISsa"
     },
-    "npiSubjectHeading" : "ZF3Y205XwEHQi",
-    "tags" : [ "yzEDK16wtPUrxf" ],
-    "description" : "PdKOtPJOy3ge85HC",
+    "npiSubjectHeading" : "vRUuUbfi7S",
+    "tags" : [ "I8ORJ0PVxUUtccUb" ],
+    "description" : "pOFWUryizfhP4j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cdd42103-92b5-43fd-85d3-44a59d92774d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f52bf731-38a8-4613-913d-3ddf9bff568c"
         },
-        "seriesNumber" : "HPt4MEl3229u5QRvxs",
+        "seriesNumber" : "Mvd2LRmNSnMdl",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c3229d5a-21c4-43f6-91c2-99ceeb0c341f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bc983f64-563a-45c0-9557-12f0099af8e7",
           "valid" : true
         },
-        "isbnList" : [ "9791351369878", "9780011117355" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9791346089774", "9780861118212" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0011117354"
+          "value" : "0861118219"
         } ]
       },
-      "doi" : "https://www.example.org/3b87209b-808c-4e92-b843-a5592dbfefcf",
+      "doi" : "https://www.example.org/7a061373-95b4-4121-9b1f-695f3f64d150",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "q40ZitnRXhI",
-            "end" : "CW4saCBCJi712"
+            "begin" : "sjKsWUsG43vK",
+            "end" : "YcZBmFy3omjrS"
           },
-          "pages" : "MDt1Mp820avPZ3Gdcba",
+          "pages" : "fbY0DmX93bcsh",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ba4738b5-9f7f-426d-9b7c-5335282d9908",
-    "abstract" : "XEcCblImGGMYQ1BrNCD"
+    "metadataSource" : "https://www.example.org/5098fe0b-4a28-4eb9-99f8-e6b1d1f74790",
+    "abstract" : "9xAYtONX8FgjktvKY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/12a4bbe5-e73c-404a-abaa-4b1af3052dd7",
-    "name" : "COUyEXkEhbxaPw",
+    "id" : "https://www.example.org/ca34c7bc-88c6-4bd6-8972-9b49a168fb8e",
+    "name" : "kSV866pyrUU0aqmsTRi",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-12-02T17:47:41.598Z",
+      "approvalDate" : "2017-07-18T09:02:07.196Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "u9epBzBO9vdm8S"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "AkQaGbB9ZoKjYs"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/99361f29-96c2-4536-a926-a74d23a66cdb",
-    "identifier" : "F5qnlJi4Y8PoEju4",
+    "source" : "https://www.example.org/6fa159cc-461c-4513-8380-5ad3df0c1f03",
+    "identifier" : "cJ3kJWjVgYQTBPyVj",
     "labels" : {
-      "af" : "piHWTnHwSDaX"
+      "hu" : "fCN0jbDe8NHuNE"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1077763107
+      "currency" : "EUR",
+      "amount" : 111700813
     },
-    "activeFrom" : "1990-09-16T16:11:57.244Z",
-    "activeTo" : "1992-01-01T20:04:10.711Z"
+    "activeFrom" : "1987-08-26T22:34:11.670Z",
+    "activeTo" : "2014-04-22T00:06:00.530Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/583d28e5-e005-4777-8651-c34523c6b408",
-    "id" : "https://www.example.org/7e0d0348-d808-49ca-8042-997b38f1477e",
-    "identifier" : "Xz8Ie26FJmDgOdf",
+    "source" : "https://www.example.org/4894d1a0-c9b0-4df0-8a59-63a3fb20940e",
+    "id" : "https://www.example.org/0afb7d11-59f5-4b9d-acd5-a831f573a7b0",
+    "identifier" : "GSxGmjcBh0U8oL4Yb",
     "labels" : {
-      "zh" : "IiZ3jZwsXIq2A"
+      "is" : "KcW1mYz2vWnAq5YeEG"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1852656787
+      "currency" : "EUR",
+      "amount" : 780146240
     },
-    "activeFrom" : "2024-01-18T18:23:25.306Z",
-    "activeTo" : "2024-02-07T06:05:02.149Z"
+    "activeFrom" : "1995-07-07T10:18:01.905Z",
+    "activeTo" : "2016-05-22T14:23:49.843Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "CristinIdentifier",
-    "value" : "1809395314",
-    "sourceName" : "uhio93apreswy5bt@ftzdjlys3j3txfjx2u"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "zxQHIamx7m8QSl",
-    "value" : "QWCwTI1IOKLJNJ4nsJW"
+    "value" : "1852314978",
+    "sourceName" : "1umsfmyy3kioai@v68fo8judhvglt"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/4bc73b43-ae24-4d2e-bea8-76a5e46ef6f7",
-    "sourceName" : "y0wgnl5i4iw4j0jkso@bbgcff3rzn4ay7"
+    "value" : "https://www.example.org/298ceb67-8550-455a-acdb-7a3158018f3b",
+    "sourceName" : "vml4abnpi8arizwhkno@5bxoe4uocy"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "DV6WyW1Pmsc",
-    "sourceName" : "k9xozr7boqn4d@ahbsb1pjkjpeje0c"
+    "value" : "Bsz3ShQri1",
+    "sourceName" : "5oeobbx4n4etvbuqf@0rizwnwwjgav67jwb"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "zQNagYH2T2msoauI",
+    "value" : "HfgBw5e3r9ShyYuUB"
   } ],
-  "subjects" : [ "https://www.example.org/32d149a4-6e3b-4a26-9d4e-f8ae3c2ebd80" ],
+  "subjects" : [ "https://www.example.org/78782aa8-ec7c-42dd-868d-a7650eb4c19f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ae199a94-2893-4424-8f75-1eca12dab8f8",
-    "name" : "bMp64pE5u1f3XAvEb4",
-    "mimeType" : "shrFCWL3S5sBzdk8V6",
-    "size" : 834086680,
-    "license" : "https://www.example.com/quwf1c4vrjfe6b",
+    "identifier" : "213a1b55-4d1e-43ca-9d6f-300d1aa4fe5f",
+    "name" : "8wqYu4Wa0voZdeqgqEd",
+    "mimeType" : "Jsj1yszCtOww7f0cnE",
+    "size" : 1035218477,
+    "license" : "https://www.example.com/8ygmug3zrs",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "5yojs4bu9SvX"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "MYuobyV6MqK",
-    "publishedDate" : "2014-11-26T05:33:58.414Z",
+    "legalNote" : "fC1E0gF30uN3QZkeroc",
+    "publishedDate" : "1988-12-20T07:02:34.857Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "9aYwy6CXDGP7x1PWv",
-      "uploadedDate" : "1979-02-23T08:03:04.123Z"
+      "uploadedBy" : "fcYqFh6Wxu9M8YdDO",
+      "uploadedDate" : "1987-12-26T03:54:30.639Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/pys8tZ0F6Fy96G70b",
-    "name" : "BwgkHuWNVz6vOXD",
-    "description" : "awC82KRIRyB"
+    "id" : "https://www.example.com/Gs2uogp6jryzR",
+    "name" : "mCL3qsMkcI1",
+    "description" : "ENh9LrQAjVnzm5NY"
   } ],
-  "rightsHolder" : "zVXhrL1iHEk",
-  "duplicateOf" : "https://www.example.org/4db4a4a6-f92e-4211-af49-6187b60410d3",
+  "rightsHolder" : "e6wiLvtr3YufG",
+  "duplicateOf" : "https://www.example.org/b7611a85-5700-40ab-925a-f34d2e7827a4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "rPKqOddwVhmE3"
+    "note" : "V4plUhuKEo"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "cnD9ZAtukezIi",
-    "createdBy" : "b4zLcsoTJDrx7V8Zbd",
-    "createdDate" : "2020-07-24T05:08:25.277Z"
+    "note" : "ekJtJoXyt44uar",
+    "createdBy" : "jGxDrmEKpwrV",
+    "createdDate" : "2020-08-16T14:14:03.635Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f6f8ef0c-b04c-416f-a369-d525114d1d5f" ],
+  "curatingInstitutions" : [ "https://www.example.org/822cbcbf-d1d5-4bd0-9eac-2b06ed990811" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "lhyiAfAN45xvl",
-    "ownerAffiliation" : "https://www.example.org/8ba4d080-a45b-4f28-b151-f40bc3956c22"
+    "owner" : "Gztvfe70FNyp6qnZ",
+    "ownerAffiliation" : "https://www.example.org/07b402cb-cd73-4892-a325-fbdc8b594e6e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7a3b4252-3ff3-4878-abb1-823fd4d0b925"
+    "id" : "https://www.example.org/4e3c06f4-f114-4bf9-a55f-ef5339f02253"
   },
-  "createdDate" : "2013-05-09T04:54:11.067Z",
-  "modifiedDate" : "2017-01-23T00:43:54.211Z",
-  "publishedDate" : "2020-10-13T19:48:18.639Z",
-  "indexedDate" : "1986-06-18T07:32:23.374Z",
-  "handle" : "https://www.example.org/13149351-1183-464c-863e-c4427c23d2c6",
-  "doi" : "https://doi.org/10.1234/itaque",
-  "link" : "https://www.example.org/02257f8d-e1ce-4d2e-9740-0f8bc289c772",
+  "createdDate" : "1984-09-05T13:04:48.819Z",
+  "modifiedDate" : "1982-02-04T14:44:33.799Z",
+  "publishedDate" : "1978-11-04T17:51:16.908Z",
+  "indexedDate" : "2012-09-05T14:03:49.271Z",
+  "handle" : "https://www.example.org/d7c833aa-b0e1-4d6a-b86e-93fb1ef7a454",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/00d2f95d-fc78-4c89-9ad7-7078a5183b9a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NzjfniYuwD747Osb",
+    "mainTitle" : "P7diDzP0EPFXhh",
     "alternativeTitles" : {
-      "ca" : "8MGZP7C55K4PV4uSB"
+      "af" : "Xycb8eGKqhzNm4vH4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HP87gFWKj5nb",
-      "month" : "Jx2NEoJUtB",
-      "day" : "09aMklFZL8Txu"
+      "year" : "aawx7ZtjSH",
+      "month" : "gHyZjG8LN5xBVq",
+      "day" : "RylTq3tFPhlJYl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7b359e52-c9cf-46c1-96bd-e8eca0ea4ec2",
-        "name" : "9ODbrxyRjvhrK6W0KC",
+        "id" : "https://www.example.org/6321fa7e-98ad-448d-809e-aae3b7a0a9a9",
+        "name" : "lKkn6lVj8BXs",
         "nameType" : "Organizational",
-        "orcId" : "D0JTCpZlMe9L1lFwx",
+        "orcId" : "U86Puj3RTml",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6Z3J49z38ac3n",
-          "value" : "QcsJujzmsrrSsbb0E"
+          "sourceName" : "ADYiaKlEdXdQxbxS8H",
+          "value" : "9bLe7oqkZDPUi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bdOu2WBYarNTUxQ",
-          "value" : "8IwWUjNtcLF1"
+          "sourceName" : "ztby0kqls8LEoS",
+          "value" : "l0PG6y9MUMHeIG73"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b3974d37-c39e-4b03-8bb7-1f53eeadf6f9"
+        "id" : "https://www.example.org/bdbd3980-4cbc-4d56-8ca8-810c26f72eac"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/30609ba6-c57c-4cc1-a040-6627b9ca07eb",
-        "name" : "8QqonuFXe2Op9V8I",
-        "nameType" : "Organizational",
-        "orcId" : "WHbWJkb5EBcZu",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/0c0b2c8b-192a-4fae-8ab3-4baba2896275",
+        "name" : "LWrwo1VNp5XBGD",
+        "nameType" : "Personal",
+        "orcId" : "Go764ExvQpRJYIT15g",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2kyxTM6zb2Qaa",
-          "value" : "7I71dsDZPBZi0z"
+          "sourceName" : "h6MpylRF0M5rQ",
+          "value" : "y414v9AdfK7xwJIb4f"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Bjm8if7xgZi51jb",
-          "value" : "vHqS7nXvR3JkcYFYT2"
+          "sourceName" : "WfKRwiIXeKMw8jHLuX",
+          "value" : "ULYj9q9YwTUn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4cd8b502-83e9-4969-9f60-6400e688fa09"
+        "id" : "https://www.example.org/ccd3da00-9caf-4f9e-bcbd-ff97f51214cf"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "W2lSYA45vD"
+      "da" : "hANA2DlGSE2"
     },
-    "npiSubjectHeading" : "8Wshxti7WkTvVOwP1L",
-    "tags" : [ "AfKoMK2dayJzF" ],
-    "description" : "xRrmZe4rq6O1lhx6ypJ",
+    "npiSubjectHeading" : "A0aee7sjrMx",
+    "tags" : [ "8bnBA5DnvYvvspuB" ],
+    "description" : "neOMA8e3Tg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "KtiSMXIWO37CxdGv",
+        "label" : "A5p3Zlu9uMYUfoprMp",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "ew2GnSqIIn9S",
-          "country" : "zDgn3tsH1R"
+          "label" : "oc5cCrqq2isGe006oD",
+          "country" : "F0KfLu1dUp20zm28"
         },
         "time" : {
           "type" : "Period",
-          "from" : "2019-12-08T09:36:15.198Z",
-          "to" : "2023-11-06T00:33:50.905Z"
+          "from" : "2015-07-01T02:02:28.414Z",
+          "to" : "2016-07-19T01:58:56.339Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/mdX2inRJ5b3rUqtM"
+          "id" : "https://www.example.com/XuByscDNET1Za"
         },
-        "product" : "https://www.example.com/vuWp3y1LYteztdSPYV7"
+        "product" : "https://www.example.com/v1MhDsESyB7ELcUsILH"
       },
-      "doi" : "https://www.example.org/3fdd5c9d-6db5-4aee-9383-eaa8577d84b9",
+      "doi" : "https://www.example.org/1f0fc940-40b9-4e80-8e3b-8a0e5c5ae425",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -122,106 +122,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c04d37fc-7d53-4e0c-b44f-04ef5dafad6a",
-    "abstract" : "ewE0JmiL3izJjooRqcR"
+    "metadataSource" : "https://www.example.org/63da52c0-daa8-4b28-b708-230debe9e922",
+    "abstract" : "q4F5HAyj7Sm3xIFzn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/57488d98-4237-4784-acb8-4e6062ecf9b7",
-    "name" : "Z31JB4LYRacj",
+    "id" : "https://www.example.org/b807ec49-3ea8-4574-8c9c-bee2e2e40ac4",
+    "name" : "qrFVPRwfTE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-12-17T13:09:37.995Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "hUHahm5yjInmCZN"
+      "approvalDate" : "2020-12-28T22:40:54.676Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "jmbSfrl360OPUD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a777f504-455d-48d5-a8b2-24cb84a331aa",
-    "identifier" : "bOLrTBsa9zIDo",
+    "source" : "https://www.example.org/932d6b1d-7a9d-4afc-9bf9-d3b0fce80d58",
+    "identifier" : "sjzpfxpzIhsRGH3RXy",
     "labels" : {
-      "fi" : "c3oKL4R9H9t7"
+      "de" : "fsi2M0ykGtsH4s"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 425044919
+      "currency" : "GBP",
+      "amount" : 933028518
     },
-    "activeFrom" : "2017-02-28T04:16:34.251Z",
-    "activeTo" : "2022-08-29T13:24:02.441Z"
+    "activeFrom" : "1982-05-07T05:27:52.368Z",
+    "activeTo" : "2006-01-07T02:19:21.358Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/86818b5d-00b2-4c82-90ec-261d5b720bad",
-    "id" : "https://www.example.org/0d3680ae-b398-4214-8846-991b3c9f9ca5",
-    "identifier" : "X7OCScTXTF5X",
+    "source" : "https://www.example.org/de576d4f-d3d6-4fda-9ae9-f0f8538a6b22",
+    "id" : "https://www.example.org/6da38df0-9b01-4297-8a93-75b3d19a66ed",
+    "identifier" : "2hstrIuE80ZN7BKWEAM",
     "labels" : {
-      "el" : "sR1YUYVvCiP5s"
+      "hu" : "PCGIGnPCi9fuADiT"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1145895617
+      "amount" : 22343800
     },
-    "activeFrom" : "1974-06-29T00:56:20.230Z",
-    "activeTo" : "1979-08-02T09:07:23.999Z"
+    "activeFrom" : "2024-08-18T19:41:30.105Z",
+    "activeTo" : "2024-08-23T16:22:32.659Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "nX5x26NIPgak3iT",
-    "sourceName" : "jswwjbadnubrl22ip3f@xckritlhrvx"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "334579461",
-    "sourceName" : "jfsfdwbpsrasv8l@uvyuzmdzxxnkkd3nay5"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e881aa0e-d250-4ca6-9a86-fc6dcfd43ffb",
-    "sourceName" : "c96czh0lfaax88zvy@thfd3iwwnywq"
+    "value" : "https://www.example.org/5b9edf3c-233c-4065-906d-9a9a369afb52",
+    "sourceName" : "pdsfapteipwpr08xmqw@obphhzyiznoo4"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "dpqYyxnH97ftoh",
-    "value" : "zAB6L8FNd1UuafXu"
+    "sourceName" : "QQ59I0YXeFsDF",
+    "value" : "wDi1T5dFbAJ6hvPeQj"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "485455195",
+    "sourceName" : "7nhivmdzh9lu@4hzglcbkrt8udosffh"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "mbCkt5UOQDxh",
+    "sourceName" : "fabi0eogdev@xac2auxj5af0nge"
   } ],
-  "subjects" : [ "https://www.example.org/a99a3235-5f96-4af3-a5f8-9cb076b8f73e" ],
+  "subjects" : [ "https://www.example.org/1150d199-7613-4ab2-b1dd-6d96aab5d294" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5ca95855-8bbf-4f13-b124-8b9fa34538de",
-    "name" : "8qzrLJzuVb",
-    "mimeType" : "LLKCqYr4p3s",
-    "size" : 2093362017,
-    "license" : "https://www.example.com/c2xhdvw71l",
+    "identifier" : "7da60296-5120-4c02-8085-7fb1f8fabe06",
+    "name" : "LGtpO1PcnKcw",
+    "mimeType" : "1eQnqVON4y8ybw3r",
+    "size" : 256662784,
+    "license" : "https://www.example.com/foqedwrge6hh",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "rJwWSL5hsv36K0BkCz6",
-    "publishedDate" : "1975-05-08T06:41:03.355Z",
+    "legalNote" : "lJZxf0F89piJa",
+    "publishedDate" : "2012-09-11T01:04:23.707Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Q6QdNj1TyLAGI",
-      "uploadedDate" : "1993-10-24T10:40:15.042Z"
+      "uploadedBy" : "HqzZs0HUYOn0",
+      "uploadedDate" : "1998-01-25T11:06:33.938Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/R2gZVCTY3OjD",
-    "name" : "h4L7MTwal1nrpxS",
-    "description" : "STgf83KTdcmAqUD5Y"
+    "id" : "https://www.example.com/9mVn9MY3eSGjgkalQ",
+    "name" : "NUNZjK4GbY0fdWEn",
+    "description" : "rPTanowWfDgY"
   } ],
-  "rightsHolder" : "u8WZGOL2EJosS",
-  "duplicateOf" : "https://www.example.org/8893890b-9f9c-4575-acd0-eb5575ae9212",
+  "rightsHolder" : "lfKtom8YMDJIR2",
+  "duplicateOf" : "https://www.example.org/431f3538-0d19-4503-baba-80606fbddd55",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "oZIY3rs1vlX"
+    "note" : "1bydLnz3L7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "cszaLpo7g7jCPnyU",
-    "createdBy" : "QAKydhsiMk",
-    "createdDate" : "1974-04-12T16:20:56.957Z"
+    "note" : "L2yqMsS13MKa0imoqH",
+    "createdBy" : "xpuQk7BtQz0zR",
+    "createdDate" : "1983-05-10T22:44:23.533Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/df058919-c38d-41a1-b452-d3c6bab12e61" ],
+  "curatingInstitutions" : [ "https://www.example.org/adc401ab-5793-4a90-98e7-fed860893621" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "HlrgFSIastLgzWfZ",
-    "ownerAffiliation" : "https://www.example.org/50e87859-898a-443a-b464-da4536881849"
+    "owner" : "rdBjBayaO7ni",
+    "ownerAffiliation" : "https://www.example.org/8a28b4db-6171-40c1-b53a-99bd435db3da"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8901433d-9934-45ab-88c1-7033e2401f97"
+    "id" : "https://www.example.org/342d3bae-422f-4bfc-9151-fea92e315368"
   },
-  "createdDate" : "1990-08-14T03:16:00.235Z",
-  "modifiedDate" : "2020-09-08T12:56:10.031Z",
-  "publishedDate" : "1988-12-25T16:13:27.908Z",
-  "indexedDate" : "1984-04-18T00:35:45.132Z",
-  "handle" : "https://www.example.org/a29ac7dd-1fb7-4bc1-895e-06a513940faf",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/2ea5ee7d-168d-4c74-bf87-ed3e93516abe",
+  "createdDate" : "2000-06-23T10:39:50.414Z",
+  "modifiedDate" : "2009-05-22T05:08:08.985Z",
+  "publishedDate" : "2006-05-09T09:46:16.913Z",
+  "indexedDate" : "1976-11-09T11:39:38.131Z",
+  "handle" : "https://www.example.org/f9f13741-b123-4674-b442-c35f1b700b3b",
+  "doi" : "https://doi.org/10.1234/laudantium",
+  "link" : "https://www.example.org/a275e44a-dfa5-4666-8e7d-48bbeb1dbedb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QjeRwuCsYFxsgui",
+    "mainTitle" : "EuJMi54g7hrrflHy",
     "alternativeTitles" : {
-      "bg" : "arzOFzAYCBzAzDKj"
+      "zh" : "3DuvfIRMR50FCn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HPdT5ciIEH",
-      "month" : "6QN4V8Vvm91oXy9C",
-      "day" : "4m7wOdW6YBcFb9G"
+      "year" : "Rko9zmUp0jT6MY2",
+      "month" : "Zgxxjd1YCxKqCZ",
+      "day" : "D4gAF2FJcjviz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/23aff68b-75f6-4213-b02c-8a032138e089",
-        "name" : "dKgbnxSzOnQZsWB3jv",
-        "nameType" : "Organizational",
-        "orcId" : "noCoISljGYHbccN",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/fa1a9fb4-da19-44df-8a00-e0ede1f256c8",
+        "name" : "qbtMIOynWcKYGzo6c5Y",
+        "nameType" : "Personal",
+        "orcId" : "xNjDzph1ysylpD9",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cpKZ31RwMCCl",
-          "value" : "Cx6cNlmgR3eZ"
+          "sourceName" : "o8W3FGmva65Ha3",
+          "value" : "MleCVE7ygRXQy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kh9Wgo8bFg2yX3wuMM",
-          "value" : "6hlvHcelQber4"
+          "sourceName" : "vohvvzZDpHKs",
+          "value" : "sppRou3mcBHMpobXsWt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/51a54ee2-360b-4b10-b5a2-6a205347991f"
+        "id" : "https://www.example.org/89ad0c8b-9510-4684-848e-2c09962ce8c3"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,180 +62,180 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3d5dcfab-4a48-4b85-a857-86ddee7b0900",
-        "name" : "Imd64Qqbl7P",
+        "id" : "https://www.example.org/3248e626-1615-4121-83c1-32c537397772",
+        "name" : "zE2j0jrsjExp",
         "nameType" : "Organizational",
-        "orcId" : "ChLsKYKHBUIOfIdpBW5",
+        "orcId" : "xVXPbzFc0OB",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PGH9erW3BCv7lUDoeym",
-          "value" : "9qo0B2KBownO2rOXu"
+          "sourceName" : "OLYoe1sASs963wc",
+          "value" : "LDRrdm5RG1w"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Tnlrc4MRngqOBjp8et",
-          "value" : "ek9PZwQuO2Q0"
+          "sourceName" : "B0tCK7tTXT",
+          "value" : "q72DrwLjykhqWwUlmE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/24810d19-1b82-4073-b398-0256b66e61b9"
+        "id" : "https://www.example.org/0ae7b1be-bfc8-4788-a6bb-075c01400ecb"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "XhOnU34m37Ly"
+      "it" : "cyEjm9RkBzxYGG3cnSu"
     },
-    "npiSubjectHeading" : "vUBWyyIdk8",
-    "tags" : [ "SxRoUCrhEJhjJbyBaA2" ],
-    "description" : "N9Iw3qzw2zBP",
+    "npiSubjectHeading" : "wHiMMcHYF9",
+    "tags" : [ "JTlPHxZfioUVXl" ],
+    "description" : "aZ76lflc8G5RBO4X",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/84a7ef05-9093-4f0c-a8f3-427a94f7f72b"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ae8b5192-f5f6-4bcd-9593-8ff15fe9fb81"
         },
-        "seriesNumber" : "RhpsBhPgn4aMIFF",
+        "seriesNumber" : "VSP7SVIe0Gr0E9eZe",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/15cd0221-87d2-49fd-8ebe-ca7471cbfb4b",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/706276e7-39a1-471d-9010-5f94ae195f56",
           "valid" : true
         },
-        "isbnList" : [ "9790710881037", "9781898246039" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9790928912028", "9780043914397" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1898246033"
+          "value" : "004391439X"
         } ]
       },
-      "doi" : "https://www.example.org/ac79575a-f6ec-4355-aa9b-9b4637a32f34",
+      "doi" : "https://www.example.org/f1caf585-8c97-42ce-9398-9b2f14e3d863",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "3gINtPiyT9rm",
-            "end" : "hHCcTJW0KMKzhKz4mm"
+            "begin" : "wkqCAINSy6c",
+            "end" : "OygH8PCjkU"
           },
-          "pages" : "0CZpSobV9Jcl3tu",
+          "pages" : "VIcD993yz0e",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "UJ1xyJBaC0ZUsmT9O2",
-          "month" : "gCUFhCoix3FYkR",
-          "day" : "MYcQkkYLoQT"
+          "year" : "hbfgGAgJfDYIHaKvG",
+          "month" : "7IhgdYt77Gse1i7Q",
+          "day" : "m8eHOSSz6HyAtE1qhS7"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3bcdda9d-a413-4a4c-aeeb-b33a174f7b29",
-    "abstract" : "AGIlS1j8eY8L7S"
+    "metadataSource" : "https://www.example.org/45f5898c-5862-46cb-abb2-77c50b1e0ffe",
+    "abstract" : "xRHxpSCPH4y8LBf5Cx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a2a75b95-66ae-42a3-8b24-607c7db15c9a",
-    "name" : "ijN0pCc8AcH",
+    "id" : "https://www.example.org/eef3785d-b034-4222-a59b-3c5cb74b0b50",
+    "name" : "YDsYuvJKCs",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2014-08-14T02:50:02.935Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Fww7Tdn7sUqD"
+      "approvalDate" : "2014-12-29T19:59:53.274Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "B3CCBs2lW2o"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3cb949c8-2afe-447c-b2d0-d24c0efc7432",
-    "identifier" : "nyGHUqbl9yudcZo",
+    "source" : "https://www.example.org/2150e6f5-f5ff-4b92-88c9-99165c57403e",
+    "identifier" : "iKXmpMEYzrpCN",
     "labels" : {
-      "is" : "G0FC1UWsfjq8LIVlDeR"
+      "fi" : "Biqw0LftiyUdxIK"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1258700075
+    },
+    "activeFrom" : "1973-02-13T19:57:56.348Z",
+    "activeTo" : "2016-10-06T18:23:52.102Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/4063a4df-6441-41b0-96f2-703744e8e585",
+    "id" : "https://www.example.org/f52cf002-8ff4-4eac-8bc3-a810eedb199a",
+    "identifier" : "2Bw9Qoj01WpvY9vn",
+    "labels" : {
+      "is" : "ROHSrDsLQJ9T"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1494245608
+      "amount" : 1381236418
     },
-    "activeFrom" : "1974-06-10T13:15:33.530Z",
-    "activeTo" : "2004-05-27T16:56:31.301Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eb6913ac-25b5-497e-b339-29eeed9604f2",
-    "id" : "https://www.example.org/ebfcb349-afa5-4f60-a234-65278661478a",
-    "identifier" : "r0WGM2qap6N4gbmk",
-    "labels" : {
-      "de" : "IOnMats7Sm"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1322283905
-    },
-    "activeFrom" : "2001-11-02T17:07:46.691Z",
-    "activeTo" : "2021-12-15T23:42:16.236Z"
+    "activeFrom" : "1978-10-18T10:16:24.354Z",
+    "activeTo" : "2024-01-20T05:28:55.846Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "BzkTFCNMygJyGqD",
-    "value" : "OUOU92fxFl5rUg67O4U"
+    "type" : "CristinIdentifier",
+    "value" : "897796110",
+    "sourceName" : "g5zs2mb3glbchakqkeb@e8clquw5mhu4wj"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/26ea3909-c24f-43a2-b975-f32c30cdcee5",
-    "sourceName" : "qfdclmjyrvp@gtsluzbew4fl"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "GoUOINdDJje3x",
+    "value" : "tlHLqKoLgB0"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "hQLBnZPXUqZbhnP",
-    "sourceName" : "cf2vvnczt6t@veueyueqpwwk70pl"
+    "value" : "HmDdhf1HReE40v",
+    "sourceName" : "l7egqw78kf@1n5bscsbup4ldoz"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1054289562",
-    "sourceName" : "ckeht4hk4vrga@o9phgx8wiwgicm"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/00fa93d8-d52b-4168-8f6d-30c7c110f193",
+    "sourceName" : "g69vdwjljedcm@uvu6daxxcjmq1uoe5ys"
   } ],
-  "subjects" : [ "https://www.example.org/21612bfb-7984-42d1-9b08-c9a01e821e5f" ],
+  "subjects" : [ "https://www.example.org/5cc53d88-3a17-42ca-9448-78972a4e0cca" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "913c1ecc-ac1a-4179-877e-2e6b49dc3bbe",
-    "name" : "97ML03TbGLSh",
-    "mimeType" : "N75TKRzkake",
-    "size" : 1531017806,
-    "license" : "https://www.example.com/ehqbga7zlvnwpcpq",
+    "identifier" : "5c7cd10a-1948-4bf1-8e41-9dea3660a040",
+    "name" : "vyyHfBJDP5",
+    "mimeType" : "QChnpTTe40pJVW",
+    "size" : 331690003,
+    "license" : "https://www.example.com/nzqf4bhon5u9yiybe",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "CCYrSg7uU6HRHYWdQ",
-    "publishedDate" : "1999-11-28T12:24:10.203Z",
+    "legalNote" : "L84StMkvqH9UqNm",
+    "publishedDate" : "2024-03-24T00:57:54.905Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "KNA662xEGrjH",
-      "uploadedDate" : "1984-02-14T10:30:17.002Z"
+      "uploadedBy" : "F8GYg6hoguZoXPV",
+      "uploadedDate" : "1996-05-04T15:03:54.715Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ldygNX0I7PrGlorB",
-    "name" : "BP5RmPrBkUvRW3n",
-    "description" : "mRkIko9akdrPvlG1H"
+    "id" : "https://www.example.com/lJq3oM2NZjALXRtf",
+    "name" : "Dgcw4avllM3puAaP",
+    "description" : "aTE9yGp2AjFt"
   } ],
-  "rightsHolder" : "xk5114vBu05lMvy9FR",
-  "duplicateOf" : "https://www.example.org/2e1fb838-cc66-4c78-9205-6257acb356b3",
+  "rightsHolder" : "FauAtNvbr3Ejv3zU",
+  "duplicateOf" : "https://www.example.org/cfadc08d-9bcd-4461-a3dd-b8173e2c63d7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "HPjHW5IoDuANYcm9fu"
+    "note" : "WhTdK1fSdOiQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ysfIjII82Kihu",
-    "createdBy" : "F9CDFyFUxxA",
-    "createdDate" : "2023-04-22T07:35:39.897Z"
+    "note" : "FBDZa4FRJYw5QO",
+    "createdBy" : "Fu8opliU0UwLf4",
+    "createdDate" : "2010-03-21T01:00:48.405Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7133abb6-7ca7-4938-8d09-f5f22eef30c0" ],
+  "curatingInstitutions" : [ "https://www.example.org/0e9b3159-471a-4d0e-acb4-72020c0feabe" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "fB0niq42mWmeM",
-    "ownerAffiliation" : "https://www.example.org/40e681b4-6816-44c4-89e0-b3be536342e9"
+    "owner" : "aIweNPsCKwMKnCB5",
+    "ownerAffiliation" : "https://www.example.org/184361c1-1bc2-4680-8e90-45834e150a48"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/bfe4f5e6-280e-49d5-bb0f-f2636e5319f7"
+    "id" : "https://www.example.org/fb54c7a8-9c07-4c9f-8cc8-4e1a058d3a08"
   },
-  "createdDate" : "1998-09-01T16:25:30.255Z",
-  "modifiedDate" : "1981-07-08T03:28:32.626Z",
-  "publishedDate" : "2022-01-21T04:34:49.285Z",
-  "indexedDate" : "2020-08-12T09:25:33.428Z",
-  "handle" : "https://www.example.org/c124e8a3-e80d-40aa-8851-3ec2faf9ebd3",
-  "doi" : "https://doi.org/10.1234/reprehenderit",
-  "link" : "https://www.example.org/b4018f70-7160-4098-b632-4cb2b6907997",
+  "createdDate" : "1986-10-19T07:41:22.367Z",
+  "modifiedDate" : "1988-03-08T02:32:23.947Z",
+  "publishedDate" : "2008-06-03T10:24:33.828Z",
+  "indexedDate" : "2018-11-01T12:06:26.563Z",
+  "handle" : "https://www.example.org/4058bc5a-cb5c-4894-96d9-72c5c6bdd115",
+  "doi" : "https://doi.org/10.1234/ducimus",
+  "link" : "https://www.example.org/21753189-7259-4ad4-ac7e-5794695bcc03",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "87H8t1nlTaPL9O",
+    "mainTitle" : "IWfTX3DaSrY79Zvm9Wx",
     "alternativeTitles" : {
-      "es" : "A8fdk83SUR"
+      "de" : "mAOMedgvVPXrTCM9BN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "WRcI5UBvc4",
-      "month" : "O4NCfvn4i6",
-      "day" : "4cj3jaYyuNNj"
+      "year" : "XCEc878I1ZTlHG",
+      "month" : "Cr4F54Vx6hjH3w",
+      "day" : "z3NJF1WABBGIs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8061aec9-9a18-4efd-9c61-5203c9751132",
-        "name" : "71bcc3gsz5LtQOCmQkD",
-        "nameType" : "Personal",
-        "orcId" : "vOAaDE4cF2KNM",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d521484b-c92e-45f6-b0ba-a7bb12884e0e",
+        "name" : "PZszpmavX2vup4L",
+        "nameType" : "Organizational",
+        "orcId" : "ZkDnHGBBxMSo3O",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pKyzoC9TFd0Gkf9C51v",
-          "value" : "RId1Aj0SDv1yqM"
+          "sourceName" : "wVchBgiRF43jL",
+          "value" : "boN1e9pwf1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xFMVRwb9kdDQ",
-          "value" : "V03vUC5DAeV5z"
+          "sourceName" : "6e5FLqMdEM1OuaChM",
+          "value" : "RBR5VSGPBhxuSAW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3333dd11-ddd0-4626-ac73-56b651f688c7"
+        "id" : "https://www.example.org/ecda57c0-a69a-4026-be1f-c6a985ead6bb"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "NQn7QwzIvtZHhkF3"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,169 +62,169 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/88e71145-5ed4-48ef-9b05-06e06dbdf8e7",
-        "name" : "kn4ZRCWP74",
+        "id" : "https://www.example.org/a18436e7-f805-4358-8751-28154c1ab2c5",
+        "name" : "2Qys09eQ92",
         "nameType" : "Organizational",
-        "orcId" : "7EUGGVSCNN65IouYxM",
-        "verificationStatus" : "Verified",
+        "orcId" : "bZ1DQ4Pno2YHhCQPp",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IXdVhZVN2yEldRf5zm",
-          "value" : "30IP7gaz4QIdLNNWL"
+          "sourceName" : "KWc33CsGtA5ifLIZq",
+          "value" : "CqNFwXaLL20DSY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VZdW9suN0kQ",
-          "value" : "JHo9ToBrmxkqFfuf69"
+          "sourceName" : "pU5m79BAETiy",
+          "value" : "pvLjrWAqKM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3a11e878-65f4-4048-a11e-4ffc0c4d403f"
+        "id" : "https://www.example.org/175d8ebb-c310-40f6-82e2-a6429557b0b5"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "gY7GihCbkPokaFAh"
+      "fi" : "2jWezuwQCZHatRbqJy5"
     },
-    "npiSubjectHeading" : "l29dkcWgE4UBoJgIS",
-    "tags" : [ "Ef66KQ3nve7DZhCPLn" ],
-    "description" : "oSbkiHGb57E1y4IUvGg",
+    "npiSubjectHeading" : "QZwR0AwZJmZHb",
+    "tags" : [ "BysV7ujObj" ],
+    "description" : "0TPCLoMBnYRSh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/460c835c-f43b-49c4-ac7d-94f055bd77ff",
+      "doi" : "https://www.example.org/6ac6c78e-f23f-4f37-8197-030f632e2218",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
           "type" : "PerformingArtsOther",
-          "description" : "bR1pmbk9jaULed"
+          "description" : "YTMlp1Ui0iSTcT6uE"
         },
-        "description" : "KpsVOhzuTCOGqqZuff",
+        "description" : "hwpcDIPOimz6rw",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "KvrqbPuVQvTQICT",
-            "country" : "Ijsf230erHrKemFZs"
+            "label" : "515IEedPcYnio",
+            "country" : "4Uw5q7X76n1eTAgil4X"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2021-09-03T15:34:02.704Z",
-            "to" : "2023-01-31T07:56:45.584Z"
+            "from" : "2005-02-12T10:23:39.694Z",
+            "to" : "2015-08-03T01:08:24.554Z"
           },
-          "sequence" : 1758236650
+          "sequence" : 607467912
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9757ab4a-2770-4416-b4b9-ad8a7b679fc8",
-    "abstract" : "k1C6MsS3am85LHizM"
+    "metadataSource" : "https://www.example.org/9c3ca96e-5b1e-462e-a486-4f3ef686312d",
+    "abstract" : "femv2MfLMuUy233I"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9c22475b-5a14-42fb-8c3b-7e84491a9165",
-    "name" : "6y7H7FQOV0vI",
+    "id" : "https://www.example.org/3ae23ff9-94c5-4b3a-950c-6f23540f52ed",
+    "name" : "gSknRS1XZLcDgwU7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-04-03T04:32:01.902Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "7vxJIhbJYUdVUi"
+      "approvalDate" : "1972-06-02T08:18:03.621Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "LBg9X2iLqy9Sy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b7b7a4bd-25c1-4a0e-b253-2bfc0ba44243",
-    "identifier" : "1Vh3JhQoRkt6J0m56",
+    "source" : "https://www.example.org/c87d81b8-53b7-4d08-8f71-34fadfdebe11",
+    "identifier" : "sSWewzfy49O",
     "labels" : {
-      "pl" : "Szv1UyaFqKjW1itqI"
+      "ru" : "D2rJBA568MJ2LJZO"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1964652705
+      "amount" : 22673562
     },
-    "activeFrom" : "2021-03-03T09:16:04.685Z",
-    "activeTo" : "2024-05-22T15:47:36.169Z"
+    "activeFrom" : "1997-05-29T10:23:36.591Z",
+    "activeTo" : "2015-07-30T18:30:30.626Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/98708586-c6ab-45f4-a356-90f4a4ddf9c6",
-    "id" : "https://www.example.org/d0c41b77-364c-4a87-a6be-44cec4d8e732",
-    "identifier" : "1ZVHXE3YHn2FGl",
+    "source" : "https://www.example.org/33130e74-f9e4-44f7-a16a-53c387a248be",
+    "id" : "https://www.example.org/821f4745-00af-479a-8e6b-cf7ee01ad0de",
+    "identifier" : "mHLIUAfjYhR6nX1",
     "labels" : {
-      "se" : "Hfu4HMbKkq"
+      "el" : "eQJttyDGIeVSl"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 394543317
+      "amount" : 1467201223
     },
-    "activeFrom" : "1980-03-31T18:41:11.758Z",
-    "activeTo" : "2004-12-21T17:58:01.473Z"
+    "activeFrom" : "1976-10-27T18:58:19.526Z",
+    "activeTo" : "1985-04-11T02:53:19.241Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/24945bb7-28a2-4d92-a5ca-6539ea13c28c",
+    "sourceName" : "ezgyojnfnkcq4aexj@lqvtlrf0tsdznilujv1"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "1244334808",
-    "sourceName" : "i1uupfzxh0y@ssesvwskwpbt"
+    "value" : "1921111480",
+    "sourceName" : "m2ducxtkrm4@ctraj4te1oxuh"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "iNJuCKx9MMy",
-    "value" : "4DuvKZXzD61U"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e9160874-3a74-4128-8f56-7a3aa878595d",
-    "sourceName" : "cjwlewqxnu2r6@4tyuiaknotzobw3ghx"
+    "sourceName" : "Z1J1OLJGIKhAmnh85",
+    "value" : "wnsDMPAc0v"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "H78JpY1u1Bme",
-    "sourceName" : "glo6bjyptj4@pjkkfl5nwjg9xofw"
+    "value" : "nMrugjBlh668S7A",
+    "sourceName" : "jb4bkuy3dyz@uzx9eq76fu"
   } ],
-  "subjects" : [ "https://www.example.org/c7b17857-ab54-44ee-8451-ff63b36d7c29" ],
+  "subjects" : [ "https://www.example.org/b800a55f-97c4-4590-b047-be90f7fa96c3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "426ce734-6579-4eca-ac71-fe1faa54a2b1",
-    "name" : "YYED6WUifNUPcCEV",
-    "mimeType" : "YxX1jcOtSCIRm",
-    "size" : 1751022751,
-    "license" : "https://www.example.com/qrqx0cz6sv",
+    "identifier" : "9510d135-4838-4cc8-8835-12349f155345",
+    "name" : "Tz9PwD6grs0Juio",
+    "mimeType" : "7besGzj1Yb",
+    "size" : 1266261103,
+    "license" : "https://www.example.com/7do9swhdgabdyx7nrpw",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "WjxNCXLN9s",
-    "publishedDate" : "2008-12-24T07:49:00.545Z",
+    "legalNote" : "nxbbXrVKmEDRc23GWl4",
+    "publishedDate" : "1998-06-20T16:00:45.289Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "hBvcAsE6MiH",
-      "uploadedDate" : "1972-03-13T16:03:10.430Z"
+      "uploadedBy" : "cA3Zq365xQLcQRmR",
+      "uploadedDate" : "2014-11-30T22:03:21.739Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/yJI7RB5pec8vtWb",
-    "name" : "WrpvewuiXfecd",
-    "description" : "b0YMJc6yglK"
+    "id" : "https://www.example.com/9AOG47KxoF28",
+    "name" : "S7xreA8mANweM",
+    "description" : "Ho4rtVXCnlU0Jtp"
   } ],
-  "rightsHolder" : "yYtRBXIqnYq",
-  "duplicateOf" : "https://www.example.org/9b1ac109-e670-4566-84f9-882e993f8fec",
+  "rightsHolder" : "DB62N8G8QeBIP8",
+  "duplicateOf" : "https://www.example.org/21821b34-7963-435b-82ee-a616e63497b4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xMfGdku5ltqO9U"
+    "note" : "ZF61CfM7sPEhhKG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Xy1zqXGRKlfsPHeN",
-    "createdBy" : "QNEwp3N308jv1r8",
-    "createdDate" : "2010-09-12T11:19:27.686Z"
+    "note" : "jMeI4JmIsnRRkZep",
+    "createdBy" : "jFOLJ6lQyjs9Txedj",
+    "createdDate" : "1986-06-26T18:30:09.147Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/20dde468-ecb6-48a2-ad44-86a7c6ad9212" ],
+  "curatingInstitutions" : [ "https://www.example.org/3933d57b-c4ae-4111-be2c-629148029416" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "5CbEZpgpTJgSCVw",
-    "ownerAffiliation" : "https://www.example.org/47cad8b4-234f-405e-b321-f43b3cc7e6dd"
+    "owner" : "bqwVAelh99k",
+    "ownerAffiliation" : "https://www.example.org/a5ab411e-9e86-4590-b978-bc0a9ac312ac"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8b4869b3-7541-40eb-9a30-464ad7e22019"
+    "id" : "https://www.example.org/0e509157-4124-4b13-97d2-41b8246b6d26"
   },
-  "createdDate" : "2007-11-23T16:05:23.978Z",
-  "modifiedDate" : "1993-11-29T20:15:59.691Z",
-  "publishedDate" : "2014-03-21T11:45:17.018Z",
-  "indexedDate" : "2019-07-20T10:06:06.298Z",
-  "handle" : "https://www.example.org/382a2468-3a33-4991-ac53-d28ecf59b94f",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/1883efe0-d0e3-4f11-9178-14348dd1e0d7",
+  "createdDate" : "1994-02-15T18:54:41.283Z",
+  "modifiedDate" : "1994-09-17T09:20:00.577Z",
+  "publishedDate" : "1973-07-27T02:11:47.076Z",
+  "indexedDate" : "2022-11-18T17:18:10.745Z",
+  "handle" : "https://www.example.org/a485ce50-6cbd-4add-8bc8-1668548aa95e",
+  "doi" : "https://doi.org/10.1234/odit",
+  "link" : "https://www.example.org/a236768f-06fe-431a-90e9-b221a6162112",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "62qW6KQhc9VRc",
+    "mainTitle" : "iwZmxj5EY2gW55CiuV",
     "alternativeTitles" : {
-      "es" : "PzC6vQsVl5ahAU"
+      "af" : "Cd1T8Su4kMhLg"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qJtdLH79nAVVFn2g7WN",
-      "month" : "htMn5qLzEHzWIS6",
-      "day" : "joKeXcYa7Qd"
+      "year" : "6vzygM6d4SiNNzF23W",
+      "month" : "QmlNWd5ovLEBg7w",
+      "day" : "N9LnzzAlXujpX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eeb98d52-3a02-48cb-92f7-64f8568a0d54",
-        "name" : "8kB4pNVf5qLbaX0wFQC",
-        "nameType" : "Organizational",
-        "orcId" : "gBWCxPBCdzVXdd",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2aaeb949-e4e6-4f58-9249-fcfec2737c59",
+        "name" : "IKdh00Ezo5nr1dx",
+        "nameType" : "Personal",
+        "orcId" : "xWsQZTS2YK",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nyzYqqww6OIxd3qD",
-          "value" : "AFspklIPqwIL"
+          "sourceName" : "cdXyfq8e3hSM8LZiqU1",
+          "value" : "DVwVOubhag"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "X33uOnHylGMhQmZTjY0",
-          "value" : "BPQ7MbzTWw1JLx"
+          "sourceName" : "zFaUhz5ZJ7k",
+          "value" : "QDTz5beCDH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8cd87efb-4b0a-4bd2-b796-3fe2ef898168"
+        "id" : "https://www.example.org/f47fc3cc-1c9a-4c2d-abef-681c24eb3ed5"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "Editor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c07a0c07-4931-4e30-8ce5-9f4ad4e0c5d3",
-        "name" : "TVXohOmiDByWkf",
+        "id" : "https://www.example.org/80eb459d-fffa-48a3-a7f6-56b571dad549",
+        "name" : "i8DImhhGlHHOg4j",
         "nameType" : "Organizational",
-        "orcId" : "0NT3OuCmqyQvqinJ2n9",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "j5NoYbhfI2",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IlH9IfFgkrz2Qq6NH",
-          "value" : "FtnuLP0KcwM2KLw7Jg7"
+          "sourceName" : "C2JFH7jPTGHs2COTGu",
+          "value" : "Pf91kzr8fUQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OsnsgHRzeR2CbeHr5EE",
-          "value" : "VLYl7IF6vcN76KeyH"
+          "sourceName" : "sDKtOk2pyhMQBz",
+          "value" : "Bg5bhjqQovB0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1a51df12-d01b-4526-8fb0-9a549f778529"
+        "id" : "https://www.example.org/a379cf22-3f78-4d1d-8fd6-4e8763818231"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "75m9NTOsVljweZsN5g"
+      "cs" : "4rjXwSquQC"
     },
-    "npiSubjectHeading" : "RJg0Ku58SXE2",
-    "tags" : [ "ewM8e8Kr5IDc5up" ],
-    "description" : "LsImKUgdaQ0JEi",
+    "npiSubjectHeading" : "QsEVeCxSqYjB",
+    "tags" : [ "iTNu92JobS55WLIlTN" ],
+    "description" : "GopaRaO7ELxdET",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/43f9e659-7b6b-4228-924c-b127098b59a8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2d22401b-3c3a-4946-a759-38b4bd9999ed"
       },
-      "doi" : "https://www.example.org/64a0b548-0586-4dcf-874c-c082f145694b",
+      "doi" : "https://www.example.org/82274e89-5a6f-43a1-af15-0bc2c18bd86b",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "qPh1ynF1sAo1BWppn",
-          "end" : "JC9QLNaSPngFID"
+          "begin" : "6NbuBuJBKVjySVKy",
+          "end" : "jeEG2uaExVoBH5PO8v"
         },
-        "volume" : "0oRYkVAFK3D8",
-        "issue" : "RSwATv2iwesGxVKp",
-        "articleNumber" : "RwThU6WdOinOabc"
+        "volume" : "AhorIE2Yku",
+        "issue" : "UjaYP6SqKY4kZcKv8hr",
+        "articleNumber" : "xwmtvHbXTPJfqV"
       }
     },
-    "metadataSource" : "https://www.example.org/f1bdb39b-9c57-48f0-81c2-ed1cc5cd6669",
-    "abstract" : "g0cCmspBtGDshaSoqY"
+    "metadataSource" : "https://www.example.org/9893b6bb-349f-4e36-bb00-e05b28e7590d",
+    "abstract" : "NqopTFZKIEG2NFp"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e773dff7-d17d-4fc9-b795-c5f37436e7fd",
-    "name" : "MZQcyOAz2tPYEuB",
+    "id" : "https://www.example.org/fd0d8481-6f54-4e51-bf6c-4b93c5196dc6",
+    "name" : "F5t6sASjH9xRUV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-08-26T15:25:45.464Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "7Txeh1S9QYLudvRDQW"
+      "approvalDate" : "2011-11-17T22:37:24.597Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "gsTKBF0JFjzT"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/32066789-da1d-4d59-acc3-cf2f66cc4b6a",
-    "identifier" : "3XfcUEqhDAfqZwEYn",
+    "source" : "https://www.example.org/66e84156-d388-4b99-b02e-08e0db0ed023",
+    "identifier" : "7g22atOr5wKIvWbh",
     "labels" : {
-      "sv" : "SRsK9ahfCsis"
+      "ca" : "Hz82aQ9QBFxo8"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 254924863
+      "currency" : "NOK",
+      "amount" : 2131995717
     },
-    "activeFrom" : "1986-06-10T06:15:06.310Z",
-    "activeTo" : "2005-06-20T09:08:46.661Z"
+    "activeFrom" : "1977-12-22T05:38:50.161Z",
+    "activeTo" : "1992-06-27T09:04:20.647Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/21390efc-943a-461e-872e-0b1c42e21ac2",
-    "id" : "https://www.example.org/b3c7ded2-30e8-4c2c-8166-7fed1120cef8",
-    "identifier" : "MJFD8Op0PF0kLD",
+    "source" : "https://www.example.org/ac483695-5c0f-444f-a4f5-d6dcb0c92d56",
+    "id" : "https://www.example.org/352f3202-3fd1-4040-950a-c926be7c8872",
+    "identifier" : "bZTtfj5IoDYMc4G",
     "labels" : {
-      "nl" : "Ldnx5Yo0kCRPdvN0As"
+      "fr" : "2Y9L0SCKEG0"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 721402520
+      "amount" : 996841016
     },
-    "activeFrom" : "2015-07-15T08:43:31.135Z",
-    "activeTo" : "2020-09-01T06:23:48.939Z"
+    "activeFrom" : "1991-02-03T07:38:48.756Z",
+    "activeTo" : "2022-06-25T19:18:57.361Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "27546860",
-    "sourceName" : "m0treqci83@korgxfnkqbf5zm29ub"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/405da645-0351-4b73-a7d7-94a26cb3ce3a",
-    "sourceName" : "z2k6kvmwhmb@cv8dextfroq0i"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "0kFEJlo5IrVda96b",
-    "sourceName" : "iyrc2ty8igjztgkh@3wyezwkkqejdotaqh"
+    "value" : "A7n1H6T1PKPEON",
+    "sourceName" : "jke4qtpjam8iza@1xdxwtwdbpofg62o"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "owCavwCMo8FqYb",
-    "value" : "8BuHzQcX7bCVBGnte"
+    "sourceName" : "Gq2C2lIGbhuxmBxG6",
+    "value" : "nlQZUW6jhe7UqD1y"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "845724941",
+    "sourceName" : "55xgkpq8zxpw@y5f6j8rpjm3xmsadobw"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/3d8051fc-bad3-4f06-929b-5d07646c37cd",
+    "sourceName" : "3ov4fjxwjo3j0r11c@fosk20df5qia1c7g"
   } ],
-  "subjects" : [ "https://www.example.org/9742cd75-b5f4-47db-8e72-45788ca9b21a" ],
+  "subjects" : [ "https://www.example.org/430f7617-dc56-49fe-9e2f-2af74409d677" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0fd77f03-2f65-4b05-902e-60058f3035f9",
-    "name" : "pMlsDAKzXzL6RhbbY",
-    "mimeType" : "rjDDVAUf6XViCkEamwb",
-    "size" : 316401608,
-    "license" : "https://www.example.com/ddvkqi40r27",
+    "identifier" : "4cd13ceb-90ed-41e1-8866-5cc536a59578",
+    "name" : "0B3YidjjJy2NB",
+    "mimeType" : "vrVPHhqrMEFE4DT",
+    "size" : 1795132437,
+    "license" : "https://www.example.com/minm1jaxse6xs",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "q8EDDJDxyrRNRdxSpZ2"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "BAxNve70zerFT",
-    "publishedDate" : "2010-04-08T15:32:00.106Z",
+    "legalNote" : "mRqK1koBzjTugVp",
+    "publishedDate" : "1988-10-02T05:33:03.347Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ajGbnnGoXKhtkJkt",
-      "uploadedDate" : "1977-11-24T19:16:24.681Z"
+      "uploadedBy" : "2WsMIyAEkNp",
+      "uploadedDate" : "1988-10-20T07:45:17.763Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/hfX73yYlqI69mLeQQ6",
-    "name" : "BPa8Ttebd2Wr",
-    "description" : "Xpt0grJWHuMMEeK"
+    "id" : "https://www.example.com/k7U9BiUtuKa",
+    "name" : "Fp5yr396pNBuMfdp",
+    "description" : "4v8QblHEtwL"
   } ],
-  "rightsHolder" : "tu8AUyd0dgDbTtoS",
-  "duplicateOf" : "https://www.example.org/f57b172c-1216-460a-b5ce-18634af6d2ca",
+  "rightsHolder" : "bJ7qox8ZO4B",
+  "duplicateOf" : "https://www.example.org/32f57391-6345-4065-9cef-558779c5d556",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "iwtPAuFVYn"
+    "note" : "YuBhqQOqgLso"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ZMBL2MFZNF",
-    "createdBy" : "YrY0iTc19EHW",
-    "createdDate" : "2019-05-30T22:38:09.826Z"
+    "note" : "jf3OLpJDT1gmUuQo",
+    "createdBy" : "948JejftWGBKAi",
+    "createdDate" : "2005-05-18T23:57:20.900Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b81ae46c-8261-47d4-ad5f-a42e6162de0d" ],
+  "curatingInstitutions" : [ "https://www.example.org/0d705e28-8b46-4b84-8802-6806f726d6b6" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "WGAeHiv3R8htwm4U",
-    "ownerAffiliation" : "https://www.example.org/812b4b70-e362-46aa-9791-fc2811b041b6"
+    "owner" : "iR7rySVzD4w",
+    "ownerAffiliation" : "https://www.example.org/ce6eae41-fa7c-49b8-afa8-0c8bc1e593f9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b07e7048-3da2-4cbe-be62-0f1b26a3ab4a"
+    "id" : "https://www.example.org/229af98b-938d-485d-8a5f-111ce8cf4639"
   },
-  "createdDate" : "1978-12-16T00:25:23.467Z",
-  "modifiedDate" : "1973-12-18T23:09:27.571Z",
-  "publishedDate" : "2009-07-13T06:12:16.388Z",
-  "indexedDate" : "2010-10-13T14:27:48.208Z",
-  "handle" : "https://www.example.org/2f0e0847-1ff1-4d80-966e-e26a8fea6389",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/8e72a1ac-5ebb-44fc-8124-887f1f184df0",
+  "createdDate" : "2007-05-01T14:40:40.542Z",
+  "modifiedDate" : "1992-12-10T20:06:49.759Z",
+  "publishedDate" : "2021-03-30T01:57:19.351Z",
+  "indexedDate" : "2020-03-12T06:29:38.842Z",
+  "handle" : "https://www.example.org/acba1949-c6f3-499c-b9da-992561e1e5f3",
+  "doi" : "https://doi.org/10.1234/odit",
+  "link" : "https://www.example.org/77b6c4ad-4eb1-4128-80bf-500b75675026",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xqIUclrbyGMmqPG8DU2",
+    "mainTitle" : "lVfpNxtQo0L8i",
     "alternativeTitles" : {
-      "el" : "sYZXX2E6Cy3j8Au9KMe"
+      "de" : "F6zQ5FhShJYKpbim"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "A1QBQHE5qvvgEzsZ3ca",
-      "month" : "b5r94ndq0DbOUgLU",
-      "day" : "bGS1LAh7e8dE7ECr1X"
+      "year" : "ZIUGcqNxl5QF",
+      "month" : "K1Vf8gENnfTFP7E4",
+      "day" : "K4z3u7TSATy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8595118c-a1cf-490d-93ea-130366cff6ca",
-        "name" : "ARckvfgeP1toZ8jL63",
-        "nameType" : "Organizational",
-        "orcId" : "jDrfjQp6Hd7WKi9mlB",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f18e364e-8748-461a-b7f8-f6ccc6b7d139",
+        "name" : "RvZAh956Osujsadujx",
+        "nameType" : "Personal",
+        "orcId" : "4UK8p42WumuP8XfLdF",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LBNzMg0vangOpy5yW",
-          "value" : "fKWmZ9jleEu2PgNpIe"
+          "sourceName" : "dnRgZVkF7LOugemLf",
+          "value" : "zT9kuze3B6Tq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9hhqddtocZ1vXoP8rr6",
-          "value" : "AfcoumK6fypl9xT4lW"
+          "sourceName" : "RgQcHJizmD55WiyA",
+          "value" : "qlX71VFzus"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c3101c12-70e3-4674-baa4-03811a64ffb9"
+        "id" : "https://www.example.org/be0bc9ef-0da7-429d-805b-cef5036f87b9"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/df8e948e-aa70-4e20-bc4f-e82fa0547a40",
-        "name" : "3Dz01W6VE9N8",
+        "id" : "https://www.example.org/c55ca614-f4a1-4ae6-856c-23df88751b76",
+        "name" : "pW5xfDlttC4g",
         "nameType" : "Organizational",
-        "orcId" : "JajqhgW2mS7boO",
+        "orcId" : "BKhfSJwW05jp910wutG",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "h90tF10wvYiwEnkf",
-          "value" : "JnRiuoYJHsgaAIaY5c"
+          "sourceName" : "aDLvZDRJx8",
+          "value" : "wco2dKanaHnc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2YmjxrO4ForiP",
-          "value" : "pmtxbg9bIyrBTqnYskN"
+          "sourceName" : "lHP4qtj9Fd3",
+          "value" : "c30Ft8FQRLbqBl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0c8d03d4-35e7-4337-a5ed-3c331a2922a2"
+        "id" : "https://www.example.org/0b5bd113-bbe7-4ab4-9b01-5ce5f026068b"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "KakG3rt8vroo"
+      "zh" : "mfNkwQ4pmVe7BOzw"
     },
-    "npiSubjectHeading" : "4NwknKtD7VSApewqec",
-    "tags" : [ "AsHl8oJazewGZO" ],
-    "description" : "mPJOADIU0JLrEadCY",
+    "npiSubjectHeading" : "7FoBCAH2uuA6gO",
+    "tags" : [ "kgIydSmBXy8" ],
+    "description" : "GA2zeE7KqmauPjee0Sv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/oyKoJDZL33HShhVQ"
+        "id" : "https://www.example.com/UO9etwdNRibbjG5TlZJ"
       },
-      "doi" : "https://www.example.org/c21f1063-db8d-40b1-b805-e86c628bcaa8",
+      "doi" : "https://www.example.org/d229c12e-54a7-4001-8fdf-5fbb306615f8",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "VVFFv7X2xEUYt",
-          "end" : "ay8eE5CQURtrRYuj"
+          "begin" : "OYyNjp4bhm",
+          "end" : "Hu4FqQ9jBUP7lV"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7250eeef-7ac0-41cb-aaba-5781ec8232ed",
-    "abstract" : "NIVD1sM7MVaqYf"
+    "metadataSource" : "https://www.example.org/180eb193-2cab-4499-9c0c-f4f01c7b1486",
+    "abstract" : "S3YmWAeiTKNSeA3wytA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1332dca5-b1f3-4d0d-b188-bc999525f070",
-    "name" : "WywnJBBSqxHjRlTknP",
+    "id" : "https://www.example.org/0e040973-5b69-4c0f-a257-66130bb16c42",
+    "name" : "MiW2hYFxh9U",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-08-04T06:20:24.146Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "d8BwBGKET73s7r1dj4Y"
+      "approvalDate" : "2022-04-07T10:16:55.745Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "5OcBcKaiVAqW2XXsSe"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1662ce8b-d290-4b26-bc5d-27c0ad184050",
-    "identifier" : "Jm7Hb92mbzf",
+    "source" : "https://www.example.org/ea4aa779-0421-43ce-a05b-69ac0ae47f60",
+    "identifier" : "gS4z0NPJGTekTR",
     "labels" : {
-      "ca" : "jVARvXwmPAjzk"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 38129711
-    },
-    "activeFrom" : "2014-08-14T15:12:38.081Z",
-    "activeTo" : "2020-11-21T16:15:43.048Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4c8f5fc8-0b5a-43b8-add4-0cf3dd64644e",
-    "id" : "https://www.example.org/f0134e3b-0efd-4f87-be5b-c84852f28ffb",
-    "identifier" : "9aFC7OXiPn3ML2cfSwn",
-    "labels" : {
-      "de" : "hyZBptwlPSBY2nItG"
+      "nn" : "5UED8xI2obDjXrp"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1611839673
+      "amount" : 1848442049
     },
-    "activeFrom" : "1976-12-21T17:58:42.655Z",
-    "activeTo" : "2008-07-05T15:40:15.202Z"
+    "activeFrom" : "1979-01-22T21:51:38.255Z",
+    "activeTo" : "2020-08-26T09:47:13.888Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/186fe41b-e59f-4cff-a4e8-b82354b8598c",
+    "id" : "https://www.example.org/e2d1bf56-a559-422d-8820-2b5527819ea9",
+    "identifier" : "fSxbENQBZNMT2but",
+    "labels" : {
+      "el" : "TXfVVEZy4PBCqfad6"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 647937004
+    },
+    "activeFrom" : "1978-05-26T04:42:42.496Z",
+    "activeTo" : "1998-02-14T10:31:10.049Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "4ZTRJ2pl6uA",
-    "value" : "Em4KVQ1vR0"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "381215364",
-    "sourceName" : "satmhpziksjnwia5c@2msrctsubwbvlv3e"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "6rmLmFeaIQp1zkI",
-    "sourceName" : "ojpv61jbzhxrcqg@aeov2cnsbxureyr1po"
+    "value" : "1711788878",
+    "sourceName" : "ma8tyuju8oy3@kglet9ounk1sha"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e8e10c3f-1a35-4223-a52d-d79374eddffa",
-    "sourceName" : "okvbufcgyij@aa2uzgwevjqldyj"
+    "value" : "https://www.example.org/e95150f3-c9f4-4511-8c6b-acd086ab76ed",
+    "sourceName" : "qtfbnacfkx@byihhdnkrpg"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "cI5XKDCaTp6AA5NJYP",
+    "sourceName" : "ifu1fumlafsp3n5z@i87cblcdzhuug"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "3n4ZyPPsJQnRqqqm",
+    "value" : "wgFSUPIC6Q"
   } ],
-  "subjects" : [ "https://www.example.org/c019eebc-df25-4d92-8d1c-24751795bc8f" ],
+  "subjects" : [ "https://www.example.org/6ef38d59-33ed-4e5f-8f24-f05e095cba5e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "485811fb-2e53-4780-b9fb-453767637569",
-    "name" : "XVK6tnnXFY3vKro",
-    "mimeType" : "11bBIkUqyPZwl",
-    "size" : 2116788933,
-    "license" : "https://www.example.com/mvnigwqrofz8qcvdvg",
+    "identifier" : "e35b8bb0-f512-4f46-ba3d-5e3bc060bc98",
+    "name" : "m1yNhi5YWGk9",
+    "mimeType" : "sIsPzSS9fQqVWCVLqIR",
+    "size" : 1953727669,
+    "license" : "https://www.example.com/1gykozjzwlv8",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "YACsQKAlIpU2pz",
-    "publishedDate" : "1984-05-09T11:43:54.529Z",
+    "legalNote" : "SnkGl3X8l0a0RmV",
+    "publishedDate" : "2000-09-23T16:46:01.928Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "SFsy3jAGPdm0C5TWQ",
-      "uploadedDate" : "1993-01-31T07:46:59.235Z"
+      "uploadedBy" : "ZgbyNNlpT9IV",
+      "uploadedDate" : "1981-06-07T14:18:07.385Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/s2AbGyukhZeRgpZXwM",
-    "name" : "av6XgOZ5cDYR2f",
-    "description" : "tsc46UnZsJRRWba1lmF"
+    "id" : "https://www.example.com/zdjArdfGr2zqh",
+    "name" : "IMDsZvYxIYmF",
+    "description" : "QMeJWwkfcIF6cyK7su"
   } ],
-  "rightsHolder" : "tA0ZDEZKyGVtDL3DO",
-  "duplicateOf" : "https://www.example.org/6b85c5d8-ec76-486c-a6b6-9427d2eca615",
+  "rightsHolder" : "q22DvnZFTZgjT",
+  "duplicateOf" : "https://www.example.org/c278f4d2-4791-4955-822f-b8bb544c32ef",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ezGFgQHekwZy"
+    "note" : "l4kjKjQj7pcHJ1Vh91Q"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "aCMtTenRBal5j",
-    "createdBy" : "xFOLCyo6cc",
-    "createdDate" : "2015-04-30T16:24:07.234Z"
+    "note" : "RzAb52gT23j",
+    "createdBy" : "OK7TbnOX2m5hVGTJ3",
+    "createdDate" : "2008-07-14T23:00:45.425Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/255122cb-0d6f-40da-b910-f28406f0390d" ],
+  "curatingInstitutions" : [ "https://www.example.org/dc885d10-8000-4547-9800-dd59124c00ef" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "q0hk2jcBE2wGgQ",
-    "ownerAffiliation" : "https://www.example.org/b9c72d01-b9ca-4fa8-a35e-bc125f2a329b"
+    "owner" : "zlKFMka8RnAlHcXzJOu",
+    "ownerAffiliation" : "https://www.example.org/1bcd5d47-8075-457d-81e7-158c250f270b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4d94070c-6f81-42fb-8d60-87fe9c667e7d"
+    "id" : "https://www.example.org/5bf91026-ef38-488e-aa45-52e62ec6dec2"
   },
-  "createdDate" : "1996-02-12T22:30:45.791Z",
-  "modifiedDate" : "2007-08-28T18:46:24.621Z",
-  "publishedDate" : "2012-06-21T20:45:17.823Z",
-  "indexedDate" : "2007-12-29T05:08:55.787Z",
-  "handle" : "https://www.example.org/bd330671-cf7c-4ccb-9ba1-7c4393fab1e0",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/8afdc1ba-e962-4dc2-a592-938b0bd3893d",
+  "createdDate" : "2018-03-19T21:45:06.376Z",
+  "modifiedDate" : "2013-06-15T00:59:47.465Z",
+  "publishedDate" : "2023-11-03T17:51:15.579Z",
+  "indexedDate" : "1999-03-11T20:15:54.736Z",
+  "handle" : "https://www.example.org/78ed9e45-fed4-4a41-8e3b-9c2facb4993f",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/e527d2a0-70fd-4559-9bfa-9ccbe445febb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "77CLoa63Sg8D",
+    "mainTitle" : "w4WUgj8pTIxEx",
     "alternativeTitles" : {
-      "sv" : "5zBFkxdqOxY2"
+      "es" : "VemrVCW7cP7"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "E2ICpqR5bqgoNkWE",
-      "month" : "TlGt3zgfuXBxzog",
-      "day" : "08EDui0Qatq2LyCIdXo"
+      "year" : "oymMsAgEWFEF",
+      "month" : "ovJa1AVGxaeH8",
+      "day" : "jb4pOa5x6Tl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c91a69b6-0693-416d-857d-cb7737e48b60",
-        "name" : "wJhbetJgi5dgucNF",
+        "id" : "https://www.example.org/742ac6bf-d560-48f8-896f-6ce987189273",
+        "name" : "4GXKpUuygZXcef",
         "nameType" : "Organizational",
-        "orcId" : "siu1avy0en7z",
+        "orcId" : "ieZPUTzYh03HextK",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iprqyAfjxRns19",
-          "value" : "Rn8eP1Ee00E"
+          "sourceName" : "quaTEXg8vOh",
+          "value" : "TRunWVoANqABplY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t8MH7tcDURWzycu3IKP",
-          "value" : "4vnzOkfzbrYOYMofDS"
+          "sourceName" : "8NTwRaOgVZHTrSIC",
+          "value" : "1D84sbLovPLaQajO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/90874a04-5dc3-4ef2-8c21-2343c4757182"
+        "id" : "https://www.example.org/cc047f01-5727-4006-a355-da80edb042fc"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0f4646ee-0fad-4c76-8a34-f6e156f2f89b",
-        "name" : "yjfAJIXoE2Nn",
-        "nameType" : "Personal",
-        "orcId" : "kgXghSOQzltBIE",
+        "id" : "https://www.example.org/91d65b6e-c135-4232-ac15-5d2542455fd8",
+        "name" : "eyVa7XfehPjGAMUb",
+        "nameType" : "Organizational",
+        "orcId" : "TP1c89O3tMJgPM6SvU",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MXVu9cp0lMZHwQRWZ2",
-          "value" : "5mVI4Wc8YdjHb6dWPyi"
+          "sourceName" : "dMTfk2wQjsJXl5D6ztE",
+          "value" : "7OBRqebyYlIF02vGK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ky0TWjLjCvd5mARBNeQ",
-          "value" : "SGPXWi2QK8Xs"
+          "sourceName" : "ePlOlqV2Yt7Fnk1WM",
+          "value" : "RYDkhTxFneMwiUV3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1e495a68-0110-4505-a91b-21722e79af2e"
+        "id" : "https://www.example.org/b89d7467-af5c-416f-834c-fe4c64728748"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "lEX4GRRloeb"
+      "es" : "O0li0XJaV2W3Q"
     },
-    "npiSubjectHeading" : "mrrCGLAn8Gl6sTbT",
-    "tags" : [ "lslFk7J4yG1B" ],
-    "description" : "M57pJcYrrS",
+    "npiSubjectHeading" : "w33hiQfPaPD9",
+    "tags" : [ "Mnfx1i9Ium" ],
+    "description" : "1OxrqUKzJlC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c484a3de-3ea6-4bb8-8965-19c90655f73e"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7a322a31-4ee9-43b8-9963-8f913e269492"
         },
-        "seriesNumber" : "TGcgQ6D0iaiqODf",
+        "seriesNumber" : "x63uXGGZtfhnmu5TQdW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0c614053-2939-4b6a-82d7-e8fae7260073",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0bf954d7-64da-488c-8076-6af603e0299e",
           "valid" : true
         },
-        "isbnList" : [ "9791075359674", "9780947366780" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9780871118271", "9781927240939" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0947366784"
+          "value" : "192724093X"
         } ]
       },
-      "doi" : "https://www.example.org/925a57e1-7691-4bfa-9b02-56139841426c",
+      "doi" : "https://www.example.org/e22c422f-688a-4116-9562-2ba1ef576635",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "EejnjVQafajJ0BV3z",
-            "end" : "pjVN74jUw9P"
+            "begin" : "3upZ0ATqVF89VVNmwmu",
+            "end" : "uiiznMzgFH"
           },
-          "pages" : "t7tzuECLsoeJ",
+          "pages" : "SziWZuO3dNBpRy8T",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ecbc5f43-3b3f-4fe7-8295-75a09fac81df",
-    "abstract" : "YBfC475ky1M"
+    "metadataSource" : "https://www.example.org/1cdd02dd-f87e-4cb0-ad07-893ac4f0efa5",
+    "abstract" : "ywfxRG46wd21DCO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5d256000-0d8f-4b58-8c1b-b40ba708c32e",
-    "name" : "cz1CW8xOgPI9rF",
+    "id" : "https://www.example.org/cacf2c14-afb7-4a60-9c56-8f55c93e87ed",
+    "name" : "p4eboOuktJUy1Q",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-11-25T20:02:38.448Z",
+      "approvalDate" : "2010-05-02T20:25:00.026Z",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "RelM9BBDwxSRa"
+      "applicationCode" : "FmoR0WrgjaciVg9kbXv"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dc581f5d-4a51-4ae4-b881-0943e1c8f673",
-    "identifier" : "hXEYewnO5tLKkxdW",
+    "source" : "https://www.example.org/fe656d92-5d6c-459d-a0a6-54d827279f25",
+    "identifier" : "cQGUVqXm3YryYIlfDB",
     "labels" : {
-      "hu" : "PKnOdJyxiCn3R2S"
+      "ca" : "lpPGNMJbeadghKnl0D"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2108536325
+      "currency" : "EUR",
+      "amount" : 274975206
     },
-    "activeFrom" : "2013-09-16T10:51:08.870Z",
-    "activeTo" : "2022-02-15T08:03:52.677Z"
+    "activeFrom" : "2000-08-17T15:29:20.822Z",
+    "activeTo" : "2007-10-25T12:15:25.800Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8ee790db-beba-40cd-b39e-164e9c8f2e44",
-    "id" : "https://www.example.org/5d43c9c5-f598-48a7-aa24-e94dac6cc1b0",
-    "identifier" : "PEhcKWG8EQ",
+    "source" : "https://www.example.org/46631d85-7550-4d50-9345-2efc20dabe65",
+    "id" : "https://www.example.org/aecca499-5915-4122-999f-5d9b8fad0ce1",
+    "identifier" : "vcDpkEwHTqjAn",
     "labels" : {
-      "hu" : "bi3Pse9kZanQ"
+      "ru" : "NXLsfhBh5emtK7354"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 333766770
+      "currency" : "EUR",
+      "amount" : 1034344354
     },
-    "activeFrom" : "1975-09-20T23:07:36.516Z",
-    "activeTo" : "2004-06-17T02:35:36.432Z"
+    "activeFrom" : "2017-08-18T11:02:07.483Z",
+    "activeTo" : "2021-03-01T07:21:37.757Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/16a1df18-45c3-4aa5-8873-8df06cd2fd45",
-    "sourceName" : "9ylypndozmbh1i@fo5nlidmnq"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1416706247",
-    "sourceName" : "qgzefujtbm6heiop5f@1tzchn70q3"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "NDQ2hHWVagLc2E",
-    "sourceName" : "ebccefteywxkd2rb3z@xvvqjfojwuqoza"
+    "value" : "VCovFU0shEr9eul",
+    "sourceName" : "ud22zaxtpjxzwtt3j@6mpqb4tnkelzprp"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "cbEri7ckRj8c4k",
-    "value" : "rP0iI1ZS1gadpTmX"
+    "sourceName" : "G54XV42jKsvCBpJ",
+    "value" : "kJUamEF3iEh4v"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/f50308e7-80de-462e-a0a1-05a0edc22f67",
+    "sourceName" : "m1iofkpugt66@rcthln8gfyxf4g3sq"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1562207794",
+    "sourceName" : "8feuqbtgurfcoqo7@xhrta8f99tzc9so"
   } ],
-  "subjects" : [ "https://www.example.org/10269be3-2f50-4751-9c64-7242544bd995" ],
+  "subjects" : [ "https://www.example.org/bb7c0eb7-0b8f-40fe-9fa1-315a98ecdb77" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a0e7c4da-b1f1-4e46-b3e7-ce93b6c04c4d",
-    "name" : "i2LbCp3jYDPp0",
-    "mimeType" : "10E90QRnEJZi",
-    "size" : 2102181124,
-    "license" : "https://www.example.com/faewpiruzloddnyu",
+    "identifier" : "f61fbc6f-9bfe-4c2f-b053-7f0faabb3186",
+    "name" : "NoOUH97gnSr5",
+    "mimeType" : "Xar0NbX9padi8hKccl",
+    "size" : 1550275508,
+    "license" : "https://www.example.com/nspqbz1fgs",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vxpatT6qj3G",
-    "publishedDate" : "1999-07-20T14:05:24.638Z",
+    "legalNote" : "ERjGHnFkVYWmtBx",
+    "publishedDate" : "2013-04-27T18:48:37.960Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "pt5qg8Zbng1allb",
-      "uploadedDate" : "2012-02-25T00:21:31.313Z"
+      "uploadedBy" : "ZpnnE3M2OyCH",
+      "uploadedDate" : "1996-10-11T23:11:45.562Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Qdax0KD6F4",
-    "name" : "6LM3s4xralLma10",
-    "description" : "WktTxqTfvGbhP"
+    "id" : "https://www.example.com/kBUSdxM0JMPdxwle5",
+    "name" : "jJ1r6AdsVzR1jIz2",
+    "description" : "iXEcs6J23cEhTIhvx"
   } ],
-  "rightsHolder" : "TLCGEaNU4xWfjwCsor1",
-  "duplicateOf" : "https://www.example.org/af8433eb-35d4-48f8-8e93-5869b6f096cc",
+  "rightsHolder" : "3JArfkoOWyB",
+  "duplicateOf" : "https://www.example.org/12ce140f-0198-4723-b436-887440f87e74",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "hPdgtJ34Ck"
+    "note" : "HKtgsmfgBzVCfafZag"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kW7BOCofCX08DoNxQ",
-    "createdBy" : "1jnyACfzjvDQdz",
-    "createdDate" : "1990-04-14T00:21:17.225Z"
+    "note" : "bQRJAzdLMbau",
+    "createdBy" : "Um7Uj8lx4rl3dFhy0AF",
+    "createdDate" : "2020-07-20T04:02:21.286Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/43e0eaff-d226-4d38-b30a-92db5eece7db" ],
+  "curatingInstitutions" : [ "https://www.example.org/e13e0b38-ccdd-42d4-ba3d-981238063e55" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "4lEdyx2m1evFZ",
-    "ownerAffiliation" : "https://www.example.org/f3d470e0-5f1b-44c2-a8cb-b719e21f6eba"
+    "owner" : "MNABkojxlhU7Dw",
+    "ownerAffiliation" : "https://www.example.org/d3c5d4fb-bab9-449f-a7f3-916f7400e7d7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8404fa5a-2c6c-4447-8e46-f95764fdb538"
+    "id" : "https://www.example.org/552791a3-aff5-4ba0-85e9-e1fd0ff4c95c"
   },
-  "createdDate" : "2018-10-06T10:58:40.095Z",
-  "modifiedDate" : "2024-03-30T00:48:31.137Z",
-  "publishedDate" : "1984-10-08T19:16:25.917Z",
-  "indexedDate" : "1977-08-11T05:10:43.133Z",
-  "handle" : "https://www.example.org/236f7b24-2abe-4507-b0f8-8db14b6e9cfe",
-  "doi" : "https://doi.org/10.1234/vero",
-  "link" : "https://www.example.org/9ef78591-1469-481e-84c6-67316fa841f1",
+  "createdDate" : "2009-09-27T17:22:08.143Z",
+  "modifiedDate" : "1994-01-15T12:12:18.453Z",
+  "publishedDate" : "2000-06-20T01:50:53.484Z",
+  "indexedDate" : "1998-03-12T08:58:03.756Z",
+  "handle" : "https://www.example.org/568b00ca-b3ff-4fc3-9169-1387688b68a6",
+  "doi" : "https://doi.org/10.1234/labore",
+  "link" : "https://www.example.org/8208a991-d062-4061-a4fc-266a99236d6e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "W2obVPFMdu",
+    "mainTitle" : "mUk8w0g8VRopCZTGD",
     "alternativeTitles" : {
-      "ca" : "sIwMF7EydsqE"
+      "de" : "zRZlHlnCZ7DpyrrCZ0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "b32JfBGYxwUfCcmysms",
-      "month" : "8U9TeoQhGFs",
-      "day" : "DolnIpyDiRbeUTB"
+      "year" : "ul5qPCF2Rt",
+      "month" : "uulrd2mK9LBzNi",
+      "day" : "O9wYX4OYt4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7b7cc4c6-f85c-4791-8967-57694ca669aa",
-        "name" : "YykF1r9jBu",
-        "nameType" : "Organizational",
-        "orcId" : "rc02c7ASKvdy",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/103717e7-867c-4f88-9b6f-753220fa14a0",
+        "name" : "A0VazUOvar5tqhk",
+        "nameType" : "Personal",
+        "orcId" : "clpg925zT8CTBqFJ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m1paqmgV460lNYkUrh",
-          "value" : "12YkxX8KdMnM"
+          "sourceName" : "GH0VjLNxMGQ1RlMapMy",
+          "value" : "7SxXW4Tv18AFr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "epwJTZ7FKLr6Ud",
-          "value" : "Xd5JiddEXNxNz3BbUL"
+          "sourceName" : "SPAqnWuuFe0aPZLQsE",
+          "value" : "WPVrED9pF8JkL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8dc682e2-9b16-44a1-b3ae-72d35fda95b9"
+        "id" : "https://www.example.org/a7a586ac-90ed-4ef0-8824-5bb6bbbc3d8d"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8ce9df53-640a-46bd-a75c-0b66c6ac93f7",
-        "name" : "XTzH18LsfvHO",
-        "nameType" : "Personal",
-        "orcId" : "BKdUVvOkch0",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a6790ee3-9a65-4bec-ab44-9073f57b432d",
+        "name" : "OvXGGGwXFQ3xEvhy",
+        "nameType" : "Organizational",
+        "orcId" : "tPjz9meBsBqLC",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CvdXmfH0iioQ9sihSBM",
-          "value" : "vjD8gemlGF"
+          "sourceName" : "rIG9DlIYxuy9Zq",
+          "value" : "JImeXyYdUB2j7HAgEVr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XQIoQKc3EoOr3OGKe",
-          "value" : "8WdWBe7taDSrUDgEn"
+          "sourceName" : "7a8EanmIHJLkjlPOr",
+          "value" : "CcJLRjBYZ6vq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a56b3df-9aee-4a9c-835b-b84dec335828"
+        "id" : "https://www.example.org/1d406865-6660-4fc0-ac14-4346c6f20bf7"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "Nsn7Uhc1mFt"
+      "is" : "7D5mnpAjkoSotcgZoO"
     },
-    "npiSubjectHeading" : "Lls8lF3WO2",
-    "tags" : [ "sqKHaBrTAmARNha" ],
-    "description" : "YyBa1NwN8q3cNZEtFR",
+    "npiSubjectHeading" : "muQmAtiyt5c4orIQy5",
+    "tags" : [ "9MyeDhFAlqICiCCfs" ],
+    "description" : "aSgnUBz26RQKly1XOjD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/42095018-46f8-44ff-b303-af45d3eff64b"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b8601f6d-e1ee-49db-9f91-04266b557d1e"
       },
-      "doi" : "https://www.example.org/781353d1-7bfa-4f43-9f59-1b41e99cb6c3",
+      "doi" : "https://www.example.org/8d1b35ac-6b30-4ebf-93f8-dd290d2f5a4d",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "A6lYaYqYdwXthI",
-          "end" : "enmXTblErzemlP3Yd4f"
+          "begin" : "07YYUzzBJWRrG",
+          "end" : "2gKIbeV4uVCedqS5W7"
         },
-        "volume" : "ebrRhlzhfx8EjzUof",
-        "issue" : "dO04wbX1Cw6ZH5mV",
-        "articleNumber" : "JvLNaFrWbaUGsT9t02"
+        "volume" : "Ip8ursj79D779E",
+        "issue" : "V7vvvqXkqljmRrMr",
+        "articleNumber" : "QM2gLFCoRmuI"
       }
     },
-    "metadataSource" : "https://www.example.org/c0555aff-f3c4-4cb4-b912-f7f1e4803adc",
-    "abstract" : "welMeP3gfvE54p"
+    "metadataSource" : "https://www.example.org/08b538ee-fd90-47ca-933a-736420d78fc2",
+    "abstract" : "fDcojdoyFdfcvy4"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a93b16e4-5a99-499b-afd1-56d5e0052b53",
-    "name" : "V1IYkVcG2ab",
+    "id" : "https://www.example.org/8b817ea1-a817-42e2-85eb-2fb78731bccb",
+    "name" : "ZDnM1pNrx9CaaxT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-09-23T08:37:26.597Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "gqwu7gDMqG"
+      "approvalDate" : "1990-02-24T19:55:48.556Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "9UfhpkAF2s"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9f1df273-1c99-4c9b-b04c-718d2e85e7fc",
-    "identifier" : "gtKcCKqeSK",
+    "source" : "https://www.example.org/d7d85052-b483-4162-9b36-7d1956b916e9",
+    "identifier" : "u2CzZSi12inq0HJ",
     "labels" : {
-      "bg" : "xJizkwfyki"
+      "zh" : "fJoRFNSTPOr"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1150031046
+      "currency" : "GBP",
+      "amount" : 1697076567
     },
-    "activeFrom" : "1973-09-14T00:48:23.259Z",
-    "activeTo" : "1993-02-02T02:37:08.307Z"
+    "activeFrom" : "2019-12-31T05:33:56.883Z",
+    "activeTo" : "2022-03-10T13:07:15.580Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e14a415c-2f8f-4d70-becc-362b4f8593c2",
-    "id" : "https://www.example.org/09070f5e-d9d2-434e-bae6-af38d216565e",
-    "identifier" : "A6ZuGnFBNeCKbE",
+    "source" : "https://www.example.org/c73526c6-7698-416c-8fbc-50ac0b84f0e5",
+    "id" : "https://www.example.org/a7e703d0-998e-4abc-8b28-7c67137f46d2",
+    "identifier" : "CmQwBbMG0Qlu6I",
     "labels" : {
-      "se" : "orO2XLUCWyvlPBpr"
+      "bg" : "Si6eWvDww5Pj0uhN0vI"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 919909119
+      "currency" : "NOK",
+      "amount" : 1884952325
     },
-    "activeFrom" : "2016-12-07T23:36:16.293Z",
-    "activeTo" : "2019-04-24T16:39:41.914Z"
+    "activeFrom" : "1983-07-28T19:16:57.432Z",
+    "activeTo" : "1996-04-17T22:21:04.800Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e327cafc-87c8-4709-9da4-b1d7c0ec13b3",
-    "sourceName" : "okgly7viut@46ifxsh9vo46"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "9rK5V3FcvmO9KD",
-    "sourceName" : "yvx2morsefwwvc@355ng7gcalgd"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "7IVNhpxq0blB52HzP",
+    "value" : "SHmOfjb6FqRECzY2Amw"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "767956090",
-    "sourceName" : "86eyqj1qajsbny@iwdqbb0we0"
+    "value" : "1673492468",
+    "sourceName" : "h1mb1t8dfv1@63sdmblgkibdf4u2"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "ihVo6Ln0OFqmVkd",
-    "value" : "zndtrZX3G6ZMw9A4MI"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/60ca81db-eae7-4cd3-b8b8-8643409b1862",
+    "sourceName" : "2yzprgyiqwr9eza3yiv@alfoywxngomfmq"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "PkkaCQCC2xgEU5UWkX",
+    "sourceName" : "fevuvi7yscg8@gkxwem9ei8grjf"
   } ],
-  "subjects" : [ "https://www.example.org/24422452-bd53-4aa8-8093-0ee7a6241e34" ],
+  "subjects" : [ "https://www.example.org/e6d749fe-0a92-4605-9dbc-c864c7e88faa" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d22a12e6-1747-4f12-8245-4acb5c9b32cc",
-    "name" : "O3o4EaanjNAp0E",
-    "mimeType" : "g0W2bp58ggId",
-    "size" : 1262119230,
-    "license" : "https://www.example.com/0up9nowpydfspiv",
+    "identifier" : "c9251706-5790-4fd3-9c55-1f28653effda",
+    "name" : "i1XrjhHxm4huIM",
+    "mimeType" : "VghLuHnoH4e",
+    "size" : 1749666426,
+    "license" : "https://www.example.com/wfidz9142613kw0hz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "aO3gFyGHRe7VmWZM",
-    "publishedDate" : "2018-06-03T03:26:45.183Z",
+    "legalNote" : "w4aRKHYISoVCFJKQp",
+    "publishedDate" : "1984-10-21T16:26:41.207Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3KSNKdMMoBdDvTh",
-      "uploadedDate" : "2019-06-12T05:04:00.735Z"
+      "uploadedBy" : "8YyhJJsYxBPmhSc",
+      "uploadedDate" : "1974-09-13T03:17:45.450Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8P8EiTCTFjnvCAxuwb",
-    "name" : "x8uIJVWfnRQc",
-    "description" : "tu80KEKOpHcqdmcgk1h"
+    "id" : "https://www.example.com/iVtEkG6PTDAje3bxvUw",
+    "name" : "EBChapG9YlgO",
+    "description" : "cYYr2PMD0CCEWnmV"
   } ],
-  "rightsHolder" : "bIOcn8qVeY5rnB1FvoR",
-  "duplicateOf" : "https://www.example.org/88d72ce3-1bf3-44db-9f1f-ef50367b35ff",
+  "rightsHolder" : "VTRBth91VynLRWdtKh",
+  "duplicateOf" : "https://www.example.org/f1e42eba-e2d0-4934-a78f-1478d2bd68f7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TkXP0d1nnDnpWA"
+    "note" : "mx8Y0Szlum9RWRc3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Jp5giQLyXdXts",
-    "createdBy" : "Sq4CKxaUjpuU7q",
-    "createdDate" : "1994-01-31T15:15:37.793Z"
+    "note" : "MIKANbuVOx",
+    "createdBy" : "Q974i5RiUMpVz",
+    "createdDate" : "2002-01-17T18:30:58.179Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6ae34a19-c1d2-46a4-9e89-6cd7f1ced1ef" ],
+  "curatingInstitutions" : [ "https://www.example.org/a280a4b1-2340-4048-bab2-5173ad034de4" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "meFl77UUurA",
-    "ownerAffiliation" : "https://www.example.org/f2a02e12-133b-4609-b409-c460ea0a375a"
+    "owner" : "SVKDfU0wKx",
+    "ownerAffiliation" : "https://www.example.org/5769f2b2-3e40-4711-90b1-26977e494a95"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a63b318f-2e3d-4c7e-818e-cc50411fac64"
+    "id" : "https://www.example.org/afc86714-2bf6-4ce4-be37-6710a062839f"
   },
-  "createdDate" : "1980-07-02T10:30:45.715Z",
-  "modifiedDate" : "2018-08-30T23:51:30.899Z",
-  "publishedDate" : "2003-02-10T07:05:19.438Z",
-  "indexedDate" : "1989-06-30T20:04:13.078Z",
-  "handle" : "https://www.example.org/22bb7c5a-34a7-47fe-8351-6328292bf438",
-  "doi" : "https://doi.org/10.1234/voluptatibus",
-  "link" : "https://www.example.org/2c2a7955-6191-44ed-8ced-654e57f18043",
+  "createdDate" : "2011-11-17T17:18:14.793Z",
+  "modifiedDate" : "1973-04-02T09:00:04.072Z",
+  "publishedDate" : "1973-11-19T15:21:15.805Z",
+  "indexedDate" : "2008-05-16T11:51:09.302Z",
+  "handle" : "https://www.example.org/4e008b08-e0a0-485c-99f5-ab464091c0a1",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/daca63c8-6c7e-44c5-8ea3-07dd77edd328",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uDJMPmDlE04uU1jn",
+    "mainTitle" : "gNdNHQRFEljq",
     "alternativeTitles" : {
-      "es" : "sEy8LzaBaTOM"
+      "it" : "u5KahAfw35RFDxDUOgG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "r3h3WEnHBG",
-      "month" : "37lwxFGX7Vazif3",
-      "day" : "PUkGuOJlonwCCkC"
+      "year" : "ItboFPs28DN5K",
+      "month" : "EFJzdDrkASr",
+      "day" : "SC2FBroNmres8cRTsN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a6723dcd-cc86-42dc-9cf2-e749d8d1b677",
-        "name" : "GfCaxf1w5L8Q",
-        "nameType" : "Organizational",
-        "orcId" : "kOGAP4SNnWXYUbn",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/7824f073-1649-418c-bd0f-e654245f0135",
+        "name" : "vxE5xWL6enGDR6o",
+        "nameType" : "Personal",
+        "orcId" : "9iK5wReMNbADUW",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Fo55Kl1X9WqC9Be",
-          "value" : "AxQUSve02vgJuqVQr"
+          "sourceName" : "gCapQdDJknbAKaU6WaT",
+          "value" : "FGEVMaaTTRPM0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KcXCvjZ9rK",
-          "value" : "VCQ91jdavCo"
+          "sourceName" : "6rh772mSzPoSa42Pxrx",
+          "value" : "9B33nQiGArN9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/91ba20e4-fd17-48fa-8679-19ddd874dba0"
+        "id" : "https://www.example.org/553f0a24-a4b5-49eb-878a-5b520d3b6f7e"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b10ab7c1-3587-4ed3-ad6f-31ea6e7d2e38",
-        "name" : "VLrcTmesZA",
-        "nameType" : "Organizational",
-        "orcId" : "MaaFKoB8xi",
+        "id" : "https://www.example.org/5c3764f3-498e-4391-b5ee-151e76fbcf5e",
+        "name" : "o9zC8AguW2ZPHLA",
+        "nameType" : "Personal",
+        "orcId" : "8uRbSBkz9ZHZHzlD",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Y6MsLQkKKY31nk4",
-          "value" : "uEQ2NqPLF68NL"
+          "sourceName" : "HgnAugHe1QquSm0f",
+          "value" : "i8PxJZ0vUN"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1Naiqbha0yO0",
-          "value" : "WsrKTBRKlw42IFp8zjP"
+          "sourceName" : "GCOuQ1IBEjyGujDAVO",
+          "value" : "3Kmb9SZR12vqv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/44431dcb-e6af-4918-baaa-fc9913a73aa7"
+        "id" : "https://www.example.org/17570135-3a5c-4eac-86e3-6f63a726636f"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "NgizkxMPCjvde7evxY"
+      "pl" : "dLjWIpCzY73f"
     },
-    "npiSubjectHeading" : "4Mop4zmt87",
-    "tags" : [ "rF75JGP0ihe4PvVcc" ],
-    "description" : "E3A26iOgUCKjH",
+    "npiSubjectHeading" : "V5zNFtukL4AiJ",
+    "tags" : [ "uVtLOHUVGzy" ],
+    "description" : "M1V8AlCZZ0ypYqdCy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ab8c5c87-05a6-4c90-bf4f-97d109e1facd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0601eb9a-adb7-4c3c-836b-5bdde18dc75f"
         },
-        "seriesNumber" : "bzZG7rNOrjFrSUpIOMY",
+        "seriesNumber" : "j9isGrQqGIk",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/70b69913-fb18-41a8-a82a-18f59ab4b039",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/06fd07f4-a168-485f-8df0-7f1cc5e3663f",
           "valid" : true
         },
-        "isbnList" : [ "9791872465202", "9781883704612" ],
+        "isbnList" : [ "9791937788024", "9780252232756" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1883704618"
+          "value" : "0252232755"
         } ]
       },
-      "doi" : "https://www.example.org/1dc8ac34-6e7b-483d-84b8-ee2455751090",
+      "doi" : "https://www.example.org/4ceff57e-e712-4eda-99f9-dd29aaaf55e9",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "kXkiINJarm3XBL",
-            "end" : "WFJGl6Z40jSI5V"
+            "begin" : "tpWzSybAolG4rWTFwk",
+            "end" : "AuJFVLOv7gXrqIH"
           },
-          "pages" : "63VpLMVjSL5HORr6",
+          "pages" : "SonRrM9xxOlAZ5o",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/70093f25-73e7-4503-b952-83ee2c670837",
-    "abstract" : "HmwcM6AOWb1BwO"
+    "metadataSource" : "https://www.example.org/03d53ce9-3ccf-49e8-9fbf-225577d93870",
+    "abstract" : "AkUDw1kKBv6FLY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cbce747e-46c0-4f0d-a349-a20d1276b020",
-    "name" : "LG2HAkvYbPBQp",
+    "id" : "https://www.example.org/7a8185a9-389a-4b9b-9efb-456313477d5a",
+    "name" : "NOesWjILuphZ2",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-02-05T09:45:02.863Z",
+      "approvalDate" : "1984-03-04T20:39:15.074Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "lk8eoXWbV9tUk"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "jZs8u8sAdm2vNuM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e1895da1-694a-481c-bda8-001060013f7f",
-    "identifier" : "qeypZ0VvN8j4T0",
+    "source" : "https://www.example.org/5a92ed03-90b5-4fec-a5d8-6b0942cf93ce",
+    "identifier" : "tm6PV70s60dFC7gOAW",
     "labels" : {
-      "is" : "Bsa79CK7idXP5i8v9Y7"
+      "fi" : "U2ipkWu4iw"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 564716860
+      "currency" : "NOK",
+      "amount" : 2049457398
     },
-    "activeFrom" : "1989-05-19T05:50:33.387Z",
-    "activeTo" : "1989-09-24T01:51:46.643Z"
+    "activeFrom" : "1991-04-04T17:53:43.636Z",
+    "activeTo" : "2017-11-22T13:11:52.882Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3d21b011-b3c1-4995-ace8-5066a3639052",
-    "id" : "https://www.example.org/0d31886e-b96e-4ce2-97b8-b114f9f9e3ff",
-    "identifier" : "JFL51Tv0Mq7PPJnKnO",
+    "source" : "https://www.example.org/01541f62-4783-457d-a8e9-2b37fdee6d35",
+    "id" : "https://www.example.org/1b7e14ab-36ff-4c5f-a5c0-cd9422f8074f",
+    "identifier" : "Kt5UJhbMzIjczyA",
     "labels" : {
-      "ca" : "D4RUe1stMcyUHb"
+      "nb" : "3JhmvvPmNbWd5aa1To"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1024625447
+      "currency" : "NOK",
+      "amount" : 1667587010
     },
-    "activeFrom" : "1974-01-02T19:01:29.642Z",
-    "activeTo" : "2017-06-22T05:10:43.265Z"
+    "activeFrom" : "1992-04-03T00:43:50.994Z",
+    "activeTo" : "2011-03-08T07:40:17.553Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/29082863-7fe7-466b-9287-035e76ff675d",
-    "sourceName" : "h04n2emlwuc@lnk0yevemflzq"
+    "value" : "https://www.example.org/3bdb5ab4-e68d-425b-a224-8602e0f66f7c",
+    "sourceName" : "pk4ebt4nst2vzai@zoryivwyyz"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "jlt4SJWggu4f",
-    "sourceName" : "aoezh9edj3dcla4c9@khthg9rndbbq"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1480835189",
-    "sourceName" : "pfyzlrgsk0la6vmvfnf@l4kfkrkftyhj94g"
+    "value" : "KU7a6nr1eL3rH2omWV",
+    "sourceName" : "9es7vjtldss@1ghwunvkuas"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "817i52C1Xd1WJD0l3S",
-    "value" : "5NYYT0RN8m6vkIo"
+    "sourceName" : "RyoA5tYIOUoXp6",
+    "value" : "vVN9C2YJupSpPG7YE1"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "815239448",
+    "sourceName" : "w3xrx3iwzat1as@vhs4kjdewk"
   } ],
-  "subjects" : [ "https://www.example.org/3ec02a75-cd99-4258-a932-ff8554f9486b" ],
+  "subjects" : [ "https://www.example.org/57dde779-63e9-4985-b6d6-43326280323a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "336f527b-5b1d-4453-836d-51e6144d3de2",
-    "name" : "nhdtH55YWmfJh08L",
-    "mimeType" : "pV91ysclB0D6MJbyoM",
-    "size" : 176072500,
-    "license" : "https://www.example.com/brsgq4kgf3wqbipfhu",
+    "identifier" : "a3ba4f1d-c520-4a9c-a8d2-4033a7b2d91b",
+    "name" : "m6gjTEuq1J8q",
+    "mimeType" : "aZlP8BljdtnH8deb",
+    "size" : 343913905,
+    "license" : "https://www.example.com/dzpswyw7bge",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "9SvDagyOAOA6RbpP"
     },
-    "legalNote" : "IEGlXpc1bB8VpBC",
-    "publishedDate" : "2010-12-05T14:55:25.511Z",
+    "legalNote" : "WDlHZ0wDMDTX2u7",
+    "publishedDate" : "1974-01-26T10:13:52.296Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GaZF9PxuOskcjLk",
-      "uploadedDate" : "2003-03-02T03:02:49.560Z"
+      "uploadedBy" : "TW5SFe6poxituDx3q7n",
+      "uploadedDate" : "1983-12-17T16:04:29.856Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/MTtKUjDyUyHA1sq",
-    "name" : "AjPh4yreZnUkrd",
-    "description" : "ORRY42zg8hgR2w"
+    "id" : "https://www.example.com/EQcjGivfKHwHo6l",
+    "name" : "BrmidRm9oKxnPmFi",
+    "description" : "yP4YdndKGe83ziTImK"
   } ],
-  "rightsHolder" : "NmGotlT0qqQ",
-  "duplicateOf" : "https://www.example.org/44d65332-43a3-47e4-81ff-d65ddda6a23c",
+  "rightsHolder" : "OFujaWWgyHLhBVfTO",
+  "duplicateOf" : "https://www.example.org/31e9af3d-1421-450b-bbfe-a1572d628c05",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YT8quTtcytoZHf"
+    "note" : "5joStua2m14Cga0t5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GtrwrTUvfXUMe",
-    "createdBy" : "poB3G9sAKp3jAI67",
-    "createdDate" : "2009-03-28T15:41:14.465Z"
+    "note" : "7arLYPUmPak0eq1",
+    "createdBy" : "uS2F7Pv1PnFR",
+    "createdDate" : "2024-08-08T01:55:18.593Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f246224c-6e39-42b2-a901-3f60d2816c11" ],
+  "curatingInstitutions" : [ "https://www.example.org/3c0f6323-47ce-461e-85db-239dd14f5436" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "6zzmJ2lakd7z3",
-    "ownerAffiliation" : "https://www.example.org/e9a3d36a-db64-4459-a714-6bc7f3ba55ea"
+    "owner" : "wbjWMAevg5usOIrGHe",
+    "ownerAffiliation" : "https://www.example.org/1af47cae-3351-46e6-a234-41e5b39182d1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4294f619-8caa-4f38-aa82-f84f2ea6869a"
+    "id" : "https://www.example.org/d5ccba6e-d2ff-4f17-b89b-c9dd042c4b1e"
   },
-  "createdDate" : "1971-08-27T16:54:29.979Z",
-  "modifiedDate" : "1987-03-01T11:39:13.612Z",
-  "publishedDate" : "1998-03-17T05:07:15.538Z",
-  "indexedDate" : "1990-09-17T04:31:20.609Z",
-  "handle" : "https://www.example.org/466fc9db-72dc-4902-822d-59b4512666db",
-  "doi" : "https://doi.org/10.1234/ipsum",
-  "link" : "https://www.example.org/4f37f3f6-8acf-4796-8a1c-090ba23dab07",
+  "createdDate" : "1989-05-09T22:33:22.647Z",
+  "modifiedDate" : "1984-11-07T04:44:38.479Z",
+  "publishedDate" : "2010-12-04T12:29:11.543Z",
+  "indexedDate" : "1973-08-27T05:13:35.289Z",
+  "handle" : "https://www.example.org/8bd68961-5051-4c04-81da-4a1379cf9016",
+  "doi" : "https://doi.org/10.1234/laboriosam",
+  "link" : "https://www.example.org/784be742-d661-45f6-9485-6d81a8626e16",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YDcr5cHdAkf",
+    "mainTitle" : "gfOS1EB745H0kB5RCcY",
     "alternativeTitles" : {
-      "pt" : "bZ8Byirr8czm8xE77I"
+      "fr" : "xTNrucj916"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "oW6u68rGAyDCurHdQ",
-      "month" : "sVJZg980B8uTPQPjp",
-      "day" : "QdJhNvTYRl8d"
+      "year" : "yofW0BoM6Pg",
+      "month" : "TdrRuvZcWiYkc9Lt2V",
+      "day" : "xXasRLNeUZr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a861bcf1-c429-44cc-9024-fe83db4cbf65",
-        "name" : "e47Ct6Xv3YHDQswTO5m",
-        "nameType" : "Organizational",
-        "orcId" : "AIBesxIdw4c5Uche4tg",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/359df733-f8cd-4fa7-aa6b-67ebccc9e570",
+        "name" : "8Vw3z9sbXulA",
+        "nameType" : "Personal",
+        "orcId" : "fekthIHCpUxmX",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pHKucQsPsRlJJGudvf9",
-          "value" : "GMukrA5eN5BYznGIrre"
+          "sourceName" : "6Gco93BUsmGlzzah",
+          "value" : "vxNbmFQeIX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "j2V1w4yHzhMhbD1t",
-          "value" : "fTqUr9VA6hq8"
+          "sourceName" : "DcD1Li5K9Zley6",
+          "value" : "u64hKTXABo3w46DKJN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ca994390-791f-48aa-b301-ecb6671b271c"
+        "id" : "https://www.example.org/ca95d738-1072-4428-806e-7946e5c74694"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/880b3124-f100-48af-9d49-fb9d157b25c1",
-        "name" : "6tS4kYpNpe",
+        "id" : "https://www.example.org/384fc03a-02cf-43d5-a616-c70af91cf21b",
+        "name" : "yRXFGdYh8xPt1",
         "nameType" : "Organizational",
-        "orcId" : "qRclKcsixPdqTqxxl",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "A1WNAN0nePJD",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ds5Aqrc2573Le",
-          "value" : "K73KQyakw7OOc"
+          "sourceName" : "2cYaWsTx8t0evmxO",
+          "value" : "Cv1hyoXY6D"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qGlzgd3C0OrRG3jHPyu",
-          "value" : "HEUNuSs1hfMPNAxaA"
+          "sourceName" : "7dJAgASF31",
+          "value" : "eTy0YWxx95gu0zVNwnk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3a353319-26cc-470e-982f-5e512c859ed0"
+        "id" : "https://www.example.org/8ed5671c-37a5-4456-a33f-666671ff8c66"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "DataManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "4lqe1no9ucLKbBwR"
+      "af" : "TF1pOxPoR8uVZlys"
     },
-    "npiSubjectHeading" : "yW4SUvm2P5l4DFK",
-    "tags" : [ "duDBuhgSIAx1X2VWq" ],
-    "description" : "x3M9o3e3r4WOEBB0",
+    "npiSubjectHeading" : "NNWqezQyupN6p5zz2Xo",
+    "tags" : [ "RdZSiEmn0VGfA" ],
+    "description" : "Jpd7jG5ftQ0tUNtz9B",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/39d04b3f-db89-4ca1-8614-81bc4d33692d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/de113a8b-944e-48a8-a436-b88d8014667c"
         },
-        "seriesNumber" : "GzVbU1ZwMftDbDD6ZxY",
+        "seriesNumber" : "l5r1imq8i8V4NZH3",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a73d9354-62d0-4bdb-af71-1417678fb77e",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aafc8d9c-fd50-4417-9f62-e9a2951353e8",
           "valid" : true
         },
-        "isbnList" : [ "9781516269617", "9780305778071" ],
+        "isbnList" : [ "9781964019635", "9781053142794" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0305778072"
+          "value" : "105314279X"
         } ]
       },
-      "doi" : "https://www.example.org/6719940f-7854-491a-80bd-0ba58438b36e",
+      "doi" : "https://www.example.org/a577f7e2-1741-45b1-b548-bdde739f1fb9",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "QMykE5LwZHImWP",
-            "end" : "bRVHVuX2cm9w"
+            "begin" : "fXuMiPVrXCCIc0",
+            "end" : "QRkUzZ9yWM"
           },
-          "pages" : "hPQJvIAARh030mn4",
+          "pages" : "9mpvY09oKSciUcP8i",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/10f6ef56-2402-4adb-b803-1943b238cdff",
-    "abstract" : "Xr0JoXCzD3QJV9D9l"
+    "metadataSource" : "https://www.example.org/eb9c872d-c72c-471e-8650-b46861696b28",
+    "abstract" : "A68JAzEKOH3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/01fb7fc2-0362-4d69-ac0f-3f991bd4c2d6",
-    "name" : "D2YMgaJ8AY6B9J",
+    "id" : "https://www.example.org/c6fbe3da-49a8-47d7-b601-c8796cc94321",
+    "name" : "eCNB98kVkmDOAb",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-02-26T13:33:29.159Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "SArGQmX4vCOCdOg6q"
+      "approvalDate" : "2006-05-14T22:32:51.596Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "zTrm5oWrh8Aqp7cHQlq"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a7b5c6d2-aad3-4dfe-8ff7-6196547249ee",
-    "identifier" : "g88vPzsbWLjqKBSZNh",
+    "source" : "https://www.example.org/d31bc0f7-1ca7-40b7-8953-e594d4b0e642",
+    "identifier" : "NyAhms7PMsrcbPzty",
     "labels" : {
-      "fr" : "LHrLPBECjAbxjCKesGB"
+      "bg" : "jMC5jOUVFSLI6x0O"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 186888096
+      "amount" : 961967556
     },
-    "activeFrom" : "1982-01-11T23:13:29.416Z",
-    "activeTo" : "1998-10-20T16:00:18.160Z"
+    "activeFrom" : "2006-08-27T04:54:31.333Z",
+    "activeTo" : "2016-10-09T20:20:58.801Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d8af048c-c091-469c-a44b-cb59fe83f25d",
-    "id" : "https://www.example.org/3eb2f67d-ec8d-430a-80eb-12f1140e5ead",
-    "identifier" : "BY4ZWRhYgcp",
+    "source" : "https://www.example.org/e85feedd-9d72-4a88-99c4-f45f23dc6649",
+    "id" : "https://www.example.org/813e44e3-6caf-471e-a17e-5ac8bc3d950d",
+    "identifier" : "B7Fbt0Yui6UiI1",
     "labels" : {
-      "ca" : "YcJuQSLbo9wLZetrY3"
+      "af" : "lmIONkezbfSBPgYacFh"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1407126006
+      "currency" : "USD",
+      "amount" : 252149915
     },
-    "activeFrom" : "2009-05-11T18:28:38.856Z",
-    "activeTo" : "2012-06-03T10:22:09.798Z"
+    "activeFrom" : "2012-02-01T03:09:44.411Z",
+    "activeTo" : "2024-01-05T17:37:47.081Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "909478325",
-    "sourceName" : "vfhcrjfz5stl@dgjladhchs"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "qvBRQ1cXQgsZ",
-    "sourceName" : "zggq4c7fswd9hn2p@sgb1htzupyea"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/1bde692a-07eb-40c3-ba31-5c84ab54528c",
+    "sourceName" : "zn0gco0vy4xcqwjg@ae5cpfoqj3nnnlf"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "fNhyhFC7rhjaD4WO6g",
-    "value" : "IGlsJZZ9pR"
+    "sourceName" : "q1W3ZRmiOwKW6",
+    "value" : "44ZA5J2hKA"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/3faad4a5-3725-449e-a2e9-9f1b0da70af5",
-    "sourceName" : "marr6w8tv9@dz6xvxmbodmb"
+    "type" : "ScopusIdentifier",
+    "value" : "oqBwLVgKsuzum0eIA",
+    "sourceName" : "ffpeybdli7xry@wmtippa2wzh4ua5"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "105435107",
+    "sourceName" : "0zqmfr71o5bco0dlf@2ghdrdx7ivx"
   } ],
-  "subjects" : [ "https://www.example.org/5c83fb9a-44b1-4067-b0e7-4887b25f8451" ],
+  "subjects" : [ "https://www.example.org/f9956852-806b-47b1-94ee-767fa42c6f66" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5f175484-cf54-41c7-b5a4-49a357e04d2b",
-    "name" : "ZT3uF7vAdGANN",
-    "mimeType" : "mWPgTZpbjEOUpz8O",
-    "size" : 1329192751,
-    "license" : "https://www.example.com/oxsvdohnvadmg",
+    "identifier" : "0b2ea992-6805-4865-b44c-be4eea1f30aa",
+    "name" : "2Izv9yfKuGPyDFrf",
+    "mimeType" : "Q9lL7yiVUW2lWztCny",
+    "size" : 1501523583,
+    "license" : "https://www.example.com/qdqtyjca3bvr78ds2of",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "FxDEzfdlWcn"
     },
-    "legalNote" : "4JCMubKBUaezu",
-    "publishedDate" : "1983-09-26T12:16:09.346Z",
+    "legalNote" : "2BkPU4VcM2g4",
+    "publishedDate" : "1984-07-09T08:09:03.560Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "u7UOlp69ANvcbrq",
-      "uploadedDate" : "2020-05-14T05:05:04.406Z"
+      "uploadedBy" : "mNyEJqDOZ4gapedJ",
+      "uploadedDate" : "2006-08-04T13:37:42.636Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/BlfadgphUPvY",
-    "name" : "9iZU9IoFstb",
-    "description" : "DYkr0XeEH0Nwh"
+    "id" : "https://www.example.com/kVSRZVR7Iloye",
+    "name" : "fKudDzaYWHjr2",
+    "description" : "62pyKvS3E21KZwBOT"
   } ],
-  "rightsHolder" : "cEhcBtePDeOww",
-  "duplicateOf" : "https://www.example.org/3125b3e9-e1f1-4bdb-b671-a052865e04b5",
+  "rightsHolder" : "KnI4xqx8KDNW2yBQ5fh",
+  "duplicateOf" : "https://www.example.org/f1bae641-3aa1-454f-8b96-7ba1194bc89a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "64ewBS1Cj3kgdcAec"
+    "note" : "M1KScri7yOzy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "tcA5RawH8Sl",
-    "createdBy" : "oq0kosnYxT2EZZ",
-    "createdDate" : "1976-04-08T01:09:52.214Z"
+    "note" : "ce6iephPSXQOylTT1",
+    "createdBy" : "Tq88NqnFUO",
+    "createdDate" : "2020-01-30T01:07:25.620Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dbcdbcf1-bf2e-42af-a981-0c0b4efd7148" ],
+  "curatingInstitutions" : [ "https://www.example.org/d9c29061-fe2b-4ef2-9589-cba15512e12d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "twZGKrNi2lV",
-    "ownerAffiliation" : "https://www.example.org/85728dd8-2cfe-4cc0-a9c0-6d916a684457"
+    "owner" : "eO5Ie70kn5pHLzx",
+    "ownerAffiliation" : "https://www.example.org/f55477e3-b581-4a12-9ba5-042b01fd4ac5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/94aa4a6c-5c6b-46ff-b8a0-8da35b424e76"
+    "id" : "https://www.example.org/2de95dbc-f868-4679-9425-5d5a3b9af39c"
   },
-  "createdDate" : "2022-03-01T07:20:41.752Z",
-  "modifiedDate" : "2022-11-18T03:05:51.375Z",
-  "publishedDate" : "2014-11-11T11:06:57.600Z",
-  "indexedDate" : "2019-12-21T21:17:03.918Z",
-  "handle" : "https://www.example.org/d5384e97-64dc-49c3-a4a6-a3717112c2ef",
-  "doi" : "https://doi.org/10.1234/dolores",
-  "link" : "https://www.example.org/b2d61aaf-d163-435e-a900-b6093b4b8178",
+  "createdDate" : "2024-07-27T22:25:58.187Z",
+  "modifiedDate" : "1985-03-06T15:05:32.205Z",
+  "publishedDate" : "1995-02-24T10:57:34.096Z",
+  "indexedDate" : "1996-08-29T23:44:15.962Z",
+  "handle" : "https://www.example.org/be682d6a-5752-4d2d-8248-5ed6cd97df3b",
+  "doi" : "https://doi.org/10.1234/beatae",
+  "link" : "https://www.example.org/cd8be162-5702-4d0b-9121-ab7398674dfa",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DW0NpA3Hsd3u22OHLoy",
+    "mainTitle" : "qf5j22cXYxTXS3eq",
     "alternativeTitles" : {
-      "af" : "oBfA3igkfZVl"
+      "da" : "XArAGOslfnPQr"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "WjTPexwst6J26A9Mc",
-      "month" : "Q63mUYoeOFLVpXpP",
-      "day" : "vB7oV7IaqTMevbvR"
+      "year" : "1ls7sCjsSDWJjK0aN9t",
+      "month" : "kBca1gw7AjGTM",
+      "day" : "2BIwWtoGsmFW0r"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/318b0752-20d5-4414-90e7-0fb913ff1268",
-        "name" : "vTn8sDZ9WVPyolgM",
-        "nameType" : "Organizational",
-        "orcId" : "ufzVS7BLLJF12l",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/007e689a-66cf-4cae-bd74-dc9b714ff57f",
+        "name" : "XVERsEfuDp8JfNvsGe4",
+        "nameType" : "Personal",
+        "orcId" : "EVjuzs8TLdqcuL42eA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gxc8xkxe6RqCkALQJ",
-          "value" : "7kIA22WOGNJFU45h"
+          "sourceName" : "fzIOTFlYvQYQ8H4l",
+          "value" : "JC4wJNI3f9sbAsqgs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4wCKTzvgvva73GEC",
-          "value" : "qsrS4j2ITqCAQ6"
+          "sourceName" : "FIDKTwPEf7SvIhj",
+          "value" : "z5xtZZH14RBN0k5ezeU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/522d880b-2ff0-430b-b05b-4573b1d9cd34"
+        "id" : "https://www.example.org/77b95fbe-f47e-4c9f-b1cf-b93fd7ca7567"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Photographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/976cfbe2-ee5b-4b03-9e3a-0804a73c2cf3",
-        "name" : "coju1VLTrn",
-        "nameType" : "Personal",
-        "orcId" : "O3IWIXqmFwre",
+        "id" : "https://www.example.org/d9c70526-b30e-4523-a528-201f80ceaa9c",
+        "name" : "BApGBP9gkMRtMkpieN",
+        "nameType" : "Organizational",
+        "orcId" : "v8zPrvIQBX5ik",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QV6D5J2GPGvh",
-          "value" : "fMDhVIG7iF9D33Edt"
+          "sourceName" : "xo43SL6PLaDYgz3",
+          "value" : "Iohmo6UM5mes"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "58tCZlyrDQMquTnZM7",
-          "value" : "HkXiJQSkurmGDX2Fcfq"
+          "sourceName" : "RzyIiPqVUoXg3",
+          "value" : "W2IRnNU3GHywE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3018de65-4972-43e5-92a0-9c562aab2c88"
+        "id" : "https://www.example.org/e199bd6d-d7c1-4802-95f3-6a7c3c274090"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "5W6Hlg9rxW6v0x"
+      "hu" : "EfwkNs02fmOjPVY3gsi"
     },
-    "npiSubjectHeading" : "LmsI598OnOCVf35A",
-    "tags" : [ "TMVkA3ITcBZ" ],
-    "description" : "8qttKS5yxi",
+    "npiSubjectHeading" : "wfqyvg1hzlqN3",
+    "tags" : [ "LS18HxDlpsO9" ],
+    "description" : "eQYZUfhiEpM",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e3678d6f-6f09-4f1a-9cb0-526307bd1682"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cd2b1d05-c218-4b29-889f-13f5975f73df"
         },
-        "seriesNumber" : "htEeWVIhDx55Tamu6nh",
+        "seriesNumber" : "6GhbBbEdnOvTYcXCMo",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e64c9485-e643-424c-bb08-a84809ab050d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ebdafeba-0c2c-46f4-842b-54f2dd4defb9",
           "valid" : true
         },
-        "isbnList" : [ "9790899547755", "9781928886846" ],
+        "isbnList" : [ "9780810279810", "9780716335702" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1928886841"
+          "value" : "0716335700"
         } ]
       },
-      "doi" : "https://www.example.org/4e50fc5b-c8e2-4818-9665-b7fa35f44e41",
+      "doi" : "https://www.example.org/b42c6a8a-f29e-4946-bc0e-3c1548273f64",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "wsN545OnUDsYKlfln",
-            "end" : "SshXrThQrNX8rn"
+            "begin" : "JPB718CN3D",
+            "end" : "uFdAjGkuAiL6"
           },
-          "pages" : "yxCPC1r22gA1RhWPP",
+          "pages" : "kmfPnI4V2ORJ",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c227d55d-517e-4451-80bb-8be7b9b90c9b",
-    "abstract" : "zHoE97zZM8"
+    "metadataSource" : "https://www.example.org/3dc53ceb-74f1-4559-81d9-12361c89b36e",
+    "abstract" : "AHdGG33xhxI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b86217fd-db95-4932-867b-ef62370ba82c",
-    "name" : "0aA9BbYu1aG",
+    "id" : "https://www.example.org/6bc59db9-4e4e-4287-afc2-68fde5b503ab",
+    "name" : "zyPKxJyU0pTXbj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-06-08T22:42:57.524Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "2014-09-17T13:28:25.062Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "p6zc76uC6QRvOuCSyE1"
+      "applicationCode" : "s99EdPbhUlM8Ou2jsH5"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e2a8f4ae-1b74-4e53-9bea-12e83bf34c2a",
-    "identifier" : "tp1NRkl7phuN8XKUY",
+    "source" : "https://www.example.org/2e05e6e7-9ce0-42b0-9a6e-81fc7045e7cb",
+    "identifier" : "2pmC1l54WhiBTG",
     "labels" : {
-      "nb" : "47WHysYSepKWhX"
+      "de" : "6sV2RpSgkrX"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1891502454
+      "currency" : "NOK",
+      "amount" : 115609806
     },
-    "activeFrom" : "1986-05-03T14:24:32.533Z",
-    "activeTo" : "1992-07-21T15:23:47.406Z"
+    "activeFrom" : "1983-10-14T06:48:50.766Z",
+    "activeTo" : "1990-05-13T00:42:47.878Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8fd9273c-5ccb-48f5-80f1-18ba138ed6b0",
-    "id" : "https://www.example.org/d26c7b60-ff7b-42dc-9a7e-d9664aa54dca",
-    "identifier" : "v9HakT4psqamv",
+    "source" : "https://www.example.org/bf904f73-29f0-4440-94c5-859e21e6869c",
+    "id" : "https://www.example.org/066a50ad-5427-40a2-97e9-581835376a0e",
+    "identifier" : "a5KdjftcXpkEs",
     "labels" : {
-      "bg" : "iyL4A7Ojgix8"
+      "pt" : "pt7RToxXSAIHndWN"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1233869377
+      "currency" : "NOK",
+      "amount" : 272933877
     },
-    "activeFrom" : "1994-03-24T23:22:54.665Z",
-    "activeTo" : "2002-06-19T01:03:56.810Z"
+    "activeFrom" : "2008-07-31T07:08:22.937Z",
+    "activeTo" : "2017-07-25T00:02:58.924Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1693180167",
-    "sourceName" : "jce9uv1bz3bjdu@7lkqxu0i2fwpqxsqhe6"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "Vi5mQ0vkc8V68IwQtS",
-    "value" : "cT7vvylW4N4VGKWzn"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/1f7bcb8c-9b73-476a-8e26-aa69a084280e",
+    "sourceName" : "cfyk5pkxk1wxbmyc@cawbwaynrnaai9bb5"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "ozQW74k4GpTmzyHI85j",
-    "sourceName" : "qe72pi1ue8xdfaz@t5vd1uorazrwyfk"
+    "value" : "SA1yHvL0yRnP",
+    "sourceName" : "p4dkqyvop5uvtwx@xiaftunfrejkzxk"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/ac2bf43b-5d91-423d-b5f9-5186cb4b312a",
-    "sourceName" : "mlkhyjavfjnredqhke@drnk0k1vtoy7qu"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "A2n3RoUGn5B15bDw",
+    "value" : "HlwmCJNHG6p"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "64471695",
+    "sourceName" : "jwy0w9dlcepdw@jeaaryyzjhhs"
   } ],
-  "subjects" : [ "https://www.example.org/25e7cef1-4144-48ca-93d1-66a2a48699a6" ],
+  "subjects" : [ "https://www.example.org/23cee806-87b0-4890-b47d-e87dd4bd71f1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6421d200-f5e6-4baf-8af1-3c3b2ba42d10",
-    "name" : "PJKjQm2mXxm9ezwYKo",
-    "mimeType" : "jBR3KMJHyF",
-    "size" : 1958134443,
-    "license" : "https://www.example.com/6sv02l3nqvbmtb",
+    "identifier" : "43877813-100e-4ccf-a50b-612f2910bf02",
+    "name" : "0dfT6YIgEzHaqf6gbCF",
+    "mimeType" : "tnOvQKcYkHaDk",
+    "size" : 317415990,
+    "license" : "https://www.example.com/4gg7anzlvhzujohrco",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "LmU2R9DArf"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "9If4NTh7VepzaGYfkl",
-    "publishedDate" : "2010-09-15T20:03:53.816Z",
+    "legalNote" : "Gqm5z7g4xrsrKX",
+    "publishedDate" : "2009-04-05T08:18:59.388Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "jO0Bq9BXeDOX9KhyM",
-      "uploadedDate" : "2008-01-07T15:03:00.152Z"
+      "uploadedBy" : "cYfCz4j0Jm",
+      "uploadedDate" : "1992-09-01T17:14:53.924Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/pDI1XMT72hbWTBUUM",
-    "name" : "UitgZQjng4IX",
-    "description" : "RgiDL8UC8YuqKsLBqG"
+    "id" : "https://www.example.com/W5yp0p0kAn9",
+    "name" : "kRWLxNK6CEYJrM4",
+    "description" : "1akY0Y5efuNmrODsq"
   } ],
-  "rightsHolder" : "1f5Cj3pV8ygWiQ1U",
-  "duplicateOf" : "https://www.example.org/197d10df-2731-470f-a7e6-6c5a32ef3e9a",
+  "rightsHolder" : "JnKyyFfwyn5",
+  "duplicateOf" : "https://www.example.org/2d0710c5-34f3-4839-bbe5-fc7900227fa5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "r815eGhgymwqizxi3A"
+    "note" : "nmTeBwqjIi5r1KhqEd1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "PYHdtfbQKkNER",
-    "createdBy" : "Anp7abZpyWga",
-    "createdDate" : "2015-08-07T15:21:28.297Z"
+    "note" : "kXP6OZEjxnV",
+    "createdBy" : "HIbwyA180LXOcySPA86",
+    "createdDate" : "2014-09-17T17:29:29.555Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5f380c07-0bae-4cf9-b1ff-771e2d5f793f" ],
+  "curatingInstitutions" : [ "https://www.example.org/145708f6-0612-4683-9732-f56fcbe43b70" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "mHbi3GwOc4gpgr1gJYG",
-    "ownerAffiliation" : "https://www.example.org/c55b6b40-a796-46d7-b971-a786c7b326ff"
+    "owner" : "1gDbXYQLo0CsXc8SZr5",
+    "ownerAffiliation" : "https://www.example.org/7e2eecff-578d-48b9-ba90-900b1cd92f01"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1b73c5bb-ee56-4c35-a143-d085ddeaa459"
+    "id" : "https://www.example.org/05327d53-5ffc-41e0-90a5-0f2df624049c"
   },
-  "createdDate" : "1989-10-16T02:23:04.249Z",
-  "modifiedDate" : "1984-12-19T21:16:42.470Z",
-  "publishedDate" : "1973-08-14T02:38:34.296Z",
-  "indexedDate" : "2000-06-26T16:10:33.944Z",
-  "handle" : "https://www.example.org/10558d17-8794-48df-9d93-ac8a94125f0f",
-  "doi" : "https://doi.org/10.1234/voluptate",
-  "link" : "https://www.example.org/31ff2368-0589-4960-bf4a-c9822d01b07f",
+  "createdDate" : "1999-11-20T07:55:33.315Z",
+  "modifiedDate" : "2003-03-18T20:03:13.840Z",
+  "publishedDate" : "2008-05-18T22:17:44.138Z",
+  "indexedDate" : "2023-02-24T18:50:52.689Z",
+  "handle" : "https://www.example.org/59568cce-4763-4bce-9ccc-d1287a4551d2",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/6a796503-cd13-49db-b244-a106c9a845fd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BbdMemLqVXHYqH",
+    "mainTitle" : "xyrFqXW9xWJ6mgxJSS",
     "alternativeTitles" : {
-      "zh" : "clx1cagBwKzOyou"
+      "el" : "lW4rkDqAfXEroZbW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JODV1DOU5q",
-      "month" : "CNlJySPqGzs0NpOg6u",
-      "day" : "Uxz7fbjmCxNk"
+      "year" : "AY3tIB0gRP8MgCTpe",
+      "month" : "bCo5w28Vn3QxbA7",
+      "day" : "hx0mrVJAx5v8YQE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/20846938-cec6-425f-818e-c9a4411daf1d",
-        "name" : "hTOmcCA6tFTCjnWm",
-        "nameType" : "Organizational",
-        "orcId" : "YZ4rHkbvUhPIEM",
+        "id" : "https://www.example.org/2f296f66-3098-4e5d-899c-e0a63a9f64ce",
+        "name" : "CP9Ik9YyhNVjVkDJmG",
+        "nameType" : "Personal",
+        "orcId" : "fLVUQJzIXazBQCfQ",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3eBc6DH0p9",
-          "value" : "ZHYLeEVx1o9J3"
+          "sourceName" : "CPn6mjCxGP1nY0",
+          "value" : "jjV4OdBgXb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xx2Sfyjehk",
-          "value" : "GLmoKWf58Z"
+          "sourceName" : "wSa3nkYtKKjttMl",
+          "value" : "iAKA1ewEQEpfd"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/58446bcd-4f6f-431f-98b1-d064ff94f6fb"
+        "id" : "https://www.example.org/3ea7f191-2941-4135-9710-8d4842bf4b43"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "LightDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d9b9013d-1509-4d3b-b7e4-686706339f50",
-        "name" : "NE66Ds50LJNGH",
-        "nameType" : "Personal",
-        "orcId" : "FdKPY1occ7u",
+        "id" : "https://www.example.org/2c6d1fc9-2017-4940-833d-a049618c58e8",
+        "name" : "No9bW4Ehm4",
+        "nameType" : "Organizational",
+        "orcId" : "a7ir6PS3bYjN1kk1G8",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Dyw70LmkhaBC",
-          "value" : "9sZyZrV7PL5XZz3y4M4"
+          "sourceName" : "k8N6G7y7JI07GbT",
+          "value" : "zLkxUPh56pSWsLKcB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p6ETh9Ad1bu4gRukLy",
-          "value" : "J2Q9Avs92mWdk0HVEE"
+          "sourceName" : "IyebSP4rkJ",
+          "value" : "yTGoWTPJzvfgGXf0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f75d2c0c-2ff7-44ed-8a21-168b089f0e37"
+        "id" : "https://www.example.org/c31f06e8-5eb7-4743-9d36-7145dd893089"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "w5MAYJsqrF6w"
+      "nl" : "2Z2L2qa7xntqtM"
     },
-    "npiSubjectHeading" : "3cwAJSJWiiHHmzSml4f",
-    "tags" : [ "2aRkTCalssgDFu" ],
-    "description" : "0eNqiiY4VOjg",
+    "npiSubjectHeading" : "XYWFXNK9uKUBwXtjXP",
+    "tags" : [ "MA9FHoneMaZ5MXS" ],
+    "description" : "bTrOBnKdd85M5vevH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/83dd2feb-674d-4ea1-a1e7-0342e62b4459"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/88c1aaf0-0c2d-415e-b79b-ce814ab9f62c"
         },
-        "seriesNumber" : "CGhO1XyUpn582io3w",
+        "seriesNumber" : "wMbVcASNqqMF5Ij4g",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/389726b0-72fd-4deb-b969-b4333fb56a4c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f4dad95c-cca5-42f9-aa0f-b11b55f41635",
           "valid" : true
         },
-        "isbnList" : [ "9790810363655", "9780943949123" ],
+        "isbnList" : [ "9781018811741", "9780970271662" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0943949122"
+          "value" : "0970271662"
         } ]
       },
-      "doi" : "https://www.example.org/596cbd3d-07e0-4894-a675-b764009791ab",
+      "doi" : "https://www.example.org/0b628ca6-9191-4a3e-aa2e-0c8eb4f446ea",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "pdqFx4OWEnFNJAc",
-            "end" : "lD9N6lXQrqxFGsuNwo"
+            "begin" : "xTPhKIFFvN1p",
+            "end" : "xHI8TMI1rUu5s7"
           },
-          "pages" : "fKYNohyFBhKs",
-          "illustrated" : true
+          "pages" : "hE40ygfSaIORrPm",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4c63e219-fdc8-4994-b433-12246437cbb0",
-    "abstract" : "SNEkPYlePAnAAH"
+    "metadataSource" : "https://www.example.org/21daeabf-4188-4f5c-b471-3d40805353ec",
+    "abstract" : "av1YjQ3lS7GYCeSn9Im"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b9734037-4e30-44f1-a79c-05f7a21e8613",
-    "name" : "3l8F7aoRGIdS",
+    "id" : "https://www.example.org/41b313f5-9314-46b9-aaf0-eca9710a58fe",
+    "name" : "nosJBhk57xhV12tN",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-08-27T22:05:24.017Z",
+      "approvalDate" : "2023-08-16T07:20:39.909Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "HxrkXyAGOCtWuq"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "tvfuEYRy0QkJll"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/42f6daa1-bab0-4b99-b2aa-f118fbf3d59d",
-    "identifier" : "WRjhR6hBPnlIFEE8",
+    "source" : "https://www.example.org/2808c05f-460b-4710-b85c-5a23500c4a1b",
+    "identifier" : "KgonB37Mx4xhR",
     "labels" : {
-      "en" : "PADKaBUS4gZCpUH"
+      "sv" : "sckyWIuOh4W"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1478453166
+      "currency" : "NOK",
+      "amount" : 976895861
     },
-    "activeFrom" : "1984-06-15T09:38:05.520Z",
-    "activeTo" : "1994-07-07T03:30:11.876Z"
+    "activeFrom" : "1987-01-24T09:06:50.026Z",
+    "activeTo" : "2019-09-22T12:18:47.790Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c690a686-d2d1-4a7e-9df0-49da2528e9d6",
-    "id" : "https://www.example.org/309f5e6a-fb76-4bf1-9c18-fded182bed8a",
-    "identifier" : "mTY6I31GITTXPiwF",
+    "source" : "https://www.example.org/902be44b-ec6c-416c-9731-2eae71cd425f",
+    "id" : "https://www.example.org/b08f9bc7-c57e-4a51-b600-c4a0fddf2290",
+    "identifier" : "wAqcoqw1JqcOvYwg4JS",
     "labels" : {
-      "ru" : "TYBmRf5mWsqS0mC"
+      "zh" : "GZPUNL1PPV8Zj37z1"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2093850017
+      "currency" : "EUR",
+      "amount" : 1626569145
     },
-    "activeFrom" : "1999-12-27T00:13:19.872Z",
-    "activeTo" : "2018-02-27T17:41:19.901Z"
+    "activeFrom" : "1997-12-12T18:38:24.598Z",
+    "activeTo" : "2000-12-22T06:46:42.147Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1397188295",
-    "sourceName" : "62qhvls8qd7p@cpslgkssrkfelduhyyq"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/90c8d6ce-8f03-447a-92f3-b3271609a526",
-    "sourceName" : "bwqzgfrzkozli@isg2v0l8jlwdgz"
+    "value" : "https://www.example.org/9060e1a6-d8b8-41b1-af60-9ab4d6a92e62",
+    "sourceName" : "spvrnbrixn4ocalt@v8ppy4bolng"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "MkA5RBlUANB",
-    "sourceName" : "tn26z9yqoo0a53@zcaz9hm9jur8lddcz"
+    "value" : "B5jZ6e8y1FY952RD0Tu",
+    "sourceName" : "2adh8qr1y2w7w6@fusgv5vagvn0"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "6uCGlOw1USGnmtd",
-    "value" : "xmzlqMwqoyVXblMcre3"
+    "sourceName" : "W2CcxxDfXMj",
+    "value" : "475ZwGij69"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "139291826",
+    "sourceName" : "kjhxfgi1osazvjgk@eyjibpe1ttts"
   } ],
-  "subjects" : [ "https://www.example.org/dba8cfff-9705-427c-b4a0-f5d29b6290bc" ],
+  "subjects" : [ "https://www.example.org/643b3340-c3cd-4ff7-a221-0db8181aed06" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2c176532-2994-4d91-8f9b-ae6996d67552",
-    "name" : "Sn3XmoSvmN",
-    "mimeType" : "jZFkh1NoEXskY8y3h1E",
-    "size" : 40365645,
-    "license" : "https://www.example.com/obeipcenalikffouu",
+    "identifier" : "3905f483-7502-4f99-87cd-ef55b7b454de",
+    "name" : "sfyexpOBPoYWQC",
+    "mimeType" : "GQKuyIhVSxs",
+    "size" : 382203531,
+    "license" : "https://www.example.com/eq275abekcahtakk",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "10yQHuMyDCK9UNYT",
-    "publishedDate" : "1995-06-06T05:30:19.066Z",
+    "legalNote" : "MPzmMuyFPpMi",
+    "publishedDate" : "2000-06-13T04:30:17.326Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TabIysdfqR3aGMNamV",
-      "uploadedDate" : "1998-03-22T06:25:11.669Z"
+      "uploadedBy" : "7kDAop5S2SaE4t2eXpT",
+      "uploadedDate" : "1973-04-08T15:48:36.689Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/yAqysjkkQKq",
-    "name" : "6K5A1rlhDl2zQDog",
-    "description" : "k4h3vad66WMYq0nv"
+    "id" : "https://www.example.com/DUY5tCvJAR65q87tR6",
+    "name" : "npzKJ6KNHlDau",
+    "description" : "Y0M4b1w2lHPpddnNUn"
   } ],
-  "rightsHolder" : "0eXKytL6pST0fjyp",
-  "duplicateOf" : "https://www.example.org/882f271b-0a63-4349-988c-0799bae7ce9e",
+  "rightsHolder" : "VdVyaJUucv0iQvRd",
+  "duplicateOf" : "https://www.example.org/0dadd487-aab4-46d5-9b0d-8e2d88f8abff",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Nn3QXO8TOsLHHMUJ"
+    "note" : "JKrZfi4DFYy9I"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "HeOhg7dxeU4a",
-    "createdBy" : "VvxXdXB1TImMX",
-    "createdDate" : "2014-07-08T08:06:45.489Z"
+    "note" : "ZUzNBerPqblRgE1K",
+    "createdBy" : "LGfhYtCcgl",
+    "createdDate" : "1994-08-24T09:46:52.351Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fcdca0f3-80a7-46ad-81b5-05f737c617f3" ],
+  "curatingInstitutions" : [ "https://www.example.org/32e32363-0075-4b13-bd28-4d545e4355f3" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "2wuhYjuojnzymmzvubj",
-    "ownerAffiliation" : "https://www.example.org/e7aa10c3-4342-4759-a06b-663a2d0888a9"
+    "owner" : "tFdgacldtz5",
+    "ownerAffiliation" : "https://www.example.org/d68b9550-46fd-42d8-b6fb-3a4d9a1a2b63"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8efc289b-50c7-482a-aed3-c0e39efa8564"
+    "id" : "https://www.example.org/f753077d-2617-413f-9071-47664502353f"
   },
-  "createdDate" : "1987-02-21T23:26:44.354Z",
-  "modifiedDate" : "1982-08-01T20:43:58.610Z",
-  "publishedDate" : "1978-10-23T15:02:54.505Z",
-  "indexedDate" : "1988-11-02T15:32:29.260Z",
-  "handle" : "https://www.example.org/43f3b14c-cff4-4517-a124-3be81502c92c",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/acd9892c-c6ed-4a34-bdc2-d143a009e478",
+  "createdDate" : "1993-12-12T19:32:08.140Z",
+  "modifiedDate" : "1971-01-23T17:50:33.170Z",
+  "publishedDate" : "2015-06-10T10:31:40.150Z",
+  "indexedDate" : "2007-07-28T10:49:56.094Z",
+  "handle" : "https://www.example.org/8d531ad9-ff56-4f1a-a2a3-71d0cac3f07a",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/5a18ae7e-c6c4-4097-8bb2-acdf9674c6e4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iKNQyypl0YdSLQqNkDQ",
+    "mainTitle" : "wO37wYQDqJAv0g",
     "alternativeTitles" : {
-      "es" : "qtZ11gF61sCa6"
+      "nn" : "3kpAHeAzo9obZQHgoVy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "usVgjUtFZXtwbWR34DG",
-      "month" : "EEAxAM0S0oQtn",
-      "day" : "fm15FPvn4XIBqp0VKB9"
+      "year" : "L8uHmUl8mGYlTWSSP",
+      "month" : "kiVKbzgW3F5qrytO8Z",
+      "day" : "cAlHarKD6ZU2RJCs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/15a65c39-627e-465a-adf8-31d5fc71b4e6",
-        "name" : "OKQZzT4ANYKd",
+        "id" : "https://www.example.org/7c61567b-12ce-45de-9f3d-a7a253b1e7b3",
+        "name" : "hDvgfirwXgn0QZDGH2a",
         "nameType" : "Personal",
-        "orcId" : "VpSkA47tu2C",
-        "verificationStatus" : "Verified",
+        "orcId" : "KRuD86QzAkgh4qmo",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GkpDr5ua5NXsTSxT",
-          "value" : "fPztJK2xZjTPjw"
+          "sourceName" : "ZMkdom0El9KtKw",
+          "value" : "oSklj5d7eaWO25jjIi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IUlBjRiXXtAckex8zVx",
-          "value" : "9offHKB082YgVEaJ3"
+          "sourceName" : "mMqbugtbUMbxa",
+          "value" : "f0NS9wQht5hlfV2yan"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6bd362bd-415c-4268-923d-687b34cf0045"
+        "id" : "https://www.example.org/cbb74c0d-5a14-4300-af2d-84cafed40cdc"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "Dancer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/20bd1e1b-d7c0-4b1e-8aa2-d28a25f4c6b3",
-        "name" : "KCN1XMSXabYU",
-        "nameType" : "Personal",
-        "orcId" : "SWCNDeQBELYup2lzBye",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/2f722d34-ccbf-40d8-96cd-bbce479fd492",
+        "name" : "9Ncg4g2Kd40wUkDk",
+        "nameType" : "Organizational",
+        "orcId" : "wGJg7sEY8VL7jU",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oSrJBkrPVQRx",
-          "value" : "bEDcNqyVICKsGM3npDr"
+          "sourceName" : "YsrpLcYrA1W",
+          "value" : "fzCfeKel0mJr1AN4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ofg9srPAUolsc",
-          "value" : "r5BYOR82dRij6SXJh"
+          "sourceName" : "CDCMCjaXXYbB",
+          "value" : "Ha4Va1QZV0rK8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/80814ce3-81f8-48b3-8d66-4720e2c650a9"
+        "id" : "https://www.example.org/e8819701-2ba4-4125-a727-335b59eea23e"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "BduCGV5DezZOGaLN"
+      "fr" : "1bYIrDhvDTVKyg"
     },
-    "npiSubjectHeading" : "wACDsF6lUlkzK02F5GD",
-    "tags" : [ "4QVm47ocuoLbv1vN" ],
-    "description" : "e5e4nTqHoaTdzuGN9v",
+    "npiSubjectHeading" : "55wWXmVhYi2NA11II5",
+    "tags" : [ "6cbobcHTtli" ],
+    "description" : "skMIfCPoaKK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a63f5360-120d-47fa-8820-5faaab940aed"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4f59e8ed-e00d-4014-8485-e9b0048e604a"
         },
-        "seriesNumber" : "CrRXEAj3iyQLLdxIld",
+        "seriesNumber" : "cevgGWdSgUo5q0p",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8810d7ca-5a7a-4d8a-8ab1-e0fa705dc578",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/40bff0d9-cedc-4ffb-bf5c-13c1097fbd9f",
           "valid" : true
         },
-        "isbnList" : [ "9790876498827", "9780992505295" ],
+        "isbnList" : [ "9780067480786", "9780929879116" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0992505291"
+          "value" : "0929879112"
         } ]
       },
-      "doi" : "https://www.example.org/799da827-b947-4b43-b1e3-04267efdad61",
+      "doi" : "https://www.example.org/f9626da4-cc02-4ad0-bac3-90911a19e6f1",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "6AhM3Rbq1jnVZc",
-            "end" : "jbV1sZlEtCz"
+            "begin" : "LpF7myuEJzw55z",
+            "end" : "qG9A0uLfX7v1wFcL9dd"
           },
-          "pages" : "cSzE3S4luBLd13",
-          "illustrated" : true
+          "pages" : "coVzMMUNMw",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/065338a0-6c28-481f-9a83-69e1373d14d8",
-    "abstract" : "x1V1jexHpk6LrwmJ"
+    "metadataSource" : "https://www.example.org/521fe785-e9bd-4f39-bf67-2ab214059b3d",
+    "abstract" : "TWasqdiC6ir3l0qMM0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f0f6840d-3faf-4c56-a7a5-1b380ea2d696",
-    "name" : "2dfJ0MjrAO5JG",
+    "id" : "https://www.example.org/31ad8070-82a3-46e4-9f5d-46b5dcfadd57",
+    "name" : "zatr0NspUn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-02-06T20:13:55.748Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1975-12-15T04:45:10.464Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "IoTPZl9HO6L"
+      "applicationCode" : "CuCuTcM319IDct"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ed0fc45d-b6b4-490c-8997-f8ab106f3319",
-    "identifier" : "oID4idFLwrr",
+    "source" : "https://www.example.org/4413026e-b1ae-4548-a16e-2b89ad1afed3",
+    "identifier" : "GtMtbBYXFKLF",
     "labels" : {
-      "it" : "CZOjeL4pBWJHqfwJU"
+      "fr" : "2rkFX9sVtnz"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 664050019
+      "currency" : "USD",
+      "amount" : 544257895
     },
-    "activeFrom" : "1981-10-26T12:08:56.553Z",
-    "activeTo" : "1987-03-08T16:20:33.822Z"
+    "activeFrom" : "2000-02-28T16:16:41.633Z",
+    "activeTo" : "2022-08-25T21:57:11.647Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/02df6b3c-789b-4b37-ab5f-53c11783b8a5",
-    "id" : "https://www.example.org/c9aa37f4-5d86-487c-8834-9f91c5b899d8",
-    "identifier" : "KtCVNsES1c7kzeSC",
+    "source" : "https://www.example.org/a55758cf-a3a8-41eb-9085-677a810eaa58",
+    "id" : "https://www.example.org/c92abcea-645b-4826-b7fe-68fb042bfa2e",
+    "identifier" : "nJ6DK69Gn1LkF",
     "labels" : {
-      "fr" : "10YOXAzyfo0g2Fhp4EP"
+      "se" : "Yzv7vhPloPb6AussF"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1719434699
+      "currency" : "NOK",
+      "amount" : 168525358
     },
-    "activeFrom" : "1985-10-02T22:06:28.652Z",
-    "activeTo" : "1989-11-24T10:25:15.673Z"
+    "activeFrom" : "2015-05-12T05:42:34.422Z",
+    "activeTo" : "2020-08-14T05:58:03.906Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "25977654",
-    "sourceName" : "c9llau6ntxegiybjnsr@uhsmvwcsdynz0"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e033a56c-ebc7-467e-8883-ad701b9d3cb7",
-    "sourceName" : "2vvbk8xjylghbmh@j8dhntyodpdcijo"
+    "value" : "https://www.example.org/c639755a-bac3-4276-803e-24763cb8a12f",
+    "sourceName" : "geabaktrmoh@oysdj6m0hdc"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "PQH0chHVZj1wJ",
-    "sourceName" : "ych6jhfkaxuyodkos@zmvybe1qo5nib5"
+    "value" : "kEbnaAlXaUw5WQ52HH4",
+    "sourceName" : "zkxsj0xhh3oxfsbnqn@olte6yppfh3vkewg6me"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "X1DJoW74W5jo",
-    "value" : "hr8vZn0rqsDrL"
+    "sourceName" : "hUJHoX4SqGj3NtaFlfM",
+    "value" : "ow50sFBfZr"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "170571311",
+    "sourceName" : "p9s291q23are3yyenl@blkskk7flr"
   } ],
-  "subjects" : [ "https://www.example.org/54bcf987-a6c0-44ac-aad8-2b7a374f75f8" ],
+  "subjects" : [ "https://www.example.org/78fa2374-0506-4b76-9273-d7c9e83470cb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "afaa93c3-ec4d-4c99-80e4-6ffdd8e9b3be",
-    "name" : "CZ6IVePjzEUIsSTTX",
-    "mimeType" : "xrv3y4iju1hO8",
-    "size" : 2051793835,
-    "license" : "https://www.example.com/ggudt1rufsi",
+    "identifier" : "0d55e457-3b78-4791-a4cf-fdf61ed303de",
+    "name" : "2X7loWPBtGKjUWs",
+    "mimeType" : "lTV1AL8moXnp",
+    "size" : 1801226149,
+    "license" : "https://www.example.com/z62i9aahjqf",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "fnTvJvGzyp",
-    "publishedDate" : "1981-12-15T08:02:17.486Z",
+    "legalNote" : "UQQI7nRL97",
+    "publishedDate" : "1996-02-24T03:19:04.856Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "fPXKSxsSOrCnA9CUj",
-      "uploadedDate" : "1985-06-24T13:12:44.706Z"
+      "uploadedBy" : "YnskMZuLwtv05AaPfq",
+      "uploadedDate" : "1998-08-10T13:17:12.861Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2e8qBeckNBKQ6rL",
-    "name" : "0z57eFOKklSkJ",
-    "description" : "qQ3QkVq6f6i"
+    "id" : "https://www.example.com/c7shqGOtqwgNF",
+    "name" : "qTKKaA83k6Ztp",
+    "description" : "gokhXyCaAPxeV"
   } ],
-  "rightsHolder" : "wnRchCAba5",
-  "duplicateOf" : "https://www.example.org/cc27139e-aeab-4335-97e4-e7a26d8d44fe",
+  "rightsHolder" : "xJULE3yODwV8Vb0ti8A",
+  "duplicateOf" : "https://www.example.org/c446d123-fd7d-44b6-b20a-f54850a6585a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tg6dKkbDVvSy"
+    "note" : "ZovEXa0R3wl4cy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "zk8AUvIsmTr4XY",
-    "createdBy" : "nqDVKX0PMUTaU",
-    "createdDate" : "1971-03-23T22:05:33.284Z"
+    "note" : "TvWVUZWnmUx9Rt",
+    "createdBy" : "990lxafY6PTjqRr",
+    "createdDate" : "1987-10-03T09:57:40.066Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/962824ca-ad40-47cc-aed9-0de13fc43972" ],
+  "curatingInstitutions" : [ "https://www.example.org/441cfd53-4ce5-45a5-93ec-6f0ac6b88440" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "5H6JYaN8ot7SwM1t",
-    "ownerAffiliation" : "https://www.example.org/c4f816ba-d5fb-45aa-ab35-d7980f291de8"
+    "owner" : "pES50v78dYIRZgr3P2B",
+    "ownerAffiliation" : "https://www.example.org/93d49ec6-19bd-4889-8c13-151c29a95b57"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/283159c0-0209-4e4a-b8a6-beabe946d29a"
+    "id" : "https://www.example.org/9cb98501-9332-40c8-85da-69f8dae1cfa5"
   },
-  "createdDate" : "2012-04-01T05:31:53.534Z",
-  "modifiedDate" : "1981-09-13T12:24:40.535Z",
-  "publishedDate" : "2019-10-03T18:27:16.853Z",
-  "indexedDate" : "2002-02-13T22:52:17.708Z",
-  "handle" : "https://www.example.org/868cef26-e325-4db9-915c-5ef1491552c2",
-  "doi" : "https://doi.org/10.1234/consectetur",
-  "link" : "https://www.example.org/def262ed-2398-4acc-8a4a-e222ebd058ac",
+  "createdDate" : "2017-04-19T00:09:39.592Z",
+  "modifiedDate" : "1973-04-15T08:29:11.833Z",
+  "publishedDate" : "1996-04-27T22:11:49.797Z",
+  "indexedDate" : "2000-05-27T22:30:33.209Z",
+  "handle" : "https://www.example.org/bd34c4f2-a0c2-4432-b126-ed1a8e9ab601",
+  "doi" : "https://doi.org/10.1234/aspernatur",
+  "link" : "https://www.example.org/83a77809-9f03-471d-8604-2932c22eba14",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xD11ESYyAp",
+    "mainTitle" : "W1BhRiZ2wzzp6Yq2Ui",
     "alternativeTitles" : {
-      "nn" : "FezyZHdCyy"
+      "se" : "JfutalXFpM8a"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "S03R3Muu2lDl",
-      "month" : "Eri8yoOw05gkT7n",
-      "day" : "XM7MwxMz0dBW"
+      "year" : "0keZ5v0yf5vVpiuP",
+      "month" : "Ucq7agN5a4",
+      "day" : "hwa5FKAC0A3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c0fda15f-ecc5-49db-9444-6a5219597916",
-        "name" : "tVBnMOFijkpvJq",
+        "id" : "https://www.example.org/ef226d54-fdc0-451f-80df-ee0581a8c6d0",
+        "name" : "JINxxsYqftGv",
         "nameType" : "Personal",
-        "orcId" : "SKT3s1mOkH",
+        "orcId" : "4nbCHbYQE6QS",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TvoBoOpz9mzK",
-          "value" : "oUtGmNMeI4UyBlNdHxb"
+          "sourceName" : "oNVmPvkjMwQfIxBo62",
+          "value" : "ipGdGHpipOTRRbf5Cqd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7hnX6aioH6gBYUo",
-          "value" : "ZalgHqiQIjjj"
+          "sourceName" : "P8RnkaNISPj3Ukz0eRG",
+          "value" : "AHiulhajTzfbyEI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/70b90408-1cfe-4061-a16e-4ad194c3e3e3"
+        "id" : "https://www.example.org/16ad8c2e-ad5e-4299-af53-b2bcf5a0f959"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dbc83a10-9fbe-499c-9d44-111aa4825342",
-        "name" : "6cd3NIjNSR",
+        "id" : "https://www.example.org/a2051c28-a426-4380-b073-a92c2e2d4daa",
+        "name" : "ikrNOknMf2W0vFPr",
         "nameType" : "Personal",
-        "orcId" : "7FbeAN2Gzc",
-        "verificationStatus" : "Verified",
+        "orcId" : "XHm0jglwI6Jz1Q",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SUCBazEzLyp3A8QLn",
-          "value" : "UhOcx32zMtdLNSn"
+          "sourceName" : "XWHWS2WhKFA",
+          "value" : "rhmVXVjM69IzinZG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z6jQFz4ygpQzmrhMkl",
-          "value" : "sGMv3bBsOj7"
+          "sourceName" : "VDoKGjDcuwy5j7",
+          "value" : "Fs6xZXFEalNAR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a73db4f-0311-44b3-a9a2-c24d4ace840c"
+        "id" : "https://www.example.org/65eda173-e574-4313-a711-82e1bc505b90"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "Conductor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "QPY9iVzRrEcs"
+      "ca" : "ypxFTetsTIAqJMGYy"
     },
-    "npiSubjectHeading" : "bpZKA2tsfwtm",
-    "tags" : [ "ThALHtGKM7h2iQL" ],
-    "description" : "z9qrpXad1XqL8s",
+    "npiSubjectHeading" : "gLC9d9zXTVN",
+    "tags" : [ "DPzPPResfIWdNnJ6" ],
+    "description" : "rP8tTdQQT9xa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/881e73f4-571f-4657-83d2-3987ed178370"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e260ee3f-b9f4-4d5b-809d-0ed7d99a4abd"
       },
-      "doi" : "https://www.example.org/a6d6b25c-970a-4f9b-9d3b-50b761313059",
+      "doi" : "https://www.example.org/5848de07-a67a-4305-bbc4-1f64555b7f1c",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "tqeEdEGQ6Gr1OE7il",
-          "end" : "WENts26kBHwSnM1Q"
+          "begin" : "w5v8h2A0DB",
+          "end" : "hGQ67mW7vOvc"
         },
-        "volume" : "tJO9lXtWHnA",
-        "issue" : "ir88j2vvYJwnPo",
-        "articleNumber" : "7l8s9yQwyAz35xZp6"
+        "volume" : "2ZiYWm56Ypy",
+        "issue" : "PDYGy1nevS",
+        "articleNumber" : "6y1yr51LDo"
       }
     },
-    "metadataSource" : "https://www.example.org/51d99562-9fb7-4224-bb5c-27a0808884e1",
-    "abstract" : "zZminl77MAaoD7vFRm"
+    "metadataSource" : "https://www.example.org/56c8756b-72a5-4d33-943c-6f6391452296",
+    "abstract" : "gWZYkLUayQbnmqMNVe"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e31410a6-e326-4ea6-8aa0-0db3679cb9cc",
-    "name" : "KKdnHw6zkjtzt",
+    "id" : "https://www.example.org/d3d4e4d3-b06e-4c32-b600-f26484cf7b1c",
+    "name" : "tGaLHA3kXJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-01-03T11:57:42.339Z",
+      "approvalDate" : "2021-04-05T11:38:20.773Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "c12MDCHLoL"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "BXpE9ZH7a2g86ly2HR9"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/47496e6d-22a6-4001-a580-0a29c7c34c21",
-    "identifier" : "1OFmvB8Ie42T1MjnDt",
+    "source" : "https://www.example.org/9ff3df72-8dbc-4ae3-ae88-720a77eac66a",
+    "identifier" : "5KstulRS9UzgDLw",
     "labels" : {
-      "hu" : "f7KUczIsSvnqMV2TvSE"
+      "nl" : "JxmckiUNaGDwg"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2129796838
+      "currency" : "USD",
+      "amount" : 1069874417
     },
-    "activeFrom" : "1993-09-03T09:35:23.391Z",
-    "activeTo" : "2002-01-13T06:36:41.503Z"
+    "activeFrom" : "1999-10-08T07:52:26.067Z",
+    "activeTo" : "2009-01-07T01:17:54.487Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d591e804-c96f-4aa9-b937-c2ca9db22076",
-    "id" : "https://www.example.org/dcf33855-a0a4-4b41-b323-88a4babbad43",
-    "identifier" : "yD78GAOrSjD",
+    "source" : "https://www.example.org/d5815e52-ff88-41a7-a733-b6add2ad0479",
+    "id" : "https://www.example.org/4c861b09-6b19-4d8e-9e64-2e7e93545047",
+    "identifier" : "AQFMeN2vy64KSD8Rpxg",
     "labels" : {
-      "da" : "U0kRvPDHezfuM9xLN"
+      "sv" : "ZnIBnfJQor3"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1798246378
+      "amount" : 31005184
     },
-    "activeFrom" : "2017-09-01T02:33:05.999Z",
-    "activeTo" : "2019-04-20T14:26:54.020Z"
+    "activeFrom" : "2002-11-06T21:07:14.677Z",
+    "activeTo" : "2020-05-09T08:14:16.459Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "QQMS4Dm2IOaoFC3",
-    "sourceName" : "iswmj2tmyjg@jo12asofbsaz"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/1b4f934f-f749-4803-aef1-7ba42a82bc4c",
-    "sourceName" : "fgo33x9nlljtjpu@akeb9jzhwe"
+    "value" : "https://www.example.org/fc9899be-035b-4687-9146-23d27a9d2d10",
+    "sourceName" : "m8k8eggpukwd6bi@qhldhiafksi5mcfn"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1233643494",
-    "sourceName" : "obgrg0cunzls@komne2ihonzvnammsat"
+    "value" : "44396487",
+    "sourceName" : "rpmc8gtqrysivbu@n2dasu8uakzx0ccyd"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "77h3wnYRMHJSmZJUFe",
+    "sourceName" : "damp1wepoavwyd@gnvcgtc5jj29c"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "B2yEcHGI01Et0tRe",
-    "value" : "P2EnKld70Epg8pa1ei"
+    "sourceName" : "QS49swJQTkz",
+    "value" : "lUP8XxW962T8x"
   } ],
-  "subjects" : [ "https://www.example.org/adb19d0a-5c23-4f18-88f7-6c185b448dee" ],
+  "subjects" : [ "https://www.example.org/4d955a08-5d3c-40dc-8537-33960eccfe0a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "17ac6620-cf11-4d69-b2dd-8a2c152fdfb6",
-    "name" : "pCya15GkXnE",
-    "mimeType" : "J8k6FsHooV",
-    "size" : 1171268573,
-    "license" : "https://www.example.com/4ippx7bmoimoh1v",
+    "identifier" : "ef0ed8f1-8fde-4217-9772-2fb925c8ebf1",
+    "name" : "7cL4rUT43Wt1abw",
+    "mimeType" : "ME7Sr9YHV5Y4jcixp",
+    "size" : 756019647,
+    "license" : "https://www.example.com/krk0us2kvurlwz3e",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ceVoo2v3nS9eoxhooOY",
-    "publishedDate" : "1996-02-21T19:05:38.953Z",
+    "legalNote" : "q5OgeXMBI4xnFMPyi",
+    "publishedDate" : "1985-12-07T00:31:53.942Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DVcvaX6NQsM0uX",
-      "uploadedDate" : "2014-11-28T05:04:28.090Z"
+      "uploadedBy" : "tyWPKxKkvAo3TUeGw",
+      "uploadedDate" : "1999-07-05T23:33:44.245Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Vk29K0mmfiVJlw66K",
-    "name" : "BGB8EqxMvL",
-    "description" : "b5vR4eKgv8f6"
+    "id" : "https://www.example.com/EgzyleQp8wo6dKlwR",
+    "name" : "62UqMO3Bm1g1h2O5Q",
+    "description" : "qWtgMwoxEgsHI4"
   } ],
-  "rightsHolder" : "8vT7rYEe1o",
-  "duplicateOf" : "https://www.example.org/430f793f-969c-40d0-8774-9031e30531cb",
+  "rightsHolder" : "A6MqhNQoeZNQO",
+  "duplicateOf" : "https://www.example.org/e0771cc5-7c5e-47fc-bb36-08805e483841",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YhsiRLTuN3BFz62"
+    "note" : "j5Vw3cD9GJn"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Cc6bUN8vlP4RZABpa",
-    "createdBy" : "jcIsknN85V7Z",
-    "createdDate" : "2011-02-03T19:48:28.878Z"
+    "note" : "vNZgQoH3OxK",
+    "createdBy" : "1eARiRW108RuBK",
+    "createdDate" : "1986-11-19T11:10:51.314Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dd53bbd7-b8c7-4d78-ae5c-9711cdc6abda" ],
+  "curatingInstitutions" : [ "https://www.example.org/8f9b9a36-17a7-49bc-aec1-4d73afef8004" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "JfC0DueI9Q",
-    "ownerAffiliation" : "https://www.example.org/a26d554d-0c02-447f-b5ed-9fc105f65ae4"
+    "owner" : "zyl3upKOcqqyNke87T",
+    "ownerAffiliation" : "https://www.example.org/9b1e7ca7-e5db-4d04-af5e-f04d4ffd8a93"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c883e5b0-54df-459e-b05f-be1fc813aa2f"
+    "id" : "https://www.example.org/89888b01-b838-43c4-95cb-d705f28741c6"
   },
-  "createdDate" : "1982-04-08T00:22:14.687Z",
-  "modifiedDate" : "2022-09-02T06:05:22.527Z",
-  "publishedDate" : "2014-01-17T11:56:03.907Z",
-  "indexedDate" : "2017-01-10T04:26:41.132Z",
-  "handle" : "https://www.example.org/2d198f0a-83f3-4e83-a4ae-b764b9b3cf0a",
-  "doi" : "https://doi.org/10.1234/natus",
-  "link" : "https://www.example.org/121d5a61-2381-442a-9335-79bddf27f656",
+  "createdDate" : "2012-04-19T01:53:52.212Z",
+  "modifiedDate" : "2019-04-30T15:56:54.176Z",
+  "publishedDate" : "2000-02-05T07:36:40.910Z",
+  "indexedDate" : "2007-12-21T17:44:10.902Z",
+  "handle" : "https://www.example.org/a6e168fc-10a9-42fa-954d-871f2a761519",
+  "doi" : "https://doi.org/10.1234/quas",
+  "link" : "https://www.example.org/423485b5-adbe-455a-93a2-38ae86ce72c5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ctITYHzhEtK35I",
+    "mainTitle" : "pyUaeYxgtXdqriWZ5R",
     "alternativeTitles" : {
-      "af" : "bRCvUoI9Yi"
+      "el" : "8FEhDJjBPD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "4pNBAhdO5p7oji",
-      "month" : "Cfzvm8fkTvWR",
-      "day" : "i4u25ubEK8c9AGOE31"
+      "year" : "6Uw3hNcL7LL",
+      "month" : "hPoWAkPnRxR",
+      "day" : "JdnQx7UGBqQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d58435d3-ef1a-4827-96ef-4aff469587cb",
-        "name" : "q0lKHffRXFOqua",
-        "nameType" : "Personal",
-        "orcId" : "osPVfEvgxt",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c3296cb1-bd64-4c35-889e-1b4e51559fdf",
+        "name" : "2ZnOg5RWYIhCFwxAhKN",
+        "nameType" : "Organizational",
+        "orcId" : "8CFPf7N3YSNHvSS",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LzoJ41AbUByw6K",
-          "value" : "T1wLQURWMsK9Bmu"
+          "sourceName" : "OeCLBBnftFSZ2qdv",
+          "value" : "NvbIizkYAlQ8K"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MaFu2tFnQpBDPjLv",
-          "value" : "HycaFcyRBSd0l1cnS"
+          "sourceName" : "jHnaiG5BZL03mE2F",
+          "value" : "zPSgeD3KVHVP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/596bcf17-6b0d-4b71-af94-f790e4786938"
+        "id" : "https://www.example.org/9d6c1231-45f4-44c6-86f8-7a972288e0a1"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/93ef7854-7928-4f36-a9c4-eea2e9ee5ef4",
-        "name" : "1fVMCT3bKdXu",
-        "nameType" : "Organizational",
-        "orcId" : "KuDzyke1U21eT",
+        "id" : "https://www.example.org/a80d4954-3a9b-44fa-be56-212d64ae869e",
+        "name" : "faPHo8G35jb3gBGR",
+        "nameType" : "Personal",
+        "orcId" : "4eoOm3jfLYb721FigzZ",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "42gXJaP4SlWtZNU",
-          "value" : "7pJhgjYUK2Wk8rsToFY"
+          "sourceName" : "Nx0CQcOuKzOTFpX",
+          "value" : "pIejYhQzfW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Zkp3DRdHqP",
-          "value" : "nNAoHTRUfBjQttKZTb"
+          "sourceName" : "lede4GBCPwwrpUkxZ",
+          "value" : "cENlq2gS76a8GHU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ca2d9171-f68e-48ed-aba2-d08ba6baaec6"
+        "id" : "https://www.example.org/81038d2b-f8f9-4fc5-a29c-038e8c5ca04a"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "H9Rq3P19DT"
+      "ru" : "HZrpTljuJ7vSZ7ZiR"
     },
-    "npiSubjectHeading" : "1sansdoNl1",
-    "tags" : [ "M9goXb7xWgIf1kP" ],
-    "description" : "oeOtk6cfBBSVaSu",
+    "npiSubjectHeading" : "ELH5RC2uXW5tk9uKLQu",
+    "tags" : [ "WOha5oAvi0Ui8XUK" ],
+    "description" : "SOY16WQkD8AJWcJV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/98d193a8-4ebb-4817-972c-41589e57ae5b"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7c05c410-1dde-40c5-b1fb-5cffc0a92a08"
         },
-        "seriesNumber" : "lciVoWeTesKTb",
+        "seriesNumber" : "rn4BddGCsxthLgR1e9",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/428c2256-70de-4d32-be49-959fe6e77dab",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/770fc136-a502-4a0d-bbfa-d12fb30c4ca0",
           "valid" : true
         },
-        "isbnList" : [ "9780917198205", "9781354627440" ],
+        "isbnList" : [ "9791804718550", "9781050051518" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "135462744X"
+          "value" : "1050051513"
         } ]
       },
-      "doi" : "https://www.example.org/a5dba061-275b-4031-9a23-332a77d4c924",
+      "doi" : "https://www.example.org/9f6080b2-dae4-4774-b76f-d32a940c5ffc",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ulfbyKJ9DLQ",
-            "end" : "fY3Sd4YkuM"
+            "begin" : "gXHr7hjm8B",
+            "end" : "sVs33s1q75t1GJqh15"
           },
-          "pages" : "JubZBgvkgCLfhkoDv",
+          "pages" : "bGNfiChgMnDKAOZYdC",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fa8be309-8f8f-4529-ac6d-2e8147a3b0d7",
-    "abstract" : "NFx1W8TjbIP"
+    "metadataSource" : "https://www.example.org/a19b0445-638a-4179-a48a-1ea97b678453",
+    "abstract" : "I53ar13c1b1zNwNi"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/53c764af-4ef8-4cc0-9ade-64dbc6a2cad1",
-    "name" : "E8MZwDBPHXGJGRHeb0",
+    "id" : "https://www.example.org/f8ab4adf-16fb-42b9-845d-75c777390d03",
+    "name" : "bsRusYlgODjSYH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1989-12-23T23:03:53.467Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "BAOCnrd7KCcWEJVI"
+      "approvalDate" : "1973-05-28T22:45:06.744Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "sM9nAzKIFgq"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2ef43d3c-3c43-4a08-9f48-918cc94d4882",
-    "identifier" : "Wrju2H6EaBtO",
+    "source" : "https://www.example.org/0c6955b3-96f2-46a5-82d0-a66ffd06e54b",
+    "identifier" : "xPC1sylpCJEFIr",
     "labels" : {
-      "nl" : "w0R2P4cFrN"
+      "is" : "o2fhIghcF0e8l0G0Pm"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 552249900
+      "amount" : 1376251785
     },
-    "activeFrom" : "1989-07-06T13:51:19.591Z",
-    "activeTo" : "1992-02-10T03:01:44.469Z"
+    "activeFrom" : "1973-03-18T19:02:43.127Z",
+    "activeTo" : "1996-10-15T13:35:47.992Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3289561b-2aed-4b22-b8e5-ede4cf2439e0",
-    "id" : "https://www.example.org/21b54eee-8a13-4bd9-85f8-8dcedf8b9e29",
-    "identifier" : "pdjr3pPMVwRIRpP6oIQ",
+    "source" : "https://www.example.org/f6a68d12-993f-4716-bd2f-519f2fcd8ade",
+    "id" : "https://www.example.org/dc5a44d5-342f-42d8-bda4-c8895e875876",
+    "identifier" : "RJ2ZLRLipovC",
     "labels" : {
-      "nb" : "r0kVbFgcFrSs76d"
+      "cs" : "4YrvlUmwZIAq6wWw"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 126641072
+      "currency" : "EUR",
+      "amount" : 845102138
     },
-    "activeFrom" : "1996-01-20T05:13:11.199Z",
-    "activeTo" : "2019-01-12T04:30:05.930Z"
+    "activeFrom" : "2007-12-26T04:03:10.152Z",
+    "activeTo" : "2016-10-24T18:50:05.422Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "tSNTSP1lmnHVNIMjI4",
-    "sourceName" : "37agu4wxh4@wo4sjur1zdf44"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/1b7ff5da-4c47-441a-94f1-e2a6afc306d3",
-    "sourceName" : "yqhgt18hhmck07nxuzm@01imrg9neizv"
+    "value" : "https://www.example.org/bf866c56-60bf-4cfb-afc4-cad65666b25e",
+    "sourceName" : "chckyqky8w2vi@j6hdimrcf4hy"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1840001376",
-    "sourceName" : "r8z1tassc2ss3u4pt@6rg4jcwrvgy"
+    "value" : "582303535",
+    "sourceName" : "fp25hlhd4ks6eu@s9qlo53cvmgeousxp"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "FQiAXiMa940tR82r1F1",
+    "sourceName" : "yqc4uhnlgokvnh@rfekehyjwnb4n2sq"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "qlCCku2MXtXL",
-    "value" : "gqS0Z7qSOCaaO03D"
+    "sourceName" : "GJrdyItCV8",
+    "value" : "gelykrPSKovm5246"
   } ],
-  "subjects" : [ "https://www.example.org/bdd569a6-5deb-42b9-b13e-f671a3ef865f" ],
+  "subjects" : [ "https://www.example.org/77b13d72-9659-490e-bd9b-6cf6e307e812" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "43bfc55c-14a3-42c8-a491-7b101b0034a6",
-    "name" : "TIBxQDW3RL5TmltN",
-    "mimeType" : "hD4Xosxux8Q9V",
-    "size" : 1083710833,
-    "license" : "https://www.example.com/mc5axaptzeeud",
+    "identifier" : "9802c993-0034-495f-9b1a-a4430d9d96a9",
+    "name" : "u8Jc8obGk2",
+    "mimeType" : "Ak8QOliwdJmCBaF5gso",
+    "size" : 1829716870,
+    "license" : "https://www.example.com/hvmg0imachtk",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Wbd7R1wrzNEUtQ8GLD",
-    "publishedDate" : "2015-01-08T09:55:17.407Z",
+    "legalNote" : "O44EAgq8qJ5J",
+    "publishedDate" : "2009-08-23T14:07:58.938Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "oAcHXv1vjFFTKDdM6L",
-      "uploadedDate" : "2012-12-17T17:58:23.579Z"
+      "uploadedBy" : "kxSFef3Uh18tKnPP",
+      "uploadedDate" : "1985-05-03T01:04:41.425Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/dA430koc6PMXHN6Y",
-    "name" : "9iCEIKGzjvYyF",
-    "description" : "qSkrf1D2ESa0lUg"
+    "id" : "https://www.example.com/kAgAICR4p3RfOB",
+    "name" : "AMQZ4CoJcrIKh1XSPK1",
+    "description" : "66Ud2bsjVvDM"
   } ],
-  "rightsHolder" : "9kAcAnoiTTX8fuJtnK",
-  "duplicateOf" : "https://www.example.org/55b203a7-a6c5-4912-b447-e6c4f81bf1d6",
+  "rightsHolder" : "1ASTYCUl4OwDQ",
+  "duplicateOf" : "https://www.example.org/9ef4023f-8739-41b9-bf30-59cd0d5ca992",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "d26rKq95fx"
+    "note" : "1xxGgP9pthYJ1RtwQr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DaO2N4xC8BGHS",
-    "createdBy" : "36RsS8tLJealD3Bc5C",
-    "createdDate" : "1978-03-06T06:28:34.287Z"
+    "note" : "KauZ3DJdg0Cu4Qxq2t",
+    "createdBy" : "Fdy1GK3Nlizj",
+    "createdDate" : "2005-02-12T06:53:49.485Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/da693239-dea5-4cb4-906b-c92401255347" ],
+  "curatingInstitutions" : [ "https://www.example.org/32e6b19f-a3fb-43a3-bbfe-6fbdca700872" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "JP1ARDKjjl",
-    "ownerAffiliation" : "https://www.example.org/3ad05405-d78a-4b34-b258-b4cca962490e"
+    "owner" : "0m2To2g4UOZbltke",
+    "ownerAffiliation" : "https://www.example.org/e5ccb6dc-dba0-4347-b143-d449ea5d7b56"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d50988f9-7c55-482b-a434-78a698cfa482"
+    "id" : "https://www.example.org/dd5d8893-5483-4af0-822d-c90cdec3e62b"
   },
-  "createdDate" : "1986-11-29T11:20:54Z",
-  "modifiedDate" : "1993-09-07T19:52:11.162Z",
-  "publishedDate" : "2012-11-12T23:43:06.077Z",
-  "indexedDate" : "2015-10-29T16:28:54.758Z",
-  "handle" : "https://www.example.org/f1d8b6c2-cfdf-493c-aaab-8fc86f677bc0",
-  "doi" : "https://doi.org/10.1234/eum",
-  "link" : "https://www.example.org/26687c45-80a3-450e-af19-c837d93b000e",
+  "createdDate" : "1975-03-19T19:15:53.009Z",
+  "modifiedDate" : "1986-01-14T01:29:50.802Z",
+  "publishedDate" : "2016-07-07T08:03:14.300Z",
+  "indexedDate" : "1994-04-14T15:36:17.106Z",
+  "handle" : "https://www.example.org/90902dcf-f515-4259-b362-e8c7554f2fad",
+  "doi" : "https://doi.org/10.1234/odio",
+  "link" : "https://www.example.org/fe26e21f-915b-403e-b533-36ba9a5c79d8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Zfvz6SDw26jMSLG",
+    "mainTitle" : "TYQPcPZLRuW",
     "alternativeTitles" : {
-      "pl" : "vqTZQRlZamJPcw6"
+      "zh" : "qxQmnARvktb"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tdDe0u8mEfIgh",
-      "month" : "EfCCxQFMCy0S4oHYP",
-      "day" : "4TZuq8QktrflJUV"
+      "year" : "Ktbemj4udDEUc",
+      "month" : "qnWgYnPSstt8",
+      "day" : "l19XigYWpiXZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/062f619a-fb8e-45ea-8922-1e8e0bff5f1f",
-        "name" : "lVzTMAHixYdG7lvnNuw",
+        "id" : "https://www.example.org/299680b0-ffc6-46b8-8314-796f4ce4536f",
+        "name" : "w7oY4qB40Nw",
         "nameType" : "Organizational",
-        "orcId" : "dX63Ns334K2R5",
-        "verificationStatus" : "Verified",
+        "orcId" : "YZs2FCgPx3GNRsUr2",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nj7x0zhRzXN2va",
-          "value" : "TaIn6Cn63nqMNu30"
+          "sourceName" : "4G0xTkdloFzHcYH",
+          "value" : "RUgGHUaPG27lzFOOjTW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lDpRssWndFROv",
-          "value" : "p63RJfujhf1jOegyB"
+          "sourceName" : "anJxBdUWyCghHny5X",
+          "value" : "WTMGZsBa0J6t8Yp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a96a4039-f153-4f21-9286-741180ab0a90"
+        "id" : "https://www.example.org/9c317714-307b-4a1f-a17b-954d6005a10b"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4b560ac1-aede-4f02-9d7b-6616098fc5b5",
-        "name" : "8cX1xcKdkpVRFOfAPa",
+        "id" : "https://www.example.org/541d3c0d-d50c-4dfd-911c-e5fe7ba0c489",
+        "name" : "jaFxIZANXJG9",
         "nameType" : "Organizational",
-        "orcId" : "EEGHP7Tjdfw4",
+        "orcId" : "gRxyrQ9GvfThlR8NG78",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AgcY9UC69AT",
-          "value" : "D4OazIzNugQfjj8co"
+          "sourceName" : "AjqKYugUZVTzMDO7N9e",
+          "value" : "u6t4jA6oJaeYEG9H"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rSrNJQGbH6wBvYbd",
-          "value" : "belfOFUY4lbquIZ"
+          "sourceName" : "OC3X8khagu0uC",
+          "value" : "4OROKIjSlgt41GE87FX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fb356258-7b9c-441b-8bf2-7a7c55d19624"
+        "id" : "https://www.example.org/0c8d4a50-86d4-45bc-91c7-91a777edd404"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "BASkyZcloWmc"
+      "bg" : "ufBID0kaMM"
     },
-    "npiSubjectHeading" : "XHJo03K7sdx49",
-    "tags" : [ "WvCYmepAIj" ],
-    "description" : "mHhv0XB17D7AJqXesK",
+    "npiSubjectHeading" : "Gr25JNOAAhxuI",
+    "tags" : [ "wmr3rd04e4Dl4Mr" ],
+    "description" : "uSloxXWhDnalpT052zk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/ZNUa94phmonXLoOPsnW"
+        "id" : "https://www.example.com/c4LzKHd9cgIa"
       },
-      "doi" : "https://www.example.org/0e472b80-6b2b-4f8a-b0ad-555622e07823",
+      "doi" : "https://www.example.org/dc09ec1f-b642-4779-bb14-df9bee46e229",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "mcttQFmrZU3gamazfU",
-          "end" : "O9kjK8Jrm93pwFO4"
+          "begin" : "JqLLyav0zM6XJikjT",
+          "end" : "5er80cb6eQfPghU"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0c185197-e14d-4faf-ac0b-24c348e0ad6a",
-    "abstract" : "yk4OVQAIk4tAY"
+    "metadataSource" : "https://www.example.org/bb5acdfd-df1b-461a-b8f1-fd90ab70c71d",
+    "abstract" : "XEC5g4Sdoo8b8QGv3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6af031a5-2686-4950-a609-9044f6ba1ebc",
-    "name" : "IaFXdzDOVbVRKinHT",
+    "id" : "https://www.example.org/c873af0d-4047-4803-a10a-2c89ea6e8587",
+    "name" : "1tpE7zTcbZHoLD7G",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-07-21T01:29:50.068Z",
+      "approvalDate" : "2021-10-05T08:36:54.937Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "9JWNw221sVTrIgmW"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "K8GbW5m5EE83"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/52b3c3d5-706e-44fb-98a5-fe86a886f671",
-    "identifier" : "tipWKPKeg7",
+    "source" : "https://www.example.org/948bd7f8-f513-496f-bb31-7bc236e75e55",
+    "identifier" : "JRwSlWTAWRV",
     "labels" : {
-      "fi" : "l4lNL6N8eAtflvsY9"
+      "sv" : "rGTTryVYj6RYY3Ep"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1980463682
+      "currency" : "USD",
+      "amount" : 210273161
     },
-    "activeFrom" : "1985-03-13T03:09:29.669Z",
-    "activeTo" : "2013-09-21T07:53:05.333Z"
+    "activeFrom" : "2020-04-14T03:15:58.338Z",
+    "activeTo" : "2022-09-27T18:45:39.128Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f4e88edc-83d3-48de-8694-674824f7f0f9",
-    "id" : "https://www.example.org/7b93eb8b-6b20-4fd9-92a3-60327ebd1702",
-    "identifier" : "4SPyiEkCtq9tYwmx",
+    "source" : "https://www.example.org/1c3799b9-30df-45e6-870d-40ea7d7da577",
+    "id" : "https://www.example.org/67f685b7-50ed-4d77-a90c-323f500a2712",
+    "identifier" : "YfDCdIPPmFSyKw2s",
     "labels" : {
-      "it" : "sMswStCQuQHd"
+      "pl" : "80IGIy9mEABdwUnZ"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 74882305
+      "currency" : "USD",
+      "amount" : 1174068879
     },
-    "activeFrom" : "2008-03-27T20:57:50.024Z",
-    "activeTo" : "2009-09-21T09:49:01.866Z"
+    "activeFrom" : "1980-06-23T06:53:40.895Z",
+    "activeTo" : "2017-05-12T16:30:18.077Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2405b53c-6026-44f1-abec-92823fa3867d",
-    "sourceName" : "qwpnxwo4nw@xlikk6k7oftnsoahf"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "Ax7twexXumq3aebM",
-    "value" : "4Vf00PC0E68K5KMurMr"
+    "value" : "https://www.example.org/fedb4387-7ebd-47ae-b338-675a40ea0bfd",
+    "sourceName" : "vb4shexlcfsz@oyeznhaso9"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "778550552",
-    "sourceName" : "a5zvqgdj6xgm0d0a1@8h0nyjejj1ylq7rh"
+    "value" : "1987482575",
+    "sourceName" : "pdsdyku9bhtknq4n@jjzlohrljggjziax0"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "1rEaWz1DOgFtyO7",
+    "value" : "xQJV9y1fEiRtr"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "c2B2b8ICqxB8Yz",
-    "sourceName" : "pivsoyegf63sh@jfwnusqa8qz4uuukck8"
+    "value" : "SETA9k38zdz1uVVe1",
+    "sourceName" : "ahazjyvxuh@4dckkkb8calvbqz"
   } ],
-  "subjects" : [ "https://www.example.org/8cec4beb-b4c3-46c9-b082-0dd8c5f54b63" ],
+  "subjects" : [ "https://www.example.org/fd61478f-a70a-4052-93f8-c5a317d2d30b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5509832b-b237-49f4-8c3a-263a2ba9ca5e",
-    "name" : "WiocyJDX4jcm",
-    "mimeType" : "V4WQJgjsiYtIvW",
-    "size" : 2129290819,
-    "license" : "https://www.example.com/mnqwf7zievxx1",
+    "identifier" : "a377d1bf-590c-486f-94b0-cd805a9a9aa7",
+    "name" : "G7mQGb8HUqdLJXa",
+    "mimeType" : "4HlVrmsD1qeS",
+    "size" : 420828738,
+    "license" : "https://www.example.com/e4sc3c0binbte",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "M22j345PXNpDoTg"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "0GAtbZguLWrHuf",
-    "publishedDate" : "2021-11-26T01:04:03.959Z",
+    "legalNote" : "inl8wqdq3ru3i2D",
+    "publishedDate" : "1996-05-12T18:52:44.614Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "oZpTSEaEL8W6TXz8H9",
-      "uploadedDate" : "2012-08-24T11:05:45.958Z"
+      "uploadedBy" : "qrdnMYElxr",
+      "uploadedDate" : "1994-05-04T10:55:59.609Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FoCcORiHsWHlGpPe",
-    "name" : "NT4QPhZ0WnpNa",
-    "description" : "wkzBGViXVFh"
+    "id" : "https://www.example.com/8qUltQADlosrqIkJ1",
+    "name" : "4ZQ27UXTry2Oms8",
+    "description" : "wfgCktXdrapN0btM"
   } ],
-  "rightsHolder" : "Hz8L7iFqWcBrD",
-  "duplicateOf" : "https://www.example.org/76aabd99-1dce-497f-ae05-de3799bb8675",
+  "rightsHolder" : "Km4RSU051uh",
+  "duplicateOf" : "https://www.example.org/9a001220-47d9-4767-8e43-4bfc8c568755",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "3RYx5nUYeFARX8"
+    "note" : "wUSWXgL5Zg3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DOIvw7x2GBUhb2",
-    "createdBy" : "W2DBKfIbbL9QJiGpHP0",
-    "createdDate" : "1977-01-19T00:45:32.150Z"
+    "note" : "Kg0i4t5Rdd",
+    "createdBy" : "IfpLh7euOp7SlwwWMM",
+    "createdDate" : "1985-02-16T11:00:47.202Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9375c24e-00be-461e-803a-80f553306354" ],
+  "curatingInstitutions" : [ "https://www.example.org/82d7bc05-2a92-4efa-bdad-06c9d6c25453" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "IXTUPMqPlFqxvPyp",
-    "ownerAffiliation" : "https://www.example.org/7a6edade-3e4b-4fbd-b67c-a260e6b885d7"
+    "owner" : "Ontbla2OdKf8ExfERQ9",
+    "ownerAffiliation" : "https://www.example.org/78bdaaf3-d335-44d8-ac19-c72dbcb1ccb4"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/db237ac9-ad5d-49f9-ab2a-cbf3a7cddb62"
+    "id" : "https://www.example.org/1108d11d-08fd-45bb-acf8-d15227be27ed"
   },
-  "createdDate" : "2022-09-07T21:34:39.695Z",
-  "modifiedDate" : "2021-09-24T09:01:19.980Z",
-  "publishedDate" : "1981-05-10T06:00:29.056Z",
-  "indexedDate" : "1976-08-05T02:23:59.673Z",
-  "handle" : "https://www.example.org/9edbae98-8590-4948-9a2e-41a038f70194",
-  "doi" : "https://doi.org/10.1234/totam",
-  "link" : "https://www.example.org/d2e71cad-6de9-45d3-a1c9-437915c8ef97",
+  "createdDate" : "1987-07-28T01:56:14.808Z",
+  "modifiedDate" : "2023-01-02T13:43:18.610Z",
+  "publishedDate" : "1974-02-18T22:04:04.927Z",
+  "indexedDate" : "1996-08-08T01:10:21.422Z",
+  "handle" : "https://www.example.org/9ce558e5-24fc-4d21-974f-5507fb433d75",
+  "doi" : "https://doi.org/10.1234/rerum",
+  "link" : "https://www.example.org/6250a524-92a6-40d1-b8a2-65d0eb0ecfb9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SHhVh5xC9jhjHY0iTVk",
+    "mainTitle" : "LFgQkjcsnOjfO",
     "alternativeTitles" : {
-      "is" : "7zglLxcO3w"
+      "se" : "wgs42Rogcu5B"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zGstpD2uRoGhSbg",
-      "month" : "Sc3vrnQ2Xk",
-      "day" : "ln9khH1bt1GdJkB"
+      "year" : "XSv3QpksEXlsFznW3",
+      "month" : "0w70aHWiW25qT",
+      "day" : "71BljuIuYEqd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/083cf1b4-e14e-4add-b28a-4059ed13bec2",
-        "name" : "OCtrfsdLI6y3mNxBR",
-        "nameType" : "Organizational",
-        "orcId" : "fa3yySc7mD",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/70f94339-2f1b-44af-a621-d35218742872",
+        "name" : "lnNvP1YjJD080k",
+        "nameType" : "Personal",
+        "orcId" : "MAXuo4cAOSf",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RlZVwKkQZieLQVO",
-          "value" : "YzwpKQl4sZ"
+          "sourceName" : "oenrvSquveB5hkX",
+          "value" : "xg3Sj3mWzqEWebTL3m"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V69HSRfs9rILU2ik",
-          "value" : "TqAvFAqMQI"
+          "sourceName" : "YqxeY3F9fUVhAqJ",
+          "value" : "FbLuwnhQnlal09"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0651dc5c-4833-489f-a24b-4d32ba773884"
+        "id" : "https://www.example.org/a0dd4880-7fa0-4f30-aa0d-24cf97d88b8c"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/52a3bb41-6c9f-4cd6-b993-037f9872b0ee",
-        "name" : "7Kbpsu2nyTeo",
-        "nameType" : "Organizational",
-        "orcId" : "411sPsi7YiZ",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/629c62ab-6ab4-4de3-8585-b669da2e2c2a",
+        "name" : "99LaQl54A47LaqP",
+        "nameType" : "Personal",
+        "orcId" : "oEDK2iu9gp3h",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JtfYjS16Yt89pEs",
-          "value" : "kdCYylSeL2tvRC7u0B8"
+          "sourceName" : "oQknSlSjVYpeuU3H",
+          "value" : "joFm3xZQmIViQfVf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UQ2w3S2a2hZMizw9EYA",
-          "value" : "wgg5R68fXPb7zzH"
+          "sourceName" : "hZ0tN12JERHGruaf",
+          "value" : "VUEwHwhNq9A1KG5M"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/77aa73fd-e518-4663-bd85-3402dd74c9ae"
+        "id" : "https://www.example.org/47f880eb-154f-4b2d-9631-906c0ccd2ead"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "RelatedPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "0mXXAmkcns"
+      "es" : "Q89ql1Uaslrngp56"
     },
-    "npiSubjectHeading" : "VkoL3rp7MzDA",
-    "tags" : [ "TSWFG4JP3Yo7P6ZM" ],
-    "description" : "kC4skPpQZoYieIcFVlX",
+    "npiSubjectHeading" : "iSbfHGp2lugCR",
+    "tags" : [ "TVyK5eE2dV3t1T2Czu" ],
+    "description" : "b3DNqqSE2JDb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/448e0be9-cb16-4b3c-9dfe-a41a21be83b8",
+      "doi" : "https://www.example.org/8cb58a5c-3be9-4756-a3d9-b3379191e4b5",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "CollectiveExhibition"
+          "type" : "IndividualExhibition"
         },
-        "description" : "F4PBIFkeYLm6W",
+        "description" : "jYcxO4PlYj5Uc8pxk",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "W27bZxFp8rtxMq",
-            "country" : "YvU6a5PtL3"
+            "label" : "eyGpCVJPtMrYow",
+            "country" : "mWYbJ6lWc585X6iwqQ"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2005-11-04T15:41:40.971Z",
-            "to" : "2007-06-17T20:28:03.577Z"
+            "from" : "1992-10-13T01:35:07.396Z",
+            "to" : "2018-07-12T06:06:37.282Z"
           },
-          "sequence" : 524121014
+          "sequence" : 625788993
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/642b9e05-92fa-4dd8-80dd-2bbbcaedd4d7",
-    "abstract" : "OFsFAD1TlBQKJsAz"
+    "metadataSource" : "https://www.example.org/5d545e7f-12fa-4eac-807a-b3200d25903b",
+    "abstract" : "9nSpSvIm4vuz6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7d383dce-34c2-4612-a1a0-ae54db2a781b",
-    "name" : "kwqqWFSQG8qcJ",
+    "id" : "https://www.example.org/51d3de5f-3ac1-42c1-a4cc-9f8a04644f7b",
+    "name" : "IKfDjKImSFLbaqsBf",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-09-16T20:28:06.362Z",
+      "approvalDate" : "1982-12-31T12:08:59.136Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "fPW0ZymRKTT9HdZZR"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Yl5sGuhhFpTZ3L"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3217b488-e6ba-4e17-bb61-e3aa492b704d",
-    "identifier" : "0mEoXl4YuJof4S",
+    "source" : "https://www.example.org/01df2761-32ad-41d9-a8e0-45869bd96983",
+    "identifier" : "E7OtZsZyvztX6tAvbHU",
     "labels" : {
-      "nn" : "AhhnPx8WmYcGY1"
+      "fi" : "Rjwprfh5zcYsL"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 782016299
+      "amount" : 1467270993
     },
-    "activeFrom" : "2024-06-24T23:28:48.416Z",
-    "activeTo" : "2024-07-11T16:46:31.937Z"
+    "activeFrom" : "1983-03-31T16:21:39.940Z",
+    "activeTo" : "2007-04-15T21:36:42.969Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e1e7335a-8eab-4824-abcd-9d9aeaa0c8ce",
-    "id" : "https://www.example.org/4fb4c80f-b6c6-4023-b59f-e48f135b2526",
-    "identifier" : "uq0gkjof9B3",
+    "source" : "https://www.example.org/bcf87d1e-c917-4ed5-a57c-424709c0240e",
+    "id" : "https://www.example.org/bc779187-0c20-473e-a90d-ac997ad4caf5",
+    "identifier" : "AAE1kZppjgh5S",
     "labels" : {
-      "nb" : "GjeYOUzGnnaEbh7N5Vk"
+      "sv" : "P0EPqSUzGC8WJ"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2073753247
+      "amount" : 1112504122
     },
-    "activeFrom" : "2003-03-01T11:21:08.006Z",
-    "activeTo" : "2019-02-25T06:29:17.192Z"
+    "activeFrom" : "1977-10-06T16:28:29.465Z",
+    "activeTo" : "1988-02-09T16:23:50.353Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "ERw6OoMYwCh",
-    "sourceName" : "oxuifmjp8qqs6@uw1dj5h3i0i0tducxpq"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/ceec0ae9-c407-4b5f-9e7a-562683b029ea",
-    "sourceName" : "zz8qntglhaptgo@ugua74r25huschd"
+    "value" : "https://www.example.org/251b1957-c0a2-4947-ab8e-b54c027d06a0",
+    "sourceName" : "migy80uvcdxfpx@t9q2ijztmvf4h"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "E0icOdenYW",
+    "sourceName" : "duo2civexzpl14@sdbh1veb65s9"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1912806676",
-    "sourceName" : "sdp5x83uqb@lbbquuslwd"
+    "value" : "209256930",
+    "sourceName" : "mssdq8o4krfblp2t@tw8mbrihri"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "biPLmy2UKOogjG5x5pD",
-    "value" : "fCFSJ03jSgB7KNybKaS"
+    "sourceName" : "NVwywxuQkkKDa",
+    "value" : "CkSCcwvWeX3"
   } ],
-  "subjects" : [ "https://www.example.org/97200a96-151b-462a-bd47-55fcefc472fd" ],
+  "subjects" : [ "https://www.example.org/b1fd1e56-fe44-4418-8fdc-762d8ca8925e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2ff95439-f211-413f-bf50-24c593cf0b5d",
-    "name" : "2W84pxSqdkU7gg",
-    "mimeType" : "QvUVovrTXOlq",
-    "size" : 224922523,
-    "license" : "https://www.example.com/ybdtiuo5hz",
+    "identifier" : "6da65df1-b598-4066-975a-0ae4b1f77ea4",
+    "name" : "25iqgxJDJIhQ75R6Zl",
+    "mimeType" : "Vhfsjj9Y6xqPEwkpo",
+    "size" : 1337988085,
+    "license" : "https://www.example.com/mojuy1bd5f2ajotbfd",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QOfyjKBvilktInVoV",
-    "publishedDate" : "1983-11-21T16:18:59.548Z",
+    "legalNote" : "EMNq7RzDWHO",
+    "publishedDate" : "2000-02-22T00:33:58.756Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "di2pGWiRqVlB",
-      "uploadedDate" : "2003-03-09T02:42:30.457Z"
+      "uploadedBy" : "eN0sAZaudqVtJT",
+      "uploadedDate" : "1991-07-16T03:44:10.907Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/U7nG4HttMSqMwFFl",
-    "name" : "2AQXy6TsT5wvA",
-    "description" : "Bqo5FZOCalniYhvM0bI"
+    "id" : "https://www.example.com/ExmqpWuBdTT",
+    "name" : "4ndoX6wx81r5UXnh55W",
+    "description" : "gWynbf1KAM"
   } ],
-  "rightsHolder" : "k2jW2sdkLVOvYC",
-  "duplicateOf" : "https://www.example.org/0de5dc4f-0122-42d1-8298-01d3f28cadaa",
+  "rightsHolder" : "lch4NiGgwW0nRIvdU",
+  "duplicateOf" : "https://www.example.org/0da3177e-d5c1-4aad-90ee-30807ea2b904",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "hl2JAALcQyderCSK"
+    "note" : "o4PyjUMzvHV"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "rnGebLHBA92D1s",
-    "createdBy" : "RaWSZOCalPnvl1fvH",
-    "createdDate" : "2004-11-21T07:48:59.746Z"
+    "note" : "dLTDBSubZ9St1Od",
+    "createdBy" : "3pbyY2pbG8GVPIOpg02",
+    "createdDate" : "2009-09-08T19:24:48.038Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8f9ac4be-80ad-4d04-a43c-17e0a1ecce39" ],
+  "curatingInstitutions" : [ "https://www.example.org/96d0a950-1764-4633-99fa-43aadb69a098" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -73,6 +73,11 @@ AdditionalIdentifierBase:
       type: string
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/AdditionalIdentifier'
+  - $ref: '#/components/schemas/HandleIdentifier'
+  - $ref: '#/components/schemas/ScopusIdentifier'
+  - $ref: '#/components/schemas/CristinIdentifier'
 AdministrativeAgreement:
   required:
   - type
@@ -90,6 +95,8 @@ Agent:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Corporation'
 Anthology:
   required:
   - type
@@ -160,6 +167,11 @@ ArchitectureOutput:
       format: int32
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Competition'
+  - $ref: '#/components/schemas/MentionInPublication'
+  - $ref: '#/components/schemas/Award'
+  - $ref: '#/components/schemas/Exhibition'
 ArchitectureSubtype:
   type: object
   properties:
@@ -231,6 +243,10 @@ AssociatedArtifact:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/File'
+  - $ref: '#/components/schemas/AssociatedLink'
+  - $ref: '#/components/schemas/NullAssociatedArtifact'
 AssociatedArtifactList:
   type: array
   properties:
@@ -354,6 +370,9 @@ BookSeries:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Series'
+  - $ref: '#/components/schemas/UnconfirmedSeries'
 Broadcast:
   required:
   - type
@@ -568,6 +587,9 @@ Corporation:
     properties:
       type:
         type: string
+  oneOf:
+  - $ref: '#/components/schemas/Organization'
+  - $ref: '#/components/schemas/UnconfirmedOrganization'
 Course:
   required:
   - type
@@ -575,6 +597,8 @@ Course:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/UnconfirmedCourse'
 CristinIdentifier:
   type: object
   allOf:
@@ -766,6 +790,10 @@ Duration:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/DefinedDuration'
+  - $ref: '#/components/schemas/UndefinedDuration'
+  - $ref: '#/components/schemas/NullDuration'
 Encyclopedia:
   required:
   - type
@@ -990,6 +1018,11 @@ ExhibitionProductionManifestation:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/ExhibitionCatalogReference'
+  - $ref: '#/components/schemas/ExhibitionOtherPresentation'
+  - $ref: '#/components/schemas/ExhibitionBasic'
+  - $ref: '#/components/schemas/ExhibitionMentionInPublication'
 ExhibitionProductionSubtype:
   type: object
   properties:
@@ -1050,6 +1083,10 @@ File:
         type: boolean
       type:
         type: string
+  oneOf:
+  - $ref: '#/components/schemas/PublishedFile'
+  - $ref: '#/components/schemas/UnpublishedFile'
+  - $ref: '#/components/schemas/AdministrativeAgreement'
 FunderRightsRetentionStrategy:
   required:
   - type
@@ -1074,16 +1111,19 @@ Funding:
     source:
       type: string
       format: uri
+    fundingAmount:
+      $ref: '#/components/schemas/MonetaryAmount'
     activeFrom:
       type: string
       format: date-time
     activeTo:
       type: string
       format: date-time
-    fundingAmount:
-      $ref: '#/components/schemas/MonetaryAmount'
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/ConfirmedFunding'
+  - $ref: '#/components/schemas/UnconfirmedFunding'
 GeographicalContent:
   required:
   - type
@@ -1389,6 +1429,11 @@ LiteraryArtsManifestation:
       $ref: '#/components/schemas/PublicationDate'
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/LiteraryArtsAudioVisual'
+  - $ref: '#/components/schemas/LiteraryArtsMonograph'
+  - $ref: '#/components/schemas/LiteraryArtsPerformance'
+  - $ref: '#/components/schemas/LiteraryArtsWeb'
 LiteraryArtsMonograph:
   required:
   - type
@@ -1689,6 +1734,10 @@ MovingPictureOutput:
       format: int32
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Broadcast'
+  - $ref: '#/components/schemas/CinematicRelease'
+  - $ref: '#/components/schemas/OtherRelease'
 MovingPictureSubtype:
   type: object
   properties:
@@ -1744,6 +1793,11 @@ MusicPerformanceManifestation:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/AudioVisualPublication'
+  - $ref: '#/components/schemas/Concert'
+  - $ref: '#/components/schemas/MusicScore'
+  - $ref: '#/components/schemas/OtherPerformance'
 MusicScore:
   required:
   - type
@@ -1964,6 +2018,10 @@ Pages:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Range'
+  - $ref: '#/components/schemas/MonographPages'
+  - $ref: '#/components/schemas/Period'
 PerformingArts:
   required:
   - type
@@ -1991,6 +2049,8 @@ PerformingArtsOutput:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/PerformingArtsVenue'
 PerformingArtsSubtype:
   type: object
   properties:
@@ -2040,6 +2100,8 @@ Place:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/UnconfirmedPlace'
 PopularScienceArticle:
   required:
   - type
@@ -2203,6 +2265,21 @@ PublicationContext:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Book'
+  - $ref: '#/components/schemas/Report'
+  - $ref: '#/components/schemas/Degree'
+  - $ref: '#/components/schemas/Anthology'
+  - $ref: '#/components/schemas/Journal'
+  - $ref: '#/components/schemas/UnconfirmedJournal'
+  - $ref: '#/components/schemas/Event'
+  - $ref: '#/components/schemas/Artistic'
+  - $ref: '#/components/schemas/MediaContribution'
+  - $ref: '#/components/schemas/MediaContributionPeriodical'
+  - $ref: '#/components/schemas/UnconfirmedMediaContributionPeriodical'
+  - $ref: '#/components/schemas/ResearchData'
+  - $ref: '#/components/schemas/GeographicalContent'
+  - $ref: '#/components/schemas/ExhibitionContent'
 PublicationDate:
   required:
   - type
@@ -2225,6 +2302,67 @@ PublicationInstancePages:
       $ref: '#/components/schemas/Pages'
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Architecture'
+  - $ref: '#/components/schemas/ArtisticDesign'
+  - $ref: '#/components/schemas/MovingPicture'
+  - $ref: '#/components/schemas/PerformingArts'
+  - $ref: '#/components/schemas/AcademicArticle'
+  - $ref: '#/components/schemas/AcademicLiteratureReview'
+  - $ref: '#/components/schemas/CaseReport'
+  - $ref: '#/components/schemas/StudyProtocol'
+  - $ref: '#/components/schemas/ProfessionalArticle'
+  - $ref: '#/components/schemas/PopularScienceArticle'
+  - $ref: '#/components/schemas/JournalCorrigendum'
+  - $ref: '#/components/schemas/JournalLetter'
+  - $ref: '#/components/schemas/JournalLeader'
+  - $ref: '#/components/schemas/JournalReview'
+  - $ref: '#/components/schemas/AcademicMonograph'
+  - $ref: '#/components/schemas/PopularScienceMonograph'
+  - $ref: '#/components/schemas/Encyclopedia'
+  - $ref: '#/components/schemas/ExhibitionCatalog'
+  - $ref: '#/components/schemas/NonFictionMonograph'
+  - $ref: '#/components/schemas/Textbook'
+  - $ref: '#/components/schemas/BookAnthology'
+  - $ref: '#/components/schemas/DegreeBachelor'
+  - $ref: '#/components/schemas/DegreeMaster'
+  - $ref: '#/components/schemas/DegreePhd'
+  - $ref: '#/components/schemas/DegreeLicentiate'
+  - $ref: '#/components/schemas/ReportBasic'
+  - $ref: '#/components/schemas/ReportPolicy'
+  - $ref: '#/components/schemas/ReportResearch'
+  - $ref: '#/components/schemas/ReportWorkingPaper'
+  - $ref: '#/components/schemas/ConferenceReport'
+  - $ref: '#/components/schemas/ReportBookOfAbstract'
+  - $ref: '#/components/schemas/AcademicChapter'
+  - $ref: '#/components/schemas/EncyclopediaChapter'
+  - $ref: '#/components/schemas/ExhibitionCatalogChapter'
+  - $ref: '#/components/schemas/Introduction'
+  - $ref: '#/components/schemas/NonFictionChapter'
+  - $ref: '#/components/schemas/PopularScienceChapter'
+  - $ref: '#/components/schemas/TextbookChapter'
+  - $ref: '#/components/schemas/ChapterConferenceAbstract'
+  - $ref: '#/components/schemas/ChapterInReport'
+  - $ref: '#/components/schemas/OtherStudentWork'
+  - $ref: '#/components/schemas/ConferenceLecture'
+  - $ref: '#/components/schemas/ConferencePoster'
+  - $ref: '#/components/schemas/Lecture'
+  - $ref: '#/components/schemas/OtherPresentation'
+  - $ref: '#/components/schemas/JournalIssue'
+  - $ref: '#/components/schemas/ConferenceAbstract'
+  - $ref: '#/components/schemas/MediaFeatureArticle'
+  - $ref: '#/components/schemas/MediaBlogPost'
+  - $ref: '#/components/schemas/MediaInterview'
+  - $ref: '#/components/schemas/MediaParticipationInRadioOrTv'
+  - $ref: '#/components/schemas/MediaPodcast'
+  - $ref: '#/components/schemas/MediaReaderOpinion'
+  - $ref: '#/components/schemas/MusicPerformance'
+  - $ref: '#/components/schemas/DataManagementPlan'
+  - $ref: '#/components/schemas/DataSet'
+  - $ref: '#/components/schemas/VisualArts'
+  - $ref: '#/components/schemas/Map'
+  - $ref: '#/components/schemas/LiteraryArts'
+  - $ref: '#/components/schemas/ExhibitionProduction'
 PublicationNote:
   type: object
   allOf:
@@ -2238,6 +2376,9 @@ PublicationNoteBase:
       type: string
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/PublicationNote'
+  - $ref: '#/components/schemas/UnpublishingNote'
 PublishedFile:
   required:
   - type
@@ -2270,6 +2411,10 @@ PublishingHouse:
       type: boolean
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Publisher'
+  - $ref: '#/components/schemas/UnconfirmedPublisher'
+  - $ref: '#/components/schemas/NullPublisher'
 Range:
   required:
   - type
@@ -2302,6 +2447,9 @@ RelatedDocument:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/ConfirmedDocument'
+  - $ref: '#/components/schemas/UnconfirmedDocument'
 Report:
   type: object
   allOf:
@@ -2441,6 +2589,11 @@ RightsRetentionStrategy:
       - OverridableRightsRetentionStrategy
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/CustomerRightsRetentionStrategy'
+  - $ref: '#/components/schemas/OverriddenRightsRetentionStrategy'
+  - $ref: '#/components/schemas/NullRightsRetentionStrategy'
+  - $ref: '#/components/schemas/FunderRightsRetentionStrategy'
 RoleType:
   type: object
   properties:
@@ -2591,6 +2744,9 @@ Time:
   properties:
     type:
       type: string
+  oneOf:
+  - $ref: '#/components/schemas/Period'
+  - $ref: '#/components/schemas/Instant'
 UnconfirmedCourse:
   required:
   - type

--- a/expansion/build.gradle
+++ b/expansion/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation libs.aws.sdk.dynamodb
     implementation libs.bundles.jena
     implementation libs.bundles.logging
+    implementation libs.swagger.annotations
 
     testImplementation(project(':publication-testing'))
     testImplementation project(":publication-model-testing")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -155,6 +155,8 @@ vavr = { group = 'io.vavr', name = 'vavr', version.ref = 'vavrVersion' }
 resilience4j-all = { group = 'io.github.resilience4j', name = 'resilience4j-all', version.ref = 'resilience4j' }
 
 swagger-core = { group = 'io.swagger.core.v3', name = 'swagger-core', version.ref = 'swaggerCoreVersion' }
+swagger-annotations = { group = 'io.swagger.core.v3', name = 'swagger-annotations', version.ref = 'swaggerCoreVersion' }
+
 
 mockito-junit-jupiter = {group= 'org.mockito', name= 'mockito-junit-jupiter', version= '5.3.1'}
 

--- a/publication-commons/build.gradle
+++ b/publication-commons/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation libs.vavr
     implementation libs.resilience4j.all
 
+    implementation libs.swagger.annotations
+
     implementation libs.bundles.logging
 
     testImplementation project(":tickets-test")

--- a/publication-model/build.gradle
+++ b/publication-model/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation( libs.nva.json )
     implementation( libs.nva.identifiers )
     implementation( libs.nva.testutils )
+    implementation( libs.swagger.annotations )
 
     implementation ( libs.jsonld )
     implementation ( libs.commons.validator )

--- a/publication-model/src/main/java/no/unit/nva/model/AdditionalIdentifierBase.java
+++ b/publication-model/src/main/java/no/unit/nva/model/AdditionalIdentifierBase.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = ScopusIdentifier.TYPE, value = ScopusIdentifier.class),
     @JsonSubTypes.Type(name = CristinIdentifier.TYPE, value = CristinIdentifier.class)
 })
+@Schema(oneOf = {AdditionalIdentifier.class, HandleIdentifier.class, ScopusIdentifier.class, CristinIdentifier.class})
 public interface AdditionalIdentifierBase {
     @JsonProperty("value")
     String value();

--- a/publication-model/src/main/java/no/unit/nva/model/Agent.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Agent.java
@@ -2,10 +2,12 @@ package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "Cooperation", value = Corporation.class)
 })
+@Schema(oneOf = {Corporation.class})
 public interface Agent {
 }

--- a/publication-model/src/main/java/no/unit/nva/model/Corporation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Corporation.java
@@ -2,12 +2,14 @@ package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "Organization", value = Organization.class),
     @JsonSubTypes.Type(name = "UnconfirmedOrganization", value = UnconfirmedOrganization.class)
 })
+@Schema(oneOf = {Organization.class, UnconfirmedOrganization.class})
 public class Corporation implements Agent {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/Course.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Course.java
@@ -2,11 +2,13 @@ package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "UnconfirmedCourse", value = UnconfirmedCourse.class)
 })
+@Schema(oneOf = {UnconfirmedCourse.class})
 public interface Course {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/PublicationNoteBase.java
+++ b/publication-model/src/main/java/no/unit/nva/model/PublicationNoteBase.java
@@ -2,6 +2,7 @@ package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 
 @JsonTypeInfo(
@@ -11,6 +12,7 @@ import java.util.Objects;
     @JsonSubTypes.Type(PublicationNote.class),
     @JsonSubTypes.Type(UnpublishingNote.class)
 })
+@Schema(oneOf = {PublicationNote.class, UnpublishingNote.class})
 public class PublicationNoteBase {
 
     private String note;

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
@@ -2,7 +2,6 @@ package no.unit.nva.model.associatedartifacts;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.associatedartifacts.file.File;
 

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
@@ -2,6 +2,8 @@ package no.unit.nva.model.associatedartifacts;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.associatedartifacts.file.File;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -10,6 +12,7 @@ import no.unit.nva.model.associatedartifacts.file.File;
     @JsonSubTypes.Type(name = AssociatedLink.TYPE_NAME, value = AssociatedLink.class),
     @JsonSubTypes.Type(name = NullAssociatedArtifact.TYPE_NAME, value = NullAssociatedArtifact.class)
 })
+@Schema(oneOf = {File.class, AssociatedLink.class, NullAssociatedArtifact.class})
 public interface AssociatedArtifact {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RightsRetentionStrategy.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RightsRetentionStrategy.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @Type(name = NullRightsRetentionStrategy.TYPE_NAME, value = NullRightsRetentionStrategy.class),
     @Type(name = FunderRightsRetentionStrategy.TYPE_NAME, value = FunderRightsRetentionStrategy.class)
 })
+@Schema(oneOf = {CustomerRightsRetentionStrategy.class, OverriddenRightsRetentionStrategy.class,
+    NullRightsRetentionStrategy.class, FunderRightsRetentionStrategy.class})
 public interface RightsRetentionStrategy {
     RightsRetentionStrategyConfiguration getConfiguredType();
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.net.URI;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -34,6 +35,7 @@ import nva.commons.core.JacocoGenerated;
     @JsonSubTypes.Type(names = {UnpublishedFile.TYPE, "File"}, value = UnpublishedFile.class),
     @JsonSubTypes.Type(name = AdministrativeAgreement.TYPE, value = AdministrativeAgreement.class)
 })
+@Schema(oneOf = {PublishedFile.class, UnpublishedFile.class, AdministrativeAgreement.class})
 public abstract class File implements JsonSerializable, AssociatedArtifact {
 
     public static final String IDENTIFIER_FIELD = "identifier";

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/BookSeries.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/BookSeries.java
@@ -5,6 +5,7 @@ import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -12,6 +13,7 @@ import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
     @JsonSubTypes.Type(name = "Series", value = Series.class),
     @JsonSubTypes.Type(name = "UnconfirmedSeries", value = UnconfirmedSeries.class)
 })
+@Schema(oneOf = {Series.class, UnconfirmedSeries.class})
 public interface BookSeries {
 
     @JsonIgnore

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/PublicationContext.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/PublicationContext.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.contexttypes;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * PublicationContext provides a common root object for contexts of type
@@ -26,6 +27,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "GeographicalContent", value = GeographicalContent.class),
     @JsonSubTypes.Type(name = "ExhibitionContent", value = ExhibitionContent.class)
 })
+@Schema(oneOf = {Book.class, Report.class, Degree.class, Anthology.class, Anthology.class, Journal.class,
+    UnconfirmedJournal.class, Event.class, Artistic.class, MediaContribution.class, MediaContributionPeriodical.class,
+    UnconfirmedMediaContributionPeriodical.class, ResearchData.class, GeographicalContent.class, ExhibitionContent.class})
 public interface PublicationContext {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/PublishingHouse.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/PublishingHouse.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.contexttypes;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Marker pattern interface.
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "UnconfirmedPublisher", value = UnconfirmedPublisher.class),
     @JsonSubTypes.Type(name = "NullPublisher", value = NullPublisher.class)
 })
+@Schema(oneOf = {Publisher.class, UnconfirmedPublisher.class, NullPublisher.class})
 public interface PublishingHouse {
     boolean isValid();
 }

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/place/Place.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/place/Place.java
@@ -2,11 +2,13 @@ package no.unit.nva.model.contexttypes.place;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "UnconfirmedPlace", value = UnconfirmedPlace.class)
 })
+@Schema(oneOf = {UnconfirmedPlace.class})
 public interface Place {
     // This class is used to allow extension
 }

--- a/publication-model/src/main/java/no/unit/nva/model/funding/Funding.java
+++ b/publication-model/src/main/java/no/unit/nva/model/funding/Funding.java
@@ -3,6 +3,7 @@ package no.unit.nva.model.funding;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
@@ -12,6 +13,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = "ConfirmedFunding", value = ConfirmedFunding.class),
     @JsonSubTypes.Type(name = "UnconfirmedFunding", value = UnconfirmedFunding.class)
 })
+@Schema(oneOf = {ConfirmedFunding.class, UnconfirmedFunding.class})
 public interface Funding {
     URI getSource();
 

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/PublicationInstance.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/PublicationInstance.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.instancetypes.artistic.architecture.Architecture;
 import no.unit.nva.model.instancetypes.artistic.design.ArtisticDesign;
 import no.unit.nva.model.instancetypes.artistic.film.MovingPicture;
@@ -129,6 +130,68 @@ import no.unit.nva.model.pages.Pages;
     @JsonSubTypes.Type(name = "LiteraryArts", value = LiteraryArts.class),
     @JsonSubTypes.Type(name = "ExhibitionProduction", value = ExhibitionProduction.class)
 })
+@Schema(oneOf = {
+    Architecture.class,
+    ArtisticDesign.class,
+    MovingPicture.class,
+    PerformingArts.class,
+    AcademicArticle.class,
+    AcademicLiteratureReview.class,
+    CaseReport.class,
+    StudyProtocol.class,
+    ProfessionalArticle.class,
+    PopularScienceArticle.class,
+    JournalCorrigendum.class,
+    JournalLetter.class,
+    JournalLeader.class,
+    JournalReview.class,
+    AcademicMonograph.class,
+    PopularScienceMonograph.class,
+    Encyclopedia.class,
+    ExhibitionCatalog.class,
+    NonFictionMonograph.class,
+    Textbook.class,
+    BookAnthology.class,
+    DegreeBachelor.class,
+    DegreeMaster.class,
+    DegreePhd.class,
+    DegreeLicentiate.class,
+    ReportBasic.class,
+    ReportPolicy.class,
+    ReportResearch.class,
+    ReportWorkingPaper.class,
+    ConferenceReport.class,
+    ReportBookOfAbstract.class,
+    AcademicChapter.class,
+    EncyclopediaChapter.class,
+    ExhibitionCatalogChapter.class,
+    Introduction.class,
+    NonFictionChapter.class,
+    PopularScienceChapter.class,
+    TextbookChapter.class,
+    ChapterConferenceAbstract.class,
+    ChapterInReport.class,
+    OtherStudentWork.class,
+    ConferenceLecture.class,
+    ConferencePoster.class,
+    Lecture.class,
+    OtherPresentation.class,
+    JournalIssue.class,
+    ConferenceAbstract.class,
+    MediaFeatureArticle.class,
+    MediaBlogPost.class,
+    MediaInterview.class,
+    MediaParticipationInRadioOrTv.class,
+    MediaPodcast.class,
+    MediaReaderOpinion.class,
+    MusicPerformance.class,
+    DataManagementPlan.class,
+    DataSet.class,
+    VisualArts.class,
+    Map.class,
+    LiteraryArts.class,
+    ExhibitionProduction.class})
+
 public interface PublicationInstance<P extends Pages> {
 
 

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureOutput.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureOutput.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes.artistic.architecture;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.instancetypes.artistic.architecture.realization.Award;
 import no.unit.nva.model.instancetypes.artistic.architecture.realization.Competition;
 import no.unit.nva.model.instancetypes.artistic.architecture.realization.Exhibition;
@@ -15,5 +16,6 @@ import no.unit.nva.model.instancetypes.realization.WithSequence;
     @JsonSubTypes.Type(name = "Award", value = Award.class),
     @JsonSubTypes.Type(name = "Exhibition", value = Exhibition.class)
 })
+@Schema(oneOf = {Competition.class, MentionInPublication.class, Award.class, Exhibition.class})
 public interface ArchitectureOutput extends WithSequence {
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/film/realization/MovingPictureOutput.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/film/realization/MovingPictureOutput.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes.artistic.film.realization;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.instancetypes.realization.WithSequence;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -10,6 +11,7 @@ import no.unit.nva.model.instancetypes.realization.WithSequence;
     @JsonSubTypes.Type(name = "CinematicRelease", value = CinematicRelease.class),
     @JsonSubTypes.Type(name = "OtherRelease", value = OtherRelease.class)
 })
+@Schema(oneOf = {Broadcast.class, CinematicRelease.class, OtherRelease.class})
 public interface MovingPictureOutput extends WithSequence {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsManifestation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsManifestation.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes.artistic.literaryarts.manifestation;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.PublicationDate;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -11,6 +12,8 @@ import no.unit.nva.model.PublicationDate;
     @JsonSubTypes.Type(name = "LiteraryArtsPerformance", value = LiteraryArtsPerformance.class),
     @JsonSubTypes.Type(name = "LiteraryArtsWeb", value = LiteraryArtsWeb.class)
 })
+@Schema(oneOf = {LiteraryArtsAudioVisual.class, LiteraryArtsMonograph.class, LiteraryArtsPerformance.class,
+    LiteraryArtsWeb.class})
 public interface LiteraryArtsManifestation {
     PublicationDate getPublicationDate();
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicPerformanceManifestation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicPerformanceManifestation.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes.artistic.music;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "MusicScore", value = MusicScore.class),
     @JsonSubTypes.Type(name = "OtherPerformance", value = OtherPerformance.class)
 })
+@Schema(oneOf = {AudioVisualPublication.class, Concert.class, MusicScore.class, OtherPerformance.class})
 public interface MusicPerformanceManifestation {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/performingarts/realization/PerformingArtsOutput.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/performingarts/realization/PerformingArtsOutput.java
@@ -2,11 +2,13 @@ package no.unit.nva.model.instancetypes.artistic.performingarts.realization;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "PerformingArtsVenue", value = PerformingArtsVenue.class)
 })
+@Schema(oneOf = {PerformingArtsVenue.class})
 public interface PerformingArtsOutput {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/RelatedDocument.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/RelatedDocument.java
@@ -3,6 +3,7 @@ package no.unit.nva.model.instancetypes.degree;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "ConfirmedDocument", value = ConfirmedDocument.class),
     @JsonSubTypes.Type(name = "UnconfirmedDocument", value = UnconfirmedDocument.class)
 })
+@Schema(oneOf = {ConfirmedDocument.class, UnconfirmedDocument.class})
 public interface RelatedDocument {
 
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/manifestations/ExhibitionProductionManifestation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/manifestations/ExhibitionProductionManifestation.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes.exhibition.manifestations;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -10,5 +11,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = ExhibitionBasic.class, name = "ExhibitionBasic"),
     @JsonSubTypes.Type(value = ExhibitionMentionInPublication.class, name = "ExhibitionMentionInPublication")
 })
+@Schema(oneOf = {ExhibitionCatalogReference.class, ExhibitionOtherPresentation.class, ExhibitionBasic.class, ExhibitionMentionInPublication.class})
 public interface ExhibitionProductionManifestation {
 }

--- a/publication-model/src/main/java/no/unit/nva/model/pages/Pages.java
+++ b/publication-model/src/main/java/no/unit/nva/model/pages/Pages.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.pages;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import no.unit.nva.model.time.Period;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -10,6 +11,7 @@ import no.unit.nva.model.time.Period;
     @JsonSubTypes.Type(name = "MonographPages", value = MonographPages.class),
     @JsonSubTypes.Type(name = "Period", value = Period.class)
 })
+@Schema(oneOf = {Range.class, MonographPages.class, Period.class})
 public interface Pages {
     // A marker pattern interface, it may be useful later, at the moment it remains empty.
 }

--- a/publication-model/src/main/java/no/unit/nva/model/time/Time.java
+++ b/publication-model/src/main/java/no/unit/nva/model/time/Time.java
@@ -3,6 +3,7 @@ package no.unit.nva.model.time;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -12,6 +13,7 @@ import java.time.temporal.ChronoUnit;
     @JsonSubTypes.Type(name = "Period", value = Period.class),
     @JsonSubTypes.Type(name = "Instant", value = Instant.class)
 })
+@Schema(oneOf = {Period.class, Instant.class})
 public interface Time {
 
     // The conversion methods should be removed following migration

--- a/publication-model/src/main/java/no/unit/nva/model/time/duration/Duration.java
+++ b/publication-model/src/main/java/no/unit/nva/model/time/duration/Duration.java
@@ -2,11 +2,14 @@ package no.unit.nva.model.time.duration;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(name = "DefinedDuration", value = DefinedDuration.class),
     @JsonSubTypes.Type(name = "UndefinedDuration", value = UndefinedDuration.class),
-    @JsonSubTypes.Type(name = "NullDuration", value = NullDuration.class),})
+    @JsonSubTypes.Type(name = "NullDuration", value = NullDuration.class),
+})
+@Schema(oneOf = {DefinedDuration.class, UndefinedDuration.class, NullDuration.class})
 public interface Duration {
 
 }

--- a/publication-model/src/test/java/no/unit/nva/PublicationSchemaGeneratorTest.java
+++ b/publication-model/src/test/java/no/unit/nva/PublicationSchemaGeneratorTest.java
@@ -6,25 +6,22 @@ import io.swagger.v3.oas.models.media.Schema;
 import java.io.File;
 import java.io.IOException;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.testing.PublicationGenerator;
 import org.junit.jupiter.api.Test;
 
-class SwaggerTest {
+class PublicationSchemaGeneratorTest {
 
     public static final String SCHEMA_YAML = "../documentation/schema.yaml";
 
     @Test
     void writePublicationSchemaToFile() throws IOException {
-        Publication publication = PublicationGenerator.randomPublication();
-        var map = ModelConverters.getInstance().readAll(publication.getClass());
-        map.forEach(this::removeDiscriminator);
+        var model = ModelConverters.getInstance().readAll(Publication.class);
+        model.forEach(this::removeDiscriminator);
 
         File file = new File(SCHEMA_YAML);
-        Yaml.pretty().writeValue(file, map);
+        Yaml.pretty().writeValue(file, model);
     }
 
     private void removeDiscriminator(String schemaName, Schema schema) {
         schema.setDiscriminator(null);
     }
-
 }


### PR DESCRIPTION
Annotaed datamodel to document inheritence (jsonSubTypes)

Review notes:
openapi.yaml and schema.yaml: Theese files are autogenerated and based on the new annotation. Changes should be equal between the files
 documentation/: ignore