### PR TITLE
adding allowed operations to tombstone

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/DeletedPublicationResponse.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/DeletedPublicationResponse.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationOperation;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName("Publication")
@@ -17,13 +19,12 @@ public final class DeletedPublicationResponse {
     private DeletedPublicationResponse() {
     }
 
-    public static Object fromPublication(Publication publication) {
-        var publicationWithoutAssociatedArtifacts = publication.copy()
-                                                        .withAssociatedArtifacts(List.of())
-                                                        .build();
-        var tombstone = PublicationResponseElevatedUser.fromPublication(publicationWithoutAssociatedArtifacts);
-        return attempt(() -> JsonUtils.dtoObjectMapper.convertValue(tombstone,
-                                                                    new TypeReference<Map<String, Object>>() {}))
-                   .orElseThrow();
+    public static Object fromPublication(Publication publication, Set<PublicationOperation> allowedOperations) {
+        var publicationWithoutAssociatedArtifacts = publication.copy().withAssociatedArtifacts(List.of()).build();
+        var tombstone = PublicationResponseElevatedUser.fromPublicationWithAllowedOperations(
+            publicationWithoutAssociatedArtifacts, allowedOperations);
+        return attempt(
+            () -> JsonUtils.dtoObjectMapper.convertValue(tombstone, new TypeReference<Map<String, Object>>() {
+            })).orElseThrow();
     }
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -122,7 +122,9 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
         if (nonNull(publication.getDuplicateOf()) && shouldRedirect(requestInfo)) {
             return produceRedirect(publication.getDuplicateOf());
         } else {
-            throw new GoneException(GONE_MESSAGE, DeletedPublicationResponse.fromPublication(publication));
+            var allowedOperations = getAllowedOperations(requestInfo, publication);
+            var tombstone = DeletedPublicationResponse.fromPublication(publication, allowedOperations);
+            throw new GoneException(GONE_MESSAGE, tombstone);
         }
     }
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/fetch/DeletedPublicationResponseTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/fetch/DeletedPublicationResponseTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.is;
 import java.util.Set;
 import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.commons.json.JsonUtils;
-import no.unit.nva.model.Publication;
 import org.junit.jupiter.api.Test;
 
 public class DeletedPublicationResponseTest {
@@ -18,7 +17,7 @@ public class DeletedPublicationResponseTest {
         var publication = randomPublication();
         assertThat(publication, doesNotHaveEmptyValuesIgnoringFields(Set.of("entityDescription.reference",
                                                                             "importDetails")));
-        var deletedPublicationResponseJson = DeletedPublicationResponse.fromPublication(publication);
+        var deletedPublicationResponseJson = DeletedPublicationResponse.fromPublication(publication, Set.of());
         var deletedPublicationResponse = JsonUtils.dtoObjectMapper.convertValue(deletedPublicationResponseJson,
                                                                                 PublicationResponseElevatedUser.class);
 


### PR DESCRIPTION
Adding allowedOperations to tombstone so frontend knows what type of operations it can perform on requested resource.