### PR TITLE
fixing bug when unpublishing publication with doi

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DoiMetadataUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DoiMetadataUpdateEvent.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.events.bodies;
 
-import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventProducer.NVA_API_DOMAIN;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -52,8 +51,8 @@ public class DoiMetadataUpdateEvent {
         this.duplicateOf = duplicateOf;
     }
 
-    public static DoiMetadataUpdateEvent createUpdateDoiEvent(Publication newEntry) {
-        URI publicationId = inferPublicationId(newEntry);
+    public static DoiMetadataUpdateEvent createUpdateDoiEvent(Publication newEntry, String apiHost) {
+        URI publicationId = inferPublicationId(newEntry, apiHost);
         URI customerId = extractCustomerId(newEntry);
         URI doi = extractDoi(newEntry);
         URI duplicateOf  = newEntry.getDuplicateOf();
@@ -128,8 +127,8 @@ public class DoiMetadataUpdateEvent {
         return Optional.ofNullable(publication.getPublisher()).map(Organization::getId).orElse(null);
     }
 
-    private static URI inferPublicationId(Publication newEntry) {
-        return UriWrapper.fromUri(NVA_API_DOMAIN)
+    private static URI inferPublicationId(Publication newEntry, String apiHost) {
+        return UriWrapper.fromHost(apiHost)
                    .addChild("publication")
                    .addChild(newEntry.getIdentifier().toString())
                    .getUri();

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/bodies/DoiMetadataUpdateEventTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/bodies/DoiMetadataUpdateEventTest.java
@@ -1,0 +1,21 @@
+package no.unit.nva.publication.events.bodies;
+
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class DoiMetadataUpdateEventTest {
+
+
+    @Test
+    void shouldCreateEventWithPublicationId() {
+        var publication = randomPublication();
+        var host = "host.no";
+        var event = DoiMetadataUpdateEvent.createUpdateDoiEvent(publication, host);
+
+        var expectedId = URI.create("https://host.no/publication/" + publication.getIdentifier());
+
+        assertEquals(event.getPublicationId(), expectedId);
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/DoiRequestEventProducerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/DoiRequestEventProducerTest.java
@@ -25,6 +25,7 @@ import no.unit.nva.stubs.FakeS3Client;
 import no.unit.nva.testutils.EventBridgeEventBuilder;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
 import nva.commons.core.paths.UnixPath;
 import nva.commons.core.paths.UriWrapper;
@@ -52,7 +53,6 @@ import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventPro
 import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventProducer.HANDLER_DOES_NOT_DEAL_WITH_DELETIONS;
 import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventProducer.HTTP_FOUND;
 import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventProducer.MIN_INTERVAL_FOR_REREQUESTING_A_DOI;
-import static no.unit.nva.publication.events.handlers.tickets.DoiRequestEventProducer.NVA_API_DOMAIN;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -278,7 +278,7 @@ class DoiRequestEventProducerTest extends ResourcesLocalTest {
     }
 
     private URI inferExpectedPublicationId(Publication publication) {
-        return UriWrapper.fromUri(NVA_API_DOMAIN)
+        return UriWrapper.fromHost(new Environment().readEnv("API_HOST"))
                    .addChild("publication")
                    .addChild(publication.getIdentifier().toString())
                    .getUri();

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -278,7 +278,7 @@ public class UpdatePublicationHandler
                                                     .source(NVA_PUBLICATION_DELETE_SOURCE)
                                                     .detailType(LAMBDA_DESTINATIONS_INVOCATION_RESULT_SUCCESS)
                                                     .detail(new LambdaDestinationInvocationDetail<>(
-                                                        DoiMetadataUpdateEvent.createUpdateDoiEvent(publication))
+                                                        DoiMetadataUpdateEvent.createUpdateDoiEvent(publication, apiHost))
                                                                 .toJsonString())
                                                     .resources(publication.getIdentifier().toString()).build())
                                        .build();


### PR DESCRIPTION
Unpublishing publication with doi failed cause doi event has been using NVA_API_DOMAIN when creating doi Event.
Using API_HOST instead and fixing fromUri to fromHost bug as well.