### PR TITLE
Np 47515 allow updating publication with existing files

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -109,7 +109,7 @@ public class UpdatePublicationHandler
     private final S3Driver s3Driver;
     private final SecretsReader secretsReader;
     private final HttpClient httpClient;
-    private final PublicationValidator publicationValidator;
+    private final DefaultPublicationValidator publicationValidator;
     private final String apiHost;
 
     /**
@@ -325,7 +325,7 @@ public class UpdatePublicationHandler
 
         var customerApiClient = getCustomerApiClient();
         var customer = fetchCustomerOrFailWithBadGateway(customerApiClient, publicationUpdate.getPublisher().getId());
-        validatePublication(publicationUpdate, customer);
+        validatePublication(publicationUpdate, existingPublication, customer);
         updateAssociatedArtifactList(existingPublication.getAssociatedArtifacts(),
                                      publicationUpdate.getAssociatedArtifacts(),
                                      extractUploadDetails(userInstance));
@@ -460,9 +460,9 @@ public class UpdatePublicationHandler
         }
     }
 
-    private void validatePublication(Publication publicationUpdate, Customer customer) throws BadRequestException {
+    private void validatePublication(Publication publicationUpdate, Publication existingPublication, Customer customer) throws BadRequestException {
         try {
-            publicationValidator.validate(publicationUpdate, customer);
+            publicationValidator.validateUpdate(publicationUpdate, existingPublication, customer);
         } catch (PublicationValidationException e) {
             throw new BadRequestException(e.getMessage());
         }

--- a/publication-rest/src/main/java/no/unit/nva/publication/validation/DefaultPublicationValidator.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/validation/DefaultPublicationValidator.java
@@ -1,6 +1,7 @@
 package no.unit.nva.publication.validation;
 
 import static java.util.Objects.nonNull;
+import java.util.List;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.file.File;
@@ -34,6 +35,16 @@ public class DefaultPublicationValidator implements PublicationValidator {
         }
     }
 
+    public void validateUpdate(Publication publicationUpdate, Publication existingPublication, Customer customer)
+        throws PublicationValidationException {
+        if (nonNull(publicationUpdate.getEntityDescription())) {
+            var existingFiles = getFiles(existingPublication);
+            var newFiles = getFiles(publicationUpdate);
+            var hasNewFiles = newFiles.stream().anyMatch(file -> !existingFiles.contains(file));
+            validate(publicationUpdate.getEntityDescription(), hasNewFiles, customer);
+        }
+    }
+
     private static String getInstanceType(EntityDescription entityDescription) {
         if (nonNull(entityDescription.getReference())
             && nonNull(entityDescription.getReference().getPublicationInstance())) {
@@ -50,5 +61,12 @@ public class DefaultPublicationValidator implements PublicationValidator {
         return nonNull(publication.getAssociatedArtifacts())
                &&
                publication.getAssociatedArtifacts().stream().anyMatch(File.class::isInstance);
+    }
+
+    private List<File> getFiles(Publication publication) {
+        return publication.getAssociatedArtifacts().stream()
+                      .filter(File.class::isInstance)
+                      .map(File.class::cast)
+                      .toList();
     }
 }

--- a/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -420,7 +420,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnBadRequestIfProvidingOneOrMoreNewFilesWhenNotAllowedInCustomerConfiguration() throws IOException {
+    void shouldReturnBadRequestIfProvidingOneOrMoreFilesWhenNotAllowedInCustomerConfiguration() throws IOException {
         final var event = prepareRequestWithFileForTypeWhereNotAllowed();
         WireMock.reset();
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -420,7 +420,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnBadRequestIfProvidingOneOrMoreFilesWhenNotAllowedInCustomerConfiguration() throws IOException {
+    void shouldReturnBadRequestIfProvidingOneOrMoreNewFilesWhenNotAllowedInCustomerConfiguration() throws IOException {
         final var event = prepareRequestWithFileForTypeWhereNotAllowed();
         WireMock.reset();
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1072,7 +1072,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldRejectUpdateIfSettingInstanceTypeNotAllowingFilesOnPublicationContainingFile()
+    void shouldReturnSuccessWhenUpdatingMetadataOnlyWhenPublishingFilesIsNotAllowedInCustomerConfiguration()
         throws BadRequestException, IOException {
 
         WireMock.reset();
@@ -1085,11 +1085,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         var event = userUpdatesPublicationAndHasRightToUpdate(publicationUpdate);
         updatePublicationHandler.handleRequest(event, output, context);
 
-        var gatewayResponse = GatewayResponse.fromOutputStream(output, Problem.class);
-        assertThat(gatewayResponse.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
-
-        var problem = gatewayResponse.getBodyObject(Problem.class);
-        assertThat(problem.getDetail(), is(startsWith("Files not allowed for instance type ")));
+        var gatewayResponse = GatewayResponse.fromOutputStream(output, Publication.class);
+        assertThat(gatewayResponse.getStatusCode(), is(equalTo(HTTP_OK)));
     }
 
     @Test


### PR DESCRIPTION
Allowing user to update metadata for publication type where customer config does not allow to update/create new files. 
Not sure if updating existing file metadata should be allowed, for example license. 
Implementing that any file change is not allowed. 

https://sikt.atlassian.net/browse/NP-47515