### PR TITLE
Remove old gmazzo classpath declaration

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.10'
     implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.10'
     implementation group: 'io.freefair.lombok', name: 'io.freefair.lombok.gradle.plugin', version: '8.4'
-    implementation group: 'com.github.gmazzo', name: 'gradle-buildconfig-plugin', version: '3.0.3'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/publication-model/build.gradle
+++ b/publication-model/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.gmazzo.buildconfig"
+    id "com.github.gmazzo.buildconfig" version '5.4.0'
 }
 
 dependencies {


### PR DESCRIPTION
For some reason, we had an old-style declaration of the gmazzo-plugin that was causing us to use an ancient version. This in turn added a number of deprecation warnings related to deprecated conventions plugin methods.

The actual usage here is a bit weird, if I'm honest, but I don't see another simple way of saying what the model version is at first glance, so I am just fixing the issue in gradle for now.

Also bumping to gradle 8.10