### PR TITLE
Np 47466 republish unpublish publication

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/EditorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/EditorPermissionStrategy.java
@@ -21,6 +21,7 @@ public class EditorPermissionStrategy extends GrantPermissionStrategy {
             case UPDATE -> true;
             case UNPUBLISH -> isPublished();
             case TERMINATE -> isUnpublished();
+            case REPUBLISH -> userSharesTopLevelOrgWithAtLeastOneContributor() && isUnpublished();
             case DELETE, UPDATE_FILES -> false;
         };
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/TrustedThirdPartyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/TrustedThirdPartyStrategy.java
@@ -16,7 +16,7 @@ public class TrustedThirdPartyStrategy extends GrantPermissionStrategy {
         return switch (permission) {
             case UPDATE, UNPUBLISH, TICKET_PUBLISH, TERMINATE -> canModify();
             case DELETE -> canModify() && isDraft();
-            case UPDATE_FILES -> false;
+            case UPDATE_FILES, REPUBLISH -> false;
         };
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/ContributorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/ContributorPermissionStrategyTest.java
@@ -19,7 +19,7 @@ class ContributorPermissionStrategyTest extends PublicationPermissionStrategyTes
 
     @ParameterizedTest(name = "Should allow verified contributor {0} operation on non-degree resources")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE, names = {"DELETE", "TERMINATE",
-        "TICKET_PUBLISH", "UPDATE_FILES"})
+        "TICKET_PUBLISH", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowVerifiedContributorOnNonDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/CuratorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/CuratorPermissionStrategyTest.java
@@ -24,7 +24,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     @ParameterizedTest(name = "Should allow Curator {0} operation on non-degree resources belonging to the "
                               + "institution based on publication owner")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE,
-        names = {"DELETE", "TERMINATE", "UPDATE_FILES"})
+        names = {"DELETE", "TERMINATE", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowCuratorOnNonDegreeBasedOnOwner(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 
@@ -49,7 +49,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     @ParameterizedTest(name = "Should allow Curator {0} operation on non-degree resources belonging to the "
                               + "institution based on contributors")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE,
-        names = {"DELETE", "TERMINATE", "UPDATE_FILES"})
+        names = {"DELETE", "TERMINATE", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowCuratorOnNonDegreeBasedOnContributors(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 
@@ -134,7 +134,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     @ParameterizedTest(name = "Should allow Curator {0} operation on degree resources belonging to the institution "
                               + "with MANAGE_DEGREE access rights")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE,
-        names = {"DELETE", "TERMINATE", "UPDATE_FILES"})
+        names = {"DELETE", "TERMINATE", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowCuratorOnDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 
@@ -180,7 +180,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     @ParameterizedTest(name = "Should allow Curator {0} operation on degree resources with matching resource owner "
                               + "affiliation")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE,
-        names = {"DELETE", "TERMINATE", "UPDATE_FILES"})
+        names = {"DELETE", "TERMINATE", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowCuratorOnDegreeWithResourceOwnerAffiliation(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/ResourceOwnerPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/ResourceOwnerPermissionStrategyTest.java
@@ -29,7 +29,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
     //region Non-degree publications
     @ParameterizedTest(name = "Should allow ResourceOwner {0} operation on own published non-degree resource")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE,
-        names = {"DELETE", "TERMINATE", "TICKET_PUBLISH", "UPDATE_FILES"})
+        names = {"DELETE", "TERMINATE", "TICKET_PUBLISH", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowResourceOwnerOnNonDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 
@@ -49,7 +49,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
 
     @ParameterizedTest(name = "Should deny ResourceOwner {0} operation on own published non-degree resource")
     @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE, names = {"UPDATE", "UNPUBLISH"})
-    void shoulDenyResourceOwnerOnNonDegree(PublicationOperation operation)
+    void shouldDenyResourceOwnerOnNonDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 
         var institution = randomUri();

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/TrustedThirdPartyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/TrustedThirdPartyStrategyTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
 
     @ParameterizedTest(name = "Should allow trusted third party {0} operation on non-degree resources")
-    @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE, names = {"DELETE", "UPDATE_FILES"})
+    @EnumSource(value = PublicationOperation.class, mode = Mode.EXCLUDE, names = {"DELETE", "UPDATE_FILES", "REPUBLISH"})
     void shouldAllowTrustedThirdPartyOnNonDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
 

--- a/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
@@ -10,6 +10,7 @@ public enum PublicationOperation {
     UPDATE("update"),
     UPDATE_FILES("update-including-files"),
     UNPUBLISH("unpublish"),
+    REPUBLISH("republish"),
     TICKET_PUBLISH("ticket/publish"),
     DELETE("delete"),
     TERMINATE("terminate");

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublicationRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublicationRequest.java
@@ -7,7 +7,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
     @JsonSubTypes.Type(UpdatePublicationRequest.class),
     @JsonSubTypes.Type(UnpublishPublicationRequest.class),
-    @JsonSubTypes.Type(DeletePublicationRequest.class)
+    @JsonSubTypes.Type(DeletePublicationRequest.class),
+    @JsonSubTypes.Type(RepublishPublicationRequest.class)
 })
 public interface PublicationRequest {
 

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishPublicationRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishPublicationRequest.java
@@ -1,5 +1,11 @@
 package no.unit.nva.publication.update;
 
-public class RepublishPublicationRequest implements PublicationRequest{
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeName(RepublishPublicationRequest.TYPE)
+public class RepublishPublicationRequest implements PublicationRequest {
+
+    public static final String TYPE = "RepublishPublicationRequest";
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishPublicationRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishPublicationRequest.java
@@ -1,0 +1,5 @@
+package no.unit.nva.publication.update;
+
+public class RepublishPublicationRequest implements PublicationRequest{
+
+}

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishUtil.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishUtil.java
@@ -1,0 +1,56 @@
+package no.unit.nva.publication.update;
+
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.model.Username;
+import no.unit.nva.publication.model.business.PublishingRequestCase;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.permission.strategy.PublicationPermissionStrategy;
+import no.unit.nva.publication.service.impl.ResourceService;
+import no.unit.nva.publication.service.impl.TicketService;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+
+public class RepublishUtil {
+
+    private final ResourceService resourceService;
+    private final TicketService ticketService;
+    private final PublicationPermissionStrategy permissionStrategy;
+
+    public RepublishUtil(ResourceService resourceService, TicketService ticketService,
+                         PublicationPermissionStrategy permissionStrategy) {
+        this.resourceService = resourceService;
+        this.ticketService = ticketService;
+        this.permissionStrategy = permissionStrategy;
+    }
+
+    public static RepublishUtil create(ResourceService resourceService, TicketService ticketService,
+                                       PublicationPermissionStrategy permissionStrategy) {
+        return new RepublishUtil(resourceService, ticketService, permissionStrategy);
+    }
+
+    public Publication republish(Publication publication, UserInstance userInstance) throws ApiGatewayException {
+        validateRepublishing();
+        var publicationIdentifier = publication.getIdentifier();
+        resourceService.publishPublication(UserInstance.fromPublication(publication), publicationIdentifier);
+        persistCompletedPublishingRequest(publication, userInstance);
+
+        return resourceService.getPublicationByIdentifier(publicationIdentifier);
+    }
+
+    private void persistCompletedPublishingRequest(Publication publication, UserInstance userInstance)
+        throws ApiGatewayException {
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase
+                                                            .createNewTicket(publication,
+                                                                             PublishingRequestCase.class,
+                                                                             SortableIdentifier::next);
+        publishingRequest.persistAutoComplete(ticketService, publication, new Username(userInstance.getUsername()));
+    }
+
+    private void validateRepublishing() throws ForbiddenException {
+        if (!permissionStrategy.allowsAction(PublicationOperation.REPUBLISH)) {
+            throw new ForbiddenException();
+        }
+    }
+}

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -188,6 +188,8 @@ public class UpdatePublicationHandler
                                      permissionStrategy,
                                      userInstance);
 
+            case RepublishPublicationRequest ignored -> republish(existingPublication, permissionStrategy, userInstance);
+
             case DeletePublicationRequest ignored -> terminatePublication(existingPublication, permissionStrategy);
 
             default -> throw new BadRequestException("Unknown input body type");
@@ -197,6 +199,13 @@ public class UpdatePublicationHandler
         publicationResponse.setAllowedOperations(getAllowedOperations(requestInfo, updatedPublication));
 
         return publicationResponse;
+    }
+
+    private Publication republish(Publication existingPublication, PublicationPermissionStrategy permissionStrategy,
+                                  UserInstance userInstance)
+        throws ApiGatewayException {
+        return RepublishUtil.create(resourceService, ticketService, permissionStrategy)
+                   .republish(existingPublication, userInstance);
     }
 
     private Set<PublicationOperation> getAllowedOperations(RequestInfo requestInfo, Publication publication) {
@@ -483,6 +492,7 @@ public class UpdatePublicationHandler
             case UpdatePublicationRequest ignored -> HttpStatus.SC_OK;
             case UnpublishPublicationRequest ignored -> HttpStatus.SC_ACCEPTED;
             case DeletePublicationRequest ignored -> HttpStatus.SC_ACCEPTED;
+            case RepublishPublicationRequest ignored -> HttpStatus.SC_OK;
             default -> HttpStatus.SC_BAD_REQUEST;
         };
     }

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1768,7 +1768,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnForbiddenWhenRepublishingNotUnpublishedPublication()
+    void shouldReturnForbiddenWhenRepublishingUnpublishedPublication()
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
         var curatingInstitution = randomUri();

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -7,7 +7,6 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
-import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.publication.model.business.TicketStatus.COMPLETED;
@@ -17,7 +16,6 @@ import static no.unit.nva.publication.ticket.create.CreateTicketHandler.LOCATION
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
-import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -710,27 +708,6 @@ class CreateTicketHandlerTest extends TicketTestLocal {
 
         var response = GatewayResponse.fromOutputStream(output, Void.class);
         assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
-    }
-
-    @Test
-    void shouldAllowUserWithAccessRightManageResourcesAllToCreatePublishingRequestTicketForUnpublishedPublication()
-        throws ApiGatewayException, IOException {
-        var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
-        resourceService.unpublishPublication(publication);
-        var requestBody = constructDto(PublishingRequestCase.class);
-        var user = UserInstance.create(randomString(), publication.getPublisher().getId());
-        var input = createHttpTicketCreationRequestWithApprovedAccessRight(
-            requestBody, publication, user.getUsername(), user.getCustomerId(), MANAGE_PUBLISHING_REQUESTS);
-        handler.handleRequest(input, output, CONTEXT);
-
-        var response = GatewayResponse.fromOutputStream(output, Void.class);
-
-        var ticket = (PublishingRequestCase) fetchTicket(response);
-        var republishedPublication = resourceService.getPublicationByIdentifier(ticket.getResourceIdentifier());
-
-        assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
-        assertThat(ticket.getStatus(), is(equalTo(COMPLETED)));
-        assertThat(republishedPublication.getStatus(), is(equalTo(PUBLISHED)));
     }
 
     private PublishingRequestCase fetchTicket(Publication publishedPublication,

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -7,6 +7,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
+import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.publication.model.business.TicketStatus.COMPLETED;
@@ -16,6 +17,7 @@ import static no.unit.nva.publication.ticket.create.CreateTicketHandler.LOCATION
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -708,6 +710,27 @@ class CreateTicketHandlerTest extends TicketTestLocal {
 
         var response = GatewayResponse.fromOutputStream(output, Void.class);
         assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
+    }
+
+    @Test
+    void shouldAllowUserWithAccessRightManageResourcesAllToCreatePublishingRequestTicketForUnpublishedPublication()
+        throws ApiGatewayException, IOException {
+        var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
+        resourceService.unpublishPublication(publication);
+        var requestBody = constructDto(PublishingRequestCase.class);
+        var user = UserInstance.create(randomString(), publication.getPublisher().getId());
+        var input = createHttpTicketCreationRequestWithApprovedAccessRight(
+            requestBody, publication, user.getUsername(), user.getCustomerId(), MANAGE_PUBLISHING_REQUESTS);
+        handler.handleRequest(input, output, CONTEXT);
+
+        var response = GatewayResponse.fromOutputStream(output, Void.class);
+
+        var ticket = (PublishingRequestCase) fetchTicket(response);
+        var republishedPublication = resourceService.getPublicationByIdentifier(ticket.getResourceIdentifier());
+
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
+        assertThat(ticket.getStatus(), is(equalTo(COMPLETED)));
+        assertThat(republishedPublication.getStatus(), is(equalTo(PUBLISHED)));
     }
 
     private PublishingRequestCase fetchTicket(Publication publishedPublication,


### PR DESCRIPTION
Republishing publication in UpdatePublicationHandler and persisting completed PublishingRequest.

Implementing republishing in UpdatePublicationHandler and not in the CreateTicketHandler because all ticket creation there is based on curator creating ticket for publication at the same institution as curator institution.
Refactoring this implementation is not worth it, in addition I think it makes more sense to do publication update (republishing is update of publication status) in UpdatePublicationHandler. 

Adding new allowed operation -> REPUBLISH