### PR TITLE
allowing related curator to edit degree

### DIFF
--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -149,6 +149,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
     public static final int JOURNAL_NSD_CODE = 339717;
     public static final String ERROR_REPORT = "ERROR_REPORT";
     public static final String ASSOCIATED_URI_TYPE = "FULLTEKST";
+    public static final int NOT_EXISTING_NSD_CODE = 0;
 
     private CristinEntryEventConsumer handler;
     private ResourceService resourceService;
@@ -956,7 +957,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         var cristinObject = CristinDataGenerator.randomObject(category.getValue());
         cristinObject.setSecondaryCategory(category);
         cristinObject.getBookOrReportMetadata().getCristinPublisher().setPublisherName(randomString());
-        cristinObject.getBookOrReportMetadata().getBookSeries().setNsdCode(randomInteger());
+        cristinObject.getBookOrReportMetadata().getBookSeries().setNsdCode(NOT_EXISTING_NSD_CODE);
         var eventBody = createEventBody(cristinObject);
         var sqsEvent = createSqsEvent(eventBody);
         handler.handleRequest(sqsEvent, CONTEXT);

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/PermissionStrategy.java
@@ -61,7 +61,7 @@ public abstract class PermissionStrategy {
                    .orElse(false);
     }
 
-    protected boolean userSharesTopLevelOrgWithAtLeastOneContributor() {
+    protected boolean userBelongsToCuratingInstitution() {
         var userTopLevelOrg = userInstance.getTopLevelOrgCristinId();
 
         logger.info("found topLevels {} for user {} of {}.",

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/CuratorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/CuratorPermissionStrategy.java
@@ -50,7 +50,7 @@ public class CuratorPermissionStrategy extends GrantPermissionStrategy {
     }
 
     private boolean userRelatesToPublication() {
-        return userIsFromSameInstitutionAsPublication() || userSharesTopLevelOrgWithAtLeastOneContributor();
+        return userIsFromSameInstitutionAsPublication() || userBelongsToCuratingInstitution();
     }
 
     private boolean canManagePublishingRequests() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/EditorPermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/grant/EditorPermissionStrategy.java
@@ -22,10 +22,10 @@ public class EditorPermissionStrategy extends GrantPermissionStrategy {
             case UPDATE -> true;
             case UNPUBLISH -> isPublished();
             case TERMINATE -> isUnpublished();
-            case REPUBLISH -> userSharesTopLevelOrgWithAtLeastOneContributor() && isUnpublished();
+            case REPUBLISH -> userBelongsToCuratingInstitution() && isUnpublished();
             case DOI_REQUEST_CREATE,
                  PUBLISHING_REQUEST_CREATE,
-                 SUPPORT_REQUEST_CREATE -> userSharesTopLevelOrgWithAtLeastOneContributor();
+                 SUPPORT_REQUEST_CREATE -> userBelongsToCuratingInstitution();
             case DELETE,
                  UPDATE_FILES,
                  DOI_REQUEST_APPROVE,

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
@@ -28,12 +28,16 @@ public class NonDegreePermissionStrategy extends DenyPermissionStrategy {
             if (isProtectedDegreeInstanceTypeWithEmbargo() && !hasAccessRight(MANAGE_DEGREE_EMBARGO)) {
                 return true; // deny
             }
-            if (!userIsFromSameInstitutionAsPublication()) {
+            if (userDoesNotBelongsToPublication()) {
                 return true; // deny
             }
         }
 
         return false; // allow
+    }
+
+    private boolean userDoesNotBelongsToPublication() {
+        return !(userBelongsToCuratingInstitution() || userIsFromSameInstitutionAsPublication());
     }
 
     private boolean isUsersDraft() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
@@ -28,7 +28,7 @@ public class NonDegreePermissionStrategy extends DenyPermissionStrategy {
             if (isProtectedDegreeInstanceTypeWithEmbargo() && !hasAccessRight(MANAGE_DEGREE_EMBARGO)) {
                 return true; // deny
             }
-            if (userDoesNotBelongsToPublication()) {
+            if (userDoesNotBelongToPublication()) {
                 return true; // deny
             }
         }
@@ -36,7 +36,7 @@ public class NonDegreePermissionStrategy extends DenyPermissionStrategy {
         return false; // allow
     }
 
-    private boolean userDoesNotBelongsToPublication() {
+    private boolean userDoesNotBelongToPublication() {
         return !(userBelongsToCuratingInstitution() || userIsFromSameInstitutionAsPublication());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/CuratorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/CuratorPermissionStrategyTest.java
@@ -158,18 +158,15 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     }
 
     @ParameterizedTest(name = "Should deny Curator {0} operation on degree resources with no matching resource owner "
-                              + "affiliation")
+                              + "affiliation or curating institution")
     @EnumSource(value = PublicationOperation.class)
-    void shouldDenyCuratorOnDegreeWithNoResourceOwnerAffiliation(PublicationOperation operation)
+    void shouldDenyNotRelatedCuratorOnDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
-
-        var cristinTopLevelId = randomUri();
-
         var requestInfo = createUserRequestInfo(randomString(), randomUri(), getAccessRightsForThesisCurator(),
-                                                randomUri(), cristinTopLevelId);
+                                                randomUri(), randomUri());
 
         var publication = createDegreePublicationWithContributor(randomString(), randomUri(), Role.CREATOR,
-                                                                 randomUri(), cristinTopLevelId);
+                                                                 randomUri(), randomUri());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/EditorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/EditorPermissionStrategyTest.java
@@ -4,7 +4,6 @@ import static no.unit.nva.model.PublicationOperation.REPUBLISH;
 import static no.unit.nva.model.PublicationOperation.UNPUBLISH;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
-import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -137,18 +136,15 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
     }
 
     @ParameterizedTest(name = "Should deny Editor {0} operation on degree resources with no matching resource owner "
-                              + "affiliation")
+                              + "affiliation or curating institution")
     @EnumSource(value = PublicationOperation.class)
-    void shouldDenyEditorOnDegreeWithNoResourceOwnerAffiliation(PublicationOperation operation)
+    void shouldDenyNotRelatedEditorOnDegree(PublicationOperation operation)
         throws JsonProcessingException, UnauthorizedException {
-
-        var cristinTopLevelId = randomUri();
-
         var requestInfo = createUserRequestInfo(randomString(), randomUri(), getAccessRightsForEditor(),
-                                                randomUri(), cristinTopLevelId);
+                                                randomUri(), randomUri());
 
         var publication = createDegreePublicationWithContributor(randomString(), randomUri(), Role.CREATOR,
-                                                                 randomUri(), cristinTopLevelId);
+                                                                 randomUri(), randomUri());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 


### PR DESCRIPTION
Before: Only curator from the same institution as resourceOwner could edit Degree. 
From now on: Only curator from the same institution as resourceOwner or curatingInstitution can edit Degree. 