### PR TITLE
Np 47374 add sequence number to related results

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
@@ -521,7 +521,7 @@ public final class PublicationInstanceMapper {
                    .orElseGet(Collections::emptyList)
                    .stream()
                    .sorted()
-                   .map(UnconfirmedDocument::new)
+                   .map(UnconfirmedDocument::fromValue)
                    .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -1154,8 +1154,8 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
                                                      .getPublicationInstance());
 
         var related = actualPublicationContext.getRelated().stream().toList();
-        assertThat(related.getLast(), is(equalTo(new UnconfirmedDocument("2"))));
-        assertThat(related.get(related.size() - 2), is(equalTo(new UnconfirmedDocument("1"))));
+        assertThat(related.getLast(), is(equalTo(UnconfirmedDocument.fromValue("2"))));
+        assertThat(related.get(related.size() - 2), is(equalTo(UnconfirmedDocument.fromValue("1"))));
     }
 
     @Test

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
@@ -80,7 +80,7 @@ class BrageNvaMapperTest {
                              .build();
         var publication = BrageNvaMapper.toNvaPublication(generator.getBrageRecord(), API_HOST, s3Client);
         var degreePhd = (DegreePhd) publication.getEntityDescription().getReference().getPublicationInstance();
-        var expectedRelatedDocuments = Set.of(new UnconfirmedDocument("1"), new UnconfirmedDocument("2"));
+        var expectedRelatedDocuments = Set.of(UnconfirmedDocument.fromValue("1"), UnconfirmedDocument.fromValue("2"));
         assertThat(degreePhd.getRelated(), is(equalTo(expectedRelatedDocuments)));
     }
 

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
@@ -554,7 +554,7 @@ public final class ReferenceGenerator {
                    .map(Builder::getHasPart)
                    .orElseGet(Collections::emptyList)
                    .stream()
-                   .map(UnconfirmedDocument::new)
+                   .map(UnconfirmedDocument::fromValue)
                    .collect(Collectors.toCollection(HashSet::new));
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/patcher/CristinPatcher.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/patcher/CristinPatcher.java
@@ -56,7 +56,7 @@ public final class CristinPatcher {
         var parent = parentAndChild.getParentPublication();
         if (ParentChildInstanceComparator.isValidCombination(child, parent)) {
             var degreePhd = (DegreePhd) parent.getEntityDescription().getReference().getPublicationInstance();
-            degreePhd.getRelated().add(new ConfirmedDocument(createPartOfUri(child)));
+            degreePhd.getRelated().add(ConfirmedDocument.fromUri(createPartOfUri(child)));
             return parentAndChild;
         } else {
             throw new ParentPatchPublicationInstanceMismatchException(

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinPatchEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinPatchEventConsumerTest.java
@@ -315,7 +315,7 @@ public class CristinPatchEventConsumerTest extends ResourcesLocalTest {
         var updatedRelatedDocuments = ((DegreePhd) actualUpdatedParentPublication.getEntityDescription()
                                                     .getReference()
                                                     .getPublicationInstance()).getRelated();
-        assertThat(updatedRelatedDocuments, hasItem(new ConfirmedDocument(expectedRelatedDocumentId)));
+        assertThat(updatedRelatedDocuments, hasItem(ConfirmedDocument.fromUri(expectedRelatedDocumentId)));
 
         var actualReport = extractSuccessReportFromS3Client(eventReference, parentPublication);
         assertThat(actualReport, containsString(parentPublication.getIdentifier().toString()));

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "BiVUkscETzpV0f",
-    "ownerAffiliation" : "https://www.example.org/286e2057-dd5b-4cdf-aa04-b4452bcf424b"
+    "owner" : "vmdEV3YbIwOoZWyJ5S",
+    "ownerAffiliation" : "https://www.example.org/8f2faf4f-c81f-4de5-bb0f-cff69a21f639"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f6820e7a-c610-43fb-ae24-b2de7b454673"
+    "id" : "https://www.example.org/8bf744e2-8a53-4a15-9946-a203ebd31662"
   },
-  "createdDate" : "1999-05-10T19:49:45.267Z",
-  "modifiedDate" : "2000-07-13T04:53:48.216Z",
-  "publishedDate" : "1982-06-06T18:55:19.304Z",
-  "indexedDate" : "1999-02-04T15:35:44.360Z",
-  "handle" : "https://www.example.org/554c8a52-98c3-49b0-b54b-8f0a1958b45d",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/a4e2e980-cfdf-40e8-a891-7159e2bd28ae",
+  "createdDate" : "1990-07-05T00:34:44.284Z",
+  "modifiedDate" : "1989-11-19T21:01:08.104Z",
+  "publishedDate" : "1983-09-16T00:59:13.868Z",
+  "indexedDate" : "1988-08-18T23:48:08.003Z",
+  "handle" : "https://www.example.org/624cf1c3-81c2-438e-b0a0-78bc53d443ce",
+  "doi" : "https://doi.org/10.1234/in",
+  "link" : "https://www.example.org/70b6b911-0aef-4bec-8cbe-d4803cde2126",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6bcjSQyHz8PlJ7OK",
+    "mainTitle" : "ywVZlrY4lUSX9rLm",
     "alternativeTitles" : {
-      "it" : "RobvWUCYPd5"
+      "cs" : "jVZ6c9vSPbclmam"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UtXFg73GpMv74xHj",
-      "month" : "00QTlrWtTMpepeBY",
-      "day" : "6OtjzCSIOq"
+      "year" : "WHw41JegCjb",
+      "month" : "60bLHBDikpD",
+      "day" : "os9vGjg9K19d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eba59faf-e689-4acf-9d36-902461cef9d0",
-        "name" : "dfMHI5V8ke6b",
+        "id" : "https://www.example.org/43b563ad-5cf0-4b73-9349-70f155cf4fc4",
+        "name" : "fiNAY34R8YaWdLHIslA",
         "nameType" : "Personal",
-        "orcId" : "g3u0Ts4o91PftS",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "x80mzYLaXbmZT6",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2eh3ezFUdwbokr7k0F",
-          "value" : "q2N0YanmTzDtuyW"
+          "sourceName" : "6E8s0tzUPI5nhGiTum",
+          "value" : "ivudeW7JEOLjJvILqrD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kkRoMv7wSJA",
-          "value" : "A4IxV7cB3pCL2nf1ZO"
+          "sourceName" : "JCKvQWHh48IxprMCOa",
+          "value" : "kdHbZ2du12Eo6J9Wil"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bb44aeb4-6ba9-4c12-bb6d-d2b4757f7d3e"
+        "id" : "https://www.example.org/04b17b1b-ec25-4ea4-8c35-d7169ece607a"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "HostingInstitution"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7cf9a71c-0fb0-4683-9e44-5f721cd6c52b",
-        "name" : "x7nO4v4WUa4Ltboz",
+        "id" : "https://www.example.org/00991f27-b031-453f-b235-70cb22749626",
+        "name" : "ZJpCN2QqqXA8l",
         "nameType" : "Organizational",
-        "orcId" : "y58XnRgVXF",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "66leDiIRGbS",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8FvKmrPWWBVwICK",
-          "value" : "KjiYFvsV3U"
+          "sourceName" : "lMAVKgFWL997qMnz",
+          "value" : "ebXcXAJKs23MHfYB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NEse8QC6qFSkTX",
-          "value" : "QOqoEzle9VtRxvPLfO"
+          "sourceName" : "9VcmkbpseU",
+          "value" : "GB5ajaOTBHPHP4UWL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0e5fc32a-b618-4649-a010-59a3febd7e4e"
+        "id" : "https://www.example.org/687deb81-eb5d-4f56-b136-1aa179cac36f"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "gjDe2QKkr1qB"
+      "ca" : "AWV2RscTmyCO0"
     },
-    "npiSubjectHeading" : "M1CVcQ7LOJoHRvn55",
-    "tags" : [ "zdi22dHI4T" ],
-    "description" : "7h415KDW2ruLrsm5",
+    "npiSubjectHeading" : "EEimp7o8KoEi",
+    "tags" : [ "f1jnUmp5opqrgi" ],
+    "description" : "v1e2AOGbV3Q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/58501d53-49ae-4d0c-a3a1-2478ad0faf70"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c36071c6-8501-4465-80a3-059a9ecf4baf"
       },
-      "doi" : "https://www.example.org/ce6308a7-4513-442b-a97d-f7ac17c17943",
+      "doi" : "https://www.example.org/56076125-76c5-41e4-8a17-38daf0585784",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "nzH6brbv0luOpnM",
-          "end" : "GHzfccIZwTBL"
+          "begin" : "TVCMNPc6K11",
+          "end" : "ZMeVQlnJ7DwUsFV"
         },
-        "volume" : "YUmI1HNjCGBJ",
-        "issue" : "X3T6LJu7NiV",
-        "articleNumber" : "cxD6rVamp3ay43n"
+        "volume" : "Q76ktizb1S970M",
+        "issue" : "aJ0iZUKrAm",
+        "articleNumber" : "qmbW11BLdRHRBf"
       }
     },
-    "metadataSource" : "https://www.example.org/e26ee54d-88de-4c66-9dc7-6c0b398ee591",
-    "abstract" : "OgZ6gHE9Fc4i5ckUB"
+    "metadataSource" : "https://www.example.org/7881b210-27e9-4c99-a62c-c4ee9601f46c",
+    "abstract" : "fck1iuRro9Q3RkEtc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3466a34e-6eae-4076-96ce-f042930c1089",
-    "name" : "CLk6izWkGfGRN",
+    "id" : "https://www.example.org/61bff601-4255-4add-ab70-d9a1bff4564d",
+    "name" : "DfYeoGGC84nKSFs6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-02-13T01:11:09.127Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1991-03-31T00:16:21.295Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "lC1BG10Nn0z2Afm6"
+      "applicationCode" : "VXhUUaGFPIE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4e08c51e-576a-43d0-90ee-27d125c3546d",
-    "identifier" : "QJoboy60S9BCNffJ",
+    "source" : "https://www.example.org/76f167d9-faae-4142-8ced-56bb675a7ad2",
+    "identifier" : "TSzJUtdajXqgLt0",
     "labels" : {
-      "da" : "NcXuZwJIBHnxy"
+      "sv" : "XCvx0idYOV4gZrFCBSK"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1008379560
+      "currency" : "USD",
+      "amount" : 1674732049
     },
-    "activeFrom" : "2016-05-24T11:36:11.048Z",
-    "activeTo" : "2024-02-02T16:08:11.926Z"
+    "activeFrom" : "1986-04-21T16:28:22.033Z",
+    "activeTo" : "2018-02-02T10:28:17.050Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6a3012fb-284d-43ff-9c29-d5ff20e2b58c",
-    "id" : "https://www.example.org/6f8c47f9-f969-402a-b8a9-3a11eac1f8ee",
-    "identifier" : "R8NhdGZjc9a",
+    "source" : "https://www.example.org/57979f5b-5fec-4559-81df-f46d61dd4d65",
+    "id" : "https://www.example.org/bb92a9aa-92f3-4368-9be6-9017f4ad1ac0",
+    "identifier" : "vrTjkBPNCTZv9",
     "labels" : {
-      "da" : "UmKmMTI34xSp7yK8iSE"
+      "hu" : "FQABbNXpRnLQ6t"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 200437027
+      "currency" : "EUR",
+      "amount" : 1557381228
     },
-    "activeFrom" : "2002-08-03T09:59:45.358Z",
-    "activeTo" : "2014-12-27T06:34:27.711Z"
+    "activeFrom" : "2010-10-03T14:53:51.040Z",
+    "activeTo" : "2018-03-03T17:19:36.848Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "ijgNY5nbuS",
-    "sourceName" : "dhutyirn6xhidcc@z1d3kljcsvdbyqgar"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "6hHusKFUXsdJnxiGnz",
-    "value" : "eglcGHtHUZsHyPjcG9M"
+    "value" : "9mbVsrrlRrkjPSMOjnG",
+    "sourceName" : "pqtddimfzcdbyyg@uii1l47wdx"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1758443585",
-    "sourceName" : "13zfvoqzecnod4p3jj3@xbxrwxtploecl"
+    "value" : "998350592",
+    "sourceName" : "smeo1zkxtty7kdme@mf56nnhx5lnqo"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/81e13db9-b59f-4673-98d2-fedf2ba8bbdf",
-    "sourceName" : "kyx00noyglrpx@jhpbz4urbrr7h54x7b"
+    "value" : "https://www.example.org/369f2a8f-2ea7-4069-9d3a-c9ccf46d8698",
+    "sourceName" : "efc0xwdjrzdbgn@5tgoekmw2s4f34"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "W8w3aQ8HblL4Lf",
+    "value" : "CmpOK1PjCAY"
   } ],
-  "subjects" : [ "https://www.example.org/cb86bf0b-723c-42fc-8a1a-27e27eb6f3c6" ],
+  "subjects" : [ "https://www.example.org/d0261aec-e0e2-4a4b-8e2c-a54ed4f29f69" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bc26a8fc-b815-44f9-87bf-cd5539055a49",
-    "name" : "ZewitrxYDcnvD",
-    "mimeType" : "27CmsCuiVRHeCpw",
-    "size" : 890938928,
-    "license" : "https://www.example.com/slzimkfeslctj",
+    "identifier" : "88cde221-e04a-4510-a9b7-bae816a891a2",
+    "name" : "POsB7pZcMD",
+    "mimeType" : "noMtStUFRuYP8XZ23kA",
+    "size" : 324267360,
+    "license" : "https://www.example.com/vmquk76zgkgukwa",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "dte8fLT7lFmEnT9z",
-    "publishedDate" : "1991-05-15T03:51:19.771Z",
+    "legalNote" : "5r6tdGPsUO4OURUwEX",
+    "publishedDate" : "2017-01-04T03:03:44.268Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1196801500@1hxPIEbSsL5A",
-      "uploadedDate" : "1977-01-23T11:45:30.253Z"
+      "uploadedBy" : "1606911928@RqozGhM1lw1V8Q3c6P",
+      "uploadedDate" : "1999-11-11T09:09:01.380Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YsuM8xGgc0IHT9GF7DP",
-    "name" : "cQdF7e9XpapHmF",
-    "description" : "rFVi0IbrRDeuaTEPOg"
+    "id" : "https://www.example.com/FH4rudqnGl",
+    "name" : "6Y6757KeYyoEn184H",
+    "description" : "s3cXevotowJ7"
   } ],
-  "rightsHolder" : "nVeiGxTRJ8J",
-  "duplicateOf" : "https://www.example.org/c85947f0-716b-41df-b59d-ca599d9e562a",
+  "rightsHolder" : "hgXqslkZmN",
+  "duplicateOf" : "https://www.example.org/d11b71eb-639f-489c-bfe0-367c7003971a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "clBsmDyZgukQ0"
+    "note" : "i2j7FlIv7OhrX"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "YfKfcD8lvSFeROo",
-    "createdBy" : "SgSUp2JJtYoM41an",
-    "createdDate" : "1997-02-09T07:49:45.283Z"
+    "note" : "dzNPjidBDhixh3QuT",
+    "createdBy" : "KhOfCL2aPgPBGLk",
+    "createdDate" : "1987-08-23T17:20:52.126Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/def47a28-bb87-4b3a-8726-88f8a4a875ce" ],
+  "curatingInstitutions" : [ "https://www.example.org/cc758401-4a82-41e0-b8e9-f6ea1d7b0757" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "5dzoAURsBPZgGC",
-    "ownerAffiliation" : "https://www.example.org/5b66ac93-cd12-4f72-89de-7834229b199d"
+    "owner" : "cAO5GZXkrQzZokiTgB",
+    "ownerAffiliation" : "https://www.example.org/947713ca-86cc-4486-af31-7e4b6330bcf0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9fa84eb3-eb58-490a-ab78-6502f3d9e8f6"
+    "id" : "https://www.example.org/f3899dda-0fa2-459f-9002-4b2ace1ba5d9"
   },
-  "createdDate" : "2000-11-06T15:05:18.758Z",
-  "modifiedDate" : "1995-10-12T22:56:45.469Z",
-  "publishedDate" : "1992-03-08T11:09:20.842Z",
-  "indexedDate" : "1973-10-23T21:03:20.006Z",
-  "handle" : "https://www.example.org/df84aa9b-94d4-4aa3-9e4d-c42b93bcdf77",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/96929887-3e20-4c3d-b2b3-408d6623baa9",
+  "createdDate" : "2005-12-23T18:16:35.708Z",
+  "modifiedDate" : "2019-08-07T21:47:37.982Z",
+  "publishedDate" : "1997-10-13T22:48:07.128Z",
+  "indexedDate" : "1975-02-28T03:48:04.911Z",
+  "handle" : "https://www.example.org/56b4993e-f48a-40a6-8883-6886af275470",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/993fa924-af04-4f9c-9511-0c5d8c85b7da",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IxWPYdVgYO2OPBk0F30",
+    "mainTitle" : "1hF51f0lBEjBtFjRzW",
     "alternativeTitles" : {
-      "af" : "FDgs6jUKgLea3Gk"
+      "af" : "TRnaSqjRk5IUB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "IkKq02mIfA5jSz",
-      "month" : "5ZLMYq1LpHkTq",
-      "day" : "Ir6WX0iHzq"
+      "year" : "Llo1mT2iOb0",
+      "month" : "ZVzFB7Ka11oC6XH",
+      "day" : "sJriaq8hkHC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a1862462-958c-49c9-8129-c4ec67cfd50e",
-        "name" : "xxiYEKju1QWa",
-        "nameType" : "Organizational",
-        "orcId" : "4ZiMbPErAj8QSIXl4",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a1871985-daa9-4cc8-ac6d-33851a896b24",
+        "name" : "ECl1huP2Whc5v",
+        "nameType" : "Personal",
+        "orcId" : "DU475qeNolx",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "12yGeUOkDF",
-          "value" : "vvQDE0mL7M9"
+          "sourceName" : "1QW110NisH7RT6",
+          "value" : "3eNFWIftVh8M"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "A4mkaW5waKGpznwNIU1",
-          "value" : "dgKRnyq9DijFSYPAK8j"
+          "sourceName" : "3wVtONjieJC0F0",
+          "value" : "6vFlQBpZ9pd"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7fdaeb7c-8dfc-43d2-9d18-2317e978014c"
+        "id" : "https://www.example.org/a05467cc-edc1-4024-bc21-bbc52c0bc7c0"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/692308ee-8ff6-4f4c-8096-e1226f61e75a",
-        "name" : "OojxRyXgM9SSJawZB5B",
-        "nameType" : "Organizational",
-        "orcId" : "QTtfLjv1tKj",
+        "id" : "https://www.example.org/940e02e6-f46c-4882-b67f-a14e47a85c36",
+        "name" : "DweDs3OwtBReoFRk",
+        "nameType" : "Personal",
+        "orcId" : "UiE8QbCw0hwcNkssi",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VzCfrNGav9AcJTOtLKL",
-          "value" : "cH1MhAp1v3"
+          "sourceName" : "z3DytYdTiFEDz7",
+          "value" : "I2LzUDguB0cq3S8yRSV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w1z0XgvJe2Xo",
-          "value" : "5rVrcJ2hiqtp"
+          "sourceName" : "woVbaT3m0wHwOokAR1",
+          "value" : "pVzxCkonaQRBLL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5742d96a-42a2-448c-9f6d-9fb3feb8cf6c"
+        "id" : "https://www.example.org/0c6b8998-62e0-4b6b-b7b7-62b086b77683"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "ZGEgyg1mpXl5JPpQ"
+      "en" : "v05oUwQKrszR"
     },
-    "npiSubjectHeading" : "8IUYjM1UKCb",
-    "tags" : [ "S2VfP3ZT47qts" ],
-    "description" : "2UW5Od1TRSIPu02clSM",
+    "npiSubjectHeading" : "VSwJYEEWACT",
+    "tags" : [ "B0vX2ZpKZK" ],
+    "description" : "FEy6GEKnqB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/9mIfRiFMOxVNawbZYrn/publication/0191e0c8eb4e-51466c0b-b4de-4fe5-86cf-323642567b72"
+        "id" : "https://www.example.com/hjjw3jia6Eri/publication/0191ff235006-13190a2c-c054-4f65-b2e0-5fb5e5e53fa0"
       },
-      "doi" : "https://www.example.org/bcadd089-26fb-40e2-9743-c09297587254",
+      "doi" : "https://www.example.org/e661c60b-40f8-4abe-a560-1ddbd7486ace",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "FzDwZxWA3gaahDZI",
-          "end" : "mVtDz3PVa3qv"
+          "begin" : "ljmjFcWFhSbckJpwT",
+          "end" : "Rif3BIE3u3CH2dVsTj"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/aef1308b-e83f-4e43-828a-c32a94d49663",
-    "abstract" : "U13O52XUCd0whZo"
+    "metadataSource" : "https://www.example.org/c14fa3a3-b49f-4557-b1b6-04a4930d84ef",
+    "abstract" : "3jE8xbK1qLPQaOB6sJJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aeebdc98-9ef3-4e4b-901b-a21b615b42d3",
-    "name" : "K5f4IMgRZr9m",
+    "id" : "https://www.example.org/0530b7f7-a333-4b9a-8d55-8040edfd8add",
+    "name" : "6BjeSe8Dz5v",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-04-05T15:03:45.462Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "8Rq6yjxT90"
+      "approvalDate" : "1985-05-27T19:14:29.497Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "MoZeJzMgajYX8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a55d21b1-061c-464d-bf24-0553cc607800",
-    "identifier" : "ePWgupxiXWSdqsMCSK",
+    "source" : "https://www.example.org/cc161ef7-436f-43b7-80c6-f4e9f46e6782",
+    "identifier" : "qENOBJDTuZo",
     "labels" : {
-      "hu" : "Goa5aZbXNXpyImTjDtu"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1579363301
-    },
-    "activeFrom" : "2017-09-10T21:19:00.436Z",
-    "activeTo" : "2018-07-15T21:49:13.971Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6616876b-b3fe-442a-b9bd-d1e5fbe8efef",
-    "id" : "https://www.example.org/fb49b9f8-1e15-497c-aa15-ed234770ec8f",
-    "identifier" : "IcqxUTnOhUP7G8",
-    "labels" : {
-      "it" : "7zHVB9JYcX"
+      "zh" : "sHw6tVAeN2"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2128695201
+      "amount" : 1647928968
     },
-    "activeFrom" : "1994-11-07T15:07:43.873Z",
-    "activeTo" : "2010-08-10T23:18:28.341Z"
+    "activeFrom" : "2020-03-12T19:17:14.612Z",
+    "activeTo" : "2022-11-18T04:38:57.453Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/a6a65072-b8e4-4717-bdb7-cbaba8e2e219",
+    "id" : "https://www.example.org/6c31ede4-27c0-4773-9fb1-234a70ec7b9d",
+    "identifier" : "phllWtIxiIgGdA",
+    "labels" : {
+      "is" : "Qj96cBobzZMgACKHb2"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1983498675
+    },
+    "activeFrom" : "2005-02-19T07:14:22.033Z",
+    "activeTo" : "2012-01-05T13:35:42.376Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "MAS2gc6ahMB9ZE",
-    "sourceName" : "czyyfexrnrsyaduq@5x2cmtqd40v"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "eZYpItjicUt1T6x",
-    "value" : "BmtoA2ITn1iUpEmFv"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/be592174-a78a-46a0-b3f2-2ed10dd659a4",
-    "sourceName" : "hksp5itb3pjgry7d@g3cmozqc7xhtmgph1"
+    "value" : "https://www.example.org/e0bcb1ce-380c-49fe-93e9-01a36ac3fb56",
+    "sourceName" : "hcnmfvukou@fbg7xcetvztyw8i"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "576551167",
-    "sourceName" : "smo5l2irnc1n9jnipyl@kfigcyvjg2fdhxftbq"
+    "value" : "39578937",
+    "sourceName" : "8ypdonrbvos4hc@rxqukwes2gmtggjs"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "nsQXvRKgPhG5pqQcJ8",
+    "sourceName" : "ap4adrpgkhgt@l1zhilyy1wr8k"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "NX7wMSCZ6n",
+    "value" : "hmNhinlHYmuwGAycb"
   } ],
-  "subjects" : [ "https://www.example.org/69115bbb-87eb-409f-b786-80a81c813522" ],
+  "subjects" : [ "https://www.example.org/a1d106cf-b2a0-4b8d-886c-8f4dab1f3ee8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2b1aaa94-b072-4e48-9ed9-771deb4843c7",
-    "name" : "LgBStoIG7S",
-    "mimeType" : "nZ62gkvc9HPEvz",
-    "size" : 1827720899,
-    "license" : "https://www.example.com/qcypzcxuhm5w",
+    "identifier" : "8e89ddf8-39ea-4651-98d0-d858b912c139",
+    "name" : "F6sUkubFFp",
+    "mimeType" : "1VOrrGTh5V",
+    "size" : 1326969220,
+    "license" : "https://www.example.com/9slwwe99wtdvuxjptsn",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "y3Sv4BKYDGaOY"
     },
-    "legalNote" : "6T3Z0VO7fckZ2",
-    "publishedDate" : "2019-12-30T18:48:46.046Z",
+    "legalNote" : "xO4l5DHUEWNUrg1R",
+    "publishedDate" : "1999-12-27T18:24:05.565Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "477510181@QUMMRmdXSdxcwt9NfZ",
-      "uploadedDate" : "1972-06-15T22:59:55.201Z"
+      "uploadedBy" : "503443963@eDlRLDQEcFxIG0L5WH",
+      "uploadedDate" : "1976-07-07T21:43:54.363Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VWyx6aYMaAgPtc",
-    "name" : "Hodmr1ddwciEKg",
-    "description" : "zUZLWNoaMPHR9uVfh"
+    "id" : "https://www.example.com/pYzHsiqIZU",
+    "name" : "2Zi6W4hYtgG2sZXTCs",
+    "description" : "XgGNECNXfHOZYG"
   } ],
-  "rightsHolder" : "TYPDAJaZTNnQJOfq",
-  "duplicateOf" : "https://www.example.org/500b3ddd-20ba-489a-9d7d-b8582597529f",
+  "rightsHolder" : "D3aESDlbFvobQ",
+  "duplicateOf" : "https://www.example.org/1e680d5f-2d57-4a5d-b539-deed19452a86",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "btFIIin2wNp"
+    "note" : "PhPFA26CNU9G"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jk3qtc9tko6Ox",
-    "createdBy" : "19Zxh51FA86HrD",
-    "createdDate" : "2004-11-24T08:38:31.777Z"
+    "note" : "jZivQ4s7gl6I8JaS",
+    "createdBy" : "NjymdVTDxAt",
+    "createdDate" : "1973-09-01T15:06:53.257Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7cc43f6f-203e-44a9-80f2-e03248d438f1" ],
+  "curatingInstitutions" : [ "https://www.example.org/324b57a9-d309-46ee-b2cb-1b0b2d9ab2d5" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "HqCVOHRugXRE",
-    "ownerAffiliation" : "https://www.example.org/18c0f86d-8698-4877-895b-b7534c2c7b9d"
+    "owner" : "8rc13ONhfxsK",
+    "ownerAffiliation" : "https://www.example.org/adb21c68-7f7b-4b98-b3d5-63ae77cb7745"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4832a261-f68d-40bb-9df5-267d29f85973"
+    "id" : "https://www.example.org/b091e756-c7ae-48a8-b436-af43a72c62dd"
   },
-  "createdDate" : "2008-12-18T01:23:18.889Z",
-  "modifiedDate" : "2008-06-30T12:01:54.205Z",
-  "publishedDate" : "2005-06-06T04:28:16.961Z",
-  "indexedDate" : "1997-01-06T04:00:14.429Z",
-  "handle" : "https://www.example.org/c0189321-d841-42c2-ad01-b60085869d0d",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/55099067-107c-43ed-a265-440cd919bbee",
+  "createdDate" : "1994-06-12T01:42:27.532Z",
+  "modifiedDate" : "1973-10-04T14:47:21.596Z",
+  "publishedDate" : "2019-01-29T13:03:12.148Z",
+  "indexedDate" : "2002-10-04T05:10:22.316Z",
+  "handle" : "https://www.example.org/26599cf9-63d9-4f66-afbb-9da3fdb769b0",
+  "doi" : "https://doi.org/10.1234/provident",
+  "link" : "https://www.example.org/072e2091-7615-4e02-85c8-2f86041a001e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TWTyOjJPSwm7tHT",
+    "mainTitle" : "BhlHEINvMkN82",
     "alternativeTitles" : {
-      "ru" : "TvvoMpe85it7jy"
+      "es" : "C7aSPOXaO3hlAqMO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BriSaKgDY7YpxM9a",
-      "month" : "D4ydpZlMfSBgEK",
-      "day" : "chgPjOQDiO9"
+      "year" : "kYArMUrvu3k",
+      "month" : "Y2uH462Re1Zf",
+      "day" : "IgXBQIzuCkMh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d137b66b-fbab-473f-84aa-b735779fbd13",
-        "name" : "4EkTEofb6wsd8uu9",
-        "nameType" : "Personal",
-        "orcId" : "USGdbpDDa69w",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/1a879679-54cc-47ab-8335-99d7cb712ec7",
+        "name" : "6D7H3Z2qEPYA",
+        "nameType" : "Organizational",
+        "orcId" : "8xc4Fdfl82UJ2h",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cC5rgWAeoD5HFTdL",
-          "value" : "Qj0HFcTIQFofHjeSCX"
+          "sourceName" : "pG2IfbSocFctxR4dVKB",
+          "value" : "YnconVD1IiQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EeguJfZkLmzpgkSp8dW",
-          "value" : "VoM6z0H1ztg0"
+          "sourceName" : "fuQ5PxepzP89YTvj5",
+          "value" : "jMorJqgSQl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3f380a3b-6214-4c23-8e39-e0e3f05f86e6"
+        "id" : "https://www.example.org/8dbfe5c2-b069-41dd-97be-223c11949039"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e2a659ff-bc16-4df9-8b58-11801f472083",
-        "name" : "PdQzgK439HL9I9o1IJC",
-        "nameType" : "Personal",
-        "orcId" : "59OLrzKqgjfnS",
+        "id" : "https://www.example.org/a5e2abb1-4ae9-44f0-929b-e64813e8e025",
+        "name" : "5DpzPMBsqAm9PXcBB",
+        "nameType" : "Organizational",
+        "orcId" : "qhngCfzBje6dTrRQC8Z",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "df6mr74X1Cl0LS13r",
-          "value" : "HCzy5cj7i4"
+          "sourceName" : "3LplyIjfmq",
+          "value" : "I1gvZuGk5C68ERs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oHVlTCEKsj1",
-          "value" : "OuJ3UZDQMi1eya"
+          "sourceName" : "GAjNJD14AYF",
+          "value" : "mE6muw4OUQWPWCACLc4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a97b31c0-94e1-4ba5-a010-ef3572d26243"
+        "id" : "https://www.example.org/f0df26ac-efeb-4590-b2cf-fedbcd2a569e"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "jNNrFohV0pGPi"
+      "nb" : "KcbLl4g9xTMIsp"
     },
-    "npiSubjectHeading" : "gtSphGfaTI",
-    "tags" : [ "KYiom3cvp18coxZ3zO" ],
-    "description" : "WbgeDKINTaO2zB8",
+    "npiSubjectHeading" : "8cSU04Wv75fE5B2",
+    "tags" : [ "iQW9NuWYyRz6" ],
+    "description" : "qyAIJoySnXvCzV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/116b4d67-1af4-4771-a7e1-47a68d138521"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1b7cc028-21eb-495c-84d2-9cf6228bc852"
       },
-      "doi" : "https://www.example.org/b51f2e58-c565-4b9d-9745-71187e44f7bf",
+      "doi" : "https://www.example.org/cff9290d-0b7d-4294-9b7a-55a9a5dcadc7",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "4rxYA4Tpe9NB3y0W",
-          "end" : "npchtMBmiEDCuMy"
+          "begin" : "kZwlVbynB6I1MmV3smz",
+          "end" : "slNTCsyWHNGflk744"
         },
-        "volume" : "pexhv1mVaz",
-        "issue" : "W85iUlnETKcy4I2KdGx",
-        "articleNumber" : "PPO8Yznmz3VcIW1"
+        "volume" : "OrQujNCjrjHqmSN",
+        "issue" : "BSYFNFR0iE",
+        "articleNumber" : "A8uVNczwcfGTsO"
       }
     },
-    "metadataSource" : "https://www.example.org/b465611b-b2ce-4d8d-866a-ca0c5e765385",
-    "abstract" : "NLT1hJRdxVOafEVLW"
+    "metadataSource" : "https://www.example.org/2bb13ce0-2e02-4068-a8d4-35553b21b67b",
+    "abstract" : "K5gcp7ygPOZWN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9650c642-395a-4522-95f9-055ac2a02de3",
-    "name" : "sFVzhXYFbqB7nmsyR",
+    "id" : "https://www.example.org/3047e7e3-b567-4e84-8f6a-a7861f682d7b",
+    "name" : "zLYJDZ9yXz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-08-11T05:15:04.557Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "WadQP8wZuioZt5zd"
+      "approvalDate" : "1980-11-22T01:06:19.602Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "LRfG6WCmx38rJ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b14533d3-3038-41bc-a499-bd5d4618a5bf",
-    "identifier" : "6Wt0lIGQAY7i6U4odv",
+    "source" : "https://www.example.org/88f4c082-818d-4da2-a52c-b349f106e080",
+    "identifier" : "AzUAM5NLNLxI41fEi",
     "labels" : {
-      "de" : "D1A20W1zY8JrIL"
+      "ca" : "LtZBeaMBHexbC"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1942292995
+      "currency" : "NOK",
+      "amount" : 667945398
     },
-    "activeFrom" : "1983-04-05T15:17:54.807Z",
-    "activeTo" : "2005-01-01T12:22:30.916Z"
+    "activeFrom" : "1984-05-04T11:54:33.342Z",
+    "activeTo" : "2021-03-16T10:07:20.553Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5bde170f-cae7-45e0-88c0-34db3c3a5ade",
-    "id" : "https://www.example.org/2daa8500-021b-4acf-8f16-5463df81d77e",
-    "identifier" : "uay5JTLbXkCFfxB",
+    "source" : "https://www.example.org/e4ac9286-fba3-42b1-9ce2-655f8fcc4e48",
+    "id" : "https://www.example.org/32928edb-cd2f-4ecf-bb42-91e6315f1b2c",
+    "identifier" : "OMYpA6DDicjVNMlIv",
     "labels" : {
-      "nb" : "q1VCm0dgi8vhR"
+      "nn" : "nVU3R4QthY70VMQ6e"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 778544228
+      "currency" : "NOK",
+      "amount" : 1708686524
     },
-    "activeFrom" : "1994-04-04T15:25:00.623Z",
-    "activeTo" : "2023-10-01T18:12:32.157Z"
+    "activeFrom" : "1997-04-03T04:24:17.551Z",
+    "activeTo" : "2013-08-03T06:50:31.533Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/5823aa6c-360c-412b-a92f-2b85cf748da2",
-    "sourceName" : "qyp8hz3re3f9ibexsj@djaoqfpsh6qb5ft"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "wZ615IWrORL",
-    "sourceName" : "ii0d6zhm178ufka@yzjy7i0d2u"
+    "type" : "CristinIdentifier",
+    "value" : "1230305101",
+    "sourceName" : "fwoqgowan82cd@cmokbclytukbnrv2"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "JlB766aVesgocC1",
-    "value" : "4IpeUWUH1Xugt"
+    "sourceName" : "FTQpD72NedbkR8ZCm",
+    "value" : "EmfMvUl3Sml9qLveg"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "568614098",
-    "sourceName" : "gvngxjwmuxw3u@qg8fyombcivyl5wv"
+    "type" : "ScopusIdentifier",
+    "value" : "nrH7CeftBi9evA",
+    "sourceName" : "hvduewdkkci873@9fvqjqwfnz55odmx"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/a48e0173-d75e-4acd-af1d-3b1ee24dcede",
+    "sourceName" : "axbkrgju7yqtftc@vplaqfzxmdp0mk3"
   } ],
-  "subjects" : [ "https://www.example.org/4bc84c3e-c106-44a0-aaad-b2d98ff16d47" ],
+  "subjects" : [ "https://www.example.org/2e030b3d-b4e6-4de8-b381-3d4d3d0ef4fd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8b393c22-8740-4c54-8c66-9eb44aa6fb8f",
-    "name" : "pYxluN1W4sull3pjj",
-    "mimeType" : "A9exlIkqmA7hN9R",
-    "size" : 170958609,
-    "license" : "https://www.example.com/xljozuzrue9l3d",
+    "identifier" : "f3f83acf-0851-4ab1-b7e6-11b636e62208",
+    "name" : "w2cWjCZawZ566l8",
+    "mimeType" : "BErtsmkLDYbcPF",
+    "size" : 95451275,
+    "license" : "https://www.example.com/qenqwxaxrrukz8tz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "EbEWl7ltvO",
-    "publishedDate" : "1998-08-01T09:22:21.301Z",
+    "legalNote" : "CDjQX6Y4bA",
+    "publishedDate" : "2004-09-04T00:19:55.217Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "838973797@rPvO0Ozp8rDM",
-      "uploadedDate" : "2014-08-25T00:25:43.211Z"
+      "uploadedBy" : "1888407963@2idKPhI3PECgxj96",
+      "uploadedDate" : "1981-11-10T23:04:17.042Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/QDldRfgc4L",
-    "name" : "avVdyNoBetN",
-    "description" : "81fCUjZZTv1c"
+    "id" : "https://www.example.com/fw1YVFoVf6a0J",
+    "name" : "ZUWlpug3LZNrhSDEORa",
+    "description" : "Grpzl7HjrRy53"
   } ],
-  "rightsHolder" : "6RiLI7Nd2T",
-  "duplicateOf" : "https://www.example.org/b9728bdc-305b-419a-8c60-fc9350ac23db",
+  "rightsHolder" : "CuSjtH2Qcea2CMg",
+  "duplicateOf" : "https://www.example.org/2eae6155-a31a-47c2-a83c-fb31d74bd049",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Z3SYzxxRWgy"
+    "note" : "Jy24YOoTdVZT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "m7e7FSyaBgXaypn",
-    "createdBy" : "r9IM2Dsx44",
-    "createdDate" : "1995-09-19T11:01:47.862Z"
+    "note" : "rO5LRN3riPuUnsC",
+    "createdBy" : "qweF9NXhCljj1RXIJ",
+    "createdDate" : "2013-09-14T20:41:29.641Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0d1e002d-65cf-489e-8ff8-f8a9b2e0de29" ],
+  "curatingInstitutions" : [ "https://www.example.org/22ed25dd-e9f7-4402-a22f-8dc68d955b9d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Cpw1ukLpoNE",
-    "ownerAffiliation" : "https://www.example.org/239e796c-dc99-4608-85c8-7b06fdced914"
+    "owner" : "5Gb2FKGlAgQ",
+    "ownerAffiliation" : "https://www.example.org/8e998007-93a0-4177-9f4c-1ce6047d1289"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c15ea6b2-1302-4da6-84ae-5cd001d4cfb5"
+    "id" : "https://www.example.org/599056fa-2d77-4a32-90e8-a68a70428b04"
   },
-  "createdDate" : "2003-10-06T19:11:26.670Z",
-  "modifiedDate" : "1984-10-14T01:48:53.900Z",
-  "publishedDate" : "2021-11-22T10:52:12.599Z",
-  "indexedDate" : "1993-09-04T02:46:40.487Z",
-  "handle" : "https://www.example.org/bd7c39a2-7527-4795-9b11-b4e2b59dddb5",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/665f3148-0637-481c-98df-b7ffc97237e7",
+  "createdDate" : "1980-10-22T16:39:20.173Z",
+  "modifiedDate" : "2017-04-25T07:10:31.029Z",
+  "publishedDate" : "2000-05-25T04:11:24.678Z",
+  "indexedDate" : "1987-10-20T20:45:26.592Z",
+  "handle" : "https://www.example.org/eb0615f1-0ec9-47a4-a6ee-da2d49d3251e",
+  "doi" : "https://doi.org/10.1234/a",
+  "link" : "https://www.example.org/9c252261-1e2e-4f12-9d99-3fc8e9d5dce5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iufo59zJgV1O",
+    "mainTitle" : "ND0M4CnYVyrMlv",
     "alternativeTitles" : {
-      "af" : "xPlkuU9TZvyzL"
+      "is" : "BT6EJobyPXYjb9Ljdvd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cc4egcLcbuvHlFuPl",
-      "month" : "skMFlNdiLTdmHpc",
-      "day" : "2bA8654ZUx"
+      "year" : "EEZFToi2jqXIRJV",
+      "month" : "VVyZc0qTLBtLPJAt",
+      "day" : "jQ9XiY6sCcb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7621e6ea-659d-4ddb-b379-41eb1af0b51e",
-        "name" : "dO4V9FlLkZio6yOO",
+        "id" : "https://www.example.org/5e4c0959-ef5f-4977-80d1-ae2b687cc373",
+        "name" : "ENU22F1jSo7ytF",
         "nameType" : "Personal",
-        "orcId" : "FHghA6zVkkiLVpwct",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "KqXL9RP0Zpj",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SLdErBwkS7VWuyJZxp",
-          "value" : "V1UZWRiaPUzWI"
+          "sourceName" : "RxWgXuKNvoizTUm",
+          "value" : "cvN2EnxuCGLT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ssBZtyTp9scNIX2bd6",
-          "value" : "6ZJKKBhqpRlYPE8p"
+          "sourceName" : "7iY1yet2iU6M09ggMO",
+          "value" : "wvDJDJY2y3DzQu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3385356d-0d54-4dff-bd8b-aa97accbcac0"
+        "id" : "https://www.example.org/0feac23f-72b5-4258-9ea0-f7435a37d549"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a4a91b7-4c19-4a30-8b21-a90a9adb3c92",
-        "name" : "EscORFUkan",
+        "id" : "https://www.example.org/275d5191-e1f3-45f1-adf1-575ebb73da3b",
+        "name" : "16Am0jxS5TBU7qX1Ic",
         "nameType" : "Organizational",
-        "orcId" : "nyt8EamFnXlRrlIfKbe",
-        "verificationStatus" : "Verified",
+        "orcId" : "lgSzWABZcRqBFKM",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rOzWQQ1x0bG9hYeGzE",
-          "value" : "85pb7Rpp7JXC"
+          "sourceName" : "t8bjWWNvKbZwPWXu",
+          "value" : "FKSH2WGCk8vc04"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FCgqb233oC2VKeMjA",
-          "value" : "8mdcicKAxGmy3z"
+          "sourceName" : "UzxPqHkCk2adI6uLN",
+          "value" : "ybfh21mR8nV0sojyX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d90d5dc5-f180-483e-ad8f-a4ea5a33e894"
+        "id" : "https://www.example.org/eb0d1db8-dc46-452e-b88d-3cd95491dfb7"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "MAASpG2rsywa0d3L1"
+      "nb" : "Dg6hIvlLjkXcquH2q"
     },
-    "npiSubjectHeading" : "9O6i4GSlAwK4D",
-    "tags" : [ "G6OyM1qWfRbie3zdgS" ],
-    "description" : "EZCmcnrLwTKxIS9s",
+    "npiSubjectHeading" : "zfaT1UO9xHQw1LO",
+    "tags" : [ "YZDXBR3yNz" ],
+    "description" : "fyLjXqIsWeez2ivRj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/95ca09db-56df-4054-ad7d-e7af2f924954"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/408effb5-7684-4475-8267-bd2c30e41158"
         },
-        "seriesNumber" : "Rmtkz5EBds2anBxW3n",
+        "seriesNumber" : "GJ5loX8dh3ML2UID",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/61e679e8-6f05-445d-a2c8-fa404cda1923",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b2e52e01-b44e-4690-a020-49e43a3c0b9a",
           "valid" : true
         },
-        "isbnList" : [ "9791384703885", "9781791122621" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9790915003395", "9781925607109" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1791122620"
+          "value" : "1925607100"
         } ]
       },
-      "doi" : "https://www.example.org/5084fb4f-2519-49cb-9552-d1a2708a5255",
+      "doi" : "https://www.example.org/d4298be3-8881-4048-b41a-e77c86857b2a",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "cPWppUGG4TZ",
-            "end" : "1Ju6hCJFz3"
+            "begin" : "dTphQ3LTalN",
+            "end" : "ydUIJ6sxl9aMAI0Au"
           },
-          "pages" : "Vt9pkBQSHd3y4U9AF7",
+          "pages" : "kt8XMX7OV8PX6WvQUo",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/668ca852-58e5-44e8-a2a3-73de7ff145bf",
-    "abstract" : "hEMFqEBFJFaDG"
+    "metadataSource" : "https://www.example.org/c3de96c2-e7c5-43a1-b92e-3e3335cc9096",
+    "abstract" : "K0JCR5QlEW8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f64c0e07-e7d0-4109-ad04-f373233d4016",
-    "name" : "pu2i78rNf87vOv",
+    "id" : "https://www.example.org/ec7bc9ff-d449-4695-81f9-fe05ace84b0d",
+    "name" : "l7bIgSlMwVkosCUYuy",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-02-21T16:28:07.184Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "J39MyvXHuso9VnWAN"
+      "approvalDate" : "2016-02-24T04:11:59.412Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "j96JWALRfryz43wx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/31e76790-abc8-4ea7-8556-a42cae7f08cc",
-    "identifier" : "N3AY8FxAQu4JeXmQG00",
+    "source" : "https://www.example.org/b7a36b54-13cd-405f-9696-d8766cf4eee5",
+    "identifier" : "owZGjmJJx3x",
     "labels" : {
-      "hu" : "ScN4DpfO9EA3f3AMN"
+      "hu" : "tfKSxbqkXZ"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 773753297
+      "amount" : 1943513166
     },
-    "activeFrom" : "1991-08-11T05:56:54.577Z",
-    "activeTo" : "2004-03-22T23:42:16.473Z"
+    "activeFrom" : "2002-12-18T13:55:52.343Z",
+    "activeTo" : "2023-12-13T08:17:25.773Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6d4c8b24-8f5e-47ef-9d98-ba52c1b0b7eb",
-    "id" : "https://www.example.org/52457edf-7a38-440a-bc3a-9b6d5e5d0156",
-    "identifier" : "C58TdhMYYc",
+    "source" : "https://www.example.org/4c87d08a-94ce-4f27-9871-afbc141a54a5",
+    "id" : "https://www.example.org/01d898df-aa75-4695-b89e-7a9e4af3e2e9",
+    "identifier" : "DtXcf5XcEPChYN2QrFC",
     "labels" : {
-      "ca" : "kA7OJVOQmwetC"
+      "pl" : "yLNgwY6PXwVXVd"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 673518701
+      "currency" : "EUR",
+      "amount" : 374392609
     },
-    "activeFrom" : "2021-10-18T03:52:12.089Z",
-    "activeTo" : "2021-10-21T10:40:21.217Z"
+    "activeFrom" : "1985-11-26T22:34:05.882Z",
+    "activeTo" : "1996-11-22T13:14:41.649Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/28c52fc5-ec9f-4d65-8034-74243798058e",
-    "sourceName" : "jpcum211pluft@eygsok3bchbig6c3amp"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "NRc4XS8grEFL",
+    "value" : "wBE1C2ZqLKd8GA3Kdz"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "XWPfZn3LhlY",
-    "sourceName" : "n2qczepbo9tdmiqeaq9@oscneekp3jzyahz"
+    "value" : "RWi6mnfGpIPyp643",
+    "sourceName" : "rrrngkhpxhtyh@ltnkutdyrrn9isu3c5x"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "nNFGfhOm5B",
-    "value" : "iHLi669EjzArvf"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/77c3f4fb-a60c-4760-8b61-516ee3217455",
+    "sourceName" : "dcyqoifoqbpm9hv@vhkbcrzhwxjsbusahl"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1990799997",
-    "sourceName" : "1mpj25le98lv@hpwttyidmh2snu"
+    "value" : "1131270654",
+    "sourceName" : "ela1y7hj24r4@fuvfr5ampej8tu"
   } ],
-  "subjects" : [ "https://www.example.org/9570ee44-f98f-4e43-a1fd-7a6ac73c9381" ],
+  "subjects" : [ "https://www.example.org/57f4dfdb-59bc-4157-8da0-90c780039b19" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f384b536-8ad2-4e85-8f14-7ad5d35add06",
-    "name" : "BQypF2BtenTM4Z",
-    "mimeType" : "qyfY3DUXF2DoorZGX",
-    "size" : 401664165,
-    "license" : "https://www.example.com/w4bsshzsk0",
+    "identifier" : "39c70091-ecbc-49e2-9350-25eea629428a",
+    "name" : "PRYkxtmNvPO3IlwX",
+    "mimeType" : "afenMEob26c",
+    "size" : 383501537,
+    "license" : "https://www.example.com/007lnfw8hhsm",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "pqaYPfILJe3YLZQu58",
-    "publishedDate" : "1976-08-17T13:42:05.150Z",
+    "legalNote" : "1ZoHPRiDXqBVK12",
+    "publishedDate" : "1982-06-12T06:58:15.784Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "284741405@SRpNu3zWCKVj9",
-      "uploadedDate" : "1984-04-20T12:42:58.341Z"
+      "uploadedBy" : "1050042577@5cHhPNPP053Qa",
+      "uploadedDate" : "1972-04-22T01:34:20.030Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KSuh08F97C6pyni0h",
-    "name" : "Xau5cViZDL4lYWsb",
-    "description" : "3gxP3d4JSVhewta6"
+    "id" : "https://www.example.com/PHAOrnUhpigVfp",
+    "name" : "9VrBkgxzoMNoQVFDYj",
+    "description" : "xFHGetlDSeiEPL"
   } ],
-  "rightsHolder" : "FvEHr3SlvEUPAbnWalA",
-  "duplicateOf" : "https://www.example.org/3b8f1eec-85f2-489b-bd5a-cfbfe8cfbc36",
+  "rightsHolder" : "pQbFUuRMbn20r",
+  "duplicateOf" : "https://www.example.org/81336205-c758-4811-9e1f-bc689d13aa12",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "NOk8PcuE74fu2Zt0u"
+    "note" : "IOnQjPGkdM7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "6Od0JSN9T1IW",
-    "createdBy" : "fcNx8rAkDs",
-    "createdDate" : "2002-01-22T06:34:10.947Z"
+    "note" : "VYhTI49tyBQphePFM9X",
+    "createdBy" : "1VvGMHQ39yRmHY",
+    "createdDate" : "1986-08-23T09:43:02.438Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/75e672fa-cf0f-4547-b3a4-f1693edbf7d8" ],
+  "curatingInstitutions" : [ "https://www.example.org/7e2427c7-e12f-49f7-b89c-63201a4cc537" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "jzVqKKwVhNT",
-    "ownerAffiliation" : "https://www.example.org/1a007f7a-e533-45c7-9365-09f17c52b775"
+    "owner" : "Srpt2Zm1PDrUyoOWzi",
+    "ownerAffiliation" : "https://www.example.org/3989cadf-3ccf-44d9-9c93-49f67210362f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6cfa0e34-4e47-45e1-bbb7-f2b5192c30b4"
+    "id" : "https://www.example.org/c487b6d1-17d2-40d1-ad44-08d2c031e2ea"
   },
-  "createdDate" : "1996-05-31T06:01:01.797Z",
-  "modifiedDate" : "1983-10-27T23:03:34.314Z",
-  "publishedDate" : "1986-07-16T05:12:38.783Z",
-  "indexedDate" : "2004-11-15T22:59:22.144Z",
-  "handle" : "https://www.example.org/842c1245-bd54-432b-baec-147f1de6443a",
-  "doi" : "https://doi.org/10.1234/earum",
-  "link" : "https://www.example.org/930d34ef-4a08-431a-9064-06c57e332c07",
+  "createdDate" : "2014-11-25T02:42:06.414Z",
+  "modifiedDate" : "1985-11-18T22:53:27.945Z",
+  "publishedDate" : "2009-07-06T14:11:00.185Z",
+  "indexedDate" : "1987-08-06T00:34:43.501Z",
+  "handle" : "https://www.example.org/337ed036-c2ef-4c6e-a972-61e56b429aa9",
+  "doi" : "https://doi.org/10.1234/cumque",
+  "link" : "https://www.example.org/bebaad5b-30f2-4f3e-a47c-38f2ff125dff",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QCIcx7yjgoZ",
+    "mainTitle" : "htV439vZCT9hsVKAiK",
     "alternativeTitles" : {
-      "de" : "KKhcbNl83Zo1p9U27hv"
+      "fi" : "5PIwF6ipcpwNp6SY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "SroP3KfME70wAJQCRM5",
-      "month" : "NpbbuUm8vUD",
-      "day" : "jEcY47GC0MYoxXW"
+      "year" : "nEsHmoET4L19s2",
+      "month" : "qPwvJ605DzF",
+      "day" : "9gxAGl3c651pm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d8e402d5-bb6a-4a52-b73c-b35ce72f5924",
-        "name" : "Op7B0achVLyjsU6S",
-        "nameType" : "Organizational",
-        "orcId" : "X8rMLnqswsc",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/884bbf39-df69-4fd5-a657-a35892ddf585",
+        "name" : "3RaUihj9ZbtIXPDprMP",
+        "nameType" : "Personal",
+        "orcId" : "4CcBG4EViRGrkb3P9Z",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FTkXbf4TEExHOoz1",
-          "value" : "nUIaMXAfso0F"
+          "sourceName" : "kQdUSpmWDoDgKsCc",
+          "value" : "qO3Ca7vXosRcd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "woupcO1trfAG4uUloDP",
-          "value" : "FhsrNebw52wo8GKTUjD"
+          "sourceName" : "x2L5TLnTTbuS",
+          "value" : "TymTciOKmuIt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4d9ab48-f4e5-47b5-8deb-9fd69fb67412"
+        "id" : "https://www.example.org/6bb07339-a433-4c83-8413-2e3a61bd8dae"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,202 +62,201 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/42477ce0-035f-417c-9e1e-a5e77afed86a",
-        "name" : "SwC7WdpFoQBLI",
-        "nameType" : "Organizational",
-        "orcId" : "eI4IxjzP2VCHuyY4T",
+        "id" : "https://www.example.org/22dfd298-dd6b-473c-8e66-12e59d168830",
+        "name" : "YYNUyAthqooYFjI",
+        "nameType" : "Personal",
+        "orcId" : "KAb0APIVBG38UHz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2g6rW73rzR2fa",
-          "value" : "PFNWtPuMEpR9b"
+          "sourceName" : "X2xjbXhrpw",
+          "value" : "P53SQWHA2yTk4lGWL0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ik4NHhU9sbNlgA",
-          "value" : "oGBLYLqyocdKkdnM"
+          "sourceName" : "AJK8qYpgyP9",
+          "value" : "TDcKqqLEpyzgARl289A"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d20d09c3-fcad-43c6-8e9a-566cda706e3f"
+        "id" : "https://www.example.org/d71eec9d-1ebc-4c84-9b23-acc994781a45"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "KmmzBEY0r7z"
+      "da" : "tNRvLAiAwFBE0rmd6im"
     },
-    "npiSubjectHeading" : "IzKnmap1Nd1SVyJhufr",
-    "tags" : [ "9X8Z3RrxN1QJV3" ],
-    "description" : "lQi1dYUoFF0jaq",
+    "npiSubjectHeading" : "IvNItZKfZwaCpCH",
+    "tags" : [ "wwfhlTwiUOB2Bgx" ],
+    "description" : "JXjfzc9BxWJQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/b3f047dd-1673-4c65-954d-3483a7e503bb",
+      "doi" : "https://www.example.org/7adf98c8-9d03-4ec4-94e8-dc57e83cd4af",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "ArchitectureOther",
-          "description" : "Q5MPU9UG0d"
+          "type" : "PlanningProposal"
         },
-        "description" : "eAoI4TSO0VxwFYRp",
+        "description" : "tzcDVNNFnn",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "hb4Joctodo",
-          "description" : "z5DSYBgjEDR76",
+          "name" : "tEcMAePlHR",
+          "description" : "YHIySBdNKwZyi5n",
           "date" : {
             "type" : "Instant",
-            "value" : "1997-08-27T17:20:12.926Z"
+            "value" : "1999-02-14T06:38:22.788Z"
           },
-          "sequence" : 322549706
+          "sequence" : 1674216092
         }, {
           "type" : "MentionInPublication",
-          "title" : "Bo87pZKa4jxfMWT6XZ",
-          "issue" : "9SaPuvuuIrJeN3T",
+          "title" : "xwnM7anf5mLLTch",
+          "issue" : "qPqARsxHfhmxUTH3",
           "date" : {
             "type" : "Instant",
-            "value" : "1989-05-16T16:46:39.105Z"
+            "value" : "2000-02-22T08:58:44.998Z"
           },
-          "otherInformation" : "Kv2fbyWbzbBvYbrf",
-          "sequence" : 461739952
+          "otherInformation" : "EkW0zgbOZJm7J",
+          "sequence" : 46624820
         }, {
           "type" : "Award",
-          "name" : "1nYfkvJdxzrUadCv",
-          "organizer" : "dqc6a42IgA",
+          "name" : "QzbaWiqhwibs9YN",
+          "organizer" : "Zxwv8kzSBQKJfD",
           "date" : {
             "type" : "Instant",
-            "value" : "2013-05-18T05:05:49.174Z"
+            "value" : "1979-04-30T20:46:53.857Z"
           },
-          "ranking" : 1423709147,
-          "otherInformation" : "CbkqOk2Ehdyuy5xyf9",
-          "sequence" : 1014371269
+          "ranking" : 274902582,
+          "otherInformation" : "EPVuMe5atG",
+          "sequence" : 1113369161
         }, {
           "type" : "Exhibition",
-          "name" : "pbiKmdunOY",
+          "name" : "64u5sR8pry0aByRBw",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Jvr8VjaJrft",
-            "country" : "QTa1O56xMcAGE5qVM"
+            "label" : "4Suf9qxbmDRTP9wMBb",
+            "country" : "QHA2tDCXOSEFsn"
           },
-          "organizer" : "f5EWPS468Zrspijucgc",
+          "organizer" : "azP6Q4BnN7HuUku9k",
           "date" : {
             "type" : "Period",
-            "from" : "2014-03-19T02:48:30.459Z",
-            "to" : "2024-07-21T16:48:24.102Z"
+            "from" : "1995-05-19T16:32:45.020Z",
+            "to" : "2014-09-29T21:00:17.314Z"
           },
-          "otherInformation" : "7AOA2TPgQcCpGs9VzaE",
-          "sequence" : 148340754
+          "otherInformation" : "O8Oesx4EyTCfGfT",
+          "sequence" : 1206626960
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fd2e6c6d-9185-4298-9199-36368a82adc2",
-    "abstract" : "K07dfwyVuG5DJzGPtr"
+    "metadataSource" : "https://www.example.org/9df8bc73-7105-4e8a-b4b5-00de8b930995",
+    "abstract" : "BvENkx1M9RHdL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/096bf012-9b89-4ce7-b0bb-837fd6515878",
-    "name" : "TC137BoFamyq",
+    "id" : "https://www.example.org/bbbfbefa-9da7-4156-8529-bb0c8e6c11a5",
+    "name" : "sJC0vgaRur",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-04-16T05:19:47.563Z",
+      "approvalDate" : "2001-04-04T21:52:50.709Z",
       "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "AseGCWARRT"
+      "applicationCode" : "wYxGjPZNsiYujc57"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2c2433e6-f05b-4076-b442-b44b794ef011",
-    "identifier" : "6qHPdDjvfa",
+    "source" : "https://www.example.org/3336b1de-4343-42f1-8ce8-df775e12c320",
+    "identifier" : "8OkzvaordH",
     "labels" : {
-      "zh" : "FqOVDt3yuY"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1921782255
-    },
-    "activeFrom" : "1984-07-10T22:26:53.107Z",
-    "activeTo" : "2013-12-31T21:24:01.470Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7009204c-8f32-4f38-8df5-6c0702e647ac",
-    "id" : "https://www.example.org/36c59bb0-4373-4174-a2be-1d76a809bac1",
-    "identifier" : "gjNz35OXtoSQM6plwl",
-    "labels" : {
-      "hu" : "iWh5GsmB7lt1gSq"
+      "ru" : "PdICHf6nkKqPIhfL3eR"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 646533841
+      "amount" : 608421723
     },
-    "activeFrom" : "2000-05-27T02:23:03.764Z",
-    "activeTo" : "2023-03-23T04:42:07.829Z"
+    "activeFrom" : "2002-12-25T21:15:33.317Z",
+    "activeTo" : "2014-02-01T21:58:39.201Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/0878fcb3-7d6d-4083-a4ce-1e445fb1b161",
+    "id" : "https://www.example.org/ee1733ae-f937-4200-b5ca-c1a91930a82b",
+    "identifier" : "8wgTrnQt6tsoZ3QD",
+    "labels" : {
+      "el" : "kOg46AfuS50G"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 123323277
+    },
+    "activeFrom" : "1998-06-23T19:58:00.528Z",
+    "activeTo" : "2009-05-11T20:16:50.142Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "BwRUobNbzQb1eHAmy",
-    "sourceName" : "kt5o637o9wu2b0c9@nrp2pk8lyftdhi"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "l9rmrbiIt3",
-    "value" : "pPGqtv4EfeUuQ"
+    "type" : "CristinIdentifier",
+    "value" : "1990485283",
+    "sourceName" : "rry12cnvksvwg@os6hryrciy7q"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/6e44c475-b430-411b-ab03-2026fc1f3f73",
-    "sourceName" : "objxqi2t5ho1lcsnpen@rdnnwqwek9eutd"
+    "value" : "https://www.example.org/d39e0549-4318-4961-ad7a-568d06e88b1f",
+    "sourceName" : "aptpjmfvk8u@xmprlofqpzzxikhw"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1817681243",
-    "sourceName" : "muy4ch13j1@lmpyiks9lfr"
+    "type" : "ScopusIdentifier",
+    "value" : "TsPJUuJaguwGLs6z",
+    "sourceName" : "nd4r7pnuzy9x5bbtjm@9rjmloi44bh"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "nh1luWre1BwTuTfkh",
+    "value" : "wgSOMMTs0eqzaciFi"
   } ],
-  "subjects" : [ "https://www.example.org/e0f30f96-43fb-4130-93e7-3bc864693677" ],
+  "subjects" : [ "https://www.example.org/a5b4606a-a88d-4237-b123-70303682f00d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ce98860f-3478-4edd-833d-d556d625a549",
-    "name" : "U8BYdge2fHp",
-    "mimeType" : "a73bqghb3ZQZxhFmtR5",
-    "size" : 981546410,
-    "license" : "https://www.example.com/mmovr0d8dzvse",
+    "identifier" : "034f9975-4e41-41ec-83f1-8f6ce90fa09c",
+    "name" : "u5MC6F4jmDJv",
+    "mimeType" : "WE5j4F8cag3ZutFwA",
+    "size" : 1954247024,
+    "license" : "https://www.example.com/ct2yilkjlmt4o",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "I2YAbrLCfgm2RGJ7f",
-    "publishedDate" : "1979-10-18T14:52:30.935Z",
+    "legalNote" : "lUQVenP6mu2t2j",
+    "publishedDate" : "2004-12-25T23:13:41.874Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1236605313@2HWNhFMOO8l1LiHT",
-      "uploadedDate" : "2024-01-15T23:20:36.665Z"
+      "uploadedBy" : "2138255974@3Kdu1DWnbNXSjH2uE",
+      "uploadedDate" : "1992-10-27T10:23:30.648Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ntSYDSE78aRGnQmk",
-    "name" : "J3GkUqJ5ZuVzwfSm",
-    "description" : "N1U82CXhHG"
+    "id" : "https://www.example.com/XV5EgqMhvm",
+    "name" : "A2C4vHssQw",
+    "description" : "SvSNTTQxhU9QR9XMC"
   } ],
-  "rightsHolder" : "OWfMHrKWxn404evgvQL",
-  "duplicateOf" : "https://www.example.org/a3e09562-9988-4ec4-ba54-33437d54c53f",
+  "rightsHolder" : "yc1u4zebNW7",
+  "duplicateOf" : "https://www.example.org/9f797907-61d1-450a-8ce4-592792de3a69",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vjopKN7DWYB7bn5v"
+    "note" : "0gowxwVrjqOO150J"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "OiJANe6jtHW",
-    "createdBy" : "NJWRLLO1dDCBU3svgkc",
-    "createdDate" : "1974-02-20T13:45:02.119Z"
+    "note" : "CLwDNZwFmt",
+    "createdBy" : "tmG3rHak4f",
+    "createdDate" : "1991-05-31T03:08:00.646Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a3638ada-5b60-4967-a290-b5067208a20a" ],
+  "curatingInstitutions" : [ "https://www.example.org/ce1d5e6e-38ff-491b-9a39-d4fabaaf1c55" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -3,55 +3,55 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "xngMkl18Ra8",
-    "ownerAffiliation" : "https://www.example.org/c3c615ea-3553-4a42-880f-878b6a59f4cf"
+    "owner" : "uDgNeOhzusZbhj",
+    "ownerAffiliation" : "https://www.example.org/820d0d87-cdba-45f1-b39b-f6766a00d47b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/37e13c3a-6980-442d-9c40-1c97e47c5618"
+    "id" : "https://www.example.org/476c781e-b862-4748-8e25-323523d9da05"
   },
-  "createdDate" : "2005-10-29T09:55:53.208Z",
-  "modifiedDate" : "2023-07-02T09:37:37.286Z",
-  "publishedDate" : "1977-03-27T21:22:52.477Z",
-  "indexedDate" : "2007-02-20T14:37:05.165Z",
-  "handle" : "https://www.example.org/7512b189-6613-4781-a7df-3fb411eb8ea5",
-  "doi" : "https://doi.org/10.1234/odio",
-  "link" : "https://www.example.org/fb2862a6-2a5f-44dd-ba99-a50d28b2fb14",
+  "createdDate" : "2014-03-27T08:40:15.215Z",
+  "modifiedDate" : "2009-08-18T16:27:49.730Z",
+  "publishedDate" : "2022-07-21T16:27:42.835Z",
+  "indexedDate" : "2012-01-20T14:36:11.591Z",
+  "handle" : "https://www.example.org/6c78b316-c134-4392-843e-a444fb8d0f27",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/d380f62e-428a-4c88-8476-eb90d090e5a9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rbW7NFGvsqaKOJi3qR8",
+    "mainTitle" : "VCJwg7JRWp6rRwO",
     "alternativeTitles" : {
-      "zh" : "KcI0cmSaCe"
+      "bg" : "AajMlVlXAPbhTX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "x6IYQBY0Mle2",
-      "month" : "s1Pv4D99nxUiutXq3",
-      "day" : "zfNAIybRcCyaF9x2"
+      "year" : "ItPRTEBRFaePtIs",
+      "month" : "dYml1VdC2IjfJ",
+      "day" : "anDEbpygmLBlg5Ke"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/547a9eb2-1051-4d61-95aa-e0c6e30d4671",
-        "name" : "rxsrbJoCNY548d",
+        "id" : "https://www.example.org/3d8315bc-1931-46d6-9e19-9cb2dc6ee511",
+        "name" : "Lyhb9MxehD",
         "nameType" : "Organizational",
-        "orcId" : "Lk8014XqNwZZd6",
+        "orcId" : "62SRsIcGqIhIJ",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PAITnbEbxq",
-          "value" : "5NDeOO72rq5n6giG3"
+          "sourceName" : "SrY8azsNFLqwQSCCeF2",
+          "value" : "9HcyPwrDr6sCD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SrlGEbVaR8V3zr7",
-          "value" : "GVnVLW2w6f"
+          "sourceName" : "qyJUGmA6uMKc",
+          "value" : "ZN29a0gnbi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f6bd0129-d848-4d52-ac22-7da305318f5f"
+        "id" : "https://www.example.org/bac65e56-28af-46cf-b92e-e9178e557f7d"
       } ],
       "role" : {
         "type" : "EditorialBoardMember"
@@ -62,181 +62,182 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7bfe1f4e-041a-4e54-bc05-451b0ef6b4b0",
-        "name" : "6t2uuGGhcPcx2rpl",
-        "nameType" : "Personal",
-        "orcId" : "pGUVmSeDwtnXPVg",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/4a642764-3e9c-478b-a750-735e5285ec03",
+        "name" : "kPMPIqW6p9qz",
+        "nameType" : "Organizational",
+        "orcId" : "fbcHUfBNgska",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Woj5hkJcmdd",
-          "value" : "4ufIUVzaVrJu28uHHY"
+          "sourceName" : "3f26WQ85PWQh",
+          "value" : "3ZIJ5mIyq62WBUQX5A"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NcEAt2UJcuLNsX",
-          "value" : "4Z8x5ubd7axgL7XtGoR"
+          "sourceName" : "Ugp3VRyZI6JRJ",
+          "value" : "nchieq4Oeb2103xr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/80b19d5f-bc6c-44f6-b8f2-0174560f5cd3"
+        "id" : "https://www.example.org/c8766ffa-a253-4cf5-9a15-78bb64d2908d"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "hgNb1AQf7vvr5J"
+      "ca" : "ekuIrDPEhQDWkA7gjX"
     },
-    "npiSubjectHeading" : "PCmQPJAl6eypxXT7gRm",
-    "tags" : [ "LV4ZLAgdAqpVOjBJ" ],
-    "description" : "JoPOhZMMBHEyJs",
+    "npiSubjectHeading" : "ELnPNf9I0XqNTLAqMT",
+    "tags" : [ "RMZiGMpsen" ],
+    "description" : "6XWnFUHXB8fy3dowWP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/ee0bf909-8e50-4081-a3f2-1fac154304e0",
+      "doi" : "https://www.example.org/534fd998-fd2a-4efc-a4a8-08e0c7b77d5c",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "LightDesign"
+          "type" : "WebDesign"
         },
-        "description" : "kp484uQargX5S",
+        "description" : "TJxKWCzkT0vsDER",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "6ctB4ml4Fc2DhG",
-            "country" : "1Pc8BEwj71Gnhmygbb"
+            "label" : "Gh95y5qqgyUgEJIpn",
+            "country" : "TXwIxFIUCqRO"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2021-07-09T05:57:22.796Z",
-            "to" : "2022-06-22T21:26:46.625Z"
+            "from" : "1987-05-24T19:38:44.778Z",
+            "to" : "1989-02-05T17:46:15.319Z"
           },
-          "sequence" : 1279477654
+          "sequence" : 1984888047
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "n1CVUgN2wR1UByr",
-            "country" : "LVXpX220SWxX"
+            "label" : "ZFpwq6VTkscH",
+            "country" : "TqY6DEftHag"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2002-08-25T02:18:05.450Z",
-            "to" : "2014-07-03T08:57:55.960Z"
+            "from" : "2016-04-18T15:44:18.640Z",
+            "to" : "2019-01-05T10:29:20.959Z"
           },
-          "sequence" : 1509056796
+          "sequence" : 2038675604
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/99e745e2-377e-4f61-a43f-cd8a4e0e395b",
-    "abstract" : "OglmATSTKJ67"
+    "metadataSource" : "https://www.example.org/2dc6bd1a-ac92-4b15-ba1b-bc03f16db0ce",
+    "abstract" : "0ZcRPhJETT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ce83549e-49bc-4863-8a59-2fad73aceb5a",
-    "name" : "D1X5f1bKR1HOLJOybN0",
+    "id" : "https://www.example.org/e1a8dd8d-169e-443f-9ecf-c5efd0998bdd",
+    "name" : "fKSfV4w64u4SAEoK3Fm",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-01-09T20:27:04.736Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Gg52NMAwBV6kHALFH"
+      "approvalDate" : "2002-08-30T05:31:14.433Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "1cq9JEF7G9"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7268700f-81c5-431c-b062-cfe3d72e878f",
-    "identifier" : "99Ark9hKZzntdWked",
+    "source" : "https://www.example.org/c0c5f650-3da5-4788-8cdb-6d9c31ba24e7",
+    "identifier" : "EUbRfS4ILrkaVZ1Rt",
     "labels" : {
-      "el" : "GDfvxkbtm56ght"
+      "af" : "ulfVCDJzeqFIV"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1807789410
+      "currency" : "NOK",
+      "amount" : 1148839872
     },
-    "activeFrom" : "1976-12-30T17:07:30.380Z",
-    "activeTo" : "1982-07-16T05:09:19.699Z"
+    "activeFrom" : "2013-06-27T09:03:34.401Z",
+    "activeTo" : "2020-09-11T04:07:12.147Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ca9e7eb3-9d33-4517-bc44-3325baf1b0eb",
-    "id" : "https://www.example.org/8dec793c-616b-48d4-87e7-e42ddaf7e36d",
-    "identifier" : "aDdsM5571vw4AMvlaA",
+    "source" : "https://www.example.org/1aaec89e-42a3-4452-96c6-cd77a02a5d4a",
+    "id" : "https://www.example.org/badcb93e-dd04-4b51-9786-4bfd79e0686b",
+    "identifier" : "71MkjLaxOwpyRX3",
     "labels" : {
-      "pt" : "yTL72krapLSWlD"
+      "es" : "zZ78ElZjRyQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 485060670
+      "currency" : "EUR",
+      "amount" : 718084367
     },
-    "activeFrom" : "2001-06-01T04:35:52.666Z",
-    "activeTo" : "2010-09-30T05:18:26.583Z"
+    "activeFrom" : "1983-03-18T05:35:47.595Z",
+    "activeTo" : "1992-03-25T06:18:17.276Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "X9MwGVXjxxdPeok5P",
-    "sourceName" : "dytuticfjuc@wyodnwnww8p8kpyp"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1898083407",
-    "sourceName" : "sxiwjoyeh50jp@pl8z2mq2qub3d"
+    "value" : "4MHadan2HId3nEU",
+    "sourceName" : "csuxcutemkhucabru0n@8b36uhfggm"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0a9a7c19-ea2a-4c64-97f3-705ac76f1493",
-    "sourceName" : "ngumdyxjcihadd9kys@xegbavksxx"
+    "value" : "https://www.example.org/7eec2c36-83ee-479c-acea-3d7c5c01db01",
+    "sourceName" : "iqozbhlbj5nydskik4@cznn30ilkzzleh8"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1544100228",
+    "sourceName" : "kaehjwllicgfvei8z@al8i8ppye0fm0f0qztc"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "N9xasKfLfpUVz",
-    "value" : "5smL7hofOIp"
+    "sourceName" : "TPtHgb56M9Loc1Ep",
+    "value" : "z3HFgNOYVf"
   } ],
-  "subjects" : [ "https://www.example.org/81752169-6a8f-4c9a-8343-ced7b2aa85ba" ],
+  "subjects" : [ "https://www.example.org/3e8d558a-1840-4cb7-a39b-33d96b4a8da2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f2f4ba74-cace-4a63-9a00-2105d69a9c66",
-    "name" : "Vp5G4fIAjgI",
-    "mimeType" : "XnDOsGScwQ8",
-    "size" : 1832065846,
-    "license" : "https://www.example.com/l0kslmhssdf",
+    "identifier" : "82b96bc7-6569-4f76-bcde-ec75ccd7bb42",
+    "name" : "MBOxNhSNSHEOuwpiV",
+    "mimeType" : "89VycaQeOb1QdPx",
+    "size" : 172052711,
+    "license" : "https://www.example.com/gqfa6rhyq2bhr8",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Ilca8nlWwai6hr"
     },
-    "legalNote" : "UlIqPDRi6q",
-    "publishedDate" : "2015-06-04T21:51:11.592Z",
+    "legalNote" : "MCOVx456PSRSmQh2LI",
+    "publishedDate" : "1992-11-03T15:06:27.421Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1087536548@Jkm7Cmp4n90",
-      "uploadedDate" : "2007-08-22T05:37:48.650Z"
+      "uploadedBy" : "1885898007@bqKpcX6PhDl",
+      "uploadedDate" : "2003-11-27T09:29:08.895Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8ax54AWEJGR5c0Z7z",
-    "name" : "TMkaajp2gAfv02QXmQ",
-    "description" : "vaYYx4QoBgo"
+    "id" : "https://www.example.com/g8Aj8POJdaAOy9",
+    "name" : "suWmpvuIHYM",
+    "description" : "znvyxZBPc3SbyD6Mep0"
   } ],
-  "rightsHolder" : "mUi3bXvSUzQ4SOw597",
-  "duplicateOf" : "https://www.example.org/469ea136-18c9-4a8b-80ef-b971b6418785",
+  "rightsHolder" : "qInyRzBbM6y",
+  "duplicateOf" : "https://www.example.org/5e50e264-d459-4321-a05a-42f9bff89ca7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "PzglByKbaDxUKL"
+    "note" : "YX3x3rtgaPR"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "9YP4XYpqLbmKAHSon",
-    "createdBy" : "EWkUQrM37kqI",
-    "createdDate" : "1990-01-23T16:41:01.164Z"
+    "note" : "5O7teTaOPdCzSUF3",
+    "createdBy" : "kMrOHC3l368F",
+    "createdDate" : "1979-03-12T08:43:38.507Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fa49f471-ead2-48b8-a0e2-d1ea2c787466" ],
+  "curatingInstitutions" : [ "https://www.example.org/ddff8c16-eaf4-4879-a0f9-c493c9823c2e" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "UcETJ3jY8ftY7Y54GkC",
-    "ownerAffiliation" : "https://www.example.org/061ea18d-e0e0-4f53-af88-3d545c5b15ca"
+    "owner" : "i7idmBTPptihk9",
+    "ownerAffiliation" : "https://www.example.org/ae0b999d-3c8f-42de-83cf-4b929358c420"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b8f006ab-2bb8-4b46-87b0-08bf0780f08e"
+    "id" : "https://www.example.org/b0bfbd0f-133a-4195-9188-26254a431d50"
   },
-  "createdDate" : "1979-10-10T05:52:10.676Z",
-  "modifiedDate" : "2013-04-12T14:14:25.808Z",
-  "publishedDate" : "1992-06-14T10:32:57.405Z",
-  "indexedDate" : "1994-06-13T06:58:41.552Z",
-  "handle" : "https://www.example.org/6037e706-2271-4406-8871-a5806ad0a32a",
-  "doi" : "https://doi.org/10.1234/odit",
-  "link" : "https://www.example.org/0b163666-8e9d-4f23-b630-de632b53ac05",
+  "createdDate" : "1993-08-03T01:30:57.203Z",
+  "modifiedDate" : "1978-03-23T09:05:59.159Z",
+  "publishedDate" : "1981-05-13T21:25:55.467Z",
+  "indexedDate" : "2018-05-20T02:36:16.135Z",
+  "handle" : "https://www.example.org/cd84d3c1-b008-4e4e-9943-3f3a2ec5984f",
+  "doi" : "https://doi.org/10.1234/eum",
+  "link" : "https://www.example.org/0e4f4650-120a-44bf-bb97-062f0d0ffc87",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QVrBPnyh7twV",
+    "mainTitle" : "mCTvn2tSJTwZk8wQ",
     "alternativeTitles" : {
-      "hu" : "gLRBm1aFkr"
+      "fr" : "bWMI6hyIu6IPxIzm"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cP1RcJQWiNTZGsN",
-      "month" : "kJFLPcDEJ3XurTk0j",
-      "day" : "JCcjbcB05egBeCvEHb"
+      "year" : "emmpPOeA7mqO",
+      "month" : "A6VHYXlKMsIUk5Ip",
+      "day" : "BgX8HZBa1kfAahas"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7520a78f-9ba6-42fc-8a0d-47483b80c0fd",
-        "name" : "zYZ4lpVZBfSh",
-        "nameType" : "Personal",
-        "orcId" : "lC6ZFmObVvkxKnzjio",
+        "id" : "https://www.example.org/b637e247-efc0-49cb-805b-85fab9cecec8",
+        "name" : "G0Z8VdAD45aA6uGd5",
+        "nameType" : "Organizational",
+        "orcId" : "9ZtfeJgsqvYuCurZ",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hBK10Oi5JHyXri",
-          "value" : "ro5JtCTDM8r"
+          "sourceName" : "etjd5wbGLL",
+          "value" : "Hjjn3P9QcK6y4h"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2ezC3Fx1cj1Lmtwg3qj",
-          "value" : "4YLIB5YwCl"
+          "sourceName" : "ofX3XS7Bkm7kKw7utfG",
+          "value" : "H7ljSsxNXQYwarRQZu7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ba4c17e1-c828-4574-820c-8f83c2a343a4"
+        "id" : "https://www.example.org/39f39d28-7814-4d33-89e1-1c102886e895"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f6b94689-e8c9-49f4-8094-00c7b93fc90f",
-        "name" : "KKz42ps1wxrA3ekc",
-        "nameType" : "Organizational",
-        "orcId" : "fQS3ZZJmt4RobZ",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/707cc63c-2f7b-4641-9fec-995dea41b72d",
+        "name" : "1p8e3g093PUrc",
+        "nameType" : "Personal",
+        "orcId" : "c3AXwmqh5G0p3kV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ImryKImPXi6C",
-          "value" : "aPosoiVmugD0m9q"
+          "sourceName" : "1mnUIgNPxbpcKOeTK5Z",
+          "value" : "IDctuMvSMDCFlliecO8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m1sOjxTuhgXq7e7",
-          "value" : "zuTGAv9y6ud"
+          "sourceName" : "G7elO0B8X0X8",
+          "value" : "GMgTbEtMBr3c9c"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dd5b1cfc-e6fc-44f5-9dc8-7831f71bf774"
+        "id" : "https://www.example.org/7d9f5bff-f409-40e8-971e-ef1b0f33d9cd"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "Vu5pP9ixFtWWEmG"
+      "da" : "heqVRctgmoc"
     },
-    "npiSubjectHeading" : "n2YVPrtl4931A",
-    "tags" : [ "4TPaObjDsHgHVPuYT" ],
-    "description" : "OtUYJDlPGUh",
+    "npiSubjectHeading" : "6PKovG5ojdUIbrp",
+    "tags" : [ "iRuHM3LmIg" ],
+    "description" : "MM6fW22yP7hf3pTMe",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c313d41d-cbce-4be0-9474-d4372ec6bb8c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2a057d9e-f11c-4a8a-876a-6083d2bfcc8a"
         },
-        "seriesNumber" : "L6J4DA5EvaqQ",
+        "seriesNumber" : "QxGWjYohHRV7smPLe",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bc429db3-4d7b-4813-b7fe-8bf4fea05489",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3d5d8aaa-1d91-4cb9-8542-4a4401eebefd",
           "valid" : true
         },
-        "isbnList" : [ "9791536067216", "9781570816666" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9780975347836", "9780234770009" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1570816662"
+          "value" : "0234770007"
         } ]
       },
-      "doi" : "https://www.example.org/370cb37a-df0e-4ef8-a2ab-7805ade3be06",
+      "doi" : "https://www.example.org/fd96bb5b-a4e5-4e26-a8b8-62262f6d943c",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "53Hpy4DSfv",
-            "end" : "YWzdWYfMIL2Qy"
+            "begin" : "OnTaES2cWNrptJWWS",
+            "end" : "zgj9yCdQWI"
           },
-          "pages" : "5fGKHjUYmceGjMe",
+          "pages" : "G0BmXIO4qdo",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b5137d2a-db3e-4640-9088-1da95ab48b5a",
-    "abstract" : "ID4ny88RUkJA3aDo"
+    "metadataSource" : "https://www.example.org/9191a862-2c8e-45a0-80e4-4a507b6e209b",
+    "abstract" : "bMjUMTpx1FWajT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/917b8aa2-7545-4b70-8155-5c573518b83b",
-    "name" : "Pjz1Z9q5eP",
+    "id" : "https://www.example.org/eb235e71-0227-4886-ab90-060db5469357",
+    "name" : "sX8QLgdGe49bVpVm",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-06-20T07:41:48.377Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2004-09-21T01:06:03.225Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "4K6xw62Obj1ZIxJ1enp"
+      "applicationCode" : "zvOYL4h0YA0xuY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5ae717d1-2ed6-4d66-a494-33af255174a7",
-    "identifier" : "XFui1fF12cCu6ODLLOS",
+    "source" : "https://www.example.org/c4545f37-4b57-4cff-a04d-515a7503ae90",
+    "identifier" : "cPgzJFDRFP1Jeqd",
     "labels" : {
-      "nb" : "PgRUzhmCDHg"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1802155607
-    },
-    "activeFrom" : "2024-08-28T05:43:25.639Z",
-    "activeTo" : "2024-08-30T17:15:20.687Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a28064f1-d1f9-462b-85a6-2f1e5fc4c0a8",
-    "id" : "https://www.example.org/65f69727-96a5-44f1-95b7-974644d2f4bd",
-    "identifier" : "geprSCYPYGaPEqj",
-    "labels" : {
-      "is" : "HD5vtY0aAx8"
+      "se" : "iq2fWBz9Qg"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 534738281
+      "amount" : 186562640
     },
-    "activeFrom" : "1995-11-24T14:43:07.280Z",
-    "activeTo" : "2007-04-01T21:02:24.319Z"
+    "activeFrom" : "1984-11-03T07:40:10.844Z",
+    "activeTo" : "2000-10-23T00:54:57.563Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/16617d26-4159-496b-b92e-400ec17448c9",
+    "id" : "https://www.example.org/5e9211d1-1733-48ca-a24a-56579726908b",
+    "identifier" : "CkqhrDRNj0xr",
+    "labels" : {
+      "da" : "8CZgbi1xEepHvv2LW"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 132207125
+    },
+    "activeFrom" : "2023-03-29T01:38:05.041Z",
+    "activeTo" : "2023-06-26T08:25:09.886Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "HKJOvd1xpCf1MMOH4",
-    "sourceName" : "fzrseoyht582mh@snjei4uwkawbxjurxh"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/8e642620-677c-4dcd-8e0e-518b69d610ae",
-    "sourceName" : "xzktqrdudz7@9yaer7wc6oxvmrn6"
+    "value" : "tKHQ0T5yrPpck",
+    "sourceName" : "fhjvdl9lvjaqgop1mt@jzr8xv3hpfjqmq"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1387988446",
-    "sourceName" : "pevcu15aqno9uqb4y@mcmetvypl6wuj"
+    "value" : "748103473",
+    "sourceName" : "dmq8khibkx93jit45p@g6mo7vapsv"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Or0fLDN2ujnU1",
-    "value" : "MMsADXFJv68SH4JX"
+    "sourceName" : "iAdo7jOlDOGLLI3d9",
+    "value" : "tFAQcoiN3Dbi3SUQZE5"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/05f38976-ed10-4362-82ae-6b489116ace2",
+    "sourceName" : "zignyvluhmez@gulqx3ugj1f"
   } ],
-  "subjects" : [ "https://www.example.org/cdc63992-4e60-44d1-a118-1cc0c9688f6d" ],
+  "subjects" : [ "https://www.example.org/7d3f3243-9812-4ac7-800e-aa71b86f255d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "118dc826-f23c-4494-a538-5bb4f9c1f6b6",
-    "name" : "JFRxA6BmRCp2F",
-    "mimeType" : "4Mtg5mOXbmPxyku",
-    "size" : 499151903,
-    "license" : "https://www.example.com/phf162eedck",
+    "identifier" : "989632b9-e9b9-4cf0-aecb-b46ca9f4b5f1",
+    "name" : "w9xchzw7bUjHMnv",
+    "mimeType" : "Sjel5UPZP5H",
+    "size" : 456012225,
+    "license" : "https://www.example.com/cxrncv9inalhikgyh",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "aDgGI7iVUj",
-    "publishedDate" : "1999-09-15T17:19:17.066Z",
+    "legalNote" : "8HnqbqKmHQDfg7q",
+    "publishedDate" : "2009-01-25T15:24:03.525Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1086315053@VyM3IyD74P1LyyN8vS",
-      "uploadedDate" : "1979-06-23T16:10:14.404Z"
+      "uploadedBy" : "81693453@q3o17lFychtiviDUCLR",
+      "uploadedDate" : "1999-06-20T04:55:52.021Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3ELk5Lm1Gq",
-    "name" : "3o2RCu19h6jlp",
-    "description" : "kP7fHSNcqVt8vRXJQK"
+    "id" : "https://www.example.com/hzZ12g8Xw1",
+    "name" : "YZUgQ8tn4y59PhKIz",
+    "description" : "odfj5Zop3YSSJrll8"
   } ],
-  "rightsHolder" : "A1hrR5rtDXmzj",
-  "duplicateOf" : "https://www.example.org/6ebf3270-2da5-42db-a045-5d533f26ad37",
+  "rightsHolder" : "LNQsP3RBKs0akz",
+  "duplicateOf" : "https://www.example.org/8cb1c37b-9f0a-4a8c-941b-57ea22e9474c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QbCgftfqPyIsGfC"
+    "note" : "3n8PNBs1MtfiiVUezlw"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hgvQAeDVdxu",
-    "createdBy" : "JiGSbAoq3siiz",
-    "createdDate" : "1998-06-04T22:48:38.115Z"
+    "note" : "8hYj4ofSVuJ",
+    "createdBy" : "Yw2pKkWyvsz3vzaf1a",
+    "createdDate" : "1984-03-09T11:46:24.914Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/786d9571-86fd-4c3d-a24c-023309b62891" ],
+  "curatingInstitutions" : [ "https://www.example.org/9749891f-2a7f-4b46-a29b-78c82cdcfa43" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "bciMc0JZpbLU0Lgnz9I",
-    "ownerAffiliation" : "https://www.example.org/fc92f6e5-5f5f-47a7-b107-f62b9a7332fb"
+    "owner" : "peg4ZDK4Av1KFbF96o",
+    "ownerAffiliation" : "https://www.example.org/8c5a7a23-f129-4662-86ce-5eb6425bba9a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4f281b67-2f27-44ae-ac23-d6ebbe361229"
+    "id" : "https://www.example.org/2b441f50-b379-42bc-b45c-435b3d1e125b"
   },
-  "createdDate" : "1985-10-19T19:58:17.485Z",
-  "modifiedDate" : "2018-11-24T06:38:27.094Z",
-  "publishedDate" : "1988-01-30T11:32:59.257Z",
-  "indexedDate" : "1985-10-17T12:26:19.974Z",
-  "handle" : "https://www.example.org/3b208a1f-459a-40a5-ab0c-ecc747f8aed0",
-  "doi" : "https://doi.org/10.1234/maiores",
-  "link" : "https://www.example.org/a6670c66-12b2-43ef-95af-b2294c28354c",
+  "createdDate" : "1981-06-08T22:37:24.159Z",
+  "modifiedDate" : "1997-05-24T02:35:22.423Z",
+  "publishedDate" : "2016-08-14T19:55:30.382Z",
+  "indexedDate" : "2019-02-08T03:44:09.643Z",
+  "handle" : "https://www.example.org/3745371b-a88a-4c66-a4dd-e290df1347c5",
+  "doi" : "https://doi.org/10.1234/reiciendis",
+  "link" : "https://www.example.org/e81e9f7d-7e84-402f-8a77-367b8dd5f997",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pD2ED545YAGajb",
+    "mainTitle" : "fIVSYbHQ3J3F5kZ9Xeh",
     "alternativeTitles" : {
-      "cs" : "m7aZPq2SCsxz7ZJwJk"
+      "is" : "VFxfJCuipQw"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "sG3ghb67btIJ9bvL",
-      "month" : "aHow3Dzgt1azW4qEAJF",
-      "day" : "KEUb1DoT8zwWla"
+      "year" : "Q5SxvFFjp8XeQ",
+      "month" : "LhQJnSn0UwOiV6",
+      "day" : "1zveW5oCm3B3P"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aec13805-f381-4592-9850-99e6929012ef",
-        "name" : "Kw66BILVNDwctWCyE",
+        "id" : "https://www.example.org/0f5941ba-6e9e-469a-bb1f-50c4ad39bcda",
+        "name" : "XW7i4xXTL2wWfvXEp2",
         "nameType" : "Organizational",
-        "orcId" : "jh03NIaQBquhBc5wMtN",
+        "orcId" : "CRqexNKA6oJBxj0Mip",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hGo7kX50GZ",
-          "value" : "K4GHz0z9lxkMjhzoU61"
+          "sourceName" : "y2R9baeCKIPbhWHXK",
+          "value" : "FP5npYoexSkr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RFJkvepM8656Ordv",
-          "value" : "Avqi8HQDjc1jZ1O"
+          "sourceName" : "qUXjOmj0OalPy6",
+          "value" : "XsPaZCxC5V"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ed0a9c45-364d-4a94-9a77-80ec4abcdb76"
+        "id" : "https://www.example.org/4515f371-24ca-40a6-8fc4-868ad7637dee"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/73164f4d-40ba-42ad-bb34-b525b2b5c00b",
-        "name" : "nwpPTFWmVsLmr6MmNA",
-        "nameType" : "Organizational",
-        "orcId" : "IJYIL2Pw9UCxQdekM9v",
+        "id" : "https://www.example.org/77bdccbc-a616-4086-8ee7-d3107dc5e8e3",
+        "name" : "EsmN66ixOg95",
+        "nameType" : "Personal",
+        "orcId" : "buvezj3zqU6R9",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OJkIQuYGZf2klp1n2",
-          "value" : "miwUtC8vJBABf"
+          "sourceName" : "TRm6pqrgo9QHJdHx",
+          "value" : "jk2YeP7ltwzbbm1R"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bLzKEMgfa2",
-          "value" : "N4RTNvN58Lf"
+          "sourceName" : "vGY70LALY2DoHjY",
+          "value" : "q77bhRDCP8qLgMOS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a8acbb2e-0ff2-44ee-abe8-e7db9b91c1a9"
+        "id" : "https://www.example.org/c06b5ec6-bf58-418b-8f86-dc4e630a8f6d"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "VFreO6X7ju9y"
+      "pt" : "Q1wvC7VMjEJ1UE"
     },
-    "npiSubjectHeading" : "E5E6KsAT5Aq7mTV",
-    "tags" : [ "T8hkZot8THsxIn" ],
-    "description" : "RbOXJk1AvbCBHOK2",
+    "npiSubjectHeading" : "kiYOZ80UGtUPa",
+    "tags" : [ "QmDGz1lVqUjxvUN0k0j" ],
+    "description" : "rt3uii28EDqOwwx",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b3b876f7-bc7a-4ee8-bd24-11d5c3c4e811"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d84d93c3-cf20-4653-93d9-bd9cc4ae4e6b"
       },
-      "doi" : "https://www.example.org/51714c10-be02-429e-be38-f96f25057efd",
+      "doi" : "https://www.example.org/5daa98ea-e245-4496-bee4-8c8cb3c094ab",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "mIyoFGe9UfLaLexQ",
-          "end" : "I2ls2dawcmcrv8T"
+          "begin" : "JUYa8Pdw7zSmhtlf0",
+          "end" : "52wCcKYHT90xCV"
         },
-        "volume" : "KHyjrhZmYO1lg0hUvMg",
-        "issue" : "Kp4gCJFhT0PkhGV6",
-        "articleNumber" : "KAML795ddDm2QS"
+        "volume" : "6pO0seqYrq",
+        "issue" : "eAi9e1cfrip",
+        "articleNumber" : "epiuvaIEKdknD6CCLrZ"
       }
     },
-    "metadataSource" : "https://www.example.org/78e1c25f-f19e-44c7-b802-dd686101e8e4",
-    "abstract" : "YdcE908odrDPH"
+    "metadataSource" : "https://www.example.org/d4987242-b899-4241-9536-384c09e9fce6",
+    "abstract" : "or7St2WbdL0mG6Uk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/73354ad1-ebea-4613-93ab-332387916066",
-    "name" : "0Eg4KcgFbaBwCgEl",
+    "id" : "https://www.example.org/0c18e943-a428-4722-b36b-e5618319e879",
+    "name" : "tYoTGPUJ1EAx3Lg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-04-11T23:18:01.211Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "6LyjhxcrUe4r5B1y"
+      "approvalDate" : "2022-04-02T10:06:10.685Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "qFoyZnZDeu66tqAQx4z"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1985834e-17be-4cc9-a1a4-513badba65f8",
-    "identifier" : "S3oWMdLHSV018Mj8RCy",
+    "source" : "https://www.example.org/1a88dc51-75eb-4664-9e33-3de8e7337590",
+    "identifier" : "w1G2rzGSJer5S",
     "labels" : {
-      "nl" : "2PZjvy7kaLUr87YJ"
+      "da" : "6PgkIsJb4q1"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1310466342
+      "currency" : "USD",
+      "amount" : 786467133
     },
-    "activeFrom" : "2021-08-14T10:57:12.032Z",
-    "activeTo" : "2021-08-26T13:54:14.175Z"
+    "activeFrom" : "1986-01-17T16:34:44.751Z",
+    "activeTo" : "2020-05-19T18:40:57.407Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b8f66ffa-f8b5-4b4e-a83f-b7306b3a73be",
-    "id" : "https://www.example.org/b85795b1-4e14-4c3d-962c-412371d0ae99",
-    "identifier" : "ZyCWKWAjhLzeNR3LAXQ",
+    "source" : "https://www.example.org/0c8eef1d-6371-46e3-a1b2-d81c7a198ab5",
+    "id" : "https://www.example.org/c87af241-a70f-4854-a35a-fe6faea1008c",
+    "identifier" : "IgKt0N1fZyjM",
     "labels" : {
-      "af" : "poUiXSaSdu9eT"
+      "it" : "UyZu4YKhdWlPFwEuLdX"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 14423184
+      "currency" : "USD",
+      "amount" : 1320147040
     },
-    "activeFrom" : "1973-12-14T06:49:37.813Z",
-    "activeTo" : "2019-02-28T05:42:58.285Z"
+    "activeFrom" : "2003-01-14T10:34:41.859Z",
+    "activeTo" : "2006-10-09T10:08:19.847Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/9a4fdad3-5095-4852-a299-85d3c65b7ed4",
+    "sourceName" : "11zmoh0oqmotn6jelb@mg1egrtxap"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "1385158610",
-    "sourceName" : "boyy2ykovrvc6af@enonxbxyo5vxyr"
+    "value" : "599235197",
+    "sourceName" : "obnkulog13jcoves@0f0rfkqqi7fcn8"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "4jHe4O0ZSB38x",
-    "value" : "ndig5lDCDfSY"
+    "sourceName" : "qTctbh2QhEzVLJaP",
+    "value" : "DcKXS02BIB6"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "nLlWdKZXnLl8zId8H",
-    "sourceName" : "nfdlhwqou3tl@fbc1aegmhutzk"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/087849e2-d110-4ebf-8798-d8aa6cf3a2e9",
-    "sourceName" : "nognp2tggu8rdxv@nwa6em1n3kxd4nj"
+    "value" : "SB2VR6flRj0Zd0EVyp",
+    "sourceName" : "ijnzhvcgenqgls@lmqxnmbomf"
   } ],
-  "subjects" : [ "https://www.example.org/67752092-2df1-4b38-84a1-6c608229d3d6" ],
+  "subjects" : [ "https://www.example.org/bb6c6a1f-af09-4a6c-bd69-897aa855d3b6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d1a0f457-a04b-4fa6-bea7-605c9a913ec7",
-    "name" : "6McFIRxlo2z",
-    "mimeType" : "YrvYPYR6s4gWz",
-    "size" : 1117927993,
-    "license" : "https://www.example.com/gaokdpl1urn8b4bavw",
+    "identifier" : "6a6cdaad-9c06-48b0-8d25-783d889ea4d9",
+    "name" : "zfbVzGLFDwDgeaOfnb",
+    "mimeType" : "i0VwHQgNhMLtadawmgy",
+    "size" : 630231007,
+    "license" : "https://www.example.com/so8gtodpqjhs",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "rEEP9klbvum",
-    "publishedDate" : "2016-01-04T01:30:22.409Z",
+    "legalNote" : "Coo4HkfNn76rw3KqUbh",
+    "publishedDate" : "1971-01-09T20:05:20.638Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "107476261@YEovOMgSPM0xf7AwJt",
-      "uploadedDate" : "2020-03-01T16:16:26.018Z"
+      "uploadedBy" : "1720706459@IGMjilLmgMo2",
+      "uploadedDate" : "2002-06-25T05:35:30.256Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/LhX3Zkw9ALAOxcGpY6g",
-    "name" : "E96a1y9wyBnmw",
-    "description" : "J7tmGvVcyOawUSenI"
+    "id" : "https://www.example.com/ab0Jc1NVs9KwgAb1x1",
+    "name" : "MMrVP1HWZGP8luJu",
+    "description" : "YFJWkcvFz6Rc"
   } ],
-  "rightsHolder" : "6KTuVyxnubL59yqk",
-  "duplicateOf" : "https://www.example.org/7364e984-8356-4b6d-8c12-5a737ca4aeb8",
+  "rightsHolder" : "ci42D0otdW3kEP",
+  "duplicateOf" : "https://www.example.org/3fbaa1cb-7024-4f7e-b228-2664f3ec4f14",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pL5WvVMqMeGuOAdo9x"
+    "note" : "hgkqLpaLxPHsPmI0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "n9flQi24eH",
-    "createdBy" : "5f8dqBdrkJk4q",
-    "createdDate" : "2020-05-27T11:52:22.767Z"
+    "note" : "YTYKJZt7YMGz1NbmI",
+    "createdBy" : "RIeiV0ZlWUoW0rzJ",
+    "createdDate" : "1979-08-03T14:55:51.321Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9d4332b4-a9aa-4c68-aa58-7921ca08ea53" ],
+  "curatingInstitutions" : [ "https://www.example.org/63b7bb6f-89da-4866-b904-14d2f2768bc3" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "n1Lirw9c2v",
-    "ownerAffiliation" : "https://www.example.org/460254b5-ea66-473b-a946-e3b4048dd5cd"
+    "owner" : "16ZP8aZA24BP2",
+    "ownerAffiliation" : "https://www.example.org/fd1f9f0b-277e-4061-8b18-31c3d0dbd86d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6f3bd4ac-79e2-44cd-9d1f-feadeff782c9"
+    "id" : "https://www.example.org/ff5cde3e-012b-4eca-90e5-d927d15d1a2c"
   },
-  "createdDate" : "1988-02-22T03:41:47.984Z",
-  "modifiedDate" : "2022-01-19T23:31:55.289Z",
-  "publishedDate" : "1985-06-19T20:53:23.358Z",
-  "indexedDate" : "2012-11-25T23:37:58.192Z",
-  "handle" : "https://www.example.org/da689510-3cf8-421b-9585-adda12d67902",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/242b941d-2711-481c-97c6-e88dc893fcec",
+  "createdDate" : "2017-08-02T03:15:54.902Z",
+  "modifiedDate" : "2010-06-01T18:51:02.974Z",
+  "publishedDate" : "2004-12-12T00:15:09.459Z",
+  "indexedDate" : "1999-01-22T19:28:12.022Z",
+  "handle" : "https://www.example.org/58a8fd8d-654f-4ca1-b7f2-b63ad4955c76",
+  "doi" : "https://doi.org/10.1234/ducimus",
+  "link" : "https://www.example.org/308ba045-bbb4-42ed-a14a-a2d7b8cbd0d4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VgqzYyOh17B96E0y",
+    "mainTitle" : "I1x2d8Jc09qt6zUGWse",
     "alternativeTitles" : {
-      "sv" : "5XUVyxMrQu7l6Kel"
+      "el" : "lxycMuK5axljME5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7UssuArLpZ",
-      "month" : "EDt1tRF7cJ08r0",
-      "day" : "d26vbsnXH2G5Cb"
+      "year" : "84nnc0JCg0E",
+      "month" : "077ly1HSIXeqM",
+      "day" : "IFadB6LCKu7nbzbeyGz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1a825893-5b7b-4ea4-a877-11968c7c57cd",
-        "name" : "ZU6MFBmfzxtjTl",
-        "nameType" : "Organizational",
-        "orcId" : "WTYE78atNV",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/91648345-220d-4b71-8555-d39b1bf3482e",
+        "name" : "n0glf1CDnLEVw6pt2me",
+        "nameType" : "Personal",
+        "orcId" : "qVkxzG72AZLIxrQnu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tSAOsdWJZgxprg",
-          "value" : "Fh0En11spchUHfwxM"
+          "sourceName" : "yuo4qdqnlGEZmH",
+          "value" : "nrjIOnrDXoGRZJroW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "W5ECH9ZaBTGXqz",
-          "value" : "E4dJpcfMi3afcnjp9VH"
+          "sourceName" : "u6eM9rUz5h",
+          "value" : "EqpYwbnmiPXBlwdT8Y"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/978c9832-f729-4e5e-8a5d-061b4b6cade4"
+        "id" : "https://www.example.org/cd6cb07e-5e2a-4aca-a665-4970578e8c0e"
       } ],
       "role" : {
         "type" : "AudioVisualContributor"
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b65ed64a-1db4-48ca-93e6-7b2d4ccaa68e",
-        "name" : "L2mnSkHLqB5Qw",
-        "nameType" : "Organizational",
-        "orcId" : "nha26W5XFjnB",
+        "id" : "https://www.example.org/1c87aa27-32d9-4f28-a699-737b5d7e4481",
+        "name" : "OlA8WaExqFtH38AvX6c",
+        "nameType" : "Personal",
+        "orcId" : "ZthgfxszFB7A04rd8yY",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "amEJJJO9Uqnp3Sr14b",
-          "value" : "v2WrOdxBro1w3h9s9kg"
+          "sourceName" : "SnTFOWjDK6HqlqI1W6Q",
+          "value" : "AIQIPUGoT5rtbNd45"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TMnp6wp0KrYX",
-          "value" : "rXnCSUHyjHKDHZxp9"
+          "sourceName" : "9noezmwTny",
+          "value" : "5LGFY7o66XPTJJP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c873d786-c6ab-40cf-8f43-7b2af4f8a66b"
+        "id" : "https://www.example.org/e278a7c6-7e7a-4dee-91fa-171748f8df1d"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "wooxllBAra"
+      "nl" : "mzUKvzHHjsGowg"
     },
-    "npiSubjectHeading" : "SoUh8OXierZSG",
-    "tags" : [ "qtXN5e2nUG" ],
-    "description" : "QpWmNv1gibqdHz47m",
+    "npiSubjectHeading" : "5niFQnzWKuHXtcLV",
+    "tags" : [ "32mxN7XVUr" ],
+    "description" : "I3mwmjUGmW8QtcX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/55QvGGDKnQ64bB/publication/0191e0c8eccf-dbdc7a1a-1798-45d8-a3dc-dea887ff1af5"
+        "id" : "https://www.example.com/lFUfpHwk2tZdzYYbnpW/publication/0191ff235040-1f9b06bd-30c9-43ba-a0a6-6d1f2168bb2a"
       },
-      "doi" : "https://www.example.org/27de5d15-e0a2-4c27-b9ed-a2fc3b5c4025",
+      "doi" : "https://www.example.org/b08a9b8b-b6cf-4168-9b45-9b96bfa2f4a9",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "E4vDrKvxI2gQMo1",
-          "end" : "YZF4nWGZS7zmheQ"
+          "begin" : "lfMemT67Grt3QoC",
+          "end" : "i4J5uxcx1gR1pxAqNsn"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/45ddd795-001b-4912-bd32-562ec2f836b8",
-    "abstract" : "1nXChYfFFZu5vz7hg"
+    "metadataSource" : "https://www.example.org/69d12a74-28fd-4256-9b0e-83fbf7236922",
+    "abstract" : "9d4RtVxHGG8US6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b3f71744-4996-415b-b3e7-042cbb271726",
-    "name" : "xBBP8HL0n43is00imb",
+    "id" : "https://www.example.org/b0725c1b-91bb-4652-b228-e417c79f4c4d",
+    "name" : "Yfofhlb6VvAMMG7T4AJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-07-31T17:42:15.981Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "RnXnpqIxyvQ7TU4b"
+      "approvalDate" : "1995-02-01T05:51:10.663Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "gdhQJS4HP4G"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a1ab1a02-c51a-477f-b8d5-cfb21045d371",
-    "identifier" : "mEDlZzA3AxQUyFj9VeP",
+    "source" : "https://www.example.org/8ff5e45a-5f88-4a2d-bb9f-338906b3b21a",
+    "identifier" : "SqPWQuVLfmCwLY",
     "labels" : {
-      "zh" : "YLZr9s31UAEw"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1081393132
-    },
-    "activeFrom" : "2000-04-02T03:05:09.686Z",
-    "activeTo" : "2014-07-22T05:26:50.728Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/79c77777-acea-4976-9e67-1670fbe36c3c",
-    "id" : "https://www.example.org/aa091c73-780b-46a7-be92-eab657744551",
-    "identifier" : "z2I5fWKW66sr",
-    "labels" : {
-      "is" : "lg1338H4RwtrStVPB4W"
+      "pl" : "yfswy9yZz8t"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2036923141
+      "amount" : 727807867
     },
-    "activeFrom" : "2007-08-09T08:29:13.557Z",
-    "activeTo" : "2008-06-14T21:58:28.138Z"
+    "activeFrom" : "2004-11-17T12:37:15.493Z",
+    "activeTo" : "2013-05-12T02:05:57.607Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/5ad62d7d-7cbf-4222-b20a-d66067cd025f",
+    "id" : "https://www.example.org/fca92400-eb1c-4c03-a4d1-88e7bae53af2",
+    "identifier" : "4uVebiX76YKCFqp1B",
+    "labels" : {
+      "el" : "mAqFyYuSMTiM1UN59O"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1995812298
+    },
+    "activeFrom" : "1983-11-13T09:57:01.724Z",
+    "activeTo" : "1991-06-12T10:15:20.015Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "lBq9Uj3JsD2",
-    "value" : "BJYlXXLeheeXITHp"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "sYDl6zCVBMURuQ63HU",
-    "sourceName" : "i18lrci9oigxviw@4whx08pblderzvv3wm"
+    "value" : "tuEfDhWMiqQ4SGmK",
+    "sourceName" : "gfnmtk7joaj@ojse7zudtur"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "762673999",
-    "sourceName" : "qhemtbw8ec@tvtv9pc51ch"
+    "value" : "990115609",
+    "sourceName" : "3t4prgqmrtiw3@jtxrsy6l19gavhh"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/a5a58011-526c-4701-8303-701b2a225110",
-    "sourceName" : "l7nfbati2k7t@ckdxcrwbvkmjncg"
+    "value" : "https://www.example.org/ce3af357-1f09-460c-9978-14d01f3c93db",
+    "sourceName" : "y5j03gwdumjzz6@rz2hynizkk8"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "qtRX73bSmQ9Xg1M39",
+    "value" : "KndMupEhSizcIeJN"
   } ],
-  "subjects" : [ "https://www.example.org/61c0db27-1a79-42e5-ba22-af2283e7ef38" ],
+  "subjects" : [ "https://www.example.org/dfdfdf07-daed-4005-ac6d-5ddef389b7a4" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "61ff2c14-e13b-40ba-b04e-595c7297b0f7",
-    "name" : "ZZsLeHT3Ul",
-    "mimeType" : "7pyMzQAJBrrjrI",
-    "size" : 1565170480,
-    "license" : "https://www.example.com/yvkq0l4ltvrc",
+    "identifier" : "77478219-f870-4912-8c2a-b83cb3d4c862",
+    "name" : "s9CBi569Co8To",
+    "mimeType" : "HClgllcIMV4",
+    "size" : 273474947,
+    "license" : "https://www.example.com/oryiqkc7zxdds62",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "HXoxtOxKUBPDynS2A",
-    "publishedDate" : "2018-05-02T09:15:22.651Z",
+    "legalNote" : "z6jz6RR5nbupRLu",
+    "publishedDate" : "1974-11-03T06:41:00.088Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "497085015@35H1lMFTbVYovDc",
-      "uploadedDate" : "2021-08-14T13:06:32.697Z"
+      "uploadedBy" : "1719358426@BB33KEkO55EI5F60b",
+      "uploadedDate" : "2014-06-09T20:37:07.529Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PZxvM86jGHW3poQm",
-    "name" : "o33wfPWcqfGMg",
-    "description" : "K4ibth3s3kqpgp5Ir"
+    "id" : "https://www.example.com/4dKXXFKXtNvqSWIdq",
+    "name" : "T5CtW2nSx77L4h8Gj3C",
+    "description" : "bE6aCw3DIV"
   } ],
-  "rightsHolder" : "aua5ytS2U2",
-  "duplicateOf" : "https://www.example.org/b8540db4-287b-4de6-8fa3-f452b6c5e640",
+  "rightsHolder" : "LD81wiMEJvB3v4g7DJ",
+  "duplicateOf" : "https://www.example.org/9cd8d7bc-ea86-49ac-9914-4ecd6ce4d78d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CPgENwMBSouH"
+    "note" : "FA0rkYut43f0NF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DqAhVH83Gx9pV",
-    "createdBy" : "jfhSgAfGcHQnSNs",
-    "createdDate" : "1989-07-07T00:17:28.335Z"
+    "note" : "S9PgYmrVxVpcn",
+    "createdBy" : "foZXTDJGT4tHb4WZK",
+    "createdDate" : "1989-01-13T07:09:54.724Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/636c0ebf-e9d9-4c1d-9118-84a41cc95bc7" ],
+  "curatingInstitutions" : [ "https://www.example.org/89cb5300-a2d1-4c43-a987-951c90944c89" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "M7bs6cRdWo7",
-    "ownerAffiliation" : "https://www.example.org/5ed814b6-3c67-496b-945f-408ba5c1b1e6"
+    "owner" : "BGM04gn3SHNuSO",
+    "ownerAffiliation" : "https://www.example.org/3ba89bbb-ff56-4342-99b5-b08e7706488f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b04a9572-f661-494e-b163-6106f710e001"
+    "id" : "https://www.example.org/fe1e7005-06ac-4202-ba87-ddef18b58290"
   },
-  "createdDate" : "2010-01-02T15:58:59.430Z",
-  "modifiedDate" : "1990-10-23T11:50:06.777Z",
-  "publishedDate" : "2008-11-09T02:37:48.512Z",
-  "indexedDate" : "2018-09-08T14:25:51.778Z",
-  "handle" : "https://www.example.org/f71e0868-b408-4d68-b82f-00c15ac305a9",
-  "doi" : "https://doi.org/10.1234/dolorum",
-  "link" : "https://www.example.org/019ba766-1f44-47f1-9b5f-063721e6a61d",
+  "createdDate" : "2008-11-10T07:02:23.198Z",
+  "modifiedDate" : "2023-01-23T18:01:49.522Z",
+  "publishedDate" : "1984-10-06T03:29:44.510Z",
+  "indexedDate" : "1996-04-16T05:35:41.984Z",
+  "handle" : "https://www.example.org/4009ec6c-b7d4-4cb4-aa54-22ef3e967dd3",
+  "doi" : "https://doi.org/10.1234/reprehenderit",
+  "link" : "https://www.example.org/b2ffd760-2183-4a73-927b-7f19ec4807bf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4jMXxoPLKCYYPr",
+    "mainTitle" : "5171wIFLb0fc7BN",
     "alternativeTitles" : {
-      "af" : "VVtM3XCnKNhx1xknE"
+      "pt" : "qt98ZalQBJrK2S5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "rhVWmHrnynfPah",
-      "month" : "sn7PXrJnB5",
-      "day" : "EimXPDpsefTJOhP4c"
+      "year" : "8JHsWzW8Uw2gsN3Qs4z",
+      "month" : "YNZz15LQug4r8p",
+      "day" : "qC0J9HLjce"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8bcf5f07-1247-4606-923f-3ab8ae179fdd",
-        "name" : "S4GYXqRdaSMGSespCP",
-        "nameType" : "Personal",
-        "orcId" : "eEETdmqxXQ2fIaRgjm",
+        "id" : "https://www.example.org/80b0b754-ea32-4c0d-970b-77b27f017b7d",
+        "name" : "VbV2bkSD3yVlFH5BZT",
+        "nameType" : "Organizational",
+        "orcId" : "gSwpV94iT4XgPwJ1",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eQppIQR9iQHrVr",
-          "value" : "7xsfFybL0vKz3s1n"
+          "sourceName" : "l6KVbOuFlLe",
+          "value" : "Xj6j2j1NwgRtRCYx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z9UjGHtHeMm0Q",
-          "value" : "YU9ea0oOdd2R"
+          "sourceName" : "LqnFLdfMf8BqZcIM",
+          "value" : "GLxnAct5eM7FWjNI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3a4db160-e969-4288-b53a-556af9d3d3e5"
+        "id" : "https://www.example.org/7e255692-2033-430a-b85e-39e27226393c"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fdc43dd1-2828-4dab-a641-e02fd8a3cb2f",
-        "name" : "CDAjzHHFO1fL",
-        "nameType" : "Organizational",
-        "orcId" : "aifvK8XDGmsH9yco",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/d3902800-0c64-4663-b144-15a8f78b837f",
+        "name" : "yYm6PgOwJ50CK",
+        "nameType" : "Personal",
+        "orcId" : "HfYj8iqYl3TFc",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HeMeKcwu7L",
-          "value" : "lyw8cInHGoTTrOEiotL"
+          "sourceName" : "9M15dPt4qj",
+          "value" : "5gTnUgRYNd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jF4DPinHC9q1Vc8p3LC",
-          "value" : "BrWy3u7H8ih"
+          "sourceName" : "yp7KoofnlB",
+          "value" : "NANLMRFn44oZvta"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5bf630b0-ee10-433c-94f4-2fb18a349b5b"
+        "id" : "https://www.example.org/47a917f1-2df4-44d7-a1b0-b76fddae44c3"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "RoleOther",
+        "description" : "UTzVDymKK2T362"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "QgoUIvnV1Pgo61io"
+      "ru" : "Kk617ZonPd6eN3j"
     },
-    "npiSubjectHeading" : "8ir6us0reqZX",
-    "tags" : [ "zoKGlfcHvy" ],
-    "description" : "DSjz17OvHWPIKcK",
+    "npiSubjectHeading" : "tkoNy2HkEvEMQVb6x",
+    "tags" : [ "WPCk6IeLWB" ],
+    "description" : "HmDtpxdfYS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/nvbXlWALfTv8OT/publication/0191e0c8ecd8-6f2f1620-5f75-4960-bc2f-37812d1d6e35"
+        "id" : "https://www.example.com/OtkCTRtVzClyf7B0pNc/publication/0191ff235045-5d94133c-7158-44ec-ae30-173205ba3fff"
       },
-      "doi" : "https://www.example.org/a62faa20-ae8d-4752-9ab1-d313a4f15d17",
+      "doi" : "https://www.example.org/e531f2a2-4b33-4eee-9d36-03a13ef09be7",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "arkgTaa3YC7gahvwk",
-          "end" : "Hgx2YDJfMn7WxQ"
+          "begin" : "wsh86Uf1Fh",
+          "end" : "CHZW8rgGAJM0H25fW"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d3d00416-1eaf-47a0-bb12-6eab3c3dc722",
-    "abstract" : "uFhW4HrRcNS8"
+    "metadataSource" : "https://www.example.org/28a6df88-fc96-48c3-887f-061322ce5efd",
+    "abstract" : "EqppZYwksLIRsP7M"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9af296cc-a325-4c21-be25-91cd0f34d245",
-    "name" : "9b0E2PPOqBQ2",
+    "id" : "https://www.example.org/deef10a7-4eda-4f5a-8d87-c6de918e11bf",
+    "name" : "ezDTUIbqjL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-12-12T16:59:56.180Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "e1Z4D4xvmb1"
+      "approvalDate" : "1979-06-07T09:56:47.919Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "JRI8TOSSGtCJ2Ohh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9364fa23-f164-47c1-a037-20349a3aad89",
-    "identifier" : "lalCZxPBfJLyLEjpwi",
+    "source" : "https://www.example.org/dff71179-ad6f-46fe-9dac-2c0c3b500804",
+    "identifier" : "y2D8jFEiNNiPEKj",
     "labels" : {
-      "pl" : "6wsl2r3iegyXRqefD"
+      "sv" : "mCWQftwEPMAeME90Yu"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1038482200
+      "amount" : 1098946831
     },
-    "activeFrom" : "2018-10-14T20:24:02.548Z",
-    "activeTo" : "2019-08-20T19:42:02.506Z"
+    "activeFrom" : "2006-02-20T19:12:04.795Z",
+    "activeTo" : "2023-01-18T07:28:00.189Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/633a792d-3239-49c8-917f-35084413fa20",
-    "id" : "https://www.example.org/84db4297-8520-4899-827f-5a024613c43a",
-    "identifier" : "gEoRwvHXVab0Itg5",
+    "source" : "https://www.example.org/f78ce281-2fbc-4c40-80e5-10f4036541e5",
+    "id" : "https://www.example.org/2063593e-7948-4902-a7ad-2b8c3f7644e4",
+    "identifier" : "fKebtx4C37gRjk",
     "labels" : {
-      "fi" : "J3GtANpu3W"
+      "pl" : "9UZU4s4wawgR1io"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2123895740
+      "currency" : "NOK",
+      "amount" : 1228501817
     },
-    "activeFrom" : "1996-06-09T23:12:03.597Z",
-    "activeTo" : "2009-08-06T06:44:35.718Z"
+    "activeFrom" : "2018-03-16T02:55:27.784Z",
+    "activeTo" : "2020-01-13T00:16:43.328Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "AlsGpkKAdRGO9ERWLEX",
-    "value" : "GnpMVJCvg7xcn"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/bc7875e2-32c7-4cf7-a695-be0a867732da",
-    "sourceName" : "vnej2csr9ynigmrjui@ktczjuyg83wo5sf"
+    "sourceName" : "ScMcYjhBnF",
+    "value" : "4e2XnuLOurdF09rGXK"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "IGWMBTVENp",
-    "sourceName" : "cip2pd2fh5tzgg12rg6@xzfvnn1flxo60u"
+    "value" : "ZfnbNTROP1SLgI7",
+    "sourceName" : "skvizwtgdcy2dse1r@z3sina5bv94z5"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/31623cf3-ff1a-4cf0-9266-22ad9a5b6f13",
+    "sourceName" : "cubx8jgrmvkduk0wodt@0anwmvvd5iedz"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "606178344",
-    "sourceName" : "60fyuei82te@go44p7k7dgpoj0gv"
+    "value" : "198795603",
+    "sourceName" : "c6bnisei9ho@5am5pnnrkfaw"
   } ],
-  "subjects" : [ "https://www.example.org/307310c2-f658-4dcb-8141-c55e3643d9ee" ],
+  "subjects" : [ "https://www.example.org/50880ac3-16c9-4e46-8724-e1f0b2f85a2f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f5353e18-04a3-4342-a91a-0292a77ae62b",
-    "name" : "eCZforI05L7zCHt9e",
-    "mimeType" : "aUlJufuw1vAe7AfcLs",
-    "size" : 1041308200,
-    "license" : "https://www.example.com/6lb8skix6gef0sy",
+    "identifier" : "77d5be6c-7f58-4fac-9742-0e72fc455175",
+    "name" : "1xKwRbPyAO4eHzsP",
+    "mimeType" : "L4mIAumr7h8Ud5",
+    "size" : 1146806578,
+    "license" : "https://www.example.com/u0qdidmrwdyarf4tj",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "hs2o4aTQrE1t5aJ9j",
-    "publishedDate" : "2003-01-22T19:09:13.448Z",
+    "legalNote" : "SmDtWm0vxDDGAnkBUC",
+    "publishedDate" : "1984-01-05T04:41:52.818Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "681397375@nKwoLrtm8OzP4",
-      "uploadedDate" : "1975-03-29T23:16:23.342Z"
+      "uploadedBy" : "776837485@Mz5zOlE01Azomv9eycB",
+      "uploadedDate" : "1986-06-30T00:46:36.222Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/liak8lsHfuZhiO",
-    "name" : "7kBv2JVNQpP5Y2",
-    "description" : "Nbnde4j83szAlCn4wI"
+    "id" : "https://www.example.com/XD5505PnnvGaFUyctu",
+    "name" : "6dVQj0H7PPUQjtx",
+    "description" : "w95sMVIlh3HUmvTpS7"
   } ],
-  "rightsHolder" : "Eyma5OvZzEYcnDXEe",
-  "duplicateOf" : "https://www.example.org/8cff993d-103b-418b-882b-da6acfda324a",
+  "rightsHolder" : "gd4N9WVx4hGydTYNNh",
+  "duplicateOf" : "https://www.example.org/56832b86-96a9-4c44-b746-ac37f3a9ac71",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Jor7Tdgb9XcA"
+    "note" : "8YqF87KlbULMTX9Bfn"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "pFrtuMLExKJc4AZ",
-    "createdBy" : "0OFi7j8cPzi6",
-    "createdDate" : "1972-09-28T21:51:56.231Z"
+    "note" : "6sHhjz5oo70sago",
+    "createdBy" : "kRKstu9qmWl5yZt",
+    "createdDate" : "1980-06-25T19:18:14.572Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a7163fb9-9bb3-4bfc-8239-75d96e7d67f2" ],
+  "curatingInstitutions" : [ "https://www.example.org/4a329009-6e8d-489a-8b0f-8ec871d75ef4" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "bm44DoP03iXpTQLNH8U",
-    "ownerAffiliation" : "https://www.example.org/7ceae550-dc29-4b4f-ba9e-3add6495523b"
+    "owner" : "UudqnBmGfXikqDZ63",
+    "ownerAffiliation" : "https://www.example.org/5a88bd44-8fcf-4f25-95ce-02cd3306ee11"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/730ce999-74f7-4f71-9c81-60b38cb65dcc"
+    "id" : "https://www.example.org/f5732e7f-b8b5-45e7-98c4-dd6fccea5f6f"
   },
-  "createdDate" : "2004-11-14T07:52:42.881Z",
-  "modifiedDate" : "1978-06-06T10:32:19.349Z",
-  "publishedDate" : "2006-08-09T01:38:34.775Z",
-  "indexedDate" : "2016-03-03T11:59:09.799Z",
-  "handle" : "https://www.example.org/7d9b86e2-e797-4991-a87a-917d096da6a3",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/c2ec864f-92f7-4b29-b738-9ebdcb48bbd0",
+  "createdDate" : "1981-02-21T15:40:14.576Z",
+  "modifiedDate" : "2001-11-05T23:52:02.089Z",
+  "publishedDate" : "2001-10-08T05:41:35.139Z",
+  "indexedDate" : "1990-08-30T15:07:40.264Z",
+  "handle" : "https://www.example.org/a983d332-1596-43d9-84d8-6073557754d1",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/d625f4df-e71e-4be2-a868-52eed803a415",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ObQnVqpAXKCX0SWW3B",
+    "mainTitle" : "jbDA7D17me",
     "alternativeTitles" : {
-      "it" : "JWxAOvsdqXU"
+      "sv" : "OKPY7oWADDJtLT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "aQpJEtWnmORWJUr",
-      "month" : "MHpDrJiiyV6f1Pc",
-      "day" : "FvvNL33cXBMKBOA2T"
+      "year" : "1ysLtjfh5Skb7nbz",
+      "month" : "OX8IJVDIdtkTUxZEH",
+      "day" : "MLFOmXyCh4No6gDi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fd2f630f-6201-4651-a4fc-44f1db586db5",
-        "name" : "JPxr9PeBujptJCAdK",
-        "nameType" : "Personal",
-        "orcId" : "8gFPqCl8Ywtk",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a1950618-d680-4704-ab3b-42e5c5b094d6",
+        "name" : "e4BImc6TZzVreRdFC",
+        "nameType" : "Organizational",
+        "orcId" : "YJP1NLZNtrVcT",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yFC5kffDFKOc",
-          "value" : "ejNYskI4oz1whnSVxl"
+          "sourceName" : "JLTNk6wPwJ4p",
+          "value" : "LvJDs9JTa8NGn6H"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FL4l2FUJgQGd",
-          "value" : "zNgVRfUvn6wh"
+          "sourceName" : "J2D3gV3HNnM7p0gz",
+          "value" : "awdcYiFFzW3ni3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4b4668e3-0e21-418d-8096-00e5e324c6f4"
+        "id" : "https://www.example.org/b460f239-1c0f-4b4c-925c-a0b618c7b8a8"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ccae3a65-6402-4e80-b30e-ab8aee117635",
-        "name" : "g4QNLwW0ClrBnBdNS",
-        "nameType" : "Organizational",
-        "orcId" : "9i2m6zOiDVb",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/9eaea4d3-ec9c-4431-b39b-2826b710027b",
+        "name" : "wb7EKs8vqnTSM9",
+        "nameType" : "Personal",
+        "orcId" : "kvUaLTPi5btn9",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DxwigFCubd4ku7k2Qr",
-          "value" : "bxJBaIINPV6"
+          "sourceName" : "onTxKVewIil",
+          "value" : "vVDvXs5GIMfKsW3Oqjn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "b83sSWRNup",
-          "value" : "CN6bMDbAZj4VtYBX"
+          "sourceName" : "xlYSD2dcLcYCurlJ",
+          "value" : "nASF84As8h5Xk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f6a191ea-7e61-40b1-87a1-36bb53b598a9"
+        "id" : "https://www.example.org/a5997305-b2bd-4c46-88a5-4debb790b0f5"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "FojK3dmEjuOIre"
+      "fr" : "XBomQousgUAn1"
     },
-    "npiSubjectHeading" : "pIawfQstsqxNN",
-    "tags" : [ "Yh7ADZY7Fk" ],
-    "description" : "M3z9VVsigT",
+    "npiSubjectHeading" : "FTLKRYWK3Ran1ugV",
+    "tags" : [ "RkWUt54Ws6jz" ],
+    "description" : "Axoa2vgal9a0KApZX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/48e16122-3f68-4708-99be-68d878479f8c"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/05fbca06-5d16-420d-8dac-7f5e9ba407e3"
       },
-      "doi" : "https://www.example.org/f89c7760-dc23-40a9-b7ed-61ace9a16c1d",
+      "doi" : "https://www.example.org/7b3277b2-0c18-4177-88be-b231d6b0e8ea",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "edkwxfJeSQZ",
-        "issue" : "SD7RucfXk10T3GVpD",
-        "articleNumber" : "qe3TZo9uOXn",
+        "volume" : "kBAupCmkAW7bIv",
+        "issue" : "ZemBSmdwwMoW",
+        "articleNumber" : "f8X4hMcgYb05VcrnO",
         "pages" : {
           "type" : "Range",
-          "begin" : "8ItH1LKZwrs27phX",
-          "end" : "HmXoirMP91Yjmf2Yk"
+          "begin" : "0L0DEH88wiIcAQfW",
+          "end" : "BQTeJculsj8H"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/10fcc257-fdd2-4e14-a367-3428ba4a0217",
-    "abstract" : "IzAA8mNBKVOyanCFai"
+    "metadataSource" : "https://www.example.org/01a0fe6d-edd4-4e9f-ba7d-0621e07cdae4",
+    "abstract" : "2p0EXj1xqo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f0601938-1dd0-4ab5-b27b-2e18b092032f",
-    "name" : "bx7r4fXCGVdw",
+    "id" : "https://www.example.org/044cbb9f-cb7b-440f-b9b9-63ba25832868",
+    "name" : "HP00SGG0wOmpnmv",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1983-02-12T05:07:42.770Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "u98pklp5SBhjA"
+      "approvalDate" : "1989-05-27T15:53:26.372Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "cYFkBifrw2z"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d20662ee-1c24-415e-914c-aca85080623e",
-    "identifier" : "J4BUJ5PUKbFyD",
+    "source" : "https://www.example.org/f6d77546-d11f-4d9a-b36d-9c3d3586698f",
+    "identifier" : "FkBSiX4oB4tbKXV",
     "labels" : {
-      "en" : "MxxQmha8BRn"
+      "bg" : "teU8EUnrDmt2YnB"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1940772141
+      "amount" : 1028424482
     },
-    "activeFrom" : "2011-11-06T08:11:52.088Z",
-    "activeTo" : "2017-03-13T21:20:25.225Z"
+    "activeFrom" : "2002-04-07T06:48:35.605Z",
+    "activeTo" : "2017-06-24T08:42:13.880Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/41ebb0b6-2ee6-49c8-89fc-05c928a4b8dc",
-    "id" : "https://www.example.org/fa827987-d525-48ea-a9ff-01f3a69eeb54",
-    "identifier" : "ZBn2P3GJmyO5Lw",
+    "source" : "https://www.example.org/c22e92c0-703f-410a-bbf8-a6c3cf5e4dc3",
+    "id" : "https://www.example.org/dc9542c6-3672-46fa-a552-c24c968130ae",
+    "identifier" : "WF8j9CbAqY93t8sOFCu",
     "labels" : {
-      "sv" : "puWrOCxPqiPxhM"
+      "hu" : "GDqlM4vOz2YSYhT"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1253766355
+      "currency" : "USD",
+      "amount" : 583874828
     },
-    "activeFrom" : "2018-01-21T13:22:27.638Z",
-    "activeTo" : "2021-05-25T02:58:18.468Z"
+    "activeFrom" : "1971-09-28T15:26:10.128Z",
+    "activeTo" : "1981-08-01T20:10:55.075Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "A0brYqyZGYJ",
-    "sourceName" : "q9kneemoydekitu@cvtl3ij0siamxchawf"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/2fb7f00e-9dee-44dd-bb15-963b4b1569ac",
+    "sourceName" : "cvzqtus4kntg@vws77tarpcvr"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "ieDlL1OUr80TcAZy",
-    "value" : "b5rcLH2UXC8vyn7vr6"
+    "type" : "ScopusIdentifier",
+    "value" : "PCkIqmcDhB20kpAhomu",
+    "sourceName" : "mhmkss8gda9pymsirj@xxxqqi3mc0sffdfjzrl"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1673286572",
-    "sourceName" : "jsky0vaqggecolhuq2u@5wxxo3mabk6jei"
+    "value" : "537812794",
+    "sourceName" : "pc7ofpld8d0hhe8@dosuvrlq48"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/a843827a-095f-4d54-b78f-6c47ea415a71",
-    "sourceName" : "q8p4cklo2vapiyhp@xn2cclxpfhcmyljo"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "N4X8iAWQsfpinQoZ",
+    "value" : "bSIXryLYPtBSe"
   } ],
-  "subjects" : [ "https://www.example.org/1d14b09c-bc83-4807-b216-8e83ef2e2cdc" ],
+  "subjects" : [ "https://www.example.org/75199bb7-eb09-4b01-9108-d17c05d5694b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "af3bd86d-0b95-4bc7-bdee-124c7f837422",
-    "name" : "kGtd2KBGOOuQFI",
-    "mimeType" : "TbpE8WaGiUdmhsyZGPc",
-    "size" : 1371509366,
-    "license" : "https://www.example.com/ljhi7ireokatm65",
+    "identifier" : "0941abff-c014-474d-a1c0-ce880f0c3803",
+    "name" : "ypY9W1y3Wdl",
+    "mimeType" : "jdiY8BTLkaRfsI20Ah",
+    "size" : 1293463365,
+    "license" : "https://www.example.com/h7fop0kg4j",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "SumTnQa01J1YR",
-    "publishedDate" : "2022-12-02T23:15:18.642Z",
+    "legalNote" : "xFkdGC4YjUk08K",
+    "publishedDate" : "2015-10-24T10:29:17.264Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "351567110@dACdMBEpEMZ",
-      "uploadedDate" : "2022-03-04T10:46:16.092Z"
+      "uploadedBy" : "1904249972@g6Zql8cCJogftfnatQ",
+      "uploadedDate" : "2014-12-30T02:39:37.037Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/E8zKn6kaamv",
-    "name" : "grPYi4D4LivTttaacU",
-    "description" : "nmf6fdM5Y2dDf"
+    "id" : "https://www.example.com/1GWwY5ePM6",
+    "name" : "Ci7B6LZPgO8h93",
+    "description" : "OmNdpjU6aYZieDiP"
   } ],
-  "rightsHolder" : "ibxvuG8mzFsKTgx4WLK",
-  "duplicateOf" : "https://www.example.org/ea8b5bda-eb86-4cc3-a4d7-96bc69692150",
+  "rightsHolder" : "LNT4ceaVES9J",
+  "duplicateOf" : "https://www.example.org/ac136adb-0a7c-4b6c-95df-00b1259dec1c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bP4xUQGZ4KBb"
+    "note" : "3MqzOEuZ9jQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "t9qU7gEM716d6fUBS",
-    "createdBy" : "qMUCSccd1pbtQqVZ4l",
-    "createdDate" : "2006-02-11T09:08:55.965Z"
+    "note" : "9JEkComYYckv3kBJ",
+    "createdBy" : "vOD2dT6vKqaxAwJX",
+    "createdDate" : "1980-01-25T23:35:37.890Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/60302381-d297-4825-a6db-3b7186201e4a" ],
+  "curatingInstitutions" : [ "https://www.example.org/11b0ff02-b93d-4bc1-814b-d0017672cf2e" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "bPHVcmkSf58P",
-    "ownerAffiliation" : "https://www.example.org/5364cd52-f79d-4929-9386-d8a639c137fb"
+    "owner" : "b2SOQmdhJmFBxfs",
+    "ownerAffiliation" : "https://www.example.org/d6553c0f-59be-4679-b0cd-5ae44611f4f0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ad97ef4c-d91d-47d4-8ed2-aa3c863888ac"
+    "id" : "https://www.example.org/6aa205a3-a7a6-46b1-bba0-8a48713628a0"
   },
-  "createdDate" : "2022-11-04T12:11:04.970Z",
-  "modifiedDate" : "2023-02-16T07:52:49.843Z",
-  "publishedDate" : "1995-10-06T13:08:31.451Z",
-  "indexedDate" : "1988-02-23T05:25:04.222Z",
-  "handle" : "https://www.example.org/c3197c03-4278-41c7-803a-5c861a64b257",
-  "doi" : "https://doi.org/10.1234/pariatur",
-  "link" : "https://www.example.org/9e2cd7b7-3171-4931-83b4-a9074ef49d57",
+  "createdDate" : "2013-04-21T14:31:26.580Z",
+  "modifiedDate" : "2021-11-12T21:10:50.757Z",
+  "publishedDate" : "1994-09-04T15:46:15.949Z",
+  "indexedDate" : "1973-09-04T21:20:46.980Z",
+  "handle" : "https://www.example.org/7e8380b1-7727-4d89-b4de-d78df494f379",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/f639d2e9-3d3b-4cee-bdcc-704f84a55afa",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oFpFieDGD1xBJfsQC",
+    "mainTitle" : "CZvgz73ENbPbiAzTRw",
     "alternativeTitles" : {
-      "de" : "bEtxBsGxwkF"
+      "ru" : "JWzTRwghk6bwRO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NimFC0yAXLtV0iDDoc",
-      "month" : "6dMs6cW8XbtzceEBDTm",
-      "day" : "PuO0Kb7fBoEE"
+      "year" : "okfLW2SPvhFjZP",
+      "month" : "Wnsva0BYkLjCICiZ",
+      "day" : "Gie8DiQ4dj7VEa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3f06dac2-3895-4d75-8af5-ddb42d53cc2e",
-        "name" : "mwI8aMQjIntGnEG",
+        "id" : "https://www.example.org/1d0a1ec5-dc7d-4b22-9468-81c3f693ed9f",
+        "name" : "tkyxfgenPkv6xc9Pt",
         "nameType" : "Personal",
-        "orcId" : "aeKikfqE7t",
-        "verificationStatus" : "Verified",
+        "orcId" : "9Kjiy9FG8PrY",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Y2iS8Xah7cVs",
-          "value" : "Ypswg1oAB7wOHjNcp"
+          "sourceName" : "Kgl4jSi1W8Oi7x92e4K",
+          "value" : "5UThYzmdzf2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EzkIaZhAkE",
-          "value" : "drdjDshWepbB"
+          "sourceName" : "pGwsqV42U2NXM",
+          "value" : "1oa7twNEnoImt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6e82a5eb-1d39-44b5-be93-5b97b6490faf"
+        "id" : "https://www.example.org/5bd3e0fe-b541-420d-aa39-70047dc3adbb"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/25fc058e-29f6-41ff-a12b-4bd304bbebe5",
-        "name" : "UOJ5nwQRXeRAv",
-        "nameType" : "Organizational",
-        "orcId" : "DlsVXwlWOA",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/f418f2c7-66e7-477e-9999-e2f1ed040f54",
+        "name" : "5Tg2UfqvnMisPf",
+        "nameType" : "Personal",
+        "orcId" : "N2oCyIvNrwd5",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WMSpvcs4Un",
-          "value" : "KpTcfVo6tq2VFFpr"
+          "sourceName" : "yOyeOS9twrXK1kE1wCA",
+          "value" : "ZLLEY5aMcNPYbw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FdmiHCR4MsOghe36j",
-          "value" : "vBjHmLSyi9qlUFSu"
+          "sourceName" : "ng7xM4KzwBr",
+          "value" : "2gvlxRMMJRgWStfqy5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/715e6ec7-4438-40bc-b439-fba0e4940f29"
+        "id" : "https://www.example.org/0ceb8c97-696e-4ba4-a0c7-27bc08fb5ab4"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "79dket21vzdEtuN67U"
+      "fi" : "wdAIHPvyOHr7gZ8j4xK"
     },
-    "npiSubjectHeading" : "8IwPrV7XL3WaF",
-    "tags" : [ "kuusuK8d8ZaoKad" ],
-    "description" : "YbZ3tN6I9geaFj5VQU",
+    "npiSubjectHeading" : "Vj6JJUSFC7DS29Ezh",
+    "tags" : [ "X76DZ8RTiIe7" ],
+    "description" : "9wAWQpo2PpqXCU9R",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "vFBjvRgLUXNYDxZ",
+        "label" : "mbJV7psgbyeFkp",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "AV3hz0tH6Q",
-          "country" : "nsFI5dHehJ0Ds53JTA"
+          "label" : "Sw6Tb2aJwUc0mV2udwa",
+          "country" : "OkJOkQY2Xp"
         },
         "time" : {
           "type" : "Instant",
-          "value" : "1980-12-14T22:50:41.890Z"
+          "value" : "1990-02-22T04:02:53.598Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/OCryhX8opd9vIT"
+          "id" : "https://www.example.com/zEQtQIEsah"
         },
-        "product" : "https://www.example.com/o8ON8LEOUfjpFacA3"
+        "product" : "https://www.example.com/688PvcUjewNdBKb"
       },
-      "doi" : "https://www.example.org/3a716a4c-e83e-4025-b8ec-fcd14fd91dad",
+      "doi" : "https://www.example.org/ed51cf90-fbd1-404b-a520-a71331d0b179",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -121,106 +121,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3c7abfdb-0ac9-4efb-8fc7-9877b6a5a5bd",
-    "abstract" : "TslTYGrbto"
+    "metadataSource" : "https://www.example.org/5788bd06-bd57-41af-a34d-f4d1495f381a",
+    "abstract" : "f2vf41UUFEzDJSYBiIW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1286855b-2082-481b-b2ee-e78390fff087",
-    "name" : "Bc0W1dHWdNo",
+    "id" : "https://www.example.org/55bb3f86-41db-479b-b9d6-6819a882654c",
+    "name" : "RO2IPbKhG9Iw83",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-06-04T10:43:34.526Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "SOxYes5PmwY"
+      "approvalDate" : "1985-05-17T23:53:35.666Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "AZVI0ITXIvb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/94010259-754e-4063-b015-c4bcdfc1ac87",
-    "identifier" : "uPbwQCfTaKa",
+    "source" : "https://www.example.org/acc9ed9b-b340-409e-94e8-84d3dc8a7dc0",
+    "identifier" : "jybJJ2Cz45efw",
     "labels" : {
-      "ca" : "QSnlQQ9iclIYEhMJF"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 770201545
-    },
-    "activeFrom" : "2005-12-11T14:37:10.531Z",
-    "activeTo" : "2017-11-14T06:55:04.496Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cdbead69-3394-45aa-a1fe-2ad12c790a41",
-    "id" : "https://www.example.org/ed6f0d41-5e56-4c8a-b02d-633830cd4aaa",
-    "identifier" : "olwp6hsPakM",
-    "labels" : {
-      "fr" : "TfdHGEfPhcfO"
+      "nl" : "odLjIn0RKNS3"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 544446061
+      "amount" : 791593674
     },
-    "activeFrom" : "2015-10-11T23:52:39.499Z",
-    "activeTo" : "2017-10-08T18:01:35.961Z"
+    "activeFrom" : "2022-02-11T08:43:55.750Z",
+    "activeTo" : "2024-08-13T00:31:15.458Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/ccd5aa60-605a-4c9a-b061-3d3a9ba6e3db",
+    "id" : "https://www.example.org/5356d404-b9dc-4e58-9819-87003be973dc",
+    "identifier" : "e4B9UTk7Ut2R",
+    "labels" : {
+      "de" : "RSf9PAgdFYzIWMixt"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1072231357
+    },
+    "activeFrom" : "1973-07-19T19:12:21.621Z",
+    "activeTo" : "2004-07-07T02:11:10.169Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1786606528",
-    "sourceName" : "h1xjqdggswmvuddzf@s1soakuyrgjxs"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/fcea5a8a-f1b7-4e9e-9fbe-1e226a60d2d1",
-    "sourceName" : "hr4uqgtnukvi@v40pvidwrhgvotfvrq"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "RVEe0OyZoQZB8pR",
-    "sourceName" : "kebkasobgw3rh@fxqmmfvi7oqbkvz0zco"
+    "value" : "KgI2S1H5Lw",
+    "sourceName" : "d8hudl8s0f1lbczieto@taca9jqhg5feziut"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1862466086",
+    "sourceName" : "31jvx2eu7wzc@r3q1bnq6fohbqj"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Xbwkx6fvEWSzqLY",
-    "value" : "TpXSgiyDN6w"
+    "sourceName" : "D72hyePbHnyEW2",
+    "value" : "BhIVLvoPaDWyAQcG"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/b48bebc5-b8be-4b07-92ed-f0b188b3b9c1",
+    "sourceName" : "musy2exegvl@8jvvyyubazdxwd"
   } ],
-  "subjects" : [ "https://www.example.org/7f4a2274-b5bd-419d-8ac1-d9f851eace83" ],
+  "subjects" : [ "https://www.example.org/7a60fb85-5ab7-49f7-8a45-35f65d2adece" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "92754137-9836-48b7-823c-2690dbed75eb",
-    "name" : "jVTSUlt41IS",
-    "mimeType" : "TmSY4gzMpIYUdNj8j",
-    "size" : 549350312,
-    "license" : "https://www.example.com/v0s1ifihfl",
+    "identifier" : "9be1d7da-ed72-4599-bec2-24b0e853d226",
+    "name" : "Qnfi3pdiGMuCkd",
+    "mimeType" : "LsReqISNHaycL",
+    "size" : 972648562,
+    "license" : "https://www.example.com/t6xi4btpkrr0iqbl",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "zsmZzlLUKxPsk9"
     },
-    "legalNote" : "HpKOMh1Ox5kx",
-    "publishedDate" : "1994-10-28T07:49:00.235Z",
+    "legalNote" : "fYxqD1YbpWcxAHSGA",
+    "publishedDate" : "1987-12-13T07:58:33.791Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "530031004@KNXi8Ufr2J",
-      "uploadedDate" : "2012-05-20T18:18:04.792Z"
+      "uploadedBy" : "1117092821@1GrPrmL3EebZzTTcPWe",
+      "uploadedDate" : "2019-04-06T00:28:47.467Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wrGEkYgSSxt",
-    "name" : "6DIbiKNT8mQQgOD",
-    "description" : "PrgTyOTJREREXKr"
+    "id" : "https://www.example.com/iM1bnLetiFx",
+    "name" : "fkmgYAcEpx9s",
+    "description" : "3rHF6SmA9hMSX8Z6cO"
   } ],
-  "rightsHolder" : "y1vF51Y1li",
-  "duplicateOf" : "https://www.example.org/c3816ecd-1d90-462b-80d3-35ff3f3804b6",
+  "rightsHolder" : "MzndQQ64uc9e",
+  "duplicateOf" : "https://www.example.org/8e70eae7-2f80-47b5-8c65-6503af2a19f8",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bAsZGIfC6b"
+    "note" : "Gd4Y5FLnGXG1sd3YJ2"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "9gUNpyMFbvi8BrF",
-    "createdBy" : "Yx7AxVksQBHI",
-    "createdDate" : "1988-08-06T09:36:10.299Z"
+    "note" : "lPuCMhTwLeB",
+    "createdBy" : "VHjzIU6K41S",
+    "createdDate" : "1998-11-18T22:02:07.162Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4029e185-bf38-47ca-abf7-b5f61017fbd0" ],
+  "curatingInstitutions" : [ "https://www.example.org/d43d06f8-65db-4c32-b591-a1a6f3341226" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "XqGW6tdgtigk",
-    "ownerAffiliation" : "https://www.example.org/e939ac12-d627-462c-8b07-5bb6019cafef"
+    "owner" : "1wqaKGjOnxKU",
+    "ownerAffiliation" : "https://www.example.org/5a51b306-7298-45aa-8c0b-bdba12a7dc5a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ca46ad69-2596-46d2-85f2-843def1ea61f"
+    "id" : "https://www.example.org/00925b7f-0643-4b4e-8db2-66d097594d38"
   },
-  "createdDate" : "2006-12-01T05:12:36.688Z",
-  "modifiedDate" : "2012-02-14T17:39:12.044Z",
-  "publishedDate" : "2020-02-21T07:52:16.488Z",
-  "indexedDate" : "2024-08-27T01:23:12.762Z",
-  "handle" : "https://www.example.org/3daa4345-9070-4d87-b814-70fff05a014b",
-  "doi" : "https://doi.org/10.1234/sunt",
-  "link" : "https://www.example.org/d2a73003-40f1-45e4-af30-f1aa7b7c3d62",
+  "createdDate" : "2014-05-17T05:47:39.603Z",
+  "modifiedDate" : "1979-03-28T17:17:12.391Z",
+  "publishedDate" : "1989-09-20T08:30:31.982Z",
+  "indexedDate" : "2022-12-30T07:25:03.197Z",
+  "handle" : "https://www.example.org/9b00b02e-a073-4af0-8fbf-c1d753a07a6b",
+  "doi" : "https://doi.org/10.1234/eligendi",
+  "link" : "https://www.example.org/17197ae4-5cf7-41f8-bc01-6601439f5b4c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VGUtqrTenVPL4qFy",
+    "mainTitle" : "LtWiMXFTfVkdc0uGx",
     "alternativeTitles" : {
-      "pl" : "KJ0goo8rc8QL4JNLIM"
+      "sv" : "ZHDBQ3fTdOzjZnhW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "g6fdZ2iiPNbZbRZsg",
-      "month" : "wAWksqWR2B1kSgpMQKd",
-      "day" : "jwyWHc7TuCuQHWbI7"
+      "year" : "3XuABEKv90nB",
+      "month" : "hofy3GfTkf2",
+      "day" : "0mhw1lpDjpka4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd291a5e-b6d5-46e1-85a7-95ef37b96ca1",
-        "name" : "AvUzv9j7fdW",
+        "id" : "https://www.example.org/d4c39363-1b30-4337-aab2-f2e2e232a855",
+        "name" : "huPbmMvC021rhTlJo",
         "nameType" : "Organizational",
-        "orcId" : "Akeo1bYEF9NYjecfM",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "27hLHbQEmqRqPfjE3y",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FbyXNOUz71W8p",
-          "value" : "GBkBn1xZ8akq"
+          "sourceName" : "D1BCJkpLg7ueAL9Rn1",
+          "value" : "alEgIYR0YAwcMn9en"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zFd5CTqCaH",
-          "value" : "DySJ1sgHNiUflwxrnIg"
+          "sourceName" : "uonniQbhCoK",
+          "value" : "e8qZ4ovNRObPLI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a08c4ca-298c-4fd8-90b5-eed422bf430f"
+        "id" : "https://www.example.org/4e00fa67-73d0-4142-9b65-e7c391751e99"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,60 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3311b802-02a4-464f-8e8c-7e6a0e7da1f5",
-        "name" : "8FH5Fv9CQXsvC9",
+        "id" : "https://www.example.org/1c7cca77-8174-4ee0-9525-96279c57123e",
+        "name" : "wHnxlvXgdmArI8v",
         "nameType" : "Organizational",
-        "orcId" : "lJObx4PLIv1IPZ8H",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "tkLdqNObhy6kQom8Mc",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "drueCKmAEN2ujX3nH5e",
-          "value" : "vh3WsR5TjhKQeX"
+          "sourceName" : "xRBplWbCChDNnDr",
+          "value" : "xLYUVYRir9LgEOa"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "euF9lxXM1N09vPxVLh",
-          "value" : "YmZQkSjY2pX5F"
+          "sourceName" : "nAsP6FOQwNjBGz",
+          "value" : "2NFWgOULe5YFsAi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fa07658f-a6f5-4b3b-9716-8aaa4aee9586"
+        "id" : "https://www.example.org/ad8b8399-fa34-4f0b-92b7-199e418ebef1"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "RoleOther",
+        "description" : "p2X20FwB2Ed"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "dPi5rvogTtZz"
+      "hu" : "7m3e7LmqlIblGH514Q"
     },
-    "npiSubjectHeading" : "SZilyfXSgIuMRgqPUi",
-    "tags" : [ "1ryUjNdaH9W4" ],
-    "description" : "4WVMC7K1czdcMD9",
+    "npiSubjectHeading" : "u1kpXpq4A0Mm",
+    "tags" : [ "ColBAuB0Qhrbia" ],
+    "description" : "aUzCv6GxqVlBg014GGE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "J4ECxChR9AMBCWReCF",
+        "label" : "Lv2hbmeuKPaHaCDEM",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "nHkkHnBKGN",
-          "country" : "c4ebPGoyMIYT7r6b2e"
+          "label" : "3DlplIwmBa",
+          "country" : "CWrsyVd9lY8otC8"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "1971-02-03T20:43:40.662Z"
+          "type" : "Period",
+          "from" : "1987-09-05T01:45:34.679Z",
+          "to" : "2009-04-12T01:56:37.756Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/xA4mXQgLMH4Cu"
+          "id" : "https://www.example.com/YtJo386Ddsu"
         },
-        "product" : "https://www.example.com/FZd8mQTDhW7y65W9uw8"
+        "product" : "https://www.example.com/Uc931c32vfzf0l2GfvB"
       },
-      "doi" : "https://www.example.org/a6345074-d185-4295-8055-2b0ca47340e2",
+      "doi" : "https://www.example.org/ac99d81e-0f6e-4f24-a798-9d5b9fb421f8",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -121,106 +123,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f8d2663e-8110-420f-9544-065f05f16b2b",
-    "abstract" : "hq8N0vyuLAny89q3c"
+    "metadataSource" : "https://www.example.org/20d425b3-929a-40bd-b7c0-e76e453e2b9c",
+    "abstract" : "TeREQZREg7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d77a074f-2f17-4596-8590-e5917a9961ac",
-    "name" : "eGMqD7WXJYyJd",
+    "id" : "https://www.example.org/7fa3df18-da21-456c-acbc-905571b06897",
+    "name" : "Zxv8Z9TR5rkDAtivX",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-04-26T12:40:13.582Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Qc0xCAQnOegwr4H9SV"
+      "approvalDate" : "1983-01-02T19:15:51.098Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "UqOfrasTuW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/57187caf-6477-491a-b03d-0a174844fa24",
-    "identifier" : "ibJQIqbWRYUnO",
+    "source" : "https://www.example.org/7796390f-2f8c-4f75-9112-27520151ca11",
+    "identifier" : "frBmgNQXA18ig",
     "labels" : {
-      "pt" : "idDlomJNVNjKT59iW"
+      "fi" : "QNJf4fJZtr7MN"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1543721665
+      "currency" : "NOK",
+      "amount" : 973163169
     },
-    "activeFrom" : "2015-08-25T18:53:40.097Z",
-    "activeTo" : "2022-12-21T15:27:50.596Z"
+    "activeFrom" : "2016-04-12T00:48:38.872Z",
+    "activeTo" : "2018-07-23T03:59:52.153Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3d53fbed-bf88-438c-a3d7-a434e6bc730a",
-    "id" : "https://www.example.org/4135d55e-d226-4c5d-a6bc-a7b806f68bc6",
-    "identifier" : "FCre64bJObrl4Ow4",
+    "source" : "https://www.example.org/d67c9fdb-7d8e-4d7e-a308-39ebf65b4b0f",
+    "id" : "https://www.example.org/87e0abfd-3b78-4d2f-be5c-81ada6004d6d",
+    "identifier" : "U0UEvCgnbGWrjaL8hKe",
     "labels" : {
-      "se" : "ccW2RnrrIkKROXuX"
+      "zh" : "rVYeSiyXlaULA"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 235470295
+      "currency" : "GBP",
+      "amount" : 1508463193
     },
-    "activeFrom" : "2016-12-24T07:52:37.305Z",
-    "activeTo" : "2023-05-12T21:18:09.054Z"
+    "activeFrom" : "1971-07-08T14:33:59.815Z",
+    "activeTo" : "2002-08-14T08:26:52.484Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "ZFfZADx3tdw",
-    "value" : "txu8PUqtHpq"
+    "type" : "ScopusIdentifier",
+    "value" : "1hwEUvI69a4S",
+    "sourceName" : "w1lfesjjgin4iv@sbrud9ardjrxpw56kat"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/8b17ebef-7e76-489b-a0ab-a63aca07fb94",
-    "sourceName" : "oli8elaly5c7binw@mfryn9o9xtmus"
+    "value" : "https://www.example.org/2d9e0e06-e8f4-41e3-9140-90677eb4bf0f",
+    "sourceName" : "ytd0tpqtt0lv@7v86dw4iuyi"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "w6UUuTwU1baB3Jaa",
+    "value" : "gyDrn24XXYwjtBFE"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1977995007",
-    "sourceName" : "osoiwb4nyc@gmv1caiyhggu17kfwd"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "jP6GsL9Kxf8O2c",
-    "sourceName" : "xjj4wsmfkh3medwz@he4azo1zkykrvq"
+    "value" : "711059786",
+    "sourceName" : "5x0frm87kium@v027oijcowtgueqplsq"
   } ],
-  "subjects" : [ "https://www.example.org/c622a121-eac5-4ac4-a66b-aca1446e855c" ],
+  "subjects" : [ "https://www.example.org/7d62032c-3207-4543-9377-9181b59b3e8d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "68f5d318-0369-45db-8ece-50aa54a38fa3",
-    "name" : "921hW9QKv6yRkH",
-    "mimeType" : "V4phEVqaHvUJENFKp",
-    "size" : 955448408,
-    "license" : "https://www.example.com/8mwiegqybbkxfbau",
+    "identifier" : "6a2d28ae-4f90-4b9b-825a-0795e2a8d5d1",
+    "name" : "SYcLrfFYo5",
+    "mimeType" : "ZKLsvHpQljL0eupH",
+    "size" : 258398844,
+    "license" : "https://www.example.com/l6oondlvuwgnospxp",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "2t0r9qbmtdt2hh",
-    "publishedDate" : "2002-09-13T07:26:43.200Z",
+    "legalNote" : "dfcVYPfXNBOggajdQA",
+    "publishedDate" : "1980-08-07T05:47:07.118Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "833129924@lggB6n90e9C",
-      "uploadedDate" : "1983-10-23T08:13:07.275Z"
+      "uploadedBy" : "515501676@bnMiUzViq3JT7o0",
+      "uploadedDate" : "2009-08-05T15:40:56.943Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XUjS2ouaSIAaiR",
-    "name" : "S7e59BsIPU",
-    "description" : "pKQGOtYY2ENy"
+    "id" : "https://www.example.com/GAqU3Gyu8GqLeCN",
+    "name" : "pyuwcm7xK3AEL1nHpac",
+    "description" : "QcVYA4p8Aa21T"
   } ],
-  "rightsHolder" : "oKpy7wAF6HymPVbB0y",
-  "duplicateOf" : "https://www.example.org/e3a5cf70-c09f-4194-aad1-b0f45fefc583",
+  "rightsHolder" : "yCnWvjv1rkb6",
+  "duplicateOf" : "https://www.example.org/fd286a55-2879-45eb-b4c5-d55b44a70ef8",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "V8ZQFVjwaz96lo"
+    "note" : "eMLocMpdpU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "r9GIQPQq5F",
-    "createdBy" : "GISLgXHGwM",
-    "createdDate" : "2005-05-15T05:25:39.984Z"
+    "note" : "meLA3VNxJfyK",
+    "createdBy" : "FIq2OQQjieQ",
+    "createdDate" : "1998-11-04T02:58:05.557Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4545fdf9-6f7d-4a2d-b704-5d4af1df736a" ],
+  "curatingInstitutions" : [ "https://www.example.org/a8f30614-fae6-4ac5-9318-fb1ae8018eaa" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "csou8r3tBN0uqCY",
-    "ownerAffiliation" : "https://www.example.org/be2100ca-b33d-457d-a8e0-040295cbcd19"
+    "owner" : "6O9zjSOeUE",
+    "ownerAffiliation" : "https://www.example.org/bbac42b1-27dd-4ce1-9982-f51486f55614"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/23be9dcf-1bf2-4bcd-be90-e6ffbcddb8cd"
+    "id" : "https://www.example.org/35195f9e-be51-483f-80ce-fc06f120c91c"
   },
-  "createdDate" : "2009-07-13T17:13:23.811Z",
-  "modifiedDate" : "1989-04-16T10:30:11.968Z",
-  "publishedDate" : "1982-10-18T21:35:06.564Z",
-  "indexedDate" : "1991-05-22T06:23:56.463Z",
-  "handle" : "https://www.example.org/b531a2cf-7c1f-45bc-9a9c-3ab2576a3d0f",
-  "doi" : "https://doi.org/10.1234/perferendis",
-  "link" : "https://www.example.org/2c5bb8ed-efc2-4496-aca8-450f41462e9d",
+  "createdDate" : "2013-09-13T21:19:35.052Z",
+  "modifiedDate" : "1974-05-17T23:29:41.101Z",
+  "publishedDate" : "1976-11-15T09:45:32.099Z",
+  "indexedDate" : "1994-03-17T16:05:06.496Z",
+  "handle" : "https://www.example.org/4b9f9122-7191-4be5-943c-6ed6ba995b0b",
+  "doi" : "https://doi.org/10.1234/nam",
+  "link" : "https://www.example.org/07db2de6-3622-4647-8092-d6d365d1f9b0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AqK6CTWf0r3",
+    "mainTitle" : "FByIEevpanqpOLGPD",
     "alternativeTitles" : {
-      "fr" : "g5nd7wzIH6XCkKCN5eu"
+      "ca" : "RLsnMLwT85k"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "33R9e4YOapECVio1pOg",
-      "month" : "ga9kZ1m8y9BTFpVNWGb",
-      "day" : "8u3znjiip7iS7AwfwB"
+      "year" : "3JwL7nlg2eqNTExnM",
+      "month" : "lYnlLjg9Ll5lx",
+      "day" : "V4OnPYlA9N"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/114e661a-fbf3-4f21-bcd6-114e2d5b5d79",
-        "name" : "ZPuOsiKt2IRp75X",
+        "id" : "https://www.example.org/995e8a03-a6df-40b3-abbb-9ef9249830b1",
+        "name" : "6lYhZPNfo8C7",
         "nameType" : "Personal",
-        "orcId" : "JapYRKrGn4j77X",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "8MpI1zINuAeDuM7x",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KLFu5DyLWIhGAIwM",
-          "value" : "bA5ABGOetGZDAd3"
+          "sourceName" : "pEbPZ0CA5TIsKE0wKr",
+          "value" : "vM2Tr1ewFo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qq9IP2b99KfIBZPTrI",
-          "value" : "RGcARoOtjSAv439Eh86"
+          "sourceName" : "mjud2zcTzg4Rqs4ner",
+          "value" : "WFacGlVKLG7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/41874ac9-30ef-4d50-a7f3-1ce010afbbc7"
+        "id" : "https://www.example.org/6405157a-8fd7-46d3-bafb-b82e06ad9308"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/da2070eb-b8d7-4fee-8f4c-fe4a96ecc380",
-        "name" : "LwwkOvXLMmijJPu7j",
-        "nameType" : "Organizational",
-        "orcId" : "nivvfK6zoOT3guL",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/463a6c2e-f3bc-4539-92ec-02e5cdfa6c85",
+        "name" : "yRLwb5bw8K",
+        "nameType" : "Personal",
+        "orcId" : "Oq7MfxSrgfA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Kz7kzDTnUl9MMHwv",
-          "value" : "PB2ETTihDpgxqlRdv"
+          "sourceName" : "O8WtAzcJft",
+          "value" : "Qxt5K2iIAeettg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dBBXiapAs7958Y",
-          "value" : "OV34JsxerlLwtlepK"
+          "sourceName" : "YpDpgXSWwZk2Ge",
+          "value" : "4TkVPIqni1e5mycAC"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1c58a95d-44de-4c24-b80b-a75765e193ac"
+        "id" : "https://www.example.org/b0f03cd4-8047-4fe6-af55-ae66d2db9d46"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "ickMrmRptIYqICsL9"
+      "nb" : "hL6URPAKun53"
     },
-    "npiSubjectHeading" : "Tj4GCS37w6AmFq",
-    "tags" : [ "xYKFaGDr1Pt4FxJN2s" ],
-    "description" : "tlc958gzN08ggoa",
+    "npiSubjectHeading" : "7Egnd8bzX9W",
+    "tags" : [ "toRuPN4dBRRmDAqrw" ],
+    "description" : "RNiy8hCYipBTxj72G7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/05e06458-3ac7-4412-a5b7-870bb68c7b94"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f5f23556-40e4-4700-b6d2-00afc5415c71"
         },
-        "seriesNumber" : "KmeWusuXWKX4RT0d",
+        "seriesNumber" : "hWKh10HeQFxq4q",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/44bf55cf-c4b2-48e2-809d-b6831c3e3d3f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a3069f8e-4641-4e4a-9945-3b7f6a0779f8",
           "valid" : true
         },
-        "isbnList" : [ "9791060638395", "9780070859944" ],
+        "isbnList" : [ "9781318122660", "9780346744745" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0070859949"
+          "value" : "0346744741"
         } ]
       },
-      "doi" : "https://www.example.org/8f60dc3b-a063-4b6c-a523-0ff1286987d6",
+      "doi" : "https://www.example.org/1732395a-5259-4881-97c3-dd6b75ff2520",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "h7yJ4YxhDcxpXQutj",
-            "end" : "bfIjk8KfR9dnSu"
+            "begin" : "M6feNZ9fhHP",
+            "end" : "9MGJjB7c5MU"
           },
-          "pages" : "dgnSgKYbK8sDDzO9WCc",
+          "pages" : "kUB6iXA9gtjABRNkVh",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1451b0ce-1425-4f2f-95a4-b2f730b4a6b3",
-    "abstract" : "WJxn1UpllUlncK"
+    "metadataSource" : "https://www.example.org/68a31b9e-f5f9-4563-af41-0cddd058a937",
+    "abstract" : "WwdvwGr9qAfS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/edca9f3b-a803-41e9-862d-b6a062436748",
-    "name" : "TL1vVVohxJoNatkl",
+    "id" : "https://www.example.org/81543bac-ddce-4c24-9e43-6012b2685f85",
+    "name" : "gCJAbIwceQm6Pb6nA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-03-28T06:25:09.737Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "rGY979rndsXs1"
+      "approvalDate" : "1972-10-15T00:03:57Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "x8wu5Y9VfDsfGSunV"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9f82e79b-710f-46a7-80cb-658e4356c584",
-    "identifier" : "Md9YxpjoNyZ",
+    "source" : "https://www.example.org/07a0f9cf-55e8-4c4a-a585-98fcbb9f920b",
+    "identifier" : "1YUfiUQDRHBYK5pNV",
     "labels" : {
-      "nn" : "Phetc1NqMP2VGa"
+      "en" : "8gdgLey28FGsMdgd"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 446803021
+      "amount" : 1203323292
     },
-    "activeFrom" : "1984-04-02T08:47:24.172Z",
-    "activeTo" : "2006-04-23T14:09:01.111Z"
+    "activeFrom" : "2006-05-08T11:35:22.602Z",
+    "activeTo" : "2021-06-24T23:24:25.122Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/71fb5e74-4d46-4c13-9083-38e5bb7c4756",
-    "id" : "https://www.example.org/9e48380b-2768-468e-9f8e-e9aa61b611a1",
-    "identifier" : "nrpub3Z8vZt389qw",
+    "source" : "https://www.example.org/ef88bc97-3d1a-4a0f-b787-4660cc21dbc7",
+    "id" : "https://www.example.org/9a4336b2-80c4-444c-bac8-600a95165251",
+    "identifier" : "fHmQdBCrnP2r6v8",
     "labels" : {
-      "se" : "Jd5LH25CaA9N"
+      "nn" : "cNMXSbTz5fdUf"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 8625901
+      "currency" : "EUR",
+      "amount" : 1902552430
     },
-    "activeFrom" : "1973-02-15T12:26:21.508Z",
-    "activeTo" : "2004-01-01T09:01:49.502Z"
+    "activeFrom" : "1972-04-17T09:39:36.675Z",
+    "activeTo" : "2011-03-09T16:01:18.815Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "MlZPw9uSM3T",
-    "sourceName" : "mcz3cqvhn2krs@ojs3sib5q00ezbdwl"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "r7wq0RODHAjfu",
-    "value" : "gkWIXCjoLL6deWwHFq"
+    "type" : "CristinIdentifier",
+    "value" : "63997328",
+    "sourceName" : "bue0wvjwwnhw@b0nmatnre5cly9jr3uv"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/b9e31b59-0b7f-4a8a-9666-69a9bb11a956",
-    "sourceName" : "luy4c0pn5wsbpnp@y4qtqprxixu6hgf8s"
+    "value" : "https://www.example.org/86795ee2-b621-4c5d-ae36-747dd1402934",
+    "sourceName" : "anejpdma75q0yyd@imzk9lhxdhzjmgot"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1401912906",
-    "sourceName" : "q2xwctb4xurlul2mj@sfyupldf0xpcedgxgt"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "aUzj78SzBdj3Fc",
+    "value" : "oTFEfwMs0a5"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "ClkKKfBbQDgKQ8",
+    "sourceName" : "2d7v6muippjo7m@dqdk3we7lw"
   } ],
-  "subjects" : [ "https://www.example.org/b5fd6851-33c3-4f46-9fd3-f959b35e7dee" ],
+  "subjects" : [ "https://www.example.org/b0f338d5-f596-461e-aba2-8199feb28a4e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "27b1f360-2394-472b-9e4a-f8387792adc9",
-    "name" : "HwagSQmkr5e",
-    "mimeType" : "dVGkK2kmkHci",
-    "size" : 1370396177,
-    "license" : "https://www.example.com/ynqybeku4p3r0j",
+    "identifier" : "84c64f75-7487-41c6-af0e-d9e5805f34d3",
+    "name" : "XNMPOcNDGag",
+    "mimeType" : "n67H2SKNbfAy",
+    "size" : 1735143778,
+    "license" : "https://www.example.com/xjsdbd9rckffqdql",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "i3mqKH1J8wFnKCy"
+      "overriddenBy" : "lbOblFNTvae9KDd"
     },
-    "legalNote" : "TlF5FBcSJs",
-    "publishedDate" : "1996-02-20T14:58:41.060Z",
+    "legalNote" : "X66mENyJKbPIl",
+    "publishedDate" : "2017-05-30T13:25:24.986Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1291994415@K452hIwdMjOB1Tgob3z",
-      "uploadedDate" : "2012-04-20T21:32:45.585Z"
+      "uploadedBy" : "176578147@nhrkG4jSMUh94t1vN4",
+      "uploadedDate" : "2023-08-11T05:35:45.389Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/eBeAhyKj2cif9KEbpz",
-    "name" : "jQVIWJRmg1WhfGRvohY",
-    "description" : "iHOVWSzZVbuK4"
+    "id" : "https://www.example.com/yEiMM21B2b0",
+    "name" : "ph8nTV1VFopOXkJqKa",
+    "description" : "fK4ob6oZDk"
   } ],
-  "rightsHolder" : "hGGbeYOYCMdkr4xujtx",
-  "duplicateOf" : "https://www.example.org/c98cb733-16f6-4720-9167-887186846e70",
+  "rightsHolder" : "aAndBPU7bcQ8v005d1",
+  "duplicateOf" : "https://www.example.org/80ca3e87-fcd0-4e84-a85d-faac7dc897c3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zz95OqOKE0eQTyz"
+    "note" : "Kg9xgnj1v2ebdD6jt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Aeuq7CtxLyCxF4Ti",
-    "createdBy" : "FlT0L0dQkKe8vr5",
-    "createdDate" : "1971-07-30T14:13:22.882Z"
+    "note" : "qfMOzFSr87G3tuSt",
+    "createdBy" : "JO0nIeiVKux",
+    "createdDate" : "2016-10-01T04:16:19.538Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6415c27e-47d2-41bc-aee6-9aa991ec595d" ],
+  "curatingInstitutions" : [ "https://www.example.org/bf3e310e-85cc-4ed6-b5a6-2efde5f89eb1" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "JDxHWTtOJa2Xu",
-    "ownerAffiliation" : "https://www.example.org/83d5e5c7-9675-4900-877c-8041b833f0dd"
+    "owner" : "4kz44dcSFHqwDMg1",
+    "ownerAffiliation" : "https://www.example.org/d44a82a1-bf82-4908-850f-fa1657fa706c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3d7483f7-0be5-438c-b03e-3d638ed47f14"
+    "id" : "https://www.example.org/870322e1-8612-4ad1-a2b8-92f43f86bbd6"
   },
-  "createdDate" : "2021-07-01T16:47:40.812Z",
-  "modifiedDate" : "2000-04-18T12:35:53.646Z",
-  "publishedDate" : "1996-01-25T19:49:16.161Z",
-  "indexedDate" : "1976-08-28T23:50:05.864Z",
-  "handle" : "https://www.example.org/8c6f801f-ab4d-4f6d-9bf9-f5aeaa2baf71",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/0e612546-55b4-4406-bff3-bcb27771f27a",
+  "createdDate" : "1984-02-18T06:08:54.737Z",
+  "modifiedDate" : "2009-04-19T01:16:04.872Z",
+  "publishedDate" : "1995-10-15T09:12:22.953Z",
+  "indexedDate" : "2024-09-02T20:40:26.447Z",
+  "handle" : "https://www.example.org/cc9d38e6-f92a-4e13-9753-b3d689fb99c5",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/2df61d20-1d9b-4331-9804-8400f40b7ee1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Az42ZudM8Us",
+    "mainTitle" : "oG0mCAACUniOJbRIDUg",
     "alternativeTitles" : {
-      "se" : "E7FJyCHq8nOTXB"
+      "nb" : "rIXAfX1IjZ3rwesxY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vizGfsBFWa77",
-      "month" : "XilE403Y3E",
-      "day" : "Zit6N69tdEh"
+      "year" : "YFWbVIA4TT2yL1E",
+      "month" : "XgIFN3kr1FCUkiK",
+      "day" : "4A5YEaV64M7GVwDS4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e523eb01-6e6f-43e2-9851-51f6a3b6cbf6",
-        "name" : "orhrpUM4dT",
+        "id" : "https://www.example.org/97ca5b3c-30b5-4a36-9244-66decfc26c6e",
+        "name" : "3I5H2QhKiVQRTuHSZS0",
         "nameType" : "Personal",
-        "orcId" : "JDwa15jFwAx",
+        "orcId" : "RdKrLkDMseUJfzi7deu",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xWnqf2Eb010nRlpm",
-          "value" : "c4L4EAWyTz"
+          "sourceName" : "4WxhzAsRRzcOCDSc5b2",
+          "value" : "Yr3EmIBGyn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bWZfyckFbS",
-          "value" : "eQGj7gFjmfBv2NVGuIv"
+          "sourceName" : "MRfW4sHmaL0",
+          "value" : "ofDKneXOhPfv7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e3a93d6e-e50c-4ae1-99b7-af48e50ea11a"
+        "id" : "https://www.example.org/1d6ec962-51b1-46ac-a20c-9f610c9a062d"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,167 +62,167 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/60e162f2-ff46-425d-b23b-7449cdf334cd",
-        "name" : "oYA8LZszaBqSlf",
-        "nameType" : "Personal",
-        "orcId" : "R3cHYg1UeTgj8B1",
+        "id" : "https://www.example.org/5c39285a-07d4-474d-b629-08a198032f79",
+        "name" : "PNCpJQRauEzi8XVV",
+        "nameType" : "Organizational",
+        "orcId" : "kbyzJJEGUF3GDK6gL",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aqaS5j1vpAKa5c",
-          "value" : "a1MRXiKZPwakRM0nwOt"
+          "sourceName" : "1h59XIQslvwXAK7",
+          "value" : "mGERDG0mn7Ebl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vjTHflBQRmgfzejf",
-          "value" : "lqfzdbtriZGIuY"
+          "sourceName" : "f9HwMmcASI9QlI",
+          "value" : "iT7SxO8sYr9xpcfZv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/64c797ab-6544-4641-997d-ce2bdaf29c3e"
+        "id" : "https://www.example.org/de8ea7e1-fb28-4fd6-b65e-bf685c6957a7"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "2ZxSWHwme656cVl769Y"
+      "ru" : "Js3UfnBnhkg"
     },
-    "npiSubjectHeading" : "B6Nhvu48Z0",
-    "tags" : [ "RcevKr2tCQPL5" ],
-    "description" : "JoByMTkpAUAvIuyYrM",
+    "npiSubjectHeading" : "cbTjQp83OBUhXdmZ",
+    "tags" : [ "zQ4jwo8MKA" ],
+    "description" : "YvpTHgagQL8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d1e1f946-e540-4dd5-be84-4c264e47db2a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/38949643-d9b8-48c0-b0c5-7454bd0f6f95",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/5ba4824d-8578-428d-afe1-36cda82d7371",
+      "doi" : "https://www.example.org/0f8fdfdb-f7df-4d6d-93cf-db81889dc801",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "y7creYkJvcy"
+          "text" : "o5rPCErw5mbygx",
+          "sequence" : 954527268
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ejTWaE0x1pTX",
-            "end" : "XTlFXNdJnpAv"
+            "begin" : "x9bVpVFuX0LKdM1YW",
+            "end" : "rRPb8Og0SYI4Xmm"
           },
-          "pages" : "UZDHVFpAGQGOZfb6se",
+          "pages" : "FJLcbui1Dr",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ba729824-4934-4aef-af9c-a2b184767cfe",
-    "abstract" : "cUgwBEAXloG"
+    "metadataSource" : "https://www.example.org/81fa27b9-d1a9-48e1-88b4-1b457b123c4d",
+    "abstract" : "A1lbUOw4GWyL5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7ec932db-d429-4772-90c5-7b5c387db35b",
-    "name" : "s049lcuA4sZWP",
+    "id" : "https://www.example.org/bc4ad260-42da-4407-b563-16a78bba64c2",
+    "name" : "H4oegdlHL1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-07-12T00:42:30.135Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ZOnWg0db75G"
+      "approvalDate" : "2018-08-03T18:53:47.603Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "0yRasnyxIOe"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5ef366dc-641b-440b-bb56-c992750a15ff",
-    "identifier" : "ynOK6T3XxMJx3Vyvu",
+    "source" : "https://www.example.org/3229058d-e6cb-4469-9878-2363def2227e",
+    "identifier" : "ELhZWm9niCb4RR",
     "labels" : {
-      "is" : "X0OZKJYmPqcZsvNAp"
+      "el" : "WXdwhEXJFV1uX6zVv"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 565362287
+      "amount" : 2096486762
     },
-    "activeFrom" : "2003-08-24T08:03:04.352Z",
-    "activeTo" : "2016-12-29T02:25:23.326Z"
+    "activeFrom" : "1977-10-28T08:59:17.447Z",
+    "activeTo" : "1998-11-14T11:29:55.013Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e2920bb8-bd76-4ad4-bd47-d9131f3df9ec",
-    "id" : "https://www.example.org/d2315c6f-6932-491b-83f9-4215ea6b13ac",
-    "identifier" : "hauQN3JPQqBGmG3P",
+    "source" : "https://www.example.org/c2ea1f0b-c3af-4701-90fe-f6660838b869",
+    "id" : "https://www.example.org/6deb0af6-30ef-4050-8a23-ac9a1ebc7f6c",
+    "identifier" : "TGg7aTeM7x",
     "labels" : {
-      "nl" : "ebxvJsKdZzcs"
+      "pt" : "5zbCWHpwJlR6wRT"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 402015113
+      "currency" : "GBP",
+      "amount" : 1012948129
     },
-    "activeFrom" : "2014-06-09T04:19:38.088Z",
-    "activeTo" : "2021-07-04T05:49:09.958Z"
+    "activeFrom" : "1973-06-01T00:08:16.911Z",
+    "activeTo" : "2017-04-28T18:40:07.994Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1360821549",
-    "sourceName" : "so8cpbip5f6o1sumqs@r8ya5xx2gbbmilc135p"
+    "type" : "ScopusIdentifier",
+    "value" : "BPzbgeXHTPGVgd5Rsip",
+    "sourceName" : "8evbdezqez@kias6k13shtedbvrgnf"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/ce5da410-625f-4500-ba00-7eaa2576fcce",
-    "sourceName" : "rb39bmouq0yq7tx70mb@j53lb9su1ukh4f7bn6j"
+    "value" : "https://www.example.org/1d7cdbb3-e0db-4f0e-831b-9f41616d5834",
+    "sourceName" : "ivjfxvwbpp@3drvz04ftn"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "619131708",
+    "sourceName" : "rchutmrojqsvr96b@l3lq9za4xl"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "G9LGkl1Hhq6",
-    "value" : "A7Yh5erXRocNF9vvv3"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "2VwS2JiT4DcZdm7YIVS",
-    "sourceName" : "zxuoxfqd8kdrrvoirf@wuq7ooffu5btod"
+    "sourceName" : "rVBzM5Y5p2",
+    "value" : "kV7qMIbZKE5wTJ"
   } ],
-  "subjects" : [ "https://www.example.org/4f82dbfd-ef61-4795-b507-8c1de09cc42b" ],
+  "subjects" : [ "https://www.example.org/c373afd5-4896-4eff-b50d-72fa41da1d02" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d4bebedc-1acf-4b15-a67b-43db500d21eb",
-    "name" : "eQ6gqrC3Cs",
-    "mimeType" : "gNMYl0ATeNiD",
-    "size" : 1567442300,
-    "license" : "https://www.example.com/hqddroza1rp",
+    "identifier" : "80748d70-16bd-4af0-9f22-1cc2d0c39dd7",
+    "name" : "9vh44gZ57WQj",
+    "mimeType" : "RxA8p12BEX",
+    "size" : 1597607343,
+    "license" : "https://www.example.com/4w0wdj2ebkwa25padm",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "NR4AwRhHoDBHO"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "cCwdTeHk3uha1Y7eA",
-    "publishedDate" : "1992-10-18T04:18:35.209Z",
+    "legalNote" : "OZiJDdYKFPLYtuiuzTy",
+    "publishedDate" : "2006-05-24T20:39:44.860Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "369396531@OykvC59Emya",
-      "uploadedDate" : "2020-06-23T00:23:23.225Z"
+      "uploadedBy" : "650320138@ITo1KhbNIDzFjw7",
+      "uploadedDate" : "2023-10-29T18:06:59.538Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/fCCpggB31a3Dw2fy0Nw",
-    "name" : "YVX1ICMRfU4mQEOED",
-    "description" : "DrP1DbWr3HUHH5Kq"
+    "id" : "https://www.example.com/medShH2cgbvFLAR8",
+    "name" : "B78Vmhq53Es3N",
+    "description" : "epbQWREwUvMa"
   } ],
-  "rightsHolder" : "5DJw9CenNU5cC3Y",
-  "duplicateOf" : "https://www.example.org/8d273265-725d-414c-a5bc-52c8b57cc557",
+  "rightsHolder" : "PYWpgLiSqmbcNJeBVa",
+  "duplicateOf" : "https://www.example.org/955c0831-aca3-42e3-a3f9-e06bcf4c5a67",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YBxHBuonBESA"
+    "note" : "lG8H6vRMgD"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VPY6RVabF4Uwf0h",
-    "createdBy" : "bSMM4eeHmk5xZKV",
-    "createdDate" : "1995-08-20T03:05:57.864Z"
+    "note" : "zOjWq4JLdFlcWp1w",
+    "createdBy" : "KzE2BtBP3Xa5Ip6u3dg",
+    "createdDate" : "1983-07-15T18:19:59.807Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4b313c8b-edfe-465a-a292-953d2eb5fad7" ],
+  "curatingInstitutions" : [ "https://www.example.org/471145c4-ebb5-46c6-bbb4-2d7c9b31ae69" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "NHvkG5JYfU",
-    "ownerAffiliation" : "https://www.example.org/bad8b032-4d77-4764-afb4-90bbcadf569f"
+    "owner" : "wkTCUVRJdmsd2",
+    "ownerAffiliation" : "https://www.example.org/499ff782-ea45-49b4-aadb-8ac069525179"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1262913b-ef35-4d90-b80b-9026bf0f22f7"
+    "id" : "https://www.example.org/57b44017-dc24-4788-baa5-61a424681f22"
   },
-  "createdDate" : "2006-06-09T07:09:28.802Z",
-  "modifiedDate" : "1982-05-01T21:16:21.550Z",
-  "publishedDate" : "2020-11-21T04:03:29.757Z",
-  "indexedDate" : "2021-12-06T10:56:56.950Z",
-  "handle" : "https://www.example.org/9d49c42e-9d99-4438-9456-7f9272103ad7",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/dbedf8bb-5c45-44fb-89e7-d5557c847010",
+  "createdDate" : "2005-11-24T01:48:48.756Z",
+  "modifiedDate" : "1976-09-21T20:34:47.639Z",
+  "publishedDate" : "1973-09-08T06:28:06.927Z",
+  "indexedDate" : "1986-04-24T16:38:24.623Z",
+  "handle" : "https://www.example.org/7e19482e-f48d-4026-abeb-de06e5b8fdf6",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/7d6461b5-0077-4a35-8545-da1a019ade25",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BIMlF9g8OK0Kbog",
+    "mainTitle" : "kCK6dmcsbsjBD5ab",
     "alternativeTitles" : {
-      "ru" : "J2AXOSVTqzs94z7QV"
+      "nn" : "fsnCd3Skp6GQPfz0OJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iLpdjsKHTJ51",
-      "month" : "VHl87aUtQVEsmV",
-      "day" : "BA1SmrjlK5"
+      "year" : "MreFPErzWWeeS2anYdU",
+      "month" : "4TxEmv63swBafSx71n",
+      "day" : "g08Wjf2GUBUWi3qW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/df75d4b2-ecec-4059-ac4c-68cd7e2e30de",
-        "name" : "zSM24aY9wAnKbKErLc",
-        "nameType" : "Organizational",
-        "orcId" : "M9v11zKiAXeV",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/b90c574c-52f7-4880-86e0-fd1036b07efb",
+        "name" : "Rwf1d36Clyhy",
+        "nameType" : "Personal",
+        "orcId" : "4nY9xuqDSnyB3XQ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BrUiF7smjajv2Lu",
-          "value" : "h1Zbo4JSWvo"
+          "sourceName" : "MogcuxJRzJkOGKijpbs",
+          "value" : "3yxzrlzQDqjrQww"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TXMHZGZFSZrwA3fh",
-          "value" : "td1mJNuDeqxgH6iPR"
+          "sourceName" : "Mcs5Ho1hpZ",
+          "value" : "hoDxvxFkScFVns6O"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/587d92e0-8fbe-4277-9832-a574d388b352"
+        "id" : "https://www.example.org/5c4a6f3c-58a0-4449-9e7f-62ef074c2d52"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,167 +62,167 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/70725290-d28d-4249-9407-919cbcc75bc0",
-        "name" : "Ynz6XOzVKMDhgDxlC",
-        "nameType" : "Personal",
-        "orcId" : "FpkM0G5VSkDjlCa",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/483f4cdb-d07c-4d42-9240-1a387df066f8",
+        "name" : "SHK2J35MWbC9sE",
+        "nameType" : "Organizational",
+        "orcId" : "vzYM6oCpwzslfjrBJ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "743zx43ZGI",
-          "value" : "X9lmqe8B69C"
+          "sourceName" : "pLbAGG9treEyKPFtxn",
+          "value" : "aSl3z9IG923UMTr4i"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nJg2hd0UTejUvzQL74",
-          "value" : "YtP0ZkTlDRXy4z"
+          "sourceName" : "ic6ZYcl7qv",
+          "value" : "y6advnrD51c"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/045741d9-af4c-4608-af87-abb5be0d35e6"
+        "id" : "https://www.example.org/4cea680a-57a8-4df2-9b0f-b9f642d27ccc"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "1KOLFAIzprUjsM8A"
+      "fr" : "KZzWKRnB4RaJqJp"
     },
-    "npiSubjectHeading" : "rFfRA4lcG43EPyD3JyO",
-    "tags" : [ "hgufnYuPD9" ],
-    "description" : "91S5KUOLzc2",
+    "npiSubjectHeading" : "vWoAyjPt6yaSF8beD8",
+    "tags" : [ "i1tGtbWGs3eOIEbqtx" ],
+    "description" : "il8OV8opSWZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/49a2c829-ca6f-49bc-8aee-cac6c1af7a87",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ede6283f-6a35-477f-9c6a-41898990200d",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/ce73b593-f4a9-46aa-91e9-9ecf3898b6e2",
+      "doi" : "https://www.example.org/f8a8c2c7-3251-4a15-8d85-369c6cd6180a",
       "publicationInstance" : {
         "type" : "DataSet",
         "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "Z0xepBkd7j5Ycz"
+          "description" : "9Ql1OAyVNE"
         },
-        "referencedBy" : [ "https://www.example.com/VefJu3BoZfPHnOrBu" ],
+        "referencedBy" : [ "https://www.example.com/8VtF9QqO9ikAc5AjlgZ" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "XGeQekWRSt"
+          "text" : "nKnz2CelKyagbpao",
+          "sequence" : 1423274733
         } ],
-        "compliesWith" : [ "https://www.example.com/kgWFpfOCISOWc" ],
+        "compliesWith" : [ "https://www.example.com/ZmooUrLqzme5" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/402ea501-c0b2-483a-ac09-4505fb8f614b",
-    "abstract" : "ADqihrDNQv1p1R"
+    "metadataSource" : "https://www.example.org/9c7d3fe6-5c6e-43ba-bc20-2e257f18e6b3",
+    "abstract" : "3r4C19SQBd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2a931448-619a-47f5-83d4-b1b983be6c54",
-    "name" : "WOQUXotOggV",
+    "id" : "https://www.example.org/19f40650-09fd-47c7-ae02-defb8375f22c",
+    "name" : "T6zMiJJmPFuCAUB",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-04-29T08:40:27.104Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "bggpH0FWfxmF"
+      "approvalDate" : "2006-05-04T07:35:11.666Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "ojlD3ytAvEspU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6e135933-d01d-43ed-a733-18f32db847fc",
-    "identifier" : "GRos3DwCjhThRsC8",
+    "source" : "https://www.example.org/084fb03b-25b1-446e-983a-17717c15ffa5",
+    "identifier" : "vQFBvjImGJJFlii",
     "labels" : {
-      "sv" : "QcCxRg11pzuZ"
+      "de" : "QzM8xfj6KqpohkP"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 941450140
+      "currency" : "GBP",
+      "amount" : 39558320
     },
-    "activeFrom" : "1993-04-26T05:51:09.844Z",
-    "activeTo" : "2007-04-21T11:47:08.334Z"
+    "activeFrom" : "1981-11-22T01:48:29.943Z",
+    "activeTo" : "2022-07-29T09:47:55.554Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a07e4087-8abc-44f6-b7fa-65598bfa3fb1",
-    "id" : "https://www.example.org/cf237ca6-d525-45ee-b474-78aae32ee3c8",
-    "identifier" : "BsUbmsVr9WuJ",
+    "source" : "https://www.example.org/899a2874-7b00-48d8-ba08-3627d47df665",
+    "id" : "https://www.example.org/a10ec3d9-eab0-40e1-a87e-86f0e61502af",
+    "identifier" : "qlg9tWBcwr9dT6Z",
     "labels" : {
-      "pt" : "3JQlYuE2Dg"
+      "it" : "XRsd2B7pbA6"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 234422334
+      "amount" : 550092514
     },
-    "activeFrom" : "1984-05-07T05:56:08.616Z",
-    "activeTo" : "2015-05-21T08:36:35.392Z"
+    "activeFrom" : "1977-01-01T23:20:59.050Z",
+    "activeTo" : "1981-11-16T09:29:02.047Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "RZ9iKFgDpvJvMNEQsj",
-    "value" : "h1XhJCzqE0c"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/f96cd8f9-25a5-48bc-803f-b8999f28ce29",
+    "sourceName" : "vtnfplyzsnc7m@hdmvw22tpuatdl"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "psmUmjRidt0o42Z1",
-    "sourceName" : "olbdeuqslhd@e7pwkfz43pi13owse"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "38BtzAbygzP86sU",
+    "value" : "iJ1lnbATqC"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "2074276721",
-    "sourceName" : "igrqnlqtltd0f@e1odjecmoomhy7px"
+    "value" : "1092210453",
+    "sourceName" : "u7yqivdvgoaq@ew6asmsvxbkoa8"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/e2081177-bbfd-40f9-a63b-aad8e8a22c67",
-    "sourceName" : "accn9a1e8p@cqoqbzxg5f3qynh"
+    "type" : "ScopusIdentifier",
+    "value" : "RFU9yjAuNNPKR7HcO",
+    "sourceName" : "btfil2ljur8ejvjxcyw@xj6p3qbhexy4kbwr"
   } ],
-  "subjects" : [ "https://www.example.org/bc66a67a-2722-480f-90b3-2ba410c63e71" ],
+  "subjects" : [ "https://www.example.org/2078c295-ef46-41c8-920a-3bf221b12585" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1f54abcd-c009-449f-9e27-eb727d7e93b5",
-    "name" : "G6bAvbMwF5lIsk",
-    "mimeType" : "fjqm7hF7A2bGLu",
-    "size" : 769276988,
-    "license" : "https://www.example.com/mvilzhnftmjazr",
+    "identifier" : "c7882b24-05b6-434d-9e63-45011c1866e8",
+    "name" : "5xqMPe5CH5vE6",
+    "mimeType" : "Gd26R3Hkvft",
+    "size" : 1782511529,
+    "license" : "https://www.example.com/t8xi280fmivoj",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "9WG5blHoKt56lIn"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "GLMCyTkUJeBV6xs7S5",
-    "publishedDate" : "1987-05-16T01:18:38.374Z",
+    "legalNote" : "TaNMvcRwB1r",
+    "publishedDate" : "1988-12-01T01:38:41.103Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1499425806@Mq41HpjvuVYEoLIAn",
-      "uploadedDate" : "2004-06-11T07:11:34.360Z"
+      "uploadedBy" : "1289001669@3AhysUZzc871c3J",
+      "uploadedDate" : "2022-06-24T01:00:07.269Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/76B1P5KkB748eV",
-    "name" : "SV15PjE7T1k",
-    "description" : "eMgHe2uyp9hw6DKLM"
+    "id" : "https://www.example.com/WamVarF3iorD5Wg3z",
+    "name" : "WvWvyJ0ZPLk",
+    "description" : "K3AOGG8mgdoNV6"
   } ],
-  "rightsHolder" : "KLXsevvWDIxW769Np",
-  "duplicateOf" : "https://www.example.org/cdb8a2b9-33a6-4618-b77a-5884f003a8b8",
+  "rightsHolder" : "ubUGjSN2DwPnidJl",
+  "duplicateOf" : "https://www.example.org/6d189a7d-8223-4f33-bf9f-af8d71488b51",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "1B8bZFtwic"
+    "note" : "MOE2n4uowf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "eOcwFz89Qt6ABz5",
-    "createdBy" : "sZeVOnDnd51o5b9Xb2R",
-    "createdDate" : "1997-02-26T09:39:25.401Z"
+    "note" : "Oge5f04MyJG",
+    "createdBy" : "gZcPSSYpbR2def1OA",
+    "createdDate" : "2017-05-17T06:23:44.578Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e46dbebc-50dc-439d-b565-8975f5429bec" ],
+  "curatingInstitutions" : [ "https://www.example.org/e918e236-8df9-4da7-b36b-3a3c4499a13f" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "6CSl2xrmaeG45B",
-    "ownerAffiliation" : "https://www.example.org/4ae33a2b-c4ac-470c-8de4-57f521cc6de9"
+    "owner" : "m4hixOehE7vujxVbPnj",
+    "ownerAffiliation" : "https://www.example.org/01866cce-28f6-4f60-a313-198c4233a39f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/01fbafc8-d898-41bd-9b45-213f7f8bdfbf"
+    "id" : "https://www.example.org/c24a2efa-0686-4cf5-a29f-2a44e6f11f00"
   },
-  "createdDate" : "2021-11-08T16:17:27.571Z",
-  "modifiedDate" : "1991-02-10T02:56:24.256Z",
-  "publishedDate" : "1996-06-06T18:09:49.836Z",
-  "indexedDate" : "2001-07-18T07:18:54.174Z",
-  "handle" : "https://www.example.org/a2a42516-8a32-4400-81db-1d211ea50149",
-  "doi" : "https://doi.org/10.1234/iusto",
-  "link" : "https://www.example.org/b95b7819-f17c-44e6-aa43-d6f7f2f6e882",
+  "createdDate" : "1998-03-04T19:29:14.297Z",
+  "modifiedDate" : "2021-11-02T19:00:16.206Z",
+  "publishedDate" : "2004-05-04T18:06:43.559Z",
+  "indexedDate" : "1974-12-27T02:27:08.028Z",
+  "handle" : "https://www.example.org/6d7a0e3e-0518-40f5-b5aa-095159c714d1",
+  "doi" : "https://doi.org/10.1234/saepe",
+  "link" : "https://www.example.org/d4591fda-504b-4e9d-9fbb-2fa1e8c216d9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1X4nm3qHmrRe7F",
+    "mainTitle" : "DDro3Fq34ogbOxzrNDp",
     "alternativeTitles" : {
-      "zh" : "wTMhU1H3yy7u"
+      "hu" : "tUrQAfoz7nQWd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cPrCNT5N2H81fnyJf",
-      "month" : "m96mzQV9ldYY",
-      "day" : "x0XZ4jrwvWjI5gZaJVp"
+      "year" : "E3rgfVKJ5x6Ie",
+      "month" : "G3eej9lKGFZxj",
+      "day" : "oKtlILr1wvqN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/580db8f6-f71d-4112-83d3-c0908a0d4179",
-        "name" : "F5QUC9TPb0wV9c3HIh",
+        "id" : "https://www.example.org/a3ed3e76-cf06-4036-a4b9-d57d393bab48",
+        "name" : "O4Hb1jvVWzL12",
         "nameType" : "Personal",
-        "orcId" : "eJ0zaOFZlDed",
-        "verificationStatus" : "Verified",
+        "orcId" : "TDPSPM6kIBNNYzd",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VXUv1eG5jNl9W9GqZ",
-          "value" : "kUWxSv3OEDQdi"
+          "sourceName" : "IXjymqNc18RuEP3Im",
+          "value" : "2BcenhPC1MxyUkJz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Utz6fzNrgHOlyHDfGRh",
-          "value" : "HCQg3diHEdRKIMLUZ"
+          "sourceName" : "t6Q07qF8Zo",
+          "value" : "c5x2XTdhVDGRVo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e8659ddf-0016-4860-888c-c29ecd8da1c1"
+        "id" : "https://www.example.org/cd6b400d-4001-4b49-b305-ffac8a870c4d"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Advisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,183 +62,183 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5e4cef5a-42fa-4715-b3f7-fa0f4218d055",
-        "name" : "nRRU084YFBTzL",
-        "nameType" : "Organizational",
-        "orcId" : "03rnjtxE3nC",
+        "id" : "https://www.example.org/a1354e05-8f4a-4883-8b06-ebd156a52f72",
+        "name" : "ah6RtRIZuM",
+        "nameType" : "Personal",
+        "orcId" : "mwuCMr8QZTQd5TmS",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fnjsnOoC1OsrU",
-          "value" : "YvO8cAQM4f3kvEN"
+          "sourceName" : "UK4y5GqWG2UcR3khUg",
+          "value" : "iyzz3c6QsibRAmE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EktopsJCh0x",
-          "value" : "UCIg6WMu1oqi7"
+          "sourceName" : "hhLx8ciVDE",
+          "value" : "OoWD2GslTwW1QXmP7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4d1826c8-f878-4abf-873e-fd715685eab4"
+        "id" : "https://www.example.org/28e74b71-e4bb-426f-a3f6-811802d4cd8e"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "4XLHAWtbxjQueoJvRf"
+      "zh" : "WuUURMfIkYlxwhlEfD4"
     },
-    "npiSubjectHeading" : "kJ9PtKgTuAGJxxFmKfv",
-    "tags" : [ "tDQZHs22kKQxnp2TQa" ],
-    "description" : "Kx5wKj3Ziw0GklOxK0",
+    "npiSubjectHeading" : "C3z67LlGpXwvR4K",
+    "tags" : [ "EHeLs3bOKauMpqWW" ],
+    "description" : "eWEU1IoD1S0FtA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/760d6ab2-8071-458d-82e1-f8ff47e01aca"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ca9f1091-4d8b-48d2-b225-d91037ea51e9"
         },
-        "seriesNumber" : "jEXcNvQxXObTQFlO",
+        "seriesNumber" : "GWsgl2ydl9jfNGuwLtd",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2676b206-9e28-4040-83ee-74b2c13e19a5",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fe9c92b3-caac-4e10-bb83-376a29419915",
           "valid" : true
         },
-        "isbnList" : [ "9781980833178", "9781875684083" ],
+        "isbnList" : [ "9780634461002", "9780946392902" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "sq3EN4W8guEjyzIN"
+          "code" : "HYdtLFb7Dk2TUD"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1875684085"
+          "value" : "0946392900"
         } ]
       },
-      "doi" : "https://www.example.org/5fcd8636-3404-4a29-b753-54b40ff77f89",
+      "doi" : "https://www.example.org/457abbd1-be8a-4e0e-b8c6-8d98545d0651",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7nPO9XHtgTz6Vz",
-            "end" : "uoijzgRspRYRo"
+            "begin" : "VlbDgNz8O31",
+            "end" : "nXeN7w1Q19S4"
           },
-          "pages" : "0icipTfij0uR3z",
-          "illustrated" : false
+          "pages" : "QnmC8qAaOH39d",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "vrN8lozlBfEY",
-          "month" : "538v4uLgTQytimxX",
-          "day" : "uyV5y8v6kXlTyQ7m3DJ"
+          "year" : "ZXB4Mfw9zjjU7FBBf",
+          "month" : "hU679kaOeYcLZe",
+          "day" : "cSmPNUcSmgpdJ1MS7O2"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/43e5b70f-7689-4307-9dfd-870f3eda13f1",
-    "abstract" : "uOUlxn5SeXf7ZZS"
+    "metadataSource" : "https://www.example.org/bb53a815-bf50-45c4-a781-f453d9ab0ff7",
+    "abstract" : "74Bbwmpv4aklmC5CmcO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/923e49d5-bc57-4416-ac00-20a024e66302",
-    "name" : "QsADv9B2MyH38S",
+    "id" : "https://www.example.org/a39d0d8a-fe55-42db-b2c4-ea6f0bbd1645",
+    "name" : "OlpRTJliakzhV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-11-20T04:46:36.251Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "B3d5JQyPyMe"
+      "approvalDate" : "2012-12-12T03:30:46.124Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "wLmNyyXOgE9IvBuW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/87e11146-7be7-429f-822f-4cd9a7d4a40d",
-    "identifier" : "bhKDakHhaFI6u",
+    "source" : "https://www.example.org/5dae37e5-17af-4661-84ca-1783f4f41daf",
+    "identifier" : "pe4YrgeUA9eJFwOOC",
     "labels" : {
-      "af" : "g0lDKWajeqTlg"
+      "en" : "KW61HBlVIx6y7w"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 2112902550
+    },
+    "activeFrom" : "1976-05-28T06:19:01.467Z",
+    "activeTo" : "2013-11-17T19:17:32.692Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/442a3cc1-56dd-4983-b21b-46b1fe1328b2",
+    "id" : "https://www.example.org/bda25a0c-4520-4fbf-ac7b-96618ea232e4",
+    "identifier" : "Mu8bdGaMenAr54v",
+    "labels" : {
+      "pl" : "Njm7gJKpyZePjA"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1150297136
+      "amount" : 897658478
     },
-    "activeFrom" : "1986-08-19T05:13:29.900Z",
-    "activeTo" : "1995-01-24T13:57:44.097Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6552fd86-b79e-4d8f-9424-e3d3c1b925c0",
-    "id" : "https://www.example.org/602720bc-c3cf-4662-a5ce-a54080281afd",
-    "identifier" : "btgfaRmEEuSWS",
-    "labels" : {
-      "pt" : "5w5RdK9ued2H8"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1967502194
-    },
-    "activeFrom" : "1982-07-24T03:35:44.660Z",
-    "activeTo" : "1992-01-22T07:48:29.964Z"
+    "activeFrom" : "2023-07-09T19:03:25.680Z",
+    "activeTo" : "2023-11-08T16:05:20.758Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2c2ea1fc-25d5-470c-b578-b55ffb4866ae",
-    "sourceName" : "gjo7w9ay2dmog@ucwi94iknw"
+    "type" : "ScopusIdentifier",
+    "value" : "rHvKopomjutcMZn",
+    "sourceName" : "hmm4oylww54jy7ozey@lsuwahyirwhg"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "qrVNnLPHod",
-    "value" : "8Iwd9FYS6WO"
+    "sourceName" : "bQuGtpjliYnXT26oDA",
+    "value" : "K3D1Gt8X5LAGO"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/83447b63-d7a2-4c50-b03e-a653c6b3ec4b",
+    "sourceName" : "monvknvsni8z@olhv5soemhnuhcgidd8"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1965048569",
-    "sourceName" : "ase9tp66hh@erfhtab4tzgnywxjd"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "Ay6A1BwHkghOnCON7aU",
-    "sourceName" : "fkdxflitrhhcb@yryapfmiuuamjdvvl"
+    "value" : "1188090674",
+    "sourceName" : "l3ih3s6pv5gsxsx4dq@rfzy3fxnck6"
   } ],
-  "subjects" : [ "https://www.example.org/fe9b0752-144d-4643-9546-4b026d9b585e" ],
+  "subjects" : [ "https://www.example.org/3d0cabfa-e5cf-4abc-a8f3-082ef084fa4e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bc29acbd-87ac-42f4-a9d6-c33a7e5a1e84",
-    "name" : "gnda1uL9et",
-    "mimeType" : "snfpkANnbjO6CBtmw",
-    "size" : 1101321750,
-    "license" : "https://www.example.com/7amdgsigvyyiglgjdzp",
+    "identifier" : "660755ed-9451-4c2e-a4e1-028a1c9a7641",
+    "name" : "8TZIoOqtPcx",
+    "mimeType" : "ZVfMinXRDo3higp3",
+    "size" : 1909209868,
+    "license" : "https://www.example.com/w2c0khvjvqwtxmssq",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "jeQkcX8gQMhW8C89b",
-    "publishedDate" : "1978-12-01T09:27:08.537Z",
+    "legalNote" : "7Ais7h8SfkleKW3N",
+    "publishedDate" : "1975-12-16T01:54:30.541Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "446546426@e7S3WFCHP6FKU2",
-      "uploadedDate" : "1972-09-16T06:01:38.898Z"
+      "uploadedBy" : "1551930053@kLssMjuNdy9CI",
+      "uploadedDate" : "1981-05-18T12:56:24.868Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YEpw2ElerjaSiVO",
-    "name" : "rWpQyHRLL4enrL1I",
-    "description" : "9OnYJ5Hf6b1luVy"
+    "id" : "https://www.example.com/BClIjfn0LyGvBxnzZJL",
+    "name" : "8nPac5jI1c7RPvV",
+    "description" : "YuFhkxtjyWNjlMaJG"
   } ],
-  "rightsHolder" : "EXUabIpOoLvdEM",
-  "duplicateOf" : "https://www.example.org/2a2628ed-c7af-4963-b591-f91ba19dde72",
+  "rightsHolder" : "27BMEXCfVqO",
+  "duplicateOf" : "https://www.example.org/bf0875fd-9e73-4403-b3ff-9833b3789563",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "AeSndidBWW04PotapjM"
+    "note" : "dvTUOea5RN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8DH0MUFLgN3CvWbO",
-    "createdBy" : "JGrW0RsdhrY",
-    "createdDate" : "1982-10-19T04:37:45.906Z"
+    "note" : "jAj3p5tVeFI",
+    "createdBy" : "l6X2dIuNEH",
+    "createdDate" : "2024-08-09T19:55:53.466Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/46f2bb46-3151-46cd-982a-7c3ef193faf9" ],
+  "curatingInstitutions" : [ "https://www.example.org/863e3520-7c15-478d-9cd1-2377d49a88ee" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "nLIFegwyivtc",
-    "ownerAffiliation" : "https://www.example.org/2ccc5360-345e-40a9-8a30-b4e7b4345a96"
+    "owner" : "ODIye0vnO0ouvoRT",
+    "ownerAffiliation" : "https://www.example.org/8a617a63-90dd-487f-af1f-ca1f94ca5814"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/07b1fdef-2f86-4de7-8f2b-bea14d12ffea"
+    "id" : "https://www.example.org/376e04d0-1c56-4739-a8c8-2950b4493650"
   },
-  "createdDate" : "2021-04-18T09:15:37.967Z",
-  "modifiedDate" : "2017-04-27T06:37:35.386Z",
-  "publishedDate" : "1998-10-15T07:18:00.231Z",
-  "indexedDate" : "2004-04-03T07:00:12.219Z",
-  "handle" : "https://www.example.org/b88c8d62-3a65-4de5-bc32-1875f8d102b1",
-  "doi" : "https://doi.org/10.1234/occaecati",
-  "link" : "https://www.example.org/7ba5a12b-f603-495e-81b8-65e2811c1100",
+  "createdDate" : "1981-05-23T02:34:37.447Z",
+  "modifiedDate" : "2010-09-19T21:56:31.574Z",
+  "publishedDate" : "1979-08-09T13:04:18.819Z",
+  "indexedDate" : "1980-03-26T07:02:42.247Z",
+  "handle" : "https://www.example.org/e3cb90bc-cb1f-4e01-9a78-cf4efca68f8d",
+  "doi" : "https://doi.org/10.1234/porro",
+  "link" : "https://www.example.org/012994e9-3998-48a2-b417-c0dd18a3ff0c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XJxwxHXMAZU",
+    "mainTitle" : "NCLAe387wwjwLb9X4Th",
     "alternativeTitles" : {
-      "ca" : "dSq45GJHCMRUqV"
+      "sv" : "aztMLhGXkCUdx6P2i2"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wF3GkvE7KD",
-      "month" : "BB6WfwG6Uy7",
-      "day" : "idpsl4WKDQAzE"
+      "year" : "swSpANlkLfRuI0xBvGB",
+      "month" : "yGPYrIKBwLASxR",
+      "day" : "TMP1tsCilOauB4gx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/97f9e319-0c71-4d3c-9a45-fb5f7e756230",
-        "name" : "1wHWj33hbOHleqJGQ5U",
+        "id" : "https://www.example.org/fd414cd2-0458-458c-83f9-85a6ea831fbd",
+        "name" : "uf6AaXiMbr",
         "nameType" : "Organizational",
-        "orcId" : "tnRj2xLSfG6nwhcoL7",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CFoCGA1kN7b9Vhu",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gonmeO2BSqZv",
-          "value" : "ZeGPPFvFPI"
+          "sourceName" : "T3e6qgOM3Fnj",
+          "value" : "tRIb6cvQLPHGVGv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "a6Wew37UgEDiiI",
-          "value" : "ssUrnYNPUPtuzkJN"
+          "sourceName" : "DWQeqRnaFv2TDoW",
+          "value" : "jaKLs5WEN4QTRkWOa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/81c1c5e9-4f5d-4d21-bfc4-e8ea11599238"
+        "id" : "https://www.example.org/a66793f2-df4f-45ee-b278-343ac103546f"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,184 +62,183 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7f2719e1-5714-4433-9ce8-1e2bdff701a2",
-        "name" : "ELSWGvHGVULAT1o",
+        "id" : "https://www.example.org/e0b2aad9-1d08-4792-93ee-e47f8a238a40",
+        "name" : "Pxmpc4vk608k0ecg",
         "nameType" : "Organizational",
-        "orcId" : "KYq8sPX0GgtaUfvpw",
-        "verificationStatus" : "Verified",
+        "orcId" : "cHAUtLPaXtwHX",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SaQ2r6W8nk",
-          "value" : "I4LwG3zcNCs"
+          "sourceName" : "5Yqu4Mdn0jZVXLkGW",
+          "value" : "Ukz95A1VwUVpd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "smzkIgEIF7Z5VVXHE",
-          "value" : "e5nKPH6WTiJXAmN4"
+          "sourceName" : "kwuPUYsQO6zH9Tje8",
+          "value" : "BOPqufJEgbhD0IbRh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/eca0294a-a930-4cda-bc47-c63a6bfdf38e"
+        "id" : "https://www.example.org/073223fb-62b3-4c9c-ade4-47b484713d81"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "xHgRHKwiIgMJZ"
+      "el" : "qTnvEn8Beg3cnLyf"
     },
-    "npiSubjectHeading" : "aw0pJ3zPPe32m1J9OgD",
-    "tags" : [ "fyj6JzmWMDg50bOL" ],
-    "description" : "oAhIuviDsCsjB",
+    "npiSubjectHeading" : "cbwcSxMPyW",
+    "tags" : [ "bgHReaYxIpP13y8D" ],
+    "description" : "tPgOKG9VZel1y",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/10a73061-a149-46bc-a352-cf28ee61ad41"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f559bdf6-65c6-4d2b-b641-92b6f8409c7b"
         },
-        "seriesNumber" : "lLopnkZg8AD65",
+        "seriesNumber" : "9lPslJCbWv7jUsRBB",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/79427ebf-7914-4be0-83d8-c1fc917fe927",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/15e4a386-8649-4051-a671-e0360f2cbf81",
           "valid" : true
         },
-        "isbnList" : [ "9790828728972", "9780955919732" ],
+        "isbnList" : [ "9790298824938", "9781974412747" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "qrkPwxL3TK9j6gD2h"
+          "code" : "Ep3M8gnW3KcUIhUk36"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0955919738"
+          "value" : "1974412741"
         } ]
       },
-      "doi" : "https://www.example.org/b4e0fadb-8011-40fb-a71f-d523884b295c",
+      "doi" : "https://www.example.org/9dc66e90-6ead-4932-b18c-353c8049f010",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "9H2eyeOPTy0hWA",
-            "end" : "IUMq6COuozYlPbm"
+            "begin" : "MSC9MVL85D",
+            "end" : "AeRZlWDlzFfW"
           },
-          "pages" : "HeKHDfT8gDpKcdmXdw2",
+          "pages" : "fzChWdPx9M2e1",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "CEx9kdml5sjHAX0h",
-          "month" : "uw8iwbHBHq34u",
-          "day" : "uUkjzKwwJpSuag"
+          "year" : "Ed1Ec3sHHHX",
+          "month" : "TMgcjDz99Rfu",
+          "day" : "VKpIx1r7MbAmB"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/058dcb59-b0a4-408d-bf20-d184d41d0693",
-    "abstract" : "JTFQzgVOCKHO"
+    "metadataSource" : "https://www.example.org/01ed0323-91b3-4a17-bfe6-f803e2d47b44",
+    "abstract" : "YgwfbRXhySC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/65e37637-f16b-4c4f-96cd-47ef2d3a3262",
-    "name" : "2CoAp5vja3cD3nz",
+    "id" : "https://www.example.org/557fa853-e25f-4908-8d04-7d658afee30a",
+    "name" : "0rzGcRFjvnFItGrE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-06-21T01:56:50.777Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "mpHmBlz1StK90A"
+      "approvalDate" : "1993-12-13T19:31:41.098Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "RVChZFTKKydcY6BWXd"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f40f09e7-df16-4425-9cf5-11902175c480",
-    "identifier" : "UA5hqKXEsVFVU",
+    "source" : "https://www.example.org/95923698-ee1c-4d4a-992d-f082ba58ff46",
+    "identifier" : "wkdAPFIIkcQv7pTz",
     "labels" : {
-      "de" : "f9fM6ZNDyOj"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 377987850
-    },
-    "activeFrom" : "2004-09-09T07:15:52.185Z",
-    "activeTo" : "2014-03-02T23:20:11.739Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cdf68f49-f37f-42c9-b6ad-2b264f826df1",
-    "id" : "https://www.example.org/d936f7ab-4b18-4151-8817-982785043d33",
-    "identifier" : "r4UtnfP1nrr57ZrFxe",
-    "labels" : {
-      "pl" : "jwMpXfgBAse"
+      "bg" : "pAhgVXnioGMt1Mi1"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1893492214
+      "amount" : 2052024090
     },
-    "activeFrom" : "2022-03-27T02:25:53.258Z",
-    "activeTo" : "2023-11-16T14:57:46.557Z"
+    "activeFrom" : "1976-10-12T04:20:12.226Z",
+    "activeTo" : "2003-07-02T08:09:20.812Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/426d58fb-d66a-4e02-aca6-8383cdd9ae79",
+    "id" : "https://www.example.org/fb5d41f1-3203-4bb6-a5fa-d21183a71a29",
+    "identifier" : "ZPVBpBfTL918Dr",
+    "labels" : {
+      "hu" : "VVQsFyLzy9M"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 798692386
+    },
+    "activeFrom" : "1983-12-27T01:18:50.634Z",
+    "activeTo" : "2004-12-16T16:46:45.934Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "zgpaxsI9O7k1qF",
-    "value" : "GYNl4ATmOpLl3"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "NZAfPhZt40tn",
-    "sourceName" : "fqj0qxqnxynha@pp6rw8ccw9i5"
+    "sourceName" : "CsY3vwhrdTX2PU",
+    "value" : "iAgJNYAy664J"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/85e68fe6-5d77-4b5c-8a82-eb9ef85724c8",
-    "sourceName" : "b7kukykeqys67ufc@lli0v5gcrfq2s2fjyqy"
+    "value" : "https://www.example.org/cbb8eb6a-ce89-479b-8b25-5f44881bbf48",
+    "sourceName" : "pzwdldlokhvq@yol7oqhookx"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "845468162",
-    "sourceName" : "jzcbixiw4g7mkedfpnx@zbgp6qpexpnvrw"
+    "value" : "734378227",
+    "sourceName" : "qqlzmula73dzlh@d45eej1rydudtw19cp"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "U27NOaAJT3obtu6rPV",
+    "sourceName" : "lvir3tebfphx@ofjclxhgbe"
   } ],
-  "subjects" : [ "https://www.example.org/fd2842f4-135c-4583-b13c-bc295c700d91" ],
+  "subjects" : [ "https://www.example.org/7797ae8f-b53b-4a9b-b45f-c0b960fa31ec" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5bb96b7d-5d79-4e41-8e04-3f562fee3d58",
-    "name" : "8hBAUTjjebWdPo",
-    "mimeType" : "uwpvRLsiHO",
-    "size" : 1821963430,
-    "license" : "https://www.example.com/vx0zbmwejjjtz5omwm",
+    "identifier" : "910f55aa-8851-481b-8b8d-64f7a46e08f6",
+    "name" : "WF8KCQrXyqZeIgH5J",
+    "mimeType" : "JgvLe2BHBYYeQbxlre",
+    "size" : 1701113415,
+    "license" : "https://www.example.com/mpmjlm4hp6wc",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Sk7O2O4hFKjepn6OD8"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "lNWIMLtDblAybs",
-    "publishedDate" : "1987-09-27T02:17:58.315Z",
+    "legalNote" : "CfoNPJzmAND1o5",
+    "publishedDate" : "1986-08-14T02:04:51.150Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1636172749@RQT6hGMfpRhywe155t",
-      "uploadedDate" : "1990-03-09T22:09:38.989Z"
+      "uploadedBy" : "417311388@KXqRDC3QvN3kQng",
+      "uploadedDate" : "1982-06-03T20:21:59.097Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8UBUvadC9qBel4",
-    "name" : "fNEIWsOHHlJCZigNS",
-    "description" : "k6FIQXMDu9nix"
+    "id" : "https://www.example.com/KRYgYYlN9B7MYzxf",
+    "name" : "nthTp8awvPUD0snxrZ",
+    "description" : "FpqOdTvRRrVO5TLLNz"
   } ],
-  "rightsHolder" : "RqnARy6u6aBFisnr",
-  "duplicateOf" : "https://www.example.org/639dc542-cd36-4706-8db3-0e396eda6873",
+  "rightsHolder" : "UDmwOvIdFXSycWlX",
+  "duplicateOf" : "https://www.example.org/9ecca75f-8d6e-43d8-b74b-995de7d0c0c2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "US8kKGZVm0JFZ"
+    "note" : "ZPqoCuFoAaFd71Gi1x"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "gLdzwpIDVVNIiZgzm",
-    "createdBy" : "5luqmMLqsL6",
-    "createdDate" : "2021-08-05T10:55:26.343Z"
+    "note" : "0Vrql6yG2JbvGNzvMh3",
+    "createdBy" : "augJxwmTfMwpTea0f8I",
+    "createdDate" : "1971-11-29T08:15:49.502Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/118236bb-53df-40ac-819f-af0073a280ec" ],
+  "curatingInstitutions" : [ "https://www.example.org/d5e3f2c6-01b3-4389-8a85-f390219ec660" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "JD1eajkvQRz3BS53",
-    "ownerAffiliation" : "https://www.example.org/ed9a7c17-075d-40c6-bb34-3e52106e24e7"
+    "owner" : "1K3vGunI7Z",
+    "ownerAffiliation" : "https://www.example.org/20b0a67e-fb70-41ba-91e7-40b84194331b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/30b3ec01-7362-4bf3-907e-f671204ee706"
+    "id" : "https://www.example.org/99fc5e18-f5af-4b69-8074-8d7e8dd80d47"
   },
-  "createdDate" : "1984-06-19T11:15:42.052Z",
-  "modifiedDate" : "1987-12-20T07:33:59.170Z",
-  "publishedDate" : "1981-03-20T04:47:16.908Z",
-  "indexedDate" : "2010-05-26T21:54:42.810Z",
-  "handle" : "https://www.example.org/55868aae-ddcd-419d-9451-4bc337d8b1f3",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/a80c677c-5c37-4a5b-b3aa-93778caa9f52",
+  "createdDate" : "2007-08-01T10:58:53.724Z",
+  "modifiedDate" : "2016-02-10T04:50:41.373Z",
+  "publishedDate" : "2007-12-18T14:45:38.589Z",
+  "indexedDate" : "2021-02-11T09:21:34.700Z",
+  "handle" : "https://www.example.org/b5c40034-a26e-4215-9373-54b8dce2790e",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/1e0f67a4-1adf-4285-b88a-fe968e1940a2",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ozypgrQHAppYQNmzHQ",
+    "mainTitle" : "4EaZLDcKPnqF",
     "alternativeTitles" : {
-      "pt" : "EuL16KtVHVMyRpt"
+      "hu" : "w05Gku0E7Bu38A"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "51KtkjB2buKKz",
-      "month" : "eTxYveI8V0fVVEjc",
-      "day" : "FScBbIbqct31sVCFi"
+      "year" : "sM9VmCfLxTSfan",
+      "month" : "tVbJV9mxKMcoi",
+      "day" : "YlZacNUNWqJy558"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/929de9cd-151e-4702-9e8a-bf0de906d915",
-        "name" : "g6uWXa0DOFAnEv",
+        "id" : "https://www.example.org/77c4ad44-0979-472b-ae1d-8d41e5e22a60",
+        "name" : "EHpOChs0yT8f9J",
         "nameType" : "Personal",
-        "orcId" : "xJVk1J4rsSO",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "bAfhTA2aR4E4i",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "osW8MZ3Z2Qhc",
-          "value" : "OQT1eUWxMqE1"
+          "sourceName" : "Te9Lqgfu1mTyGt",
+          "value" : "ALvtKoaWfEpzOS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kstfRPRJrP0oL2nlWg",
-          "value" : "FWcNNXXvpyILM"
+          "sourceName" : "2imcVjm1aNdJd9NjPsl",
+          "value" : "tw13zwPOY94NCSZVqOr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/da13dee9-ecef-42fa-ac92-451fad15db29"
+        "id" : "https://www.example.org/d9790116-32fa-4f0b-a9c3-331cfd6203fb"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,183 +62,184 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bfffe795-0ab8-4067-9d76-9d6564eb3048",
-        "name" : "zUM8XXckonHlaJ",
-        "nameType" : "Organizational",
-        "orcId" : "S7NVAT0FYms1M",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f3acd18f-e5d3-4412-9640-aa109a230a2e",
+        "name" : "8i4Dn0Kd3k0",
+        "nameType" : "Personal",
+        "orcId" : "c0bpL69jk3sYNxx",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QsYRYYUV3VbuXgB",
-          "value" : "I8adwij88ZQWQ9D"
+          "sourceName" : "HOYjTt34KNJOKEG",
+          "value" : "L78Ht6K3EP6WReXTwkF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ONL3CgZQEtGApO00",
-          "value" : "fmNo2aCuFE6"
+          "sourceName" : "GK0GYQIjbjymqcm",
+          "value" : "cCdvQZZBqsaY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c6cc8720-f063-4864-b651-b64022e27695"
+        "id" : "https://www.example.org/43daa122-7080-4a5a-8b61-4e7489ca26b8"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "Fr99WBMXLavm52Xt6"
+      "fr" : "WSW9Kxg2woi"
     },
-    "npiSubjectHeading" : "6byTOiTQbDRsNN",
-    "tags" : [ "A9nLsQ619EZowbI8" ],
-    "description" : "5VePGHLx2XJi8",
+    "npiSubjectHeading" : "ayq8VGW3ZvR0QkN3k",
+    "tags" : [ "XYd0ScVaSrlc4l" ],
+    "description" : "Q2jdbUSFwR44P",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3c3a5481-62b7-46bb-9708-1ecdc3bade9d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6dc0a8b6-ff7d-4fde-8d80-3950d58c2d36"
         },
-        "seriesNumber" : "vo4fNTb5mxetR1Fg0FO",
+        "seriesNumber" : "XiS9ADnY0coL",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/128c72fd-a7b8-46ca-a00f-2a4f8390bfeb",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9bd0d297-91c4-41af-a1b1-e7af6bbc2b41",
           "valid" : true
         },
-        "isbnList" : [ "9790863350657", "9781519486271" ],
+        "isbnList" : [ "9780951306857", "9780771624469" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "9QBt4jHNbJ"
+          "code" : "o5sre9vFWh9iUCK"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1519486278"
+          "value" : "0771624468"
         } ]
       },
-      "doi" : "https://www.example.org/b9220bd8-2708-4145-8947-694521bd88d0",
+      "doi" : "https://www.example.org/b421aa69-2a9d-4fd0-9884-19e21b290f4e",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "OXjDBMHXYViWro",
-            "end" : "9KoQ57e1TgGixvOp69"
+            "begin" : "U9kOF2j9SULL",
+            "end" : "IgVdpYN5wfXuqSIUQff"
           },
-          "pages" : "3u3TloHeTAhmnAkIjiC",
-          "illustrated" : false
+          "pages" : "PNh8IX18jZpI5WvNUci",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "0RvMm413UyXmJCY",
-          "month" : "jBOuJt8sUn",
-          "day" : "3P1FP4nEoZ"
+          "year" : "LHZ1k2n6RCBPt",
+          "month" : "yJu3ECOC4t1KN46",
+          "day" : "XFaT6UeePPkx6"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4511038a-ddd7-4c0e-9368-9234ab89a45b",
-    "abstract" : "FxS3nJKgk7PjCG"
+    "metadataSource" : "https://www.example.org/573bb547-c0f6-46cd-9933-93bf531bca74",
+    "abstract" : "YXRYJoJgWIJlSKY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/001fd858-e1f3-4e16-9405-98ca82cd9718",
-    "name" : "4YPDGcv6MDL3kMDJ15",
+    "id" : "https://www.example.org/cdc11842-e46b-4c13-ad32-f2bde4b47e3e",
+    "name" : "F2cBL6pAdHDV5Mz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-10-25T04:14:44.913Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "2gcCISdmn5FcuL4"
+      "approvalDate" : "1995-11-10T10:06:18.389Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "NhPzHC7t5Ga"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/03ac5e42-c180-4634-9642-27eb4ff06266",
-    "identifier" : "ZJlaVj8NL3yxuf2W",
+    "source" : "https://www.example.org/9c64911d-fcac-4fad-ae1f-4c2ddfd62995",
+    "identifier" : "qwScb6AhgR9PLbY9W9",
     "labels" : {
-      "af" : "jpHpXbkq7zF"
+      "nn" : "91o8S9PTQzHqSjE74WA"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 966970584
+      "currency" : "NOK",
+      "amount" : 680446028
     },
-    "activeFrom" : "1974-01-26T22:57:07.620Z",
-    "activeTo" : "2024-08-08T00:08:57.873Z"
+    "activeFrom" : "2007-03-14T12:20:49.300Z",
+    "activeTo" : "2011-10-31T04:13:02.631Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d272ac67-cd8b-4564-b9ae-72633ce6c622",
-    "id" : "https://www.example.org/54a20fd3-dd16-442c-b770-da0506ef38be",
-    "identifier" : "IoIiIUyy3AN9YHE",
+    "source" : "https://www.example.org/65bc1a70-bf81-450e-a6f1-3fcf7330105c",
+    "id" : "https://www.example.org/30fa5e24-4478-4412-a4dd-7c8512e6f0a3",
+    "identifier" : "TFRamLHJW8sLVCsPYY",
     "labels" : {
-      "fi" : "NrLPpZWN3S0lcs"
+      "pl" : "mp750RE2AK"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 714723700
+      "amount" : 29000639
     },
-    "activeFrom" : "1974-09-03T11:59:15.602Z",
-    "activeTo" : "1984-01-26T09:08:48.035Z"
+    "activeFrom" : "1990-08-02T14:42:42.334Z",
+    "activeTo" : "1994-01-19T14:04:45.263Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "nkQsGXXJtah",
+    "value" : "fF41eEMfwqHKopl"
+  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/cf8a7c4b-2a72-4332-991c-18ba81010dd1",
-    "sourceName" : "pbxovklzrtc6ictd7ri@6ooj0gskwwtr"
+    "value" : "https://www.example.org/c2fa9692-55b5-4fb8-ab76-4601b702804e",
+    "sourceName" : "ai3um9yq9yyz@jlchwmzn9r"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "T1C44k7QurE",
-    "sourceName" : "oramgujwdmfats5qp3b@0dgnzdu9wm7voc"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "2p9S1CqhqZCC0zXFNB3",
-    "value" : "bO40JnlQSj"
+    "value" : "mqF53JZUv7VvE6VX",
+    "sourceName" : "nszxeg3trppp@ljq7zgcjmfj"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1707910431",
-    "sourceName" : "hp9s1tlhizrxcmo9@1mll9uk2xfswa"
+    "value" : "1379685037",
+    "sourceName" : "4zbhbixpxgrxme@nlv3mfd0wwfwxtsy"
   } ],
-  "subjects" : [ "https://www.example.org/8f0021ae-4e75-4560-a78a-32ddca5b8b77" ],
+  "subjects" : [ "https://www.example.org/1831108b-2153-4106-8862-1e12929b9c56" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2752dbe9-fdcb-414d-b3e5-df82b0125697",
-    "name" : "1NY50XbVBt77KGSli06",
-    "mimeType" : "sAq38Y6J9G",
-    "size" : 1532904983,
-    "license" : "https://www.example.com/xjyeppdaksjouoyjg",
+    "identifier" : "177ff712-a795-4d77-b275-0922adc94f22",
+    "name" : "f0QLNQdY4g",
+    "mimeType" : "yAmlvNvpeVdLc",
+    "size" : 1810262785,
+    "license" : "https://www.example.com/8q1i0ofjvywub9jwl8p",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "FXtEbPIdgDpRDjNZ"
     },
-    "legalNote" : "sMwwJ5dwy0f4xsXx",
-    "publishedDate" : "2007-12-10T17:46:30.848Z",
+    "legalNote" : "vyO4cGAjpU6QT",
+    "publishedDate" : "1992-06-07T01:48:15.316Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1921376205@tsVVNBKsCWl",
-      "uploadedDate" : "2019-06-24T02:04:58.792Z"
+      "uploadedBy" : "1340745214@Qkhnyitix0kjfI",
+      "uploadedDate" : "1989-12-02T06:27:02.208Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5R0kiI2A2n",
-    "name" : "4DViBN2TrsanigRSH",
-    "description" : "hfweTGuVwieXevF"
+    "id" : "https://www.example.com/HFaPcvHg8QvlQswJh",
+    "name" : "zSSvp0xOczM4xGYmYmW",
+    "description" : "Raps8vGRATsPGt"
   } ],
-  "rightsHolder" : "EqZRORuQ0LLDOhuO4",
-  "duplicateOf" : "https://www.example.org/ba5e6336-657d-497b-93d5-bf9e6d09fcf5",
+  "rightsHolder" : "PZtjZjPnu7Yh",
+  "duplicateOf" : "https://www.example.org/6091a790-4766-4d96-83f4-56adb9ee98a3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "43sE2KwpZh1V8RP"
+    "note" : "Gf22LxEzMHCMkr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vqOCNuUaWMNSJbvL",
-    "createdBy" : "EpVhY3P03g9xL",
-    "createdDate" : "2003-05-14T10:00:18.087Z"
+    "note" : "K5oCM3wTZ9wrpAy",
+    "createdBy" : "ZXHadtRH63YpHvX",
+    "createdDate" : "1971-11-17T18:52:28.139Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d4a999ad-452b-402b-862d-9982b20ca4e8" ],
+  "curatingInstitutions" : [ "https://www.example.org/31422cca-65a6-4db6-9f86-722dc73829dc" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "QKdGjCma9s4lgGJ3O",
-    "ownerAffiliation" : "https://www.example.org/7d7fe134-74a8-45f0-a1b1-066020311835"
+    "owner" : "oktcuRANSL",
+    "ownerAffiliation" : "https://www.example.org/6ddd4fb5-d260-4ccf-952f-62368aa02ea5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/40289d75-f8b3-4210-8fe3-443a412292f4"
+    "id" : "https://www.example.org/b2057015-52a9-42df-a39d-5bbdf66c5c00"
   },
-  "createdDate" : "2008-08-29T03:27:32.769Z",
-  "modifiedDate" : "2009-09-12T13:15:17.100Z",
-  "publishedDate" : "2022-12-20T18:58:09.625Z",
-  "indexedDate" : "2009-09-06T10:27:19.666Z",
-  "handle" : "https://www.example.org/3c861725-a71f-45dc-8ffc-8d65f33db841",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/ac0daac1-b494-4869-9768-2d8c2ea2f4af",
+  "createdDate" : "1993-07-23T05:48:04.990Z",
+  "modifiedDate" : "1989-03-27T06:26:52.423Z",
+  "publishedDate" : "1985-08-21T14:22:59.485Z",
+  "indexedDate" : "2018-06-16T17:28:09.851Z",
+  "handle" : "https://www.example.org/bc5cce8c-a7c9-4182-af10-37940edfa2b8",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/2d67c61e-3135-47d9-bd70-fd47ba323bee",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IPZliBsJlz4lRPTjP",
+    "mainTitle" : "gU1vN1HFMMZW2X",
     "alternativeTitles" : {
-      "ca" : "0cvFgRCOBfYHrUeT6"
+      "it" : "q6uCToYfzhG7UkD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GgIHVdWiCBB",
-      "month" : "7Fy8cLMaNToK",
-      "day" : "2nnn4ebmhW82"
+      "year" : "wg3E6zHPR9jGAr9WlZ",
+      "month" : "vZluLxELoOTdgFm9Atm",
+      "day" : "4TNQcQspQgh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/45247e4d-e927-49c8-b683-1d811f35da11",
-        "name" : "gMnOpJ3j41GE2WuD0Te",
-        "nameType" : "Personal",
-        "orcId" : "mDUIP7a1RqF7I5nTn",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/a878c3a2-b7a6-45b5-acde-8bc39502b7d5",
+        "name" : "TRGNdfBreSvNnTo",
+        "nameType" : "Organizational",
+        "orcId" : "2oGQCQRHTW2y",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HwmKiM82BIGJe8F3i",
-          "value" : "F1r6gpf2mrt"
+          "sourceName" : "RzKiJ58HlTuzm5Pzc",
+          "value" : "goLF7Il2JlK8wGEHe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "etNZK6JzScVlJdv",
-          "value" : "GgkksXIrebMwmz2X"
+          "sourceName" : "SlLL88MvOJWwOG",
+          "value" : "ZLvKOB2ibz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e0cefdde-68ac-4c52-bc56-414e6195af1f"
+        "id" : "https://www.example.org/102a9420-ca06-453a-82f0-9535c479439a"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,190 +62,193 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fb009b4d-ae4e-42d5-85ed-d069e3859603",
-        "name" : "N7o6p9R5UAQvd5tmrZ",
-        "nameType" : "Organizational",
-        "orcId" : "SNdrcBEiHNZZh60GJMl",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/7eb241df-78e4-498c-a9ef-c55ac1d8abd2",
+        "name" : "LdqIvxDTwuMb",
+        "nameType" : "Personal",
+        "orcId" : "8Z0kCM71emXt",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YY2T3q1uxhXx",
-          "value" : "N1hGiH5lrU"
+          "sourceName" : "p08i5eh46adE2hQkHL",
+          "value" : "A4YeNgFY3Izv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7wXyyVMgVOC1J1RP",
-          "value" : "I0fW0Knq6qTuQk4tX"
+          "sourceName" : "HFdqEB3maOWYgzD4jz",
+          "value" : "POtpONzQdGS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b9286fa1-bd31-4d36-abbd-e570da837d0f"
+        "id" : "https://www.example.org/c5df1f3e-6f64-4f18-898b-c707a27cf20d"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "PSwFZPHWQw"
+      "es" : "fDBuMO6xXAusRchP9fh"
     },
-    "npiSubjectHeading" : "0in8WgK2APvDyv68",
-    "tags" : [ "UE7DjxgCd7ksFH" ],
-    "description" : "EXHtJHxk9FVkz6P",
+    "npiSubjectHeading" : "rDcgGbqvJ7urDC3",
+    "tags" : [ "bxKtzwdemOhn" ],
+    "description" : "hvQ7m9pLU2S1RR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bc39f288-31bb-4ef1-887e-215f2930da3c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/720b08c8-4599-42d1-8ed8-c35eb3ea052e"
         },
-        "seriesNumber" : "3PyVynv4tuk",
+        "seriesNumber" : "i42ljg4ONzh67EdagL",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/084e094e-e1ec-4742-9ee8-a2bed2014cfd",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9f00bd56-70ac-4b90-95e1-2cdb0018ea5e",
           "valid" : true
         },
-        "isbnList" : [ "9790577816487", "9780825771880" ],
+        "isbnList" : [ "9781478143475", "9780774754781" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "qVE9C4zYbxLInOZ17LA"
+          "code" : "vi2R5FHEmS3S6WwglCe"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0825771889"
+          "value" : "0774754788"
         } ]
       },
-      "doi" : "https://www.example.org/f3a3bc42-c279-4e0d-9ae7-a8dd6e8d21c1",
+      "doi" : "https://www.example.org/252b573b-5d54-48c7-aaf2-d8fe68e4b24c",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "qQLIExazRv7",
-            "end" : "Qt7dZOd3mpxRUSEL8"
+            "begin" : "QMGpUR9joklJG",
+            "end" : "PaxtYNbYwyq3fojyzH"
           },
-          "pages" : "VEojNFxgzeOBzR7",
-          "illustrated" : false
+          "pages" : "aIYpZHEEVNbKvsC",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "0WgTySPUl8QxC2hBlu",
-          "month" : "WBsrYc9onuVnh",
-          "day" : "O0eL3u9mwDFURBEMC"
+          "year" : "klRcwKNI95BY",
+          "month" : "H8VuamUOmFRyc6vE",
+          "day" : "XbMDAiHG0c1a"
         },
         "related" : [ {
           "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/PfLXGxLL2xE3ingp"
+          "identifier" : "https://www.example.com/bCemphxDrSS6JftH",
+          "sequence" : 1825314767
         }, {
           "type" : "UnconfirmedDocument",
-          "text" : "IIYjkwB3xLPm"
+          "text" : "GiLBNBO6X41",
+          "sequence" : 1285452849
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/9681543f-4ac7-4366-8658-c56b9f64e9b0",
-    "abstract" : "ZoWD9px1mibu"
+    "metadataSource" : "https://www.example.org/ae5d5162-33cb-45e3-b8e8-187cae896163",
+    "abstract" : "C9JL0k9Z6xm9dMPNb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/da6d1aad-eb09-4203-b1e3-e892414bc9fb",
-    "name" : "UhXndBtOw9IKhfbiH",
+    "id" : "https://www.example.org/61b6072b-d1e6-4f80-aca5-04e2ed575bd3",
+    "name" : "oWygXuZSA92",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-07-17T22:38:29.455Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "eazi5kvQlZq6"
+      "approvalDate" : "1992-07-17T12:54:58.242Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "P4EQ9ghOqAjMDFiGa0o"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8a243546-122f-4f40-b0dc-a37ed1a6caa7",
-    "identifier" : "bKgKlESUxuY",
+    "source" : "https://www.example.org/36b1b114-ba06-43f7-8145-96fa7a464245",
+    "identifier" : "MIvCanqxazstEGrvf",
     "labels" : {
-      "zh" : "hlZNStLDPiVNshgt"
+      "ru" : "cUf3gpfWtC"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 637961336
+      "currency" : "USD",
+      "amount" : 1115230797
     },
-    "activeFrom" : "1979-03-03T12:41:46.902Z",
-    "activeTo" : "1980-07-12T18:35:48.335Z"
+    "activeFrom" : "2018-08-04T18:24:39.326Z",
+    "activeTo" : "2020-11-03T01:01:05.565Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f7e85452-eb67-4cc1-b622-5893901c0529",
-    "id" : "https://www.example.org/76ac3210-8327-4c73-8476-59989ea03ef1",
-    "identifier" : "Lj3vFYdLmCgkPK",
+    "source" : "https://www.example.org/2ef65556-bbd9-483c-ba8f-9d478b8fecad",
+    "id" : "https://www.example.org/748a813d-1cae-42f5-b558-c2bfa95b6c05",
+    "identifier" : "AZRrt5rOUUA2zth",
     "labels" : {
-      "nn" : "OPIq1UpTgdTu"
+      "pl" : "kRwY1EwxW2TJnH"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1823032531
+      "amount" : 1478757360
     },
-    "activeFrom" : "2000-05-22T14:33:56.364Z",
-    "activeTo" : "2009-04-06T08:10:17.493Z"
+    "activeFrom" : "1998-05-01T22:52:35.701Z",
+    "activeTo" : "2013-11-18T00:37:04.518Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/9c00f6a3-b188-4dd2-bc41-ffa526855619",
-    "sourceName" : "aedc41wg7gf@zcphln0adt7fpgveglj"
+    "value" : "https://www.example.org/a036eeba-f5e4-48ae-8056-0062bf6a8c8c",
+    "sourceName" : "ugdtkufku5e9sy@l8xabuumhzk6"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "544548865",
-    "sourceName" : "dh4q1imbiylrkz@o6qgigx8yg"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "4NvOk4a7aOgQtG",
-    "sourceName" : "en8pobr3e7@enfdzaatsllq6fdor"
+    "value" : "1646743951",
+    "sourceName" : "dt63thbnllodam0iw@eoe7kemcbsrk6d"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Don2JfjAwm",
-    "value" : "mo9ufpvEA69enOyaor"
+    "sourceName" : "A2OkmP4wWBjT53ntW",
+    "value" : "eOB2oKvOiBJ8vV"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "FNWpWEwuvxfWMQ2N4rD",
+    "sourceName" : "5p3nxhgkixljmawbs@ztw1mzmmnwvu"
   } ],
-  "subjects" : [ "https://www.example.org/0faf5ed0-c277-41b3-bf2b-6e71ce835c0a" ],
+  "subjects" : [ "https://www.example.org/9ce1bc9a-de4a-4592-8f82-77b562d17596" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7c4fd896-8dd2-40ca-b2f5-1d04ac36d6a1",
-    "name" : "clc5GVWVkMsaL",
-    "mimeType" : "gMVfx0RU1GDC6H9h",
-    "size" : 77112471,
-    "license" : "https://www.example.com/thf0ckpi79",
+    "identifier" : "efd5a783-a975-4b86-b309-d974ec7e2034",
+    "name" : "F0c5AteNhu1PYtr",
+    "mimeType" : "t83fkVYm9PapnabE",
+    "size" : 1060935812,
+    "license" : "https://www.example.com/ozuui9lwqo4zli",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "y1QEwD5A6qwMPF2R"
     },
-    "legalNote" : "H5M5SqWBkbK",
-    "publishedDate" : "1999-06-07T07:27:12.210Z",
+    "legalNote" : "UqcJmKNf2jOENs4PWa4",
+    "publishedDate" : "2020-04-29T07:29:45.914Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "604200506@fPTLmlP45xA7cMzYjM",
-      "uploadedDate" : "2015-04-25T05:32:33.864Z"
+      "uploadedBy" : "385144871@olo17BuKThLL7aK",
+      "uploadedDate" : "2023-07-26T00:53:58.465Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gfYGSdUjFavG73",
-    "name" : "JivmGdiUSG2",
-    "description" : "xEFSqmYQXskY"
+    "id" : "https://www.example.com/Op5DrQmZrwWANRF4y",
+    "name" : "8OmixBu1lGcC",
+    "description" : "DfueeoYmM9A"
   } ],
-  "rightsHolder" : "JdGYz6m0F48Vo",
-  "duplicateOf" : "https://www.example.org/5d6d64d6-c86c-40ed-9840-bc85473d35e4",
+  "rightsHolder" : "3AX5AqUOW4",
+  "duplicateOf" : "https://www.example.org/f7be98ed-9d52-4b91-ab36-93b387120758",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "2BEd6l7r2KCBHCq"
+    "note" : "7hZM4kqacajc2y"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sXHXo9lMKog",
-    "createdBy" : "mj7vTg5v9Sl9uS9w",
-    "createdDate" : "2021-02-26T15:47:02.299Z"
+    "note" : "vyAlxr1foMmGMkd539",
+    "createdBy" : "JAya6FjFUi99zJ4M2sg",
+    "createdDate" : "1978-11-28T08:01:15.445Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9c9226fb-0c4f-4c79-947d-86dabcbf39d3" ],
+  "curatingInstitutions" : [ "https://www.example.org/48b0214b-9438-4c5a-88cb-8bceb2d8f418" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "FNlFEn3rL0E86",
-    "ownerAffiliation" : "https://www.example.org/a555f34d-321a-41c6-8998-bebd3eb53d4a"
+    "owner" : "l1H8e5jkaY",
+    "ownerAffiliation" : "https://www.example.org/aa7b7769-0759-47a2-8a5a-ae34f8ca916f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/25cf75ce-5581-464b-a0d8-b5363df8c487"
+    "id" : "https://www.example.org/ee6113ef-ed7c-4f4c-b102-4c5277f51da6"
   },
-  "createdDate" : "1971-07-15T08:31:44.114Z",
-  "modifiedDate" : "1982-04-24T17:02:41.313Z",
-  "publishedDate" : "2023-11-29T04:18:22.546Z",
-  "indexedDate" : "2010-03-10T08:47:58.430Z",
-  "handle" : "https://www.example.org/9829660e-3b03-4030-bafe-051ae8560252",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/308575fe-8c05-4272-a6d3-084370ffbf4d",
+  "createdDate" : "1982-01-19T20:03:16.110Z",
+  "modifiedDate" : "2001-02-16T17:57:04.177Z",
+  "publishedDate" : "2015-09-19T09:42:45.444Z",
+  "indexedDate" : "1998-12-13T01:03:31.282Z",
+  "handle" : "https://www.example.org/f403c703-415b-4e38-81d2-6b52e87fd61c",
+  "doi" : "https://doi.org/10.1234/autem",
+  "link" : "https://www.example.org/bf722cfc-50a7-489d-b476-4ef965d1cfa7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lokROKrB8PyPRs",
+    "mainTitle" : "UMuF3mqZLaRLjC",
     "alternativeTitles" : {
-      "pt" : "R4eZRfwMkMIjYvyR"
+      "is" : "fooDv4Web16AkphB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Tkcb1UImJu8ghau",
-      "month" : "XQEDWXlhrsTqx6Bb9ax",
-      "day" : "axhjUmHr7N4kt"
+      "year" : "StA9sPNZskaEPZw",
+      "month" : "Fg1LHtD1Vcec394JlHf",
+      "day" : "jvpiisbQaE9pjGnn"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/407d3067-4c9f-47b9-b162-b087a118dcaf",
-        "name" : "6Bg9tVi7TBFD2",
-        "nameType" : "Organizational",
-        "orcId" : "BGsvr6Xn0q",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/16a4bb3c-45f6-492d-8405-782e4e77ccac",
+        "name" : "PsoXdMMEwcpUqbcv2na",
+        "nameType" : "Personal",
+        "orcId" : "KsskakRWQsa9ESRt",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U0Wpg9Vo7fnz8J",
-          "value" : "UVEGVrx6Hu3nV1mz"
+          "sourceName" : "FvaOVUZ3rZHQ9GZ4M",
+          "value" : "wLEbu8cBO3QHIYW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1JS0tWQzUWTXcEc",
-          "value" : "rpODz6b3yjO4pKf"
+          "sourceName" : "JqE81L9QG4",
+          "value" : "RYjVFJQw2ylxWk8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5ff91b1a-edff-43a2-b273-439477e4297c"
+        "id" : "https://www.example.org/2d60e49d-4c58-402c-bac5-04f7c4baf29f"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,175 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3c1dc38e-1bb9-4ea3-b7f3-60f5f130c9ff",
-        "name" : "I1CVRKnySvsZYiw44H",
+        "id" : "https://www.example.org/dd1b4fa0-3681-4eaf-8325-457868a1bd2a",
+        "name" : "RMYbWiaHjn377bI3Fx",
         "nameType" : "Organizational",
-        "orcId" : "VWpFAD6RN82LKpoa4sE",
+        "orcId" : "fU41n9kxFI8HdkW",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ESx7OH6WPnBM4my",
-          "value" : "jRN3C4MtCqaInW"
+          "sourceName" : "PaPYOzuFjQmb",
+          "value" : "EfdPbbnmcpQ9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ePpy5OwKTcKj",
-          "value" : "PSNmU70nSvpN36ja"
+          "sourceName" : "D6hWXpqz8pIeN",
+          "value" : "w5MdJcmCreHw8wNUMk1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3bdad4e8-734c-40d3-a710-428f4d30b8a3"
+        "id" : "https://www.example.org/0ff24a3c-06e6-421d-b3f6-cf0799b60c24"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Curator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "MCJ6cb01hKlXe"
+      "af" : "2uXuoY6BkJ"
     },
-    "npiSubjectHeading" : "ZI9SJLgOnrINoCg",
-    "tags" : [ "zZpZnyk0iBHSUEHb" ],
-    "description" : "ziVNnTCccgdYEG",
+    "npiSubjectHeading" : "n1BFzT1T1PT7WMoLj0",
+    "tags" : [ "6CNECtRVVKY3cgXilz" ],
+    "description" : "UTEfJH5k99N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c1f209f2-d23d-48a7-add5-1a7e9cf49fcc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b36db019-9da9-4008-9747-8a60f093b2d9"
         },
-        "seriesNumber" : "H74gBAwq8TKsvqQn",
+        "seriesNumber" : "nmPGFhbT47d1u",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c917ba9a-7b8e-4e2b-a8da-9f6f1f2a5c15",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/20b73761-aeb9-4e1f-b283-03193c6e48b7",
           "valid" : true
         },
-        "isbnList" : [ "9790050600770", "9781886733732" ],
+        "isbnList" : [ "9781934080177", "9780072568165" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1886733732"
+          "value" : "007256816X"
         } ]
       },
-      "doi" : "https://www.example.org/99dd6dd6-52f3-4602-9cc5-1d17bf840870",
+      "doi" : "https://www.example.org/65ff14b8-8f3a-438f-af55-8632fcb474ca",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "9lBeMOG3XoT4f1",
-            "end" : "P8yEh20G6IXdCR5WXZM"
+            "begin" : "p5fSG1iDR8rcHKy",
+            "end" : "buj9QR9Z1iimd"
           },
-          "pages" : "NOOOX0CJTxnMm4035",
+          "pages" : "qgXiPIULCe",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e58b5239-1e8e-4e8e-8424-199e744af00f",
-    "abstract" : "3mABv2f9nI"
+    "metadataSource" : "https://www.example.org/eef5cfca-7ac2-4dbe-89ad-4c0308c2aaf7",
+    "abstract" : "t64V88AnLSdTJJtaDC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/422cc323-1db3-416a-ae14-667a0b4c1735",
-    "name" : "Gc31Fp4UCBA4gYb",
+    "id" : "https://www.example.org/cd69a2ac-df61-402a-b45f-fda6a78850a8",
+    "name" : "Eh5y24ylvl4egclqw",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-11-18T07:21:44.614Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "XVYULcwwl5z"
+      "approvalDate" : "1998-01-18T23:31:47.212Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "D7r6ZVmGlejhH499fbj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5a4c9d4d-2254-475b-8039-64a85755d8b2",
-    "identifier" : "X39I4YreOeIzhnt",
+    "source" : "https://www.example.org/b53bc45b-7f89-45c6-8626-763f924cb4a5",
+    "identifier" : "ECMnQ9RDdIbU",
     "labels" : {
-      "it" : "KV99h4FQabSR6"
+      "bg" : "dsJodkz6qA6"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 182121478
+      "currency" : "GBP",
+      "amount" : 1578429470
     },
-    "activeFrom" : "2004-11-12T10:47:21.730Z",
-    "activeTo" : "2006-08-05T08:03:00.144Z"
+    "activeFrom" : "1988-10-12T03:06:24.350Z",
+    "activeTo" : "2008-05-10T15:04:23.378Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ec91fe58-32aa-4548-b751-39fb9e57e196",
-    "id" : "https://www.example.org/390fdd78-af8a-4758-b58e-630c246410e2",
-    "identifier" : "irlLXiLs2Mg",
+    "source" : "https://www.example.org/65a92764-1c8c-47f2-a175-8fc32629ce7c",
+    "id" : "https://www.example.org/97d54c97-876a-4d45-a612-ffe5615b2c4f",
+    "identifier" : "yhjtFOfBRHXgiQ",
     "labels" : {
-      "en" : "XIxp4vbziyYtmrgQ"
+      "bg" : "dghx2qU8DQM8S"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1586399083
+      "currency" : "EUR",
+      "amount" : 850116632
     },
-    "activeFrom" : "1989-05-30T07:12:01.756Z",
-    "activeTo" : "2003-11-15T04:43:17.557Z"
+    "activeFrom" : "1987-11-04T23:52:49.263Z",
+    "activeTo" : "1998-01-05T04:47:48.307Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/84cf053b-f6a5-419e-9f3b-70c143389be0",
-    "sourceName" : "sxr6logdsv1x166@vikbs3jivwf645a"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "R1NRyzNqIpyTt0",
-    "sourceName" : "y8kno2mku45l@245dzg2b63b"
+    "value" : "6gFCRSvLywF7pw72",
+    "sourceName" : "wtu88gnhpmsgrzev3j0@uv6z2tm2gbpk2yxgjas"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/cab9684d-7ccc-4dd3-959c-e061e4a50ffb",
+    "sourceName" : "1bekkym74mzyyj6zsly@ext9wecwsnlqfx"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "286679966",
-    "sourceName" : "u11fu5y7svsjud@e7xevvqwjxrj"
+    "value" : "1969246417",
+    "sourceName" : "mrkuaa114njnrzrttjq@lqylr2sc6olgjpku8st"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "O0TYS6Zv7x",
-    "value" : "lTnD58AdsLAjWdM81"
+    "sourceName" : "yBcFrBBwPcvNJ",
+    "value" : "og6hbisV6zJiN"
   } ],
-  "subjects" : [ "https://www.example.org/488e37d3-5911-45e2-90e8-791b4af30eb0" ],
+  "subjects" : [ "https://www.example.org/b616129c-3ba7-4c91-80fc-87583af20932" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "55746eee-645d-4764-916d-8f80c8071e95",
-    "name" : "Cv4EFzqBybCT",
-    "mimeType" : "gHc79IqYirvhMl",
-    "size" : 89032382,
-    "license" : "https://www.example.com/r6ey2ziia2p0m5y1g",
+    "identifier" : "b62a2535-1353-4ec8-90dd-cc5efc7aefaa",
+    "name" : "Br39r5ICEH",
+    "mimeType" : "uCD3n1G2s07kvy15C1K",
+    "size" : 2056788991,
+    "license" : "https://www.example.com/gikftjcaktu3eafmsx6",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "29BHPcc0lwtd"
     },
-    "legalNote" : "Qj7MYlietIK2gaQBu",
-    "publishedDate" : "1981-04-20T00:44:47.634Z",
+    "legalNote" : "qijIdUkaAO",
+    "publishedDate" : "1983-12-18T10:42:27.423Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "141774125@2HKXE68zept6tSaRp",
-      "uploadedDate" : "1984-05-23T01:13:17.858Z"
+      "uploadedBy" : "1397533835@l1N7TSGIdVSpRzz",
+      "uploadedDate" : "1996-04-05T12:35:56.163Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HltU4mFVbd9EP4a",
-    "name" : "4jBr7vrnqShyW93Yy",
-    "description" : "UFJDGkRIIMLuCKj"
+    "id" : "https://www.example.com/9PLZxbrhW5osm",
+    "name" : "iJccoIwRpS",
+    "description" : "zkdsqTPBgBMO"
   } ],
-  "rightsHolder" : "FUEv8EsgaV",
-  "duplicateOf" : "https://www.example.org/643f8c15-67bc-4916-8bd1-9d2ffbcc0685",
+  "rightsHolder" : "In8yiKMLu1at97aUK",
+  "duplicateOf" : "https://www.example.org/1c623738-31f3-4396-946c-582bfa05dd8d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Pl6UTj81PkiH"
+    "note" : "X6GV2tGoWOedRwBs5vi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kWqLqwRdYkpvO",
-    "createdBy" : "8lsAbotwkSd",
-    "createdDate" : "2012-07-22T08:59:16.799Z"
+    "note" : "upqCRqr4f1daxFYD79",
+    "createdBy" : "XONSYrA3oROAWVcC",
+    "createdDate" : "2013-09-19T11:49:16.432Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/319dcb44-ed80-4f4a-ae47-c5d42a542f59" ],
+  "curatingInstitutions" : [ "https://www.example.org/0c864ae1-0df4-4b72-915c-edf94066e897" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "RNChPyfUymk7xgD4qWE",
-    "ownerAffiliation" : "https://www.example.org/1fcb1341-d92f-456e-a96b-43b63a8e4c5c"
+    "owner" : "8Jk4x1sNzln0EyWpR",
+    "ownerAffiliation" : "https://www.example.org/a53fadf0-21dd-46f1-9ea0-6622ace1b596"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/886d8fbb-a154-49cf-ae17-eb2eb0863ed2"
+    "id" : "https://www.example.org/d0cd9380-1802-4185-bb49-fa931e0d4460"
   },
-  "createdDate" : "2001-01-11T02:39:03.164Z",
-  "modifiedDate" : "2005-12-31T15:33:55.504Z",
-  "publishedDate" : "1985-12-14T08:42:42.387Z",
-  "indexedDate" : "1976-08-09T08:48:43.916Z",
-  "handle" : "https://www.example.org/f54516bd-811a-4df5-8f75-dfe0a43ad950",
-  "doi" : "https://doi.org/10.1234/in",
-  "link" : "https://www.example.org/bd062424-85e2-4f47-a91e-c782b0d7f344",
+  "createdDate" : "1991-03-21T19:15:54.603Z",
+  "modifiedDate" : "2012-01-22T16:41:58.010Z",
+  "publishedDate" : "1996-11-22T19:16:45.178Z",
+  "indexedDate" : "1992-07-07T04:23:26.544Z",
+  "handle" : "https://www.example.org/cbc1c736-a693-4d7f-8797-5ffce1c88aaa",
+  "doi" : "https://doi.org/10.1234/quis",
+  "link" : "https://www.example.org/07405557-6cd8-4765-9179-385847b365a0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "11mkhRElDDB7XksR",
+    "mainTitle" : "54bNGURoC1CqFvd",
     "alternativeTitles" : {
-      "el" : "3caHhugIeymuF"
+      "af" : "sofC3iOyAFFFD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Ow30FhWze5pu1M",
-      "month" : "2FlMVPJRl3iUWK1rv",
-      "day" : "uEgg8vpVtYrg"
+      "year" : "q9QMxd5JnvIuqI4",
+      "month" : "bltKHUwv7t",
+      "day" : "uPPfFlcmPZmBEcv4N"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/29b47972-dda5-4ba3-b048-0a183bf5d1e0",
-        "name" : "N48TN6apLJTmtdHR",
+        "id" : "https://www.example.org/4665a5fd-25bc-4071-bd11-a9119014e82e",
+        "name" : "dWNCLNaniG3E",
         "nameType" : "Personal",
-        "orcId" : "xk5J0e6ubItGDMvfk9m",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "NKim129s8XjilZq1MF",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w6ZeCrdfUw",
-          "value" : "vdvCqC2FsMqcPDJyO"
+          "sourceName" : "FWj6DnlgGw",
+          "value" : "aqJ4O2zSsfhLfuG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZG3kUb2HkdCpEy",
-          "value" : "grwZSlp79PNiS"
+          "sourceName" : "ojGBk4Uojq",
+          "value" : "XWfF3rwp6FTsF2uBZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a1593a78-531e-4992-aab7-376486821207"
+        "id" : "https://www.example.org/ff262570-8275-40d2-b107-6140c75dbefd"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e7df973b-3bef-4d41-bb0e-9694266a9ceb",
-        "name" : "XqJfLpcXsJCZuoCHdR",
+        "id" : "https://www.example.org/86589c70-34b5-4fec-9b6f-3ff47903ee89",
+        "name" : "7FKaXx5MkiohK",
         "nameType" : "Organizational",
-        "orcId" : "zSSfrCBvooxU1jie7",
+        "orcId" : "pTHc5ofUIj4E",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ffburSq7G8Vfn9QlcQY",
-          "value" : "bVMOaHjlpBXt7Eb"
+          "sourceName" : "ZmbCkjqFEeO",
+          "value" : "EfMH0O9nB2U3UCs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GOvV1AY7aqB",
-          "value" : "SHDEvIJ59L3tBabW"
+          "sourceName" : "vrYlf67bo42T",
+          "value" : "xFzRH8E90BSyMfYge"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7ab8d2a2-9e02-4680-9d20-3042b15a5a06"
+        "id" : "https://www.example.org/650fab25-72c6-47c0-bab3-4fa1717e0e3c"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "Kd2eAmnXkihAwYtQc3f"
+      "da" : "6Q3QQFJa3s5cTkNuG"
     },
-    "npiSubjectHeading" : "CdZHSPBmnPw",
-    "tags" : [ "7ktI1TeVbSGExX5hcI" ],
-    "description" : "Ys8ZeZqRzN",
+    "npiSubjectHeading" : "k2l8fRNeBPqDu3A",
+    "tags" : [ "PPxVqKUNaGwj" ],
+    "description" : "6JGHy6PW3iTj28YV7q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/8ZvMaz2lwve1nmm/publication/0191e0c8eb55-28bdd4c3-c4da-4f62-81ce-a74029e1d0e9"
+        "id" : "https://www.example.com/WuaoEziymGs/publication/0191ff23500b-98c7a62e-72c2-4b87-a2dc-9953dac1e69c"
       },
-      "doi" : "https://www.example.org/6c4b9909-4f55-455c-bb76-66e81b002e0f",
+      "doi" : "https://www.example.org/4dbb090d-fb77-43b7-9cde-60685797be1c",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "GyEEZHBfafek",
-          "end" : "zXmKqY2MUcVovCL"
+          "begin" : "9XnEmWa3OTrDz",
+          "end" : "JDiozhiEsGfum5Eh"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/50352ebd-45a4-473f-acd0-2901678146d5",
-    "abstract" : "hcMCzBjQf6"
+    "metadataSource" : "https://www.example.org/c3b8ea20-a5aa-4971-af40-d108552e4c08",
+    "abstract" : "hV8VXDztZl8qTmM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3668960b-12bf-47c2-ad07-9dd723a6f901",
-    "name" : "QjNYjZkk6xPBohricV",
+    "id" : "https://www.example.org/14a22e4e-1de8-4fee-8424-72bc0f0aaa0f",
+    "name" : "QCXxFvpsq3INKeS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-11-29T19:03:46.500Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "2012-06-02T01:19:45.231Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "vgofSIZ2Fcg2p9b80MX"
+      "applicationCode" : "zKqyFkK2BHdCTR1X"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4db9f0b2-d50c-4207-9957-18aa0dd24f67",
-    "identifier" : "U91AjtHLZlzf8",
+    "source" : "https://www.example.org/0fbb7f88-072b-4c25-9669-202cda9bb3bb",
+    "identifier" : "34BhC5d7gSQgb",
     "labels" : {
-      "nn" : "RM5jFXxpAxNQ"
+      "pt" : "NbJcNP1sP4EZEZoxHax"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 224474091
+      "amount" : 727231326
     },
-    "activeFrom" : "1978-09-14T02:31:22.475Z",
-    "activeTo" : "1996-12-16T23:36:16.049Z"
+    "activeFrom" : "1973-06-12T17:47:00.784Z",
+    "activeTo" : "2019-12-09T05:48:39.267Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/62f33470-4bcd-4428-9578-c6c2cf236d56",
-    "id" : "https://www.example.org/a1f4a075-4c72-43a4-8586-4242f251ae64",
-    "identifier" : "MpQVBJ2Snl",
+    "source" : "https://www.example.org/050a1fdf-2389-43e3-92f3-5e94c4bb7eef",
+    "id" : "https://www.example.org/02f71321-8ce6-41c1-963c-8cd4686bc483",
+    "identifier" : "BABDUhjtb9uL7",
     "labels" : {
-      "es" : "QMSvkTrwVd468W2f"
+      "pt" : "hYiWOn1zogYSGxJ"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 560731104
+      "currency" : "GBP",
+      "amount" : 647572236
     },
-    "activeFrom" : "1994-11-16T23:39:31.703Z",
-    "activeTo" : "2017-01-12T13:08:03.688Z"
+    "activeFrom" : "2022-09-10T17:17:18.955Z",
+    "activeTo" : "2024-01-25T02:25:15.388Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "667724564",
-    "sourceName" : "5j1whozxodepmci@ml7ede64zc32g26fs"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/f3275c55-bbd2-4d53-bc02-9df88d45b62d",
-    "sourceName" : "qytprvdusulxsb26i@qciilz3buajsoq"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "3ItaUB6a43OoWpCr",
+    "value" : "zEbL4JhJeYuw7TCzrqF"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "GzDwoWQfz3jJWuQ07",
-    "sourceName" : "j0itklgjvhs9rzzp@dznpvsjigjypzcqil3"
+    "value" : "J6Es1hQ853vHupL",
+    "sourceName" : "suzoqp1wdzypu26emwl@omorydqiueunkmr"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "VKMbwiZDp6WWnn8D6W",
-    "value" : "Q1KrL2rqnM"
+    "type" : "CristinIdentifier",
+    "value" : "809729017",
+    "sourceName" : "svms133ta0f@ndfhwiqdvhy"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/5c0307ed-fe23-487f-ad2f-684ebd79c572",
+    "sourceName" : "vfdpdzhtg0wku8ysv@qsoobyp0s77mpatzi0g"
   } ],
-  "subjects" : [ "https://www.example.org/d60701ae-5429-48a0-8a3f-a564d5552081" ],
+  "subjects" : [ "https://www.example.org/4f028bd2-0d3c-47b1-933b-0ce763c5ccde" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8ef26183-3289-4b45-a6fa-1ec62c810876",
-    "name" : "ViUsQZxxJjYeEVSy",
-    "mimeType" : "g3ZSxSlIGpGSrSe8Da",
-    "size" : 1124234189,
-    "license" : "https://www.example.com/qfffdd5atbg",
+    "identifier" : "2261a64e-2645-40a8-983f-c1a5595a3acf",
+    "name" : "cs84squJDGSpt2sx4",
+    "mimeType" : "Ea0IReWmiwxs3I",
+    "size" : 130381314,
+    "license" : "https://www.example.com/8ijycjxbrapwgtu",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Oxj1u1QH9LyNb"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Y7xUMUytjV3O",
-    "publishedDate" : "2011-02-20T07:30:36.581Z",
+    "legalNote" : "piJj6uDspF",
+    "publishedDate" : "1977-03-17T04:48:40.937Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "833910849@RNdQGOjDtWF",
-      "uploadedDate" : "2018-06-19T10:33:47.494Z"
+      "uploadedBy" : "794066117@sxqjgZsdllOJ1",
+      "uploadedDate" : "2015-05-15T15:01:18.088Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gy08YakTKgQ",
-    "name" : "QqZqYLUBAOKFKZHhHz",
-    "description" : "fPL3FANQHx8hk"
+    "id" : "https://www.example.com/1AGMZsAkWBt7zu",
+    "name" : "FTem1PWoHNI6e0KPLj",
+    "description" : "m4UyNFkqexM98D7DW7"
   } ],
-  "rightsHolder" : "lmKAbWe2IclLYR8",
-  "duplicateOf" : "https://www.example.org/f602d990-55d7-4818-8fce-cdf5cbb4de4b",
+  "rightsHolder" : "g7FDkEXLezmf2yuM",
+  "duplicateOf" : "https://www.example.org/71cea67f-320a-4d5d-a415-eebbb52afc00",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lh3TjUkUy6TWw0"
+    "note" : "GbhJqr8S0k"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "m9PZn9IShU",
-    "createdBy" : "CdKugNPF7IXeoqdTf4",
-    "createdDate" : "2021-03-26T02:19:49.329Z"
+    "note" : "hPqftULh5NPDlBbtrMk",
+    "createdBy" : "RCJu4Vdj3pIk",
+    "createdDate" : "1977-09-27T18:50:01.098Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/31a3fa68-3e9d-4b44-bc62-7d979f0af384" ],
+  "curatingInstitutions" : [ "https://www.example.org/5879d59e-2776-4c19-9347-4957add5b8bc" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "nlNaqUhBWritO9yT",
-    "ownerAffiliation" : "https://www.example.org/f8375b1a-e6b3-4f34-88ef-c2f9733b1a47"
+    "owner" : "sIl2HTYr8v",
+    "ownerAffiliation" : "https://www.example.org/7d289ab8-bd93-4853-97fb-0f6e5200d9cd"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d020a719-99cc-4424-bcf7-0e38e3a9024e"
+    "id" : "https://www.example.org/d07c11c9-2a59-416c-afba-c04c15ec2fd2"
   },
-  "createdDate" : "1971-12-20T07:09:10.418Z",
-  "modifiedDate" : "2018-08-02T09:22:50.004Z",
-  "publishedDate" : "2023-11-15T14:49:55.660Z",
-  "indexedDate" : "2017-08-24T05:12:50.887Z",
-  "handle" : "https://www.example.org/f816d5e9-8e64-4d2f-bbeb-974dd62ef74e",
-  "doi" : "https://doi.org/10.1234/tempore",
-  "link" : "https://www.example.org/68922d8a-fc2f-4662-8515-439a2c477e77",
+  "createdDate" : "2023-11-07T09:31:03.854Z",
+  "modifiedDate" : "2018-07-11T02:17:29.231Z",
+  "publishedDate" : "1982-01-02T14:10:50.841Z",
+  "indexedDate" : "1991-06-10T15:34:51.564Z",
+  "handle" : "https://www.example.org/9a2b5a34-3a1c-490f-a9bc-5800d18834b0",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/a5ce52e5-3f76-4d80-876d-3c37e45638e7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1JC29MDqY7wCw",
+    "mainTitle" : "rcHM01hU2LGBeorm",
     "alternativeTitles" : {
-      "en" : "ipDQgdnOJAmJGbXJ1"
+      "zh" : "3c5wkpAOUQF7Jo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vtGzC7ZGZbZCa3",
-      "month" : "VGItWOpK3C6LJ",
-      "day" : "qyTXKaVYXlf9DpJWaW"
+      "year" : "Ex23XdlDOvS92",
+      "month" : "CbGJqQIBYodJ6oQ4j",
+      "day" : "Nj82TgnZofsQq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/308146c0-1bc9-4a5d-9156-46feeec0e521",
-        "name" : "kuPujQgN7RU9BAhsC8",
-        "nameType" : "Organizational",
-        "orcId" : "NxCjAeV7tYKHQt6Q",
+        "id" : "https://www.example.org/4928ff41-63ee-472f-9de0-6ed8e3f52c6a",
+        "name" : "JCoZkflqusv",
+        "nameType" : "Personal",
+        "orcId" : "IVKolZOWKnSIGQKSjNI",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AxZWI7tQTC4Tlpb",
-          "value" : "mXTcdHcnXD0LTvYob"
+          "sourceName" : "NYA6LEZiHbHq3",
+          "value" : "PTG15lzbuxOUXkq5l"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mm8qtHh5ev",
-          "value" : "nzeOn20aY3rK5aC"
+          "sourceName" : "NrySLzyj9Ej",
+          "value" : "KAE2CJsBZ5PdQnFr8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8c506ea1-b674-4eaa-9bcb-2a16c11b9c17"
+        "id" : "https://www.example.org/e461abd0-43af-4f22-86ee-8cceb0574ed4"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "DataCollector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cdea791b-438f-4363-b074-1ea063a5c073",
-        "name" : "LpABT6M1IWW6iuBjyd",
-        "nameType" : "Organizational",
-        "orcId" : "CEUGIVLqVy1",
+        "id" : "https://www.example.org/b32d779c-4d88-4426-b8ab-e4434f7d5cf2",
+        "name" : "gSwNxlVAi2jiAAuB",
+        "nameType" : "Personal",
+        "orcId" : "g4P9FOd4etM1TufMf3l",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hwD2kwaUfQgzsov",
-          "value" : "LIScEj4zvxVi8JRmE"
+          "sourceName" : "gvjqWUmMQl2jWz9",
+          "value" : "dBUZWPgiZCd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PiRqJS7tdT9hCbzt",
-          "value" : "Zc6oMGW12YTf"
+          "sourceName" : "23P2BpgZGA",
+          "value" : "DffZy0GE3FPpH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/25a7eba7-f0d8-4b79-b26e-408cf102ffd8"
+        "id" : "https://www.example.org/70f843a2-8778-4f8f-9684-3a70cd2b86c0"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "wm4unhK48OJbPpRI25"
+      "cs" : "a6lomGSRE1BK351"
     },
-    "npiSubjectHeading" : "TCL1Sg3eKN0PIPC2VQ8",
-    "tags" : [ "Q13b3iK9eHe" ],
-    "description" : "xN1kV6aaUiAWFb",
+    "npiSubjectHeading" : "6E2tTCL2Tv4oE9S",
+    "tags" : [ "gxxPZxD0losjX3KO" ],
+    "description" : "i3KCwLI3r6De",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8ed2eca3-795f-4440-b2ab-3592fa30455c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5dbe0da4-d158-4448-94bd-1a88f085bd2f"
         },
-        "seriesNumber" : "4Mfcz06AJKEoeTN3Ov2",
+        "seriesNumber" : "bX3hr1I3a9KPWifFetE",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c84deb01-da03-47d1-965a-17233c3449b6",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a76aad0c-64c5-4c25-81cb-d7721dbb35cc",
           "valid" : true
         },
-        "isbnList" : [ "9780968138625", "9781975565442" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9790285221719", "9781945868337" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1975565444"
+          "value" : "1945868333"
         } ]
       },
-      "doi" : "https://www.example.org/a2a583b7-be57-4713-8e6e-a7fd9d1d96a5",
+      "doi" : "https://www.example.org/a6dc525a-e42a-4deb-915e-dbe62cedfa32",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "4qoTCqVgHPcSvxw2T",
-            "end" : "5MyIuIEnmCtYUvosW4v"
+            "begin" : "mWW4nSe1RqvD2xN4",
+            "end" : "mm22111FSzt"
           },
-          "pages" : "xbTChDneYl6uW",
-          "illustrated" : true
+          "pages" : "IDp2wPGPPB",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5b7ddfa7-09bf-47eb-b0cc-8413f82392fb",
-    "abstract" : "9qGyjJRuK6Oko0s0"
+    "metadataSource" : "https://www.example.org/54a9686e-8b02-405a-96e3-9d01be6da916",
+    "abstract" : "COsoDRfMqpEY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4ef4e99e-d37c-4601-9f70-ed7efd8b0130",
-    "name" : "xAff5b7jR6",
+    "id" : "https://www.example.org/6800d1ea-858f-405b-a035-26e6c9aef64d",
+    "name" : "uQzAuIADl6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-12-12T09:58:12.253Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2020-01-10T22:25:22.059Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "ibIrleIYNw8s"
+      "applicationCode" : "DWu3trqzNeLmqN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/eeb8ba68-584b-4bf5-b884-f605a9616cd3",
-    "identifier" : "AwuHcBDE15l",
+    "source" : "https://www.example.org/8e9fb5ce-f8dc-4e22-a8d1-eb2ff974b88b",
+    "identifier" : "RRnVapunfwrmSn",
     "labels" : {
-      "nn" : "75X4vjm9SHAFcD3"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1684478366
-    },
-    "activeFrom" : "2020-08-11T23:16:07.635Z",
-    "activeTo" : "2024-05-30T17:11:26.743Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/da632594-d0da-41d8-8935-46d7fbbde0e3",
-    "id" : "https://www.example.org/16ea1606-9691-4825-99ba-a03eca27e4e5",
-    "identifier" : "UOkwXHtDHhqYzcFyx4z",
-    "labels" : {
-      "da" : "U1GZHxhq5Mja4i"
+      "pl" : "r2FstgeuetwLRH2cnKq"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 85769527
+      "amount" : 724497373
     },
-    "activeFrom" : "2020-09-20T20:48:52.312Z",
-    "activeTo" : "2020-12-03T19:20:10.914Z"
+    "activeFrom" : "2009-03-16T10:07:54Z",
+    "activeTo" : "2015-09-28T19:55:27.901Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/9408d96a-131c-4cbb-bf3a-a6fd2b31d66a",
+    "id" : "https://www.example.org/a100732f-3be1-4295-b65f-d7a340d1f479",
+    "identifier" : "mEh0YwvMUGPPgvA",
+    "labels" : {
+      "fr" : "h6GwiPesiqRosypusbJ"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 641821002
+    },
+    "activeFrom" : "1998-10-03T19:42:30.576Z",
+    "activeTo" : "2024-07-11T14:59:05.305Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/91838d2c-e67c-4c73-a514-0d738f4af802",
-    "sourceName" : "pknpw3bz1glgdo4@fp5c7dzjfkjfv"
+    "type" : "ScopusIdentifier",
+    "value" : "e83va2xaaGjtK09Z",
+    "sourceName" : "kqjyy3ddjxzlbrztr@5niximj29x3mqocpx"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "xr1nfYqrQUxg4",
-    "value" : "QFusjSU8915"
+    "sourceName" : "FVqsnFYcYjZZK",
+    "value" : "f2koT6kSV8NQgs8"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "ZK5FUZaOROHTmgOCA12",
-    "sourceName" : "enyjdrxp720lajzd3@3jkwhvoo7xj2"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/ee81360a-4088-4c82-b6e2-3227ccace84d",
+    "sourceName" : "zji5rxo8gogipvlnzv7@1iyfwq8yt4cvnu"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1928408640",
-    "sourceName" : "dywd2snvbxmw@nzdwhcdc4ckku"
+    "value" : "875017209",
+    "sourceName" : "dslticshjvv@lqnhivbezalzfqtrg0f"
   } ],
-  "subjects" : [ "https://www.example.org/be2f1934-fb6a-48b7-b7ee-f1fd08473458" ],
+  "subjects" : [ "https://www.example.org/7de5954d-e8e6-4286-a499-68fcc2e1ca12" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3f9285a6-d886-4cc2-98b3-d74743c7a67d",
-    "name" : "1RIsMlwOlhuGPQE",
-    "mimeType" : "WWmkwaNIkPch",
-    "size" : 748836619,
-    "license" : "https://www.example.com/ek3mfzfcby8",
+    "identifier" : "471aa283-f273-43ea-87a5-2f12594a9a1f",
+    "name" : "nPeshQdKCYRhG",
+    "mimeType" : "3zItJuLmC1hcyndvRSY",
+    "size" : 1338748035,
+    "license" : "https://www.example.com/yztkflhnhop",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "4Z91IN0eifsZVS",
-    "publishedDate" : "1988-12-31T17:28:09.449Z",
+    "legalNote" : "4CThRmT6sdBkvJ3D",
+    "publishedDate" : "1977-04-03T18:34:35.595Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "294847564@MAKfu4lZB1",
-      "uploadedDate" : "1996-05-16T19:50:31.030Z"
+      "uploadedBy" : "985075359@YzGCBci1w1k",
+      "uploadedDate" : "2016-12-23T12:57:19.784Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qYHqjc45Ii3FGX",
-    "name" : "EOVqAllcqEUP",
-    "description" : "DCTnXQQACA9IxkiBx"
+    "id" : "https://www.example.com/X4IMw3bK4W",
+    "name" : "NmGdaMMpORBkq",
+    "description" : "SePxF5OHEpBe"
   } ],
-  "rightsHolder" : "sxYkmCtDrWFao3",
-  "duplicateOf" : "https://www.example.org/c79ac99f-4898-49eb-bbaf-cbc27cc45fe5",
+  "rightsHolder" : "DYccJ7OJEgoq4MIDn",
+  "duplicateOf" : "https://www.example.org/70b9d82c-369f-4992-9c60-37579c867d61",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "EuyG6HtxvbmpBAuj9"
+    "note" : "0pIDAlWINBBf4B"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "V4y7aUTaxDu1yueh8r6",
-    "createdBy" : "VOsCwDtyRETr",
-    "createdDate" : "2013-11-30T20:13:59.300Z"
+    "note" : "m2yoLliWvgnStxx",
+    "createdBy" : "az5V3Eo4c0",
+    "createdDate" : "2021-06-26T17:24:54.821Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/544dbeac-7d64-4e85-a296-4899235b31af" ],
+  "curatingInstitutions" : [ "https://www.example.org/b49d9616-d313-4a91-83db-2fa9dc94b324" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "dTlIwgES3VGu",
-    "ownerAffiliation" : "https://www.example.org/3d6de03f-ba80-4105-b384-0825b4e00799"
+    "owner" : "neTaCBaBUFwu",
+    "ownerAffiliation" : "https://www.example.org/61215ff2-bb00-46da-9580-2df14b1fb506"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/687621f5-8bc4-4674-9f39-f23b53cf24c4"
+    "id" : "https://www.example.org/131cb766-c820-4387-9db1-00efef4cad07"
   },
-  "createdDate" : "2021-02-14T12:13:28.232Z",
-  "modifiedDate" : "2005-04-03T06:01:05.025Z",
-  "publishedDate" : "1976-10-03T02:36:53.890Z",
-  "indexedDate" : "2006-08-31T10:17:17.077Z",
-  "handle" : "https://www.example.org/80ebf3bb-54d2-401c-b3ea-732a46c4104b",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/8d5914b2-25e3-46be-b585-b94dcf2a1583",
+  "createdDate" : "2021-10-02T14:30:54.304Z",
+  "modifiedDate" : "1994-10-27T03:53:52.975Z",
+  "publishedDate" : "2022-10-03T02:20:42.920Z",
+  "indexedDate" : "1989-10-06T13:39:06.613Z",
+  "handle" : "https://www.example.org/1a50bcff-bcab-4b17-989d-099489f5836f",
+  "doi" : "https://doi.org/10.1234/aliquam",
+  "link" : "https://www.example.org/ed5355a4-7111-45dd-82e3-1248c90684a1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5iCes6wR8O",
+    "mainTitle" : "5gPv5tdjj2wXvJA",
     "alternativeTitles" : {
-      "es" : "zjMSGBkXfB"
+      "ru" : "ohkdL4c7Gx9"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "8OM5CNGnGa8egtt",
-      "month" : "vrC4qB5rL8tIM3zs",
-      "day" : "SJbguunkmFvGJZaWx3V"
+      "year" : "o85zckM5FfO5",
+      "month" : "VJ1HSWXxl8F5",
+      "day" : "u72ZzGt32NdpT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/79b0d54d-c7e0-4a27-91cc-75de98a8da58",
-        "name" : "fuqe7uW0LlcESMpp1",
-        "nameType" : "Personal",
-        "orcId" : "1fNc5U2yPrup7I",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/c1390b91-1770-4fb2-b06a-7903f19c452a",
+        "name" : "Wo57IZIAk8",
+        "nameType" : "Organizational",
+        "orcId" : "diQT7CLUm373GU0IVi",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eWGZoJV4TfN",
-          "value" : "J7N4eS0b82MOR5BM"
+          "sourceName" : "8dKvMZ37PZVjinjnfUS",
+          "value" : "9CYoLhAUyE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fXgEzJZFP5H46zRA",
-          "value" : "rACOgLpo3SVLdqwtKJ"
+          "sourceName" : "6rLE3UPpPxEgNhlXI0F",
+          "value" : "HkzRtdDJxjINV"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f6a6f75c-c57c-4169-99ae-1a336c8cb7ee"
+        "id" : "https://www.example.org/42829d50-6fcd-4a28-9009-7a68bdade1af"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/be9b6a66-9ccf-4e76-a275-0d20f4604136",
-        "name" : "rxA6SvuTysLBjIjur7Q",
-        "nameType" : "Personal",
-        "orcId" : "ikSLpWw0DZ",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/72d9f946-dc91-4317-b9fb-0defcc4da23b",
+        "name" : "RtD7dMFocjhZB8sIb7D",
+        "nameType" : "Organizational",
+        "orcId" : "qn5aioUBCZWdx8k",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lQ8yQupHlQlD9",
-          "value" : "EwohCwomXhx5PSq"
+          "sourceName" : "iISFYV6DEJFG",
+          "value" : "wwNUFP2as8Q8tqf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FtJuUW3vXvZryJ",
-          "value" : "8ivB48ggaqdsiLIdsZ"
+          "sourceName" : "ENg8HaYKni49E8",
+          "value" : "VZFD5sWOgcNjZoac"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7adc5827-0e77-429e-a94d-3bb90fbb4238"
+        "id" : "https://www.example.org/6fde9e58-b9b0-449a-b42b-186fcd300634"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "pfEvM4gJUJwUE4g87Ct"
+      "af" : "77pBdaIupwHKAW"
     },
-    "npiSubjectHeading" : "gSF3iNXKhvUPJ",
-    "tags" : [ "pAspRGgzCfPsSRs" ],
-    "description" : "ojyPbq0r2fuTPHJEpy1",
+    "npiSubjectHeading" : "1bgdggoaF97miqQ5",
+    "tags" : [ "idNdU2Rm3Wsc5" ],
+    "description" : "G1mFRMvCoJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/dQ2j2Sc26kO3Kgl/publication/0191e0c8eb98-f841c0cd-ae1f-4c4c-9cc1-0ede3861167e"
+        "id" : "https://www.example.com/6QfBTPQhiGzuPcfr7/publication/0191ff235012-6c09f2dc-e054-485c-92d5-a2951c635d55"
       },
-      "doi" : "https://www.example.org/87403426-6664-4c14-9227-0ca83f132cce",
+      "doi" : "https://www.example.org/7dc160cc-ff87-443c-9f4b-93f2dda2ea36",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "woT8PIk4pmWAyP9MaTe",
-          "end" : "ezmN8Tq9qKz30mCeT1"
+          "begin" : "vxz0djZBvU",
+          "end" : "D0mpSRaTgp79s26N"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ec880a4f-c1dd-4417-b924-497fbc3d3bf3",
-    "abstract" : "7XBdyjY0wiHEH"
+    "metadataSource" : "https://www.example.org/7a42c9c6-c250-4cca-86a2-3000d092e155",
+    "abstract" : "n7HdcRLuo6E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dd814629-c49f-4a6a-a845-1d13a3b98c34",
-    "name" : "YeFoyDlHB7",
+    "id" : "https://www.example.org/2661b92f-b8f4-48c7-9798-83ad684d0f22",
+    "name" : "Fm0yG8Mn6WTk",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-11-20T05:45:30.959Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "WXNpGejozXjF"
+      "approvalDate" : "2001-02-23T16:50:11.347Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "irSTFpsFs9f"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/06dab1dc-ca2a-4b41-b0bc-ed6610aea5ed",
-    "identifier" : "FOJyDtOaWePEYk7H4MY",
+    "source" : "https://www.example.org/dffe70f3-0c4b-4db6-8eab-971e84e9c0b9",
+    "identifier" : "RKEkpXc2EUlb4pVcPK",
     "labels" : {
-      "hu" : "nRd42Bu41oDoE5ir6Am"
+      "nn" : "n9KcuGP2U8N0"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1668392897
+      "currency" : "EUR",
+      "amount" : 2101169752
     },
-    "activeFrom" : "2022-09-26T11:29:15.554Z",
-    "activeTo" : "2023-04-26T06:30:05.727Z"
+    "activeFrom" : "2001-06-06T12:38:54.121Z",
+    "activeTo" : "2007-11-02T18:42:29.735Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/70584b97-9a3f-4c90-ba60-58f6ef49e7d1",
-    "id" : "https://www.example.org/d713d62b-10d1-464a-a758-0e95d816256f",
-    "identifier" : "PUKpZT7JaKL9",
+    "source" : "https://www.example.org/796d1cd9-a7a6-4766-858b-4add4377c8a2",
+    "id" : "https://www.example.org/80c9c972-3373-43e7-a29e-0c27d56b6500",
+    "identifier" : "dw2DArd49zIxiiX8ON",
     "labels" : {
-      "se" : "jmwSMoBhq4M5hZicWKJ"
+      "en" : "dsYTI6h1Hk4XTS1buVP"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1577305040
+      "currency" : "EUR",
+      "amount" : 1459070067
     },
-    "activeFrom" : "1979-02-24T16:09:14.638Z",
-    "activeTo" : "1998-10-03T21:00:28.310Z"
+    "activeFrom" : "1997-03-10T18:26:17.969Z",
+    "activeTo" : "2005-01-16T20:04:19.945Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0155525c-4650-402c-82df-32a22b384dab",
-    "sourceName" : "3ciu7glb9lfwdaf9p@qd8jzupxnj"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1323527478",
-    "sourceName" : "gujwglfjbbzsfehw@nw9ejl97howvh4qiy"
+    "value" : "1216291241",
+    "sourceName" : "wy8n6a2zdzk@ialj489revfeiz7jess"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "h3v4wWLfxTXlAfQ",
-    "sourceName" : "zdcfqfhdo4xxhui4@axcyveasne5zgbpimd"
+    "value" : "oJvW6k9IBO",
+    "sourceName" : "hirllhfn50auyf3@gvie7t6g62gybz4src"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "LYUYhLdV4VuoDYZT3",
-    "value" : "cH3kmDrbcQr8V"
+    "sourceName" : "Xtrau6Pl9eAxQHcECqq",
+    "value" : "q7qN8FcGuYJrL"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/62b870a7-dca8-4744-b549-d13a059c4922",
+    "sourceName" : "chdf7yps28@qbjopj5tvs"
   } ],
-  "subjects" : [ "https://www.example.org/9eeda5ee-cd3b-49c1-885d-4c2ae7f5541e" ],
+  "subjects" : [ "https://www.example.org/4050707e-3f9c-4a47-b807-639d11618f65" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "53452f11-ca37-483c-98b9-908ca275d46a",
-    "name" : "cmEbsziLgqwuzJ0KV",
-    "mimeType" : "8NedRBtoTEwwj2K7v",
-    "size" : 2026546856,
-    "license" : "https://www.example.com/ubbjbczhwaey62rf",
+    "identifier" : "e002294f-fb94-4333-b47c-9ae7fe8ee03c",
+    "name" : "wDiMT5Qjs1m",
+    "mimeType" : "omJSSOSrhzBei",
+    "size" : 2096625508,
+    "license" : "https://www.example.com/pxhknlbchveecklovrj",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "1oT13polr4Ug"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Ir2HlGfJTGDaZ7chfb",
-    "publishedDate" : "1998-02-07T08:44:26.474Z",
+    "legalNote" : "5Mpwg04Ztc",
+    "publishedDate" : "2009-08-10T17:58:35.096Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "656543256@tGQvj3JGpWN",
-      "uploadedDate" : "1980-01-02T09:37:25.291Z"
+      "uploadedBy" : "1448489881@CwfIMm1vPGgtDuLeb",
+      "uploadedDate" : "1978-01-16T07:52:43.538Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NfGJXaqxtiPegettj",
-    "name" : "GsMArkuEQeDn",
-    "description" : "beKOXYPJY6lhHD3"
+    "id" : "https://www.example.com/wualCOLrOzUvD722Z0",
+    "name" : "CfLhdVIKwHcVaELu5",
+    "description" : "Ne4Kz1rbttY"
   } ],
-  "rightsHolder" : "Hu0aBX24I95",
-  "duplicateOf" : "https://www.example.org/cbeed19d-3eae-4e84-8131-41833055ad1a",
+  "rightsHolder" : "lNJf54qABTkhs",
+  "duplicateOf" : "https://www.example.org/263696a9-9758-4587-9628-4ad9c827952d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "GwcmeY3AcTy"
+    "note" : "JYaOtaV9xK2gigWKT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2QUVgIKGgA",
-    "createdBy" : "Q47pdHOIy3EVMFoBgZy",
-    "createdDate" : "1973-02-28T18:52:21.385Z"
+    "note" : "M5c2ZoD3uquy",
+    "createdBy" : "PpJahhG13e",
+    "createdDate" : "1993-09-06T00:09:10.016Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/aed31042-81b8-413e-a56b-16d553c07e10" ],
+  "curatingInstitutions" : [ "https://www.example.org/f6e34898-b7e5-4de4-9f45-e60a5cd4c77d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "wX8gMtQLG3",
-    "ownerAffiliation" : "https://www.example.org/3fdcc3cb-7ab3-4f7b-b718-00981396fb84"
+    "owner" : "OwskXZBfHShks",
+    "ownerAffiliation" : "https://www.example.org/e24eacb9-79fa-4b7d-9f23-3f91539c9d70"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/24113cfb-d5c6-42d1-9c0a-8498f96cd27a"
+    "id" : "https://www.example.org/5da00b7d-63d8-4797-a797-2030807d6faa"
   },
-  "createdDate" : "2000-07-18T05:37:58.575Z",
-  "modifiedDate" : "1974-05-31T09:01:30.700Z",
-  "publishedDate" : "1971-08-10T07:58:55.127Z",
-  "indexedDate" : "2019-12-12T17:19:05.877Z",
-  "handle" : "https://www.example.org/e6241677-25e3-4e8c-b30b-1749a38850b7",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/5b824c11-ae34-4316-9386-265bb38bbfd6",
+  "createdDate" : "1973-04-03T17:04:39.127Z",
+  "modifiedDate" : "1988-08-09T06:03:24.636Z",
+  "publishedDate" : "1993-11-13T08:26:05.052Z",
+  "indexedDate" : "1993-03-09T06:13:32.700Z",
+  "handle" : "https://www.example.org/1ebb2925-2589-4c25-b6c4-7db3f01234b4",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/d0c850c1-d42e-4079-8edc-b2fe00abe9fb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "O001cZrumoIpUGrRM",
+    "mainTitle" : "nUZUzHNp5TIiE",
     "alternativeTitles" : {
-      "de" : "LB16NySF6tbn"
+      "pl" : "SEUZiVhJPkMkvf"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ohmLENQ6KYUhqLn",
-      "month" : "JC81u1AbqIuY",
-      "day" : "zQQSKxDEF23y"
+      "year" : "VGP5m9qqSM5",
+      "month" : "oqxGo4tRJN6XfK",
+      "day" : "b1cenaOv6JxnURBA3B"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f265339a-d6a3-49d5-aec3-4cbdd3618227",
-        "name" : "Sdox4SE0Rb0VpO",
+        "id" : "https://www.example.org/0f657693-5b71-441c-a37a-adffd328e458",
+        "name" : "O5DZLZJsDQ7Y",
         "nameType" : "Organizational",
-        "orcId" : "zJcxhxKH2Wxbc",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "3qr3gHnduR5N",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Yh1oUb0NvG",
-          "value" : "40KqXvzwSVzxfp6"
+          "sourceName" : "OOxd0xLIta6g",
+          "value" : "VoxVdEo6CYhVKDRv04"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GZctkw608x",
-          "value" : "Er0dnYQ4Zucfy55jrh1"
+          "sourceName" : "OGjj46ea3NxFNawxetT",
+          "value" : "im0QMIPTU5wvMw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1d4f7e0d-c909-4e5f-8440-44351e1a2b4c"
+        "id" : "https://www.example.org/0fcaabd7-56d7-4140-83dd-3f8ab87ed572"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,94 +62,95 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7752d049-f523-46eb-9b29-aa15a6ccb690",
-        "name" : "logoSlNK1W9D",
-        "nameType" : "Organizational",
-        "orcId" : "zk6vtN84vcNdC8S",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/9598671e-d71e-4d99-a0c1-ac1e8644aa9c",
+        "name" : "iXhwdSPkxAdnrKBHDIS",
+        "nameType" : "Personal",
+        "orcId" : "rCPWbePtYAaiCzx7v",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "q4QW1noCA1irKK1",
-          "value" : "EVrJflDfR0wqH6n2gs7"
+          "sourceName" : "Rig6sZIqfMxvQE3Cwn",
+          "value" : "GyJHszmbsERoY0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vjYr9tZI5fhhARzJ",
-          "value" : "WaNdU3gWwurVQ"
+          "sourceName" : "PqKOHrfNxWy7VTnl",
+          "value" : "KNXP7nX9IdGnSIq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/897a10ce-150c-4e77-8a63-61a47de90150"
+        "id" : "https://www.example.org/37b602fd-624f-4fd1-a564-a7d056601006"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "bQtF34dVC7jhDvPrT2s"
+      "cs" : "WAaV3QaoBrcB3"
     },
-    "npiSubjectHeading" : "pyBPRfK5icwc2aW1",
-    "tags" : [ "GqUmLemuKsHyOjyig" ],
-    "description" : "8va2CnL8NcghERWMz",
+    "npiSubjectHeading" : "cRkqj2PG153bskI1",
+    "tags" : [ "0DpBrf4BCpDFo3PEW" ],
+    "description" : "tKOu7EANDDevpQz910",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/5e6d6291-50dc-4229-9c1c-315e7c1aeb20",
+      "doi" : "https://www.example.org/1c214cce-8670-4b7d-a726-20373406bf6b",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "AmbulatingExhibition"
+          "type" : "ExhibitionProductionOther",
+          "description" : "Q3etSzOBUjMRSG"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/CXLvLaOHddcwHZdun"
+          "id" : "https://www.example.com/HLsl28rV3hsFZbe"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "4usyar1ZJX"
+            "name" : "B3azMPicrSvb6PZM1y"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "WD4rC9oa7rF9YmBy1l",
-            "country" : "WFee8mfDPeJekL4eYuY"
+            "label" : "8kKe42ihvZ6foLxYbha",
+            "country" : "wjnTPr4mmvS"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2012-02-21T02:44:27.246Z",
-            "to" : "2018-10-16T11:54:00.366Z"
+            "from" : "1975-08-17T06:09:04.418Z",
+            "to" : "2005-01-12T14:42:42.401Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "KxXr8rSpjsmx",
-          "issue" : "tYUD0uJRyUb9IcFPo",
-          "pages" : "Ie1hw4hdyDAM",
+          "title" : "ABLpLFKZWNtR07sOa",
+          "issue" : "88jwOxXq74nw",
+          "pages" : "NL81x13V0FJ",
           "date" : {
             "type" : "Instant",
-            "value" : "1981-06-29T09:42:15.072Z"
+            "value" : "1985-02-11T05:26:34.843Z"
           },
-          "otherInformation" : "347eTlNLhM89"
+          "otherInformation" : "0bydRsjIIg"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "MmaEN60LJISwU3",
-          "description" : "sbjeJyfIWtSfL",
+          "typeDescription" : "6KGbB9UvebDmz",
+          "description" : "LjEgGRk67CsoDfEd",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "rjnLCvq4LQXOp2V",
-            "country" : "1BVVdOFtHijK"
+            "label" : "paRSNGYUkOJYKuHtMQF",
+            "country" : "XMWrXt9TUl"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "p69KKIzyzjAcWUQt",
+            "name" : "ZzvIIkvsF51gNa",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2018-07-24T16:12:29.916Z"
+            "value" : "1988-03-14T20:22:37.020Z"
           }
         } ],
         "pages" : {
@@ -157,106 +158,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/32265215-dd05-472f-a478-728e18118feb",
-    "abstract" : "XtLil2BcSW"
+    "metadataSource" : "https://www.example.org/704d6e10-9844-47a8-822e-53437821db92",
+    "abstract" : "UadaYQgf6v210V5Y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f014d48a-8590-4d38-bcef-ef0e38b51fde",
-    "name" : "NLZBN8vrXm",
+    "id" : "https://www.example.org/490e4611-aaba-47a0-970f-0d6ad687ff11",
+    "name" : "wR4J7gWDDpfEflC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-06-11T15:53:37.803Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2004-08-25T15:16:14.166Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "WcTaVb2SDtv"
+      "applicationCode" : "iXddZBtV0dky"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f1f35b3b-5246-438e-8f18-6d4981f65472",
-    "identifier" : "VsBw4DvQDPO",
+    "source" : "https://www.example.org/ed367eeb-dc3d-4b06-82d8-ca717d5f5c70",
+    "identifier" : "7y8hdaan2VgQVDCmdkd",
     "labels" : {
-      "pl" : "Jk5ehGmKWmH8mZxZ5Y"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1127929559
-    },
-    "activeFrom" : "2019-03-04T05:31:00.467Z",
-    "activeTo" : "2021-02-12T00:21:25.145Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8504a977-e521-4b1b-b354-6e2569c158c0",
-    "id" : "https://www.example.org/023fc6e7-d9ed-4a9d-ad85-133bdc56580c",
-    "identifier" : "rfm6xa9RfolozoWQD",
-    "labels" : {
-      "en" : "fy0vN6wXFRSr1L5"
+      "bg" : "hFFkPJJpvpb"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1886927438
+      "amount" : 1715949797
     },
-    "activeFrom" : "1975-06-12T05:38:27.130Z",
-    "activeTo" : "1975-11-03T15:31:03.212Z"
+    "activeFrom" : "1980-12-27T08:31:45.812Z",
+    "activeTo" : "2004-07-24T23:43:27.609Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/c4bb0353-0d5c-4620-b473-846d0864c8bb",
+    "id" : "https://www.example.org/eebf828d-c8cf-458c-b28e-7ed067531bfc",
+    "identifier" : "y2i6eUiHCyLCs",
+    "labels" : {
+      "el" : "PWivIqelcSq0rgimL"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 671366694
+    },
+    "activeFrom" : "2022-05-15T11:07:40.004Z",
+    "activeTo" : "2023-07-23T01:48:52.853Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/ecd8c2d7-cf6c-4da0-a690-5062262b25ab",
-    "sourceName" : "1z2i6fryjkijdsa4o@ibsvnqqtowvc7suidf"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "dgbaXm4QP5U58b2",
-    "value" : "iYZ0GHJ5EkK18u0YRD"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "170020891",
-    "sourceName" : "g6yata0rzbxo@obixofaghxuhuww0vsf"
+    "value" : "https://www.example.org/2b453cc7-2649-4434-ad41-9804ad76b98a",
+    "sourceName" : "ooouqqfacevi@guqjxbhp1oggghtjec"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "MzYkNvJoOzpMg",
-    "sourceName" : "gfi3xyhpfffbj2v@k5mgvaxux0mk09u73"
+    "value" : "PNtvrIoYpGPbN3e8Elz",
+    "sourceName" : "pty0q4e4c6wdp@f1ncjmwcwnss"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "sv9znPHAjZn",
+    "value" : "BThYQUlhM0oWfVZ8W"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1482724304",
+    "sourceName" : "13hazsqjjvtxw7@cubjaewwuwmke"
   } ],
-  "subjects" : [ "https://www.example.org/1e171080-5243-42e8-9579-a038b18b54f6" ],
+  "subjects" : [ "https://www.example.org/68c91bf9-6bea-4255-bdc5-beed9837e534" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b456cbc3-ed2b-46b6-9017-817277737140",
-    "name" : "6INV27dAgvUpzA",
-    "mimeType" : "htWxjBQfrX",
-    "size" : 715126877,
-    "license" : "https://www.example.com/ooa5npfrtsqozj76fee",
+    "identifier" : "effa3948-8684-4892-b6b6-cb90a00db4c8",
+    "name" : "wgZWZz6DDWo",
+    "mimeType" : "SjSceluT1k28A",
+    "size" : 1117520241,
+    "license" : "https://www.example.com/hsdvp5sbjpxqt",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "aKFsP7rvmXBzLa3",
-    "publishedDate" : "2009-08-20T05:43:56.312Z",
+    "legalNote" : "cNAesJdLwOEzbJeviPd",
+    "publishedDate" : "1975-11-13T03:47:33.428Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "256905568@uA1VyFPRzX",
-      "uploadedDate" : "1975-09-15T11:34:24.433Z"
+      "uploadedBy" : "1405660625@TmqhaYMfH30fGnURA",
+      "uploadedDate" : "2016-12-17T17:00:40.504Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TnUHI8vtZ8D2r",
-    "name" : "6LSjwg18SfQbbpC",
-    "description" : "yF197MQj2AChbcGS"
+    "id" : "https://www.example.com/EzToEtOea20zWTSkaY",
+    "name" : "ZrWLGpf1hWN",
+    "description" : "klho6gZom5LzmAw2mB"
   } ],
-  "rightsHolder" : "PsMWRAJubHVORIfdMO",
-  "duplicateOf" : "https://www.example.org/b2b59ec8-4c15-4faf-9a27-e5f4d981076d",
+  "rightsHolder" : "jd5cVdtoWOOQB1gK",
+  "duplicateOf" : "https://www.example.org/f5266c16-8b4c-46c1-891b-d35224efd7b2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "p2phxEfLnJ"
+    "note" : "r84svfXXC24"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "XB86Rjqi8QgDsIg2WsI",
-    "createdBy" : "ybbC5nuOF0HTKX",
-    "createdDate" : "2006-09-15T07:38:09.629Z"
+    "note" : "PshRCdsY48phGO",
+    "createdBy" : "iMIrT6LHkNu",
+    "createdDate" : "1983-12-15T03:35:41.481Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c9f795e6-d56d-46e9-9bf4-31aee18b99fc" ],
+  "curatingInstitutions" : [ "https://www.example.org/c7f1af4e-dac8-444e-a221-a84c455b58c7" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "IDnMAklX5wjUqC",
-    "ownerAffiliation" : "https://www.example.org/c7c418cb-a032-4368-b9fe-0d6391771084"
+    "owner" : "vd2G9LhTszx",
+    "ownerAffiliation" : "https://www.example.org/6810acb4-5797-4523-bb42-7ad950fa5411"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c2fb9a30-0ce8-4e30-b64a-47d0a5974a9f"
+    "id" : "https://www.example.org/6232215f-7599-4b1b-9018-2ff9a1b56be3"
   },
-  "createdDate" : "1997-07-07T18:01:06.646Z",
-  "modifiedDate" : "1975-09-22T02:11:37.315Z",
-  "publishedDate" : "2020-04-16T14:45:11.028Z",
-  "indexedDate" : "2011-03-27T01:49:11.572Z",
-  "handle" : "https://www.example.org/13d5d94c-d140-49b7-957c-bed558adde58",
-  "doi" : "https://doi.org/10.1234/deserunt",
-  "link" : "https://www.example.org/d7b3d4e1-462d-424f-9101-074629e4327b",
+  "createdDate" : "1984-08-19T06:49:25.423Z",
+  "modifiedDate" : "1988-01-04T01:13:43.295Z",
+  "publishedDate" : "1984-11-12T21:51:31.715Z",
+  "indexedDate" : "1976-01-31T20:31:49.270Z",
+  "handle" : "https://www.example.org/343274fd-2653-4f76-a446-c522efae268b",
+  "doi" : "https://doi.org/10.1234/quae",
+  "link" : "https://www.example.org/15b5106a-265c-4131-b45d-9fa8a532df0f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3gyDPaGYNUUuN4iAmeK",
+    "mainTitle" : "oT4z4sG5B8",
     "alternativeTitles" : {
-      "de" : "glNBg5yq3UEynXF1"
+      "fr" : "izCCtZ6FByT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XhxFBvbummpg1K50tOF",
-      "month" : "fpmpxHLpWe5bdkeOIv",
-      "day" : "tEMevfn0TQmJpp"
+      "year" : "z9OWTFFo3oDDq5ts",
+      "month" : "btLBvDZufME",
+      "day" : "AdQvqmTNx7d2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/84be9f7c-d726-4254-8f65-92cfd432edc6",
-        "name" : "dafx53knWYH31TOJ",
-        "nameType" : "Personal",
-        "orcId" : "WhNCv5XE47TVu",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/02567eb7-6f2f-441a-b6e0-17214c49be9a",
+        "name" : "hiJ2oYVOPDhHbn",
+        "nameType" : "Organizational",
+        "orcId" : "ymP2e25MCrxSs8",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Pte05kjM02tLjSf",
-          "value" : "nKQ6votUW1hsdAdXJZG"
+          "sourceName" : "yVRTBxeYNjiPreCA",
+          "value" : "cUnzuH3B8t52JGriJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ryn1YGpGMLUg",
-          "value" : "gCrsCOnYPsWOpPNaC0"
+          "sourceName" : "3kX2whzjYZQz",
+          "value" : "UfEhMkdRZV1H"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6dac2a2f-2000-4341-a9cb-ab4df7f9748a"
+        "id" : "https://www.example.org/5469f61e-9d72-4e89-9cfe-8c93a15bc453"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "InterviewSubject"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b789b144-3954-4388-9b68-bc487f31d611",
-        "name" : "P0c5hR5mZRh5Ab",
+        "id" : "https://www.example.org/d67171b3-e3e7-42e5-a6c9-1d939edbf82f",
+        "name" : "gRJI5zHOHdVVIIhW",
         "nameType" : "Organizational",
-        "orcId" : "s1TkguzHa8",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "amzufTqwbQI",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0oA0eQAGGaMMmeH",
-          "value" : "sutB3THwRnpNB3"
+          "sourceName" : "BnokxcWD1VA5BIS",
+          "value" : "MmmN5Bocvv88FpTOMD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ALxFRZ3132IVyMqsN",
-          "value" : "0WKIt1pnnbNxX3"
+          "sourceName" : "KUOE5fZOVr9YgoD",
+          "value" : "NlASlJAlCc2lykQDFS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3c9e3019-0d01-49c6-a797-489df9a303d3"
+        "id" : "https://www.example.org/ea24cbd0-4529-43c0-8639-5c3a2525a96e"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "BkcS1KNOxLH"
+      "it" : "ctM0lTNX04k0v0Dv2bw"
     },
-    "npiSubjectHeading" : "OfBH5s7CpcOxKivik",
-    "tags" : [ "iLvQoyTtbvoyB2aW98d" ],
-    "description" : "lUTGq7n6Ygch57m3G",
+    "npiSubjectHeading" : "F49C4nIq8m",
+    "tags" : [ "K4jllTCpGDjEEwkTg" ],
+    "description" : "WWpwies3F5LjTCPc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/H7OykuttCrkHgbV15/publication/0191e0c8ec6c-a62d1087-cb0f-4c47-8d81-654f295b113c"
+        "id" : "https://www.example.com/M7ccyhoAm7GNIeaZBv/publication/0191ff235018-25ccd11b-ba08-4e71-9222-9b20b7a6b507"
       },
-      "doi" : "https://www.example.org/dcb445cc-1ba9-4ee7-8792-77ccf7315f56",
+      "doi" : "https://www.example.org/d2a639f7-0406-4283-8950-689a266eecd3",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "EkRYlgFEyZtcMiBRS",
-          "end" : "ZYlGzleU5c0IWwsH"
+          "begin" : "QYUm0pQVtRqiAO",
+          "end" : "PGgf3yIUsNlc1QpeuY"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e8e78863-1658-4138-b1e6-f80cf5ea7243",
-    "abstract" : "LYkfkQwLYFam"
+    "metadataSource" : "https://www.example.org/b9b72dcb-f8dc-4ef9-b174-df850df8273e",
+    "abstract" : "5XW4jhrqVYUdw4Zc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ae138e78-6f7f-4fc6-a0bd-8f19a1af42d9",
-    "name" : "cIgg11qCxQXV",
+    "id" : "https://www.example.org/e507bbd2-72f5-45ae-ad50-d6700b8716d2",
+    "name" : "vh1jTA77flD1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-05-30T09:25:55.555Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "2008-03-22T02:41:09.572Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "zcnr4TlkWDogDGgyYVQ"
+      "applicationCode" : "gmYJVgeDOPgD7Ocfn2p"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4222b345-ed88-425a-a174-57077ef59a6a",
-    "identifier" : "TlCJlDy8UkfE",
+    "source" : "https://www.example.org/3cc4ada5-d30f-477e-bda9-a9b3f9edc429",
+    "identifier" : "u6TvbHN4P7EDY",
     "labels" : {
-      "en" : "kYGdekBNwZTt"
+      "el" : "oHGeTAkMOKG"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1267881426
+      "currency" : "USD",
+      "amount" : 301660783
     },
-    "activeFrom" : "2021-11-02T05:16:06.697Z",
-    "activeTo" : "2022-09-15T23:02:22.295Z"
+    "activeFrom" : "2023-04-21T23:07:57.554Z",
+    "activeTo" : "2024-08-15T04:43:12.074Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/62bb8a26-ca77-46aa-9a31-06919c6c942c",
-    "id" : "https://www.example.org/65f87e5a-2288-4f94-b7ea-2209a84e1935",
-    "identifier" : "BWIL7eGMOG",
+    "source" : "https://www.example.org/8d8c612c-84c7-4c62-a3b4-e53289d6233c",
+    "id" : "https://www.example.org/9308fa63-e334-4156-a993-6de3356755e4",
+    "identifier" : "m8iNz5terEK30lkb",
     "labels" : {
-      "af" : "KZ7LVbOpoMk"
+      "se" : "RFMsgymWoW"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1615561827
+      "currency" : "NOK",
+      "amount" : 976421876
     },
-    "activeFrom" : "1972-06-28T10:18:08.101Z",
-    "activeTo" : "2017-04-03T19:07:22.577Z"
+    "activeFrom" : "2017-05-19T22:41:18.108Z",
+    "activeTo" : "2023-06-21T19:19:55.755Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "VY5hXMZgwCwFbgbl",
-    "sourceName" : "maj94n9zezgxur@s11a0rgoc625qnxx"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/a8cece09-25e2-43ef-8516-59202d977876",
-    "sourceName" : "ysjhlq5hzdrwvj@uyewhnh4cisvex"
+    "type" : "CristinIdentifier",
+    "value" : "1548308235",
+    "sourceName" : "3vysgkodfflp3o@ad6ild5fcpteyk"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "cML3VawQoe",
-    "value" : "Z1OFLfInNPjSrvCue"
+    "sourceName" : "k8tp8Vgc7JN3rA3",
+    "value" : "oMIuZQ2ADGnhLD3Satx"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "750555524",
-    "sourceName" : "qvpxxrirqbzbvsz38y2@uhghxi5ixubruc"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/8d04c7fc-97fa-453f-8da1-952557358409",
+    "sourceName" : "jea2mlhjovn@fldcehgmprkm5c5"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "aszNC99cijFS4R",
+    "sourceName" : "fizsl3isbfttj@up0y4akjuczgtfbvjc"
   } ],
-  "subjects" : [ "https://www.example.org/593a39b6-9a7a-4e2f-86b6-dbb5a7bb369f" ],
+  "subjects" : [ "https://www.example.org/5ae5ec3d-a840-4e3a-874e-09744ce9270e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "eec39659-d3b6-4256-a8ef-7786e433b510",
-    "name" : "DEwefEVqclEk",
-    "mimeType" : "uEWtZwDi4jbBLFDMCP6",
-    "size" : 947656928,
-    "license" : "https://www.example.com/60l7xyxv1skpo",
+    "identifier" : "fd165904-818f-4897-9ff7-1c58dab1b2cb",
+    "name" : "BCY4AnwCSmzQLrJVm3",
+    "mimeType" : "J4rsPPn5983PXP7T",
+    "size" : 1692940099,
+    "license" : "https://www.example.com/t3tl2nr9brsk7ti8",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "39dloMJxNwt",
-    "publishedDate" : "1975-07-28T11:59:44.414Z",
+    "legalNote" : "Kx4kkoecM75XKH29",
+    "publishedDate" : "1975-10-13T03:38:07.659Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "912967881@JPq81qvf8y",
-      "uploadedDate" : "2006-07-16T20:52:17.211Z"
+      "uploadedBy" : "2012491140@LCK7acxEAZboLWpnq",
+      "uploadedDate" : "2007-12-18T09:38:04.616Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ixqCTR6qqUCGtL5bQ",
-    "name" : "LPrfgpA2fG4F8S",
-    "description" : "h53wPk8195"
+    "id" : "https://www.example.com/bB3jxG07WNA5Pp",
+    "name" : "d882TVMtSq0c",
+    "description" : "V77K4mDvv0nFqUkmvJ"
   } ],
-  "rightsHolder" : "TwIJoh6LlZkDXJicWu",
-  "duplicateOf" : "https://www.example.org/89786685-561c-4b13-9c4a-022efb6a2cf8",
+  "rightsHolder" : "virUO7CO4v2KPC",
+  "duplicateOf" : "https://www.example.org/d6276f8e-0c27-47ce-a32d-4ff823bf862c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "mHcjf647O8XjlWc6"
+    "note" : "BWZP7XbzcTEnaCTvT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "V7WKr52KdXqJ3LZoIze",
-    "createdBy" : "uFJlbRz44AcT7CcxUch",
-    "createdDate" : "1989-03-21T06:54:08.850Z"
+    "note" : "iPeGMO3HrjxYrax",
+    "createdBy" : "Hae7oLHC8o",
+    "createdDate" : "2021-09-01T13:37:49.238Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4dbe4316-c138-412c-bdf9-d71559c4ce25" ],
+  "curatingInstitutions" : [ "https://www.example.org/42db261e-5068-4047-b372-92db3f2eab80" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "4ouUFfHuI0W",
-    "ownerAffiliation" : "https://www.example.org/09232975-f185-46b6-baeb-af24a2b3a3b8"
+    "owner" : "ip6aT3px660XqUhm7",
+    "ownerAffiliation" : "https://www.example.org/e22c5abb-95aa-405b-a9e1-9ad5248f541b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/195ed64c-ff42-4145-98d3-9dac3203172b"
+    "id" : "https://www.example.org/cbf442cc-7d87-4581-a9e8-bca0c80aab4a"
   },
-  "createdDate" : "2006-10-03T14:22:36.732Z",
-  "modifiedDate" : "1978-05-09T05:21:16.852Z",
-  "publishedDate" : "1979-11-30T05:20:56.696Z",
-  "indexedDate" : "2017-02-20T23:01:44.812Z",
-  "handle" : "https://www.example.org/15b9b0c7-bae3-4a06-b55c-c715c1f80bdc",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/0fd7baee-03bf-466c-bddf-8ccc7b743154",
+  "createdDate" : "2010-07-04T22:26:34.091Z",
+  "modifiedDate" : "1990-04-28T08:10:31.199Z",
+  "publishedDate" : "2009-10-21T22:03:11.589Z",
+  "indexedDate" : "2008-08-25T09:52:04.270Z",
+  "handle" : "https://www.example.org/3344d039-e656-4b07-aa16-5e23b819423b",
+  "doi" : "https://doi.org/10.1234/quos",
+  "link" : "https://www.example.org/0ab16ff8-6ae9-42f6-88bc-a06cf3bb67b8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TNpM82Tv32jX",
+    "mainTitle" : "W3GkElUVGygprYQ3P",
     "alternativeTitles" : {
-      "nb" : "RNtW8ed7Hg1g6eKIH"
+      "da" : "n5wuO7B1Qqx"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "FnXDeMrd6g094dFZZsi",
-      "month" : "eOOWwJ7KI15VzMuWzL",
-      "day" : "aPeb4ivITnqZvf5"
+      "year" : "Ua98dCli42v4lVLVJz",
+      "month" : "KCLpkYZr8BIm",
+      "day" : "e6yjU3taS4I"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c1fb77b1-c60d-4e68-9b1f-6a1390123cd0",
-        "name" : "XqPA5E67nKl",
+        "id" : "https://www.example.org/105b21c5-5f4b-4258-b65f-ebc89be46802",
+        "name" : "4DQwHWeaN0ADku57jE",
         "nameType" : "Organizational",
-        "orcId" : "h7MyOJOHM5",
-        "verificationStatus" : "Verified",
+        "orcId" : "oqvAjbXqWYzSJjBGdLm",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BaqysOfju5vu",
-          "value" : "pOUIIjckPCLMnnW15OG"
+          "sourceName" : "oC1a8Ox4NRoGl",
+          "value" : "noQEYbPNNv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "L56lwKPzmiAnVWZ",
-          "value" : "0YNwQ3TsD1lJC"
+          "sourceName" : "tsdjakrIF9iJ5X3Yg",
+          "value" : "TapqFezhTC3YQ1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/aa0efd7e-88ca-4ea9-80c7-2ffd869a196e"
+        "id" : "https://www.example.org/bc8ffa5c-ee89-47a2-8eb4-bade2843fc27"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,158 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b62f459c-293c-49b2-8768-e0ed1ff1ac4f",
-        "name" : "AhOYKUlBO8lvdi2oy",
-        "nameType" : "Personal",
-        "orcId" : "yqxBa4SnJvHZLtE",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c439e168-5307-4ff1-86e2-ee2131f4b61e",
+        "name" : "h2UmVLDXGIO",
+        "nameType" : "Organizational",
+        "orcId" : "K2qMfZPopeJO",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rbX4Y3lszGPSFo4",
-          "value" : "3OF5L54eCxtidDAn1Z"
+          "sourceName" : "kAaXB0yoG1ro",
+          "value" : "VnUVYvTnmML35a7d"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o465y54DDEWC6mgjsCw",
-          "value" : "5xnEDMUpsFFZM9fkRd"
+          "sourceName" : "U75ZlOTpPiYrhCW",
+          "value" : "S7FmUKwZIY1s"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/804d757d-0a80-4eb6-b69f-7e5fadd9bd8a"
+        "id" : "https://www.example.org/567e695e-130f-4026-966e-034f2ccd2a4a"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "Distributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "MbdZ93rXtrLbZ264LYx"
+      "nl" : "eqEMRGBOTmt22VE"
     },
-    "npiSubjectHeading" : "P7G0vl2jtvoTQTPfWHe",
-    "tags" : [ "TT4RRFH1nL" ],
-    "description" : "PdlCe4TYkKGNuIiN6",
+    "npiSubjectHeading" : "zX48XE8d6dB",
+    "tags" : [ "gYd54AfEQYRu" ],
+    "description" : "9QIvZeK4tJTI5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5c0ec1b6-5956-4cfc-abdc-cbb962f573e7"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f9296c45-2fe8-4bdf-b5c2-bdd33fe7674a"
       },
-      "doi" : "https://www.example.org/ff5235a1-f94e-4699-ab52-5b8edcde784f",
+      "doi" : "https://www.example.org/f16e40ed-d0fc-40dc-979e-adae7e118019",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "Jh50wnhqGPHJuJjR20j",
-        "issue" : "4mIFQlyec6iVY",
-        "articleNumber" : "5wkytDfuMjK1C9oKeKT",
+        "volume" : "6jhe8GOnZ6e",
+        "issue" : "averEVeh4frq5RBB",
+        "articleNumber" : "Q7ne3uldWdAp",
         "pages" : {
           "type" : "Range",
-          "begin" : "6TkY1hZIysn",
-          "end" : "RBhAJZGNU5DbBtAc"
+          "begin" : "3ZTVNXXuLmevfoz1IWt",
+          "end" : "TGk0ovt1hTQ"
         },
-        "corrigendumFor" : "https://www.example.com/UR7xnzf5ppEn4Kl"
+        "corrigendumFor" : "https://www.example.com/wmDaSJMOeF1bC8"
       }
     },
-    "metadataSource" : "https://www.example.org/9218cc4a-c51a-49ab-ae37-99d56862c3d1",
-    "abstract" : "07OMkM8Wbxz"
+    "metadataSource" : "https://www.example.org/918c8758-b984-4428-8b19-167b5a445b0f",
+    "abstract" : "1WVSwGZLwXPOOF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/deb65edd-81fa-424d-a3c0-d2b63713b80a",
-    "name" : "05qQgf02JXvn",
+    "id" : "https://www.example.org/4587b77f-ea35-4e8d-8461-af5125d35812",
+    "name" : "afsfUYMYAI8lhMThryD",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-04-28T05:20:19.427Z",
+      "approvalDate" : "2012-05-14T21:49:25.289Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "5gfkPwnq648b0s0bz"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "0uar2hN83BsPg6YdQ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/08f11745-9bbf-488c-894b-cee0b86f063e",
-    "identifier" : "7LshcNZvdwYCrCoKCXD",
+    "source" : "https://www.example.org/8fb34d04-af76-4677-a016-c6ed214677ef",
+    "identifier" : "Y8gv4gCluK",
     "labels" : {
-      "se" : "T6FCTL8VdfMn3of"
+      "hu" : "jcyxgDTohpIPgoc"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1027279713
+      "amount" : 41410178
     },
-    "activeFrom" : "1989-11-24T08:10:36.957Z",
-    "activeTo" : "1996-05-03T03:55:45.314Z"
+    "activeFrom" : "1995-03-28T08:06:11.412Z",
+    "activeTo" : "2011-12-01T13:35:55.775Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3febd608-69af-4f94-90d0-c6ce1eb99289",
-    "id" : "https://www.example.org/137e320c-5261-4897-815a-d45c587c5a6b",
-    "identifier" : "uV0YsjoacBqHPX5",
+    "source" : "https://www.example.org/8a6ce639-ccef-4f01-a98d-198798c13abc",
+    "id" : "https://www.example.org/e0883138-cdd0-4405-af33-1fb083d87d02",
+    "identifier" : "myyBW5fLrxL6",
     "labels" : {
-      "it" : "zbuVOkh0GmCHAN"
+      "ru" : "X7uqeNw9xCKuP4Xc8o"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 775253562
+      "currency" : "NOK",
+      "amount" : 522768460
     },
-    "activeFrom" : "2009-12-04T22:44:00.182Z",
-    "activeTo" : "2015-09-27T14:46:19.527Z"
+    "activeFrom" : "1973-01-21T17:06:20.959Z",
+    "activeTo" : "1993-06-22T19:34:33.693Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1728153409",
-    "sourceName" : "unz1bohibomfeuyp@aafb8qcqngemse"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/030ae205-e9e8-4b4d-bf25-63a6f9bb9ba5",
-    "sourceName" : "ae8reqgmz2fpyadxq@vpfjsxegrn6"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "zUY8xW3KJ2",
-    "value" : "PydsL45ONcIKRsg"
+    "value" : "https://www.example.org/ad631a8e-05c2-4376-8348-5e65d581cfc2",
+    "sourceName" : "bpgmbczqhzh6cv@1ssmcswnrggbc"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "zFzbqADNNxa",
-    "sourceName" : "hifaohva8y@i9zk0ys9ow"
+    "value" : "y4jmzeOOfaowkXCTle",
+    "sourceName" : "i8ao8gpl8b2vvwqj@7oju76lxoez"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "162429587",
+    "sourceName" : "nzlnxlolfq6@vyzizowkvtvj3"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "UxBCaVH8y3kw",
+    "value" : "6oWtC6VOmd5MOm1ao"
   } ],
-  "subjects" : [ "https://www.example.org/0a3e48f7-bbee-4e5a-8dff-568d73268947" ],
+  "subjects" : [ "https://www.example.org/6d5e7f1b-f769-4499-97d0-8d7050ba72fe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "aba74e19-0905-4837-b984-a1909888844f",
-    "name" : "0JDtmNrp2ER3",
-    "mimeType" : "qS1VhETirhq0l2bdR",
-    "size" : 694793452,
-    "license" : "https://www.example.com/kzucsfcw7hh9ze",
+    "identifier" : "c90c7cad-2aa1-4864-a995-342c88a95a9b",
+    "name" : "GoQIC805whCAxl7",
+    "mimeType" : "WBfg328gtqpbHGuYs",
+    "size" : 909677559,
+    "license" : "https://www.example.com/u5corbdptqpv",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "GDPczQverD5p9H3e"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "4rhu9URwdG60ByfJc",
-    "publishedDate" : "2022-09-03T03:43:48.726Z",
+    "legalNote" : "hhsTHuvWXLYELgdac",
+    "publishedDate" : "1989-09-16T05:02:55.462Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1417103050@jFxNZ6BQjZCBF",
-      "uploadedDate" : "2020-08-28T17:43:14.659Z"
+      "uploadedBy" : "1790306217@GONU7baj7aTN",
+      "uploadedDate" : "2011-07-26T03:33:18.313Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ATsLefKjt6in",
-    "name" : "MdiCGTsEO6k0XZ",
-    "description" : "38lMviVmSOszW33cp"
+    "id" : "https://www.example.com/8HVKX8eSIpUnF0",
+    "name" : "vzyZgVvFCAl",
+    "description" : "NgNImR7QsBjG"
   } ],
-  "rightsHolder" : "jVuU4p4TSs5aE",
-  "duplicateOf" : "https://www.example.org/368ddcb1-8703-4c2e-8a67-891f6656d10d",
+  "rightsHolder" : "ZIdMeVZ2IvVd3DoFA",
+  "duplicateOf" : "https://www.example.org/9989509e-574b-42da-ab5c-b748b404c2b5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "02uMfRkIAyOqP"
+    "note" : "jxeP4wkVLhvWSXhntf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ntFTSSYYgd",
-    "createdBy" : "oyhsXySbcT8Y3a",
-    "createdDate" : "1993-03-13T08:10:54.764Z"
+    "note" : "f110zQPqBh6",
+    "createdBy" : "vcciEUOhiRu",
+    "createdDate" : "1983-01-23T06:24:26.588Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6034e931-980d-4b62-9472-1863413c8f08" ],
+  "curatingInstitutions" : [ "https://www.example.org/ed2f97e0-e6d1-4d57-86a4-0c35aa119d41" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Po5bWTH1aCfBE",
-    "ownerAffiliation" : "https://www.example.org/49e51cec-a19a-4821-aa97-afe2639e4149"
+    "owner" : "dFdhxZDBPE",
+    "ownerAffiliation" : "https://www.example.org/7893261f-80c8-4e60-907e-e4704225070a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/bde11a48-810f-402d-9205-e4f2576ec01f"
+    "id" : "https://www.example.org/5dc0d8ac-f546-4643-b273-b0395b57cd3e"
   },
-  "createdDate" : "2010-02-16T10:51:21.891Z",
-  "modifiedDate" : "1995-02-09T23:50:05.917Z",
-  "publishedDate" : "2009-02-22T14:30:44.204Z",
-  "indexedDate" : "1972-05-15T16:45:16.870Z",
-  "handle" : "https://www.example.org/e6d3a4eb-6ed1-4a3e-8ca4-a53bfcac4f21",
-  "doi" : "https://doi.org/10.1234/dignissimos",
-  "link" : "https://www.example.org/9b0d8031-5d04-4665-b038-70c235635e7e",
+  "createdDate" : "1990-09-16T09:49:22.696Z",
+  "modifiedDate" : "1976-12-31T12:58:16.103Z",
+  "publishedDate" : "2002-05-29T15:28:41.231Z",
+  "indexedDate" : "2004-04-03T19:52:08.073Z",
+  "handle" : "https://www.example.org/ce0943bf-6788-4faa-a229-82d1738bcfe3",
+  "doi" : "https://doi.org/10.1234/illo",
+  "link" : "https://www.example.org/b65f3e95-d36d-40bb-99e2-8f63140ee6b3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "l3NBQHIqIBj7JblcS",
+    "mainTitle" : "EOMnu9TuZ9bU",
     "alternativeTitles" : {
-      "en" : "LqsltMudUQHvG"
+      "bg" : "dtnQrdN7t3z8t0rQW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ieDSXRE2WXfAtFCHub",
-      "month" : "haKIyRaQAGQt",
-      "day" : "lFqmd5ZP6NpJ3Ll0"
+      "year" : "mF74VXBgOn2TUBA",
+      "month" : "PY7HdHppDSQinPmWT",
+      "day" : "WxwQoWVY68PEe58"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f36e6fec-5b9c-4c2d-857d-08e93706941b",
-        "name" : "n3ZNYFUeKhz",
-        "nameType" : "Personal",
-        "orcId" : "2m4ufBAcu4rr3UD",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/eea0bf13-2752-46a3-a2ea-8190acbab84a",
+        "name" : "fX35IttYbiKm",
+        "nameType" : "Organizational",
+        "orcId" : "l4GsPvdvgEyIsp",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4fG2HgazezU7",
-          "value" : "CN6r4UYp37s9Yg5kUVm"
+          "sourceName" : "pu6eRGiMzgjlnuL",
+          "value" : "2PsVflK135s"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Y8XfJlJKmSSJ8Tg9VeG",
-          "value" : "3V5uUEXdb0Ph"
+          "sourceName" : "j3xmez4zcfzuXOYx",
+          "value" : "QpbwVSCUIgn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/03b0dd0e-2430-4e0c-8f34-ea2588c3ab7f"
+        "id" : "https://www.example.org/a3ca5d7b-ce1c-4f31-acbe-9787cfb8696d"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9b2179ac-669b-4b82-9ef1-7605aa024b95",
-        "name" : "tffLpkwUp0S",
+        "id" : "https://www.example.org/04c75ab2-e651-4a70-b065-288b9f70257b",
+        "name" : "rNKk4YuoOuw6",
         "nameType" : "Organizational",
-        "orcId" : "FlsLESzVghYk",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "dw2XBdRESbwXb",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "C4s7vVeoDC",
-          "value" : "BASNUdpXyCW7l"
+          "sourceName" : "wyNuFeHjGOr",
+          "value" : "WEvjtB3STKSB3ogWpC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z06VoEFxR8upd8sOn7",
-          "value" : "6C5HI6FsQQLWagH"
+          "sourceName" : "rFT1RmjG4rW",
+          "value" : "RuMZTOhDl3g00S"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/edde0b07-918c-4db7-9735-d2e26da7d9db"
+        "id" : "https://www.example.org/6384fd9c-d96f-4437-8f64-5380c10f30cc"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "QAXpZRW6RrFhlUdY"
+      "en" : "FL19sQbGmv8jMklsJ4"
     },
-    "npiSubjectHeading" : "MhEWgjwhUXkqYfz3V1",
-    "tags" : [ "hnonBmOsLI6jpNK" ],
-    "description" : "cnqHR1XCka",
+    "npiSubjectHeading" : "s7sxnps7bQ1CEh0",
+    "tags" : [ "b3mTVldDxkyt88zt" ],
+    "description" : "iLIjrVQADxms",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/db9fbb7a-22c3-4a81-8d1d-d3e1360f6c4f"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e80856e0-171b-42a4-9446-b4c14a7ecafb"
       },
-      "doi" : "https://www.example.org/bd5d9f5f-b0a0-4f51-b653-c144c4021bc7",
+      "doi" : "https://www.example.org/80b505d4-be37-4695-b96c-43fcd2a8d462",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "mypHW42Ykvm",
-        "issue" : "kcX6yNr9rOGjuQmSgrB",
-        "articleNumber" : "d9RojrqZa1ZUyU11GS",
+        "volume" : "ScvbAgbeaNODZ",
+        "issue" : "cD05CMEdifYt",
+        "articleNumber" : "B9AQ73s6iyxnuNSH",
         "pages" : {
           "type" : "Range",
-          "begin" : "inxOFxG0BsjkyIwj",
-          "end" : "xWZCxWnIN6inzBzz"
+          "begin" : "2NGalTLziB",
+          "end" : "BgPHgtg06vins"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/39fbfaed-3d8d-4e9c-926f-a1baba70fd30",
-    "abstract" : "CG6JuAW9NmGPyQDQZ"
+    "metadataSource" : "https://www.example.org/ffc13b1a-e543-4a90-81cc-fb3eb89e491e",
+    "abstract" : "FiDiGMJg8IYoptXlXs"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2bf10b25-aa73-4c22-9b80-2b44120b16b3",
-    "name" : "K7WawV5E8ql6yp",
+    "id" : "https://www.example.org/1df1be43-b136-4632-ad21-f5815ba662ef",
+    "name" : "LcCPrXTUzLjxpYkWHK",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1977-05-30T11:49:44.388Z",
+      "approvalDate" : "2018-04-08T16:57:51.141Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "dltaJghUb9i2SCFCa"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "jKm7mwDP2uiWtdpr"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a51b4126-dcac-4413-a0f2-8bc9a6922b99",
-    "identifier" : "j32n2asG8K",
+    "source" : "https://www.example.org/edf94260-7cd7-4198-a180-9794e96f89d5",
+    "identifier" : "tIrN9iLrCT",
     "labels" : {
-      "en" : "5MiJlyOxKngbliS"
+      "it" : "Xf0UGK4VlaANTh"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 512366603
+      "currency" : "EUR",
+      "amount" : 2122098381
     },
-    "activeFrom" : "2020-01-03T23:04:59.522Z",
-    "activeTo" : "2022-07-13T15:08:05.963Z"
+    "activeFrom" : "2000-04-16T07:33:17.484Z",
+    "activeTo" : "2016-05-21T14:10:10.473Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/40a34f70-9746-4485-aebc-19c856fac43d",
-    "id" : "https://www.example.org/d388a9b0-bccc-4536-9ffc-eff1a5b61838",
-    "identifier" : "eAYWPK2JYcPZAX",
+    "source" : "https://www.example.org/36ba7be4-3893-4e22-abc2-cdc47909ff6a",
+    "id" : "https://www.example.org/c8ae5c03-9d1c-4c4a-bdad-923bde3de722",
+    "identifier" : "Ek82Fxd3aMdu3VYcXb",
     "labels" : {
-      "zh" : "nobVvmZUAC0GEsf"
+      "pt" : "zy4fnJ06BNF6B3v"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 151925798
+      "currency" : "EUR",
+      "amount" : 1465763213
     },
-    "activeFrom" : "2022-07-09T15:04:13.180Z",
-    "activeTo" : "2024-04-23T01:56:18.846Z"
+    "activeFrom" : "1973-09-03T23:50:29.843Z",
+    "activeTo" : "2007-05-15T23:59:16.597Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "4rUk5nVscy827kwbh9d",
-    "sourceName" : "nn2uub0ezeapmqh@hhrlftqvpyav6ty"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/9bcc124b-f417-4302-af87-22cae460e3ec",
+    "sourceName" : "rrtrnpcux4hp@4ppzlw5alffti"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "1L6byUl7wqpLUl",
-    "value" : "3VeEkg8kB0JSt2dG"
+    "type" : "ScopusIdentifier",
+    "value" : "Icc7rx1VCykU9aewt",
+    "sourceName" : "keexq1qonakuhgllyf@4lcr1qnhnke"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "864379686",
-    "sourceName" : "qgup8j5yywpten7mn@gs4q5bh8l4deh1n"
+    "value" : "290102931",
+    "sourceName" : "rtzgaltfh9zkq@zahsxqhlz6cc4g"
   }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2719968b-b6bc-41d1-9897-db17717d36bb",
-    "sourceName" : "rkvu2nnnw1v@3gphbertdxokqjt"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "fUxilpjst2J6p",
+    "value" : "CZUrZSEnVMYaOOcsf46"
   } ],
-  "subjects" : [ "https://www.example.org/628627e7-f888-40fd-8a96-6674a61414f6" ],
+  "subjects" : [ "https://www.example.org/58a4321b-80ad-4264-b484-7d4329a8f219" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e41bbfb1-4225-45cc-9596-d8dc69696cbc",
-    "name" : "rfryuK0vmoq",
-    "mimeType" : "bJ9KR1EQM16OrIgO",
-    "size" : 500693145,
-    "license" : "https://www.example.com/th8anrxzms4gsch",
+    "identifier" : "ad3de5d0-d829-41a7-b8c3-abf3fe2e5526",
+    "name" : "puCbVw1ZKdqrtJ",
+    "mimeType" : "MztcntMPuP63o5i",
+    "size" : 717362978,
+    "license" : "https://www.example.com/5vqkbalgso6f",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "svQwfpHKExM0vyPTq"
     },
-    "legalNote" : "UrP8i22UWP",
-    "publishedDate" : "2014-11-04T17:21:30.356Z",
+    "legalNote" : "kBWopgfCynqwG4",
+    "publishedDate" : "2007-02-04T05:40:09.827Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "735210505@my4qFiBYtUZY5PW0f",
-      "uploadedDate" : "1985-11-09T09:56:26.849Z"
+      "uploadedBy" : "101118306@YU1eEvU3CSJvQoHSm2h",
+      "uploadedDate" : "1983-10-06T21:13:54.998Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tXJXSQLciUDh1sbFR",
-    "name" : "9ZPxLIcGUrkFkJ",
-    "description" : "Enyyb8jZwnKn"
+    "id" : "https://www.example.com/hWTbBWwJFokNogv9I",
+    "name" : "3pUOUQcOT2MZyP",
+    "description" : "uM7IvMgkVxBKw7R"
   } ],
-  "rightsHolder" : "suVTX1MzreJSWCTv",
-  "duplicateOf" : "https://www.example.org/f0e67951-ecac-4a2b-84a0-177794ea8299",
+  "rightsHolder" : "MbBhnGwKaR",
+  "duplicateOf" : "https://www.example.org/1c3879fd-a04d-4ac4-af18-befa34094ee4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "wlLgnwFvblC6i"
+    "note" : "SAwYOspa2S9c11"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kEwRIFHcCuq",
-    "createdBy" : "x0GCRdarNeTzAmp0b1D",
-    "createdDate" : "2020-12-19T22:32:28.860Z"
+    "note" : "WoJaBWLqLlKfeu2o4fy",
+    "createdBy" : "UbMRf6exvCNe5PCP8",
+    "createdDate" : "2003-10-13T01:24:40.047Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3d6a4c50-83fd-45b8-b59c-f4745b8d875d" ],
+  "curatingInstitutions" : [ "https://www.example.org/e0529f10-7d16-4f7e-bb4b-e0b81460cfdb" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "MIgBk2Xunq2",
-    "ownerAffiliation" : "https://www.example.org/28c2e895-afda-40c3-8b22-637085d57685"
+    "owner" : "KWUe9BXC6XxIDZQPNe",
+    "ownerAffiliation" : "https://www.example.org/0014532c-2b49-4c18-8021-5cfd6786a035"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3d5eddf3-701c-453c-a6de-e0e491d6c504"
+    "id" : "https://www.example.org/63658c2e-3776-44ac-be4b-0c4bf834d68a"
   },
-  "createdDate" : "1977-09-29T10:24:53.577Z",
-  "modifiedDate" : "1973-02-16T09:21:36.335Z",
-  "publishedDate" : "1991-11-21T05:18:56.677Z",
-  "indexedDate" : "1995-01-27T15:22:36.501Z",
-  "handle" : "https://www.example.org/b0a5645d-620d-41b4-8e76-6e69f62a1b77",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/471e1e00-2e07-4591-9f2d-a7d47ac5b3ee",
+  "createdDate" : "2022-06-26T18:01:07.454Z",
+  "modifiedDate" : "1975-12-31T03:12:18.450Z",
+  "publishedDate" : "2003-05-09T12:45:27.071Z",
+  "indexedDate" : "1986-10-02T08:00:58.865Z",
+  "handle" : "https://www.example.org/6bf0fa1a-51fe-4ece-9546-189f8dead1a2",
+  "doi" : "https://doi.org/10.1234/placeat",
+  "link" : "https://www.example.org/47d3c674-4713-4c7f-9fb9-fa0096299c6c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "i43oq7SQnD0bHl",
+    "mainTitle" : "NnZy1fhnaz5qDBn8nr",
     "alternativeTitles" : {
-      "en" : "7pLEtaPf0oNZme"
+      "bg" : "itn7WD54He78vhPQx9"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OeflauWJOoLr35",
-      "month" : "gMtctBSwGtDybW1t",
-      "day" : "IdkxaW2Tlx0s"
+      "year" : "UJig5GWQgn",
+      "month" : "npOfj2nScDzkMPG",
+      "day" : "en8bG5xTkTV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b556aaa2-6daf-4834-a7ab-3172a10e3728",
-        "name" : "QkuyJTSsI6eNKA",
-        "nameType" : "Personal",
-        "orcId" : "ZuOUFHdvfHSEL2Ncu4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/986dd9de-323f-4074-b121-22ddf820972c",
+        "name" : "nZrBvyg0acdg7TVWber",
+        "nameType" : "Organizational",
+        "orcId" : "iMjhCKrK6n",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rCiSHiuhtys8SbL",
-          "value" : "wV1Uzei3ixOGl1n02n"
+          "sourceName" : "glIocViMOj3ojB9Wvl",
+          "value" : "8R6dChEudlv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2TgZXS4twtDI",
-          "value" : "KJMLt8k47A"
+          "sourceName" : "MZIka5uEIlHuDVvZoPR",
+          "value" : "bS6ZjJYZj3A1yhjg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a37a0660-a794-4736-8545-f77df6321fae"
+        "id" : "https://www.example.org/b17d8c68-fecb-448f-a57b-5cf4624da744"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/06600b94-63cf-4c12-b3e6-ab7b34ed129d",
-        "name" : "xdXJjE8qIad6",
-        "nameType" : "Organizational",
-        "orcId" : "uBYdCKLHId6Jtnu8GR",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/11269409-9f03-445d-99f1-3364729cb282",
+        "name" : "iCBSQCbC06djnKd49r",
+        "nameType" : "Personal",
+        "orcId" : "CBVVYC2nUJ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4u05SJiTjb5c",
-          "value" : "JMRiDPHHxtxjmCs44EX"
+          "sourceName" : "dLBmu5kcRc8F7",
+          "value" : "3iE2BM8XBi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mhRC0Mlg4n6B5",
-          "value" : "WnOGzRaIhY7l7vVm"
+          "sourceName" : "01fcIWxGd0",
+          "value" : "rPPtMc6mdVa92UR8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/865b6fd8-1c0f-48c2-8ab5-a206f1537bd7"
+        "id" : "https://www.example.org/297d3ccb-430b-45d3-b278-9bc19d45b170"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "VcLy5tQA8RlY9MOa1s2"
+      "nl" : "BhQblxjh41vzoD9LTLH"
     },
-    "npiSubjectHeading" : "1XA9afZwTmz2LHWDA",
-    "tags" : [ "vMOteQg2QYOeiODHq" ],
-    "description" : "hk9bsdBzc3gJRRGiD",
+    "npiSubjectHeading" : "iUngjkHED9zsUAy2O",
+    "tags" : [ "3IxCBLDu1kyR6" ],
+    "description" : "Kwld633aWj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9cb99321-7c2c-45f8-8a75-0fd709dfbfdc"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cac2833b-3f00-415f-941c-1f270bba01b1"
       },
-      "doi" : "https://www.example.org/c13b008b-46a6-4758-a589-09334daea3aa",
+      "doi" : "https://www.example.org/d28aa15d-4595-4b4e-b464-8a718bb54d0c",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "nuCh9KA7AThghtCqtJ",
-        "issue" : "KQtsjemOHEmwfhI",
-        "articleNumber" : "DlUA7PdcKozT",
+        "volume" : "9sMfAZLdsp7rkCxY12P",
+        "issue" : "Ps7x9qnFItEQEMN",
+        "articleNumber" : "Dw0NZF120tO",
         "pages" : {
           "type" : "Range",
-          "begin" : "E6umxc69rQYjj",
-          "end" : "OBvT9rUJHh1MN"
+          "begin" : "qAEsBialnj5SnhyVq",
+          "end" : "J8EY4uxzRrUonz"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/689cc47c-0999-4a05-990c-d855ec7eefb8",
-    "abstract" : "IBusxZy5q8j6oX"
+    "metadataSource" : "https://www.example.org/3e57b52c-7f1b-434d-8a82-d9d6c6a66645",
+    "abstract" : "DdlNcujMIEjiLw2E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f020c19e-ea5f-4ba1-86d4-0bca7e82940e",
-    "name" : "oUrmdfi77dJvaLdC",
+    "id" : "https://www.example.org/74bb2c3e-0c62-4446-ba52-92650cc3710f",
+    "name" : "yQiBA9pyQd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-03-03T01:46:40.573Z",
+      "approvalDate" : "1998-01-13T13:54:55.841Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "apSbX0gkbvUXCIf"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "tcOvr7aGuxpHROaRw"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ebba264f-0d64-482c-944a-0f74201ea6b9",
-    "identifier" : "vf7NjrnCi1d",
+    "source" : "https://www.example.org/ceb7082c-f741-42a8-a98a-74043b6be76a",
+    "identifier" : "iOMbmB8i0yr",
     "labels" : {
-      "fr" : "5KDuSDQ2GKDnDLl8"
+      "cs" : "qGGum6OAuUHUs0VZ5Jg"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1221717106
+      "currency" : "GBP",
+      "amount" : 841027336
     },
-    "activeFrom" : "1991-09-03T20:39:29.685Z",
-    "activeTo" : "2016-08-10T09:34:10.426Z"
+    "activeFrom" : "1984-01-08T06:35:13.578Z",
+    "activeTo" : "1988-03-31T22:51:49.276Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/028e56ea-8122-4b7e-ac93-4347a31310d9",
-    "id" : "https://www.example.org/d968f5d3-6dc7-44a3-b426-7d7d9a9b4035",
-    "identifier" : "qrmLkw8zRkfcQ6pu6",
+    "source" : "https://www.example.org/af4d63ef-f9a6-467a-b6ce-fd91e62ebd29",
+    "id" : "https://www.example.org/75371283-9293-4cba-8b41-454e95a6e1f9",
+    "identifier" : "CZfCvl0Pex",
     "labels" : {
-      "en" : "Ss52VomeQjg4Ht"
+      "pt" : "CROpwgNijpYQrVFNK"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1929066788
+      "currency" : "GBP",
+      "amount" : 1601342998
     },
-    "activeFrom" : "2021-10-23T00:49:11.311Z",
-    "activeTo" : "2022-07-04T05:44:38.184Z"
+    "activeFrom" : "2020-01-20T10:17:57.202Z",
+    "activeTo" : "2021-12-09T04:26:24.379Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0b3550b5-a781-42ec-bea3-dccfaed8f1ac",
-    "sourceName" : "k1vhcadwyr5z6ygw3j@ljasxyfpsem"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "2061761464",
-    "sourceName" : "zqujl9gvt4ehtxzxtx@kjahlb43zuvn1aznma"
+    "value" : "881704821",
+    "sourceName" : "cvyrfwqmvh704f@1lhpbqrcctizfzombo"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/25a6870d-d401-43f5-91d4-2610d76b54fa",
+    "sourceName" : "lwqwdgoucq@krj5tsnqn1sgs"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "iNltH7VVoQJTfuBzf",
-    "value" : "PD29oJrYUlysbG"
+    "sourceName" : "9SNsTQwa2LjBuj",
+    "value" : "TB3AkqUV5k"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "4APQpubkRQ5kp",
-    "sourceName" : "pjueq0yluitlcyqsi@kooz0smw2cb"
+    "value" : "sRCLAOcd5EvLXpjT",
+    "sourceName" : "ocwvcxe7kcjeijv@qtmd738psz"
   } ],
-  "subjects" : [ "https://www.example.org/3f06a808-74a9-4443-90d9-1d3f545ed21a" ],
+  "subjects" : [ "https://www.example.org/223ba0ad-75ef-4854-a701-ca22285ed704" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1afe387c-06b1-4855-9eae-9cd5b0eb0e2e",
-    "name" : "8lhpEy3liLfBVz",
-    "mimeType" : "sA35gJZEAEzeTg",
-    "size" : 777384345,
-    "license" : "https://www.example.com/awkjixytuozgte5ky",
+    "identifier" : "6119cb48-f5be-437a-8156-61144699f81e",
+    "name" : "O9oCyle7f7cGUE",
+    "mimeType" : "8DEJRAejlETi9j7T",
+    "size" : 290264187,
+    "license" : "https://www.example.com/hxnvccjnqcqt65",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "AdX151idxn25fic",
-    "publishedDate" : "2015-07-05T07:28:16.673Z",
+    "legalNote" : "e6eVOhyLSn0",
+    "publishedDate" : "1971-03-04T15:40:06.640Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1220146897@TMc5gQqpAJr5veMjO2B",
-      "uploadedDate" : "2023-11-10T15:34:33.967Z"
+      "uploadedBy" : "1176870786@1UBJ1p0YBQ0E",
+      "uploadedDate" : "2022-12-20T22:25:19.397Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Hyk74t1TToQRh0",
-    "name" : "59VPMMJZLBBP8zoi",
-    "description" : "mmrspDGUgtNLMNF"
+    "id" : "https://www.example.com/Ng4ZQwteMYP",
+    "name" : "j71UCFThIWvYi7Ciz",
+    "description" : "UMogjRgpnrzKb2hDg"
   } ],
-  "rightsHolder" : "WSiWHSAKus3nK09D",
-  "duplicateOf" : "https://www.example.org/70e6e52d-44f5-4f60-8e9a-063ef6b7bb95",
+  "rightsHolder" : "Zuu576hdqZq6BTtl",
+  "duplicateOf" : "https://www.example.org/d6f663e4-7601-4973-b8fe-8441311715ab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WFTpMFXqYg9OpXl0zCw"
+    "note" : "XkAr6J9nxxsR4XNT44"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kPhFaNobnqslhtYc9",
-    "createdBy" : "f858T0yhvK9v",
-    "createdDate" : "1976-02-26T18:42:59.329Z"
+    "note" : "ruAkGFgiS5ObFv",
+    "createdBy" : "0cEOwLbc0OR65PufAm1",
+    "createdDate" : "1996-11-05T09:10:16.913Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d50ee73f-0bf9-4f02-b889-11c38b68a88e" ],
+  "curatingInstitutions" : [ "https://www.example.org/1c31d995-63b3-42de-aa7f-e8ec21f97f10" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "7S5HBKML2D",
-    "ownerAffiliation" : "https://www.example.org/0d1f47d0-e0c3-4644-a943-b94bd9dc30ff"
+    "owner" : "I2HArz5qkCrt6MuQAH",
+    "ownerAffiliation" : "https://www.example.org/634f1100-f224-4abf-9e38-e5e30a5a0996"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f0190b26-fa0d-4118-b85d-74ac3da4a4cb"
+    "id" : "https://www.example.org/baae97cf-ee4d-4e24-a1ec-b03e0f380b55"
   },
-  "createdDate" : "1975-06-24T20:56:11.478Z",
-  "modifiedDate" : "1986-12-14T01:22:35.537Z",
-  "publishedDate" : "2002-09-27T20:48:41.456Z",
-  "indexedDate" : "1991-03-21T16:46:45.909Z",
-  "handle" : "https://www.example.org/6bd13309-760a-4b55-a7b2-ae456ded7b1d",
-  "doi" : "https://doi.org/10.1234/vel",
-  "link" : "https://www.example.org/79e55f73-4a76-4bf3-8019-d0ffc0ffbe26",
+  "createdDate" : "1993-06-09T07:09:14.447Z",
+  "modifiedDate" : "1976-08-19T17:59:31.520Z",
+  "publishedDate" : "1973-07-17T17:41:27.671Z",
+  "indexedDate" : "2003-04-18T22:35:21.656Z",
+  "handle" : "https://www.example.org/10e95acf-75e6-4444-8904-1f88a62197b5",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/4a0f8328-580c-4cce-afd7-2fcf0d529a51",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RBolOZtxttZH0ZQ2X",
+    "mainTitle" : "lgQQuOiH39aFH5h1VN",
     "alternativeTitles" : {
-      "pl" : "f6RuAEJUUbngfmJA"
+      "ru" : "7MmOqfctWeHvQX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tddvR1E34ncUdD2ceC",
-      "month" : "ooJtqVajVW8I3",
-      "day" : "lzaa2NBjdP8dAkjyC"
+      "year" : "dFgzGgi0gHWk2rc7o",
+      "month" : "fTFr0NW5wy4WjHRG4qj",
+      "day" : "JMwSaYuSVEfzOGlrQJ8"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/37dfb05f-b302-42e3-98bc-f96909a5f861",
-        "name" : "vBpKPg1wI2eXe9",
+        "id" : "https://www.example.org/5fdcf7c0-3458-4af2-93cb-200d2ce06c12",
+        "name" : "9tFzk7qswQucU",
         "nameType" : "Organizational",
-        "orcId" : "gb2G2GHVsLPoifUc1",
+        "orcId" : "zWeZUsaYpmeJ1ddf",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WCDqsdF3m4O1",
-          "value" : "zLjqutChmbMut"
+          "sourceName" : "eyiXgSZ8GtkRJdnYx",
+          "value" : "YvA40Pwyqq96SZ5e"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AFi1gLieKv",
-          "value" : "bbI180Cgt050E8C"
+          "sourceName" : "5cg9oG12fWE",
+          "value" : "dZsFPpVBFuoja"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cb9159fd-a73e-4f09-af75-4367dabd6dd5"
+        "id" : "https://www.example.org/867dbd1b-6fc6-4139-a4de-838920379add"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0813d92a-8514-4df2-9707-6c9c0c2923c3",
-        "name" : "pXT1wC7AkPN",
-        "nameType" : "Personal",
-        "orcId" : "rQvck02WpHA5SePPA",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/0b05d0a3-e275-46c4-8c94-e2a3773b4eca",
+        "name" : "FXcL6quPqMU",
+        "nameType" : "Organizational",
+        "orcId" : "0MLTCMo6ZHaJwKaY57t",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nTEETIAxpJb5Z5Wv",
-          "value" : "sqpdrbR5dkwvpg"
+          "sourceName" : "hAAXabO7tiRKOAW",
+          "value" : "JmivHSVcJeQI689XAb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xs2MhRra5xMmpa",
-          "value" : "dSNfK5Sv0jze"
+          "sourceName" : "qY7RsvuXvLJNTZbA2",
+          "value" : "5JYpxv8OasDHrG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3a82eecc-736c-4a79-b964-f6105eaa519c"
+        "id" : "https://www.example.org/4d69933a-6fc4-4c08-94f4-9fb568f85232"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "Q57efXOcoVXY"
+      "it" : "9UIOpO3LuU1eYhQfB"
     },
-    "npiSubjectHeading" : "FaOJNKNAGR1g",
-    "tags" : [ "qRgo4o8H4EXhARCz" ],
-    "description" : "8fBIZusNKXKq",
+    "npiSubjectHeading" : "oXHY8O2vpLX",
+    "tags" : [ "z6HohtLIZ1FH4yG0sMe" ],
+    "description" : "GOIDtbfHhyDl6Lko",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ab8283a-bcfe-4492-9a5d-d779392eb422"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/47fa9fb8-5f32-4b66-93ef-df42ed20f569"
       },
-      "doi" : "https://www.example.org/7735ce7d-5cb7-421e-93cc-563155b2b7d3",
+      "doi" : "https://www.example.org/ad25c909-ec13-4e77-be10-9ef3bff52871",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "OjfYfMBBWeKO",
-        "issue" : "yuUYxGLMbFg",
-        "articleNumber" : "lYFPuj8a1JPBdS",
+        "volume" : "WK9jsHPiU5fJv0",
+        "issue" : "2sJT7WHDzFtvOczqaYv",
+        "articleNumber" : "4MhkZcmsND",
         "pages" : {
           "type" : "Range",
-          "begin" : "JsNBWTDXLpkpW",
-          "end" : "NskdW9SvagaCHAycJhj"
+          "begin" : "MSdyONzvEcXSt5bmTl",
+          "end" : "4GXa2OEFE8v00RXoZ0"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fdcda2ad-e12d-452b-a29f-4f5118018030",
-    "abstract" : "IFjbJUGxEYpQxRXQ"
+    "metadataSource" : "https://www.example.org/ca467f0f-c76b-4377-a328-e08d036be6e9",
+    "abstract" : "Y4IqoGOWviBh3Rw1x"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fcd5e188-8fbe-4e10-85ca-c49fdefaf22f",
-    "name" : "XGXjHAuFgudnoIZ4GI",
+    "id" : "https://www.example.org/60fb27fa-1c7d-41fd-a012-e730aa018d1b",
+    "name" : "HroTEbzDbLZ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-08-24T06:19:19.881Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "S6ue9N5h9unupNr"
+      "approvalDate" : "1986-12-05T03:24:28.538Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Q7FWwBFF7AXX"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/fe854ea5-ad0e-454f-bc9c-470c62bd3f56",
-    "identifier" : "Vtp6F4deW5QsTdFO0",
+    "source" : "https://www.example.org/d17190e0-91e1-47df-b340-8d6fca3e5c13",
+    "identifier" : "mDSAmKHNPj",
     "labels" : {
-      "da" : "Ei8kIXODQO"
+      "en" : "7R3ZaJlhUNiELTrjDlo"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1895549163
+      "currency" : "NOK",
+      "amount" : 1865254831
     },
-    "activeFrom" : "2013-04-20T17:22:50.615Z",
-    "activeTo" : "2014-10-03T22:01:36.898Z"
+    "activeFrom" : "2022-10-02T07:05:10.344Z",
+    "activeTo" : "2024-01-09T05:51:58.346Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7fd2e0cd-150d-4ab3-abd6-6ff62659e2a6",
-    "id" : "https://www.example.org/677dc2ed-a008-4a50-9870-f93bd37f5592",
-    "identifier" : "n8gxDxhBXNOVMRWO",
+    "source" : "https://www.example.org/89b1f26c-b271-4606-ad7d-b68559fa6017",
+    "id" : "https://www.example.org/03393d22-83b4-437d-9d0b-31915fee3271",
+    "identifier" : "IJa2wd9YvxU5fKdN",
     "labels" : {
-      "sv" : "yNqgt3rGvKzn84w"
+      "nb" : "h4p9ArXzSVXfMxeT7"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1176100347
+      "currency" : "USD",
+      "amount" : 380691610
     },
-    "activeFrom" : "2003-11-19T19:35:03.708Z",
-    "activeTo" : "2013-12-12T00:38:35.358Z"
+    "activeFrom" : "2009-11-08T04:18:30.915Z",
+    "activeTo" : "2019-01-02T09:00:00.314Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "5760902",
-    "sourceName" : "lda4fohvqq@3qkgxvw6j5"
+    "type" : "ScopusIdentifier",
+    "value" : "dkT7dSbO7QJt",
+    "sourceName" : "jelgj0v4vno4qq5@twyjxcfpnv"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "VaW9Rw2Rws7d5s6xE",
-    "value" : "k9X0Vb00FVQp1"
+    "sourceName" : "WGjVWQQGGYAONm",
+    "value" : "2W2GxWX7lQJVKL"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "418794232",
+    "sourceName" : "tsizyezcn5xyi2@xswnmbi4ju5pob"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d5e4ad9d-ff9a-4d80-bcb7-cc20fc57f8e2",
-    "sourceName" : "0riaysicowjo@ic4jlskqgm50vj"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "6dxqsuP50t",
-    "sourceName" : "1ql0zubxlwl@1nycctnyspqliqnmluf"
+    "value" : "https://www.example.org/b452d14f-919b-43dd-8864-67723813d6e0",
+    "sourceName" : "xxaydutfbgv@sp7knmvip87cm"
   } ],
-  "subjects" : [ "https://www.example.org/39410f95-ceda-4be0-a59f-183412e81436" ],
+  "subjects" : [ "https://www.example.org/f5287662-77ad-4fd3-8161-e9fcc0f094b4" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ef0583e5-7dc0-49cf-a5b6-ffd042d81eae",
-    "name" : "XvAKuLSmGpJeGoEw",
-    "mimeType" : "yXdigrmMIxmd",
-    "size" : 801259333,
-    "license" : "https://www.example.com/zc5e1xwf6lnt5cmuqq",
+    "identifier" : "1f9642f3-bcea-45de-beca-550f4ea0a53f",
+    "name" : "zsF65XYhQ1jve4zQVGb",
+    "mimeType" : "JKCozfykRvY",
+    "size" : 115099772,
+    "license" : "https://www.example.com/fgu1vwjo8kczadkk",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "BROe9ole9G",
-    "publishedDate" : "2013-01-28T04:38:41.317Z",
+    "legalNote" : "vjDTpyNMEURIDlP",
+    "publishedDate" : "1981-03-18T20:07:14.626Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1669346570@WnYBrGf7CFIja0rs",
-      "uploadedDate" : "2022-03-18T22:31:17.426Z"
+      "uploadedBy" : "947355686@6nyGm1ZJ89Td",
+      "uploadedDate" : "2020-07-30T17:33:19.453Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SIddqLGavOIyxokOl1",
-    "name" : "r2boquujyG",
-    "description" : "0GnahWqrkC"
+    "id" : "https://www.example.com/SRux3xXH2Qv",
+    "name" : "fzov2uHN3PyJB",
+    "description" : "35S11qxUFAtl4YB"
   } ],
-  "rightsHolder" : "CLI2Q39ll7",
-  "duplicateOf" : "https://www.example.org/bcc7a5b6-89c8-4a5c-9d71-bb0a9e9b3105",
+  "rightsHolder" : "OaCTmQIiEY",
+  "duplicateOf" : "https://www.example.org/1aa9e94d-6c2f-46a6-8466-46415936a246",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CVbDX9yNSHBlXt9y"
+    "note" : "cNHezWHmBMRr3o15fon"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GmgvOCZkHXJF2a5",
-    "createdBy" : "5gR1i113jqFfIkb",
-    "createdDate" : "1982-11-17T16:38:50.904Z"
+    "note" : "svXo2zd14Ppz",
+    "createdBy" : "JEhmnug503iMjJ",
+    "createdDate" : "2010-07-29T22:27:04.781Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/07d13d9c-60c0-4835-ac62-086573246cec" ],
+  "curatingInstitutions" : [ "https://www.example.org/7550f310-e975-491a-bcfa-06c59fe96e8f" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -3,59 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "tUkYWR8EqYKyNqfIF",
-    "ownerAffiliation" : "https://www.example.org/9b924bbf-d2b8-4131-b44b-62b0987e9107"
+    "owner" : "n3tElYS6BXZqCeiGVwD",
+    "ownerAffiliation" : "https://www.example.org/13c05035-ebb6-44d0-b3c6-7228c52bcca3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fd250d38-32ee-469d-9c74-83d78f0f0ca7"
+    "id" : "https://www.example.org/b5820dcc-c8ad-42b5-bae1-a129dd673ea8"
   },
-  "createdDate" : "1996-06-19T19:51:25.420Z",
-  "modifiedDate" : "2016-05-02T06:28:17.506Z",
-  "publishedDate" : "1997-10-18T05:42:10.349Z",
-  "indexedDate" : "1994-05-17T05:31:31.897Z",
-  "handle" : "https://www.example.org/ce0b9115-2dd5-4ec2-b39f-1a87af01de21",
-  "doi" : "https://doi.org/10.1234/porro",
-  "link" : "https://www.example.org/6b805e2d-0a41-417a-888a-d5f261ac0984",
+  "createdDate" : "2005-06-29T14:13:56.951Z",
+  "modifiedDate" : "1999-07-31T00:37:58.371Z",
+  "publishedDate" : "1993-10-09T04:25:50.835Z",
+  "indexedDate" : "2009-12-17T05:25:36.582Z",
+  "handle" : "https://www.example.org/71754cca-a12a-458d-9b10-49e87582be9d",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/f517c3cf-203c-4bb1-b38c-3a675c6427c4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JJyppkKCilvXLiafQ",
+    "mainTitle" : "cVud2d9DVgAFL",
     "alternativeTitles" : {
-      "da" : "Ja0deTUMM8KB"
+      "sv" : "eVvvZLaCxezSdbn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ZEv6UlPXVMSEHF5dRw",
-      "month" : "oZ6yX2VkNV",
-      "day" : "a3Nbb6VTqN"
+      "year" : "h0ZPEUUjWUA",
+      "month" : "ejukO0aVQ2ii9htcq4l",
+      "day" : "XV44ipf9RO65"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94352602-cfe5-44d1-95d8-a770ed331958",
-        "name" : "ASgABFBrY2tnUEmKx",
-        "nameType" : "Personal",
-        "orcId" : "rK214pp66aXdSN9G",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/654c6db3-81dc-4c40-911c-ee21cdc4b025",
+        "name" : "JG9FaPWXh0xtzSu34",
+        "nameType" : "Organizational",
+        "orcId" : "BiZRIVyeOIJNjQ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QrlO6Xaz5GdIxP7TJCd",
-          "value" : "Uax9PrJHynkvFVUhlT"
+          "sourceName" : "iMgv9QgIzEO1fO",
+          "value" : "u7yrr6iX3EhO9k"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QnKIzggZVdj1pjgj2",
-          "value" : "na2LAkFXnXRK"
+          "sourceName" : "63EPGtHCJPDoj0fqX",
+          "value" : "UX74x15k4ZCuAod"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/63099792-387f-485d-ada8-64f93929c6f3"
+        "id" : "https://www.example.org/f63bda5f-b1b9-4aba-9973-d9fd7190c7b5"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "asXMtxqOYYCsJZ1"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3738b33b-c060-4e51-8a05-a77d224d334f",
-        "name" : "FggcL8KqXDp4uAuqYF",
+        "id" : "https://www.example.org/481764a3-7ea8-496d-afbb-04fc825462e5",
+        "name" : "Bs7eVZlScY8C13yFv",
         "nameType" : "Organizational",
-        "orcId" : "0OnnSj5aXhT",
+        "orcId" : "YLtMZOLZLdHK1P86IEO",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pjD2YJiH6r",
-          "value" : "R7j93pibRIvcG"
+          "sourceName" : "p61d4Gf89O5bTt",
+          "value" : "83fZXA1vjs1U1x"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fHSenxpLA3miQv",
-          "value" : "tCtTuk4PQR0UVHCU"
+          "sourceName" : "gzlbRFGQJeL0",
+          "value" : "OSTnRsnwtX2olWe3kf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/209207d3-4ee0-4e1f-879a-4bc4fb6809c8"
+        "id" : "https://www.example.org/885fce01-ee0e-4bb6-ac5b-91b5bc9d4ed4"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "vYzGGaMiQIeO70Ku"
+      "is" : "tM2sOmL3wM"
     },
-    "npiSubjectHeading" : "hUAWZJ3Jgqk",
-    "tags" : [ "l60tpTBEw0P8IAmZFx" ],
-    "description" : "BWL9c6nlbZuu",
+    "npiSubjectHeading" : "tVpxuf1SJZ1BV8pNcC9",
+    "tags" : [ "nb2ecRCIYtc4" ],
+    "description" : "vwy3YfLMnOa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dae0a395-af8d-4ec2-a350-676a6136782f"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4cd587af-9eaa-4c48-862c-506d31f96238"
       },
-      "doi" : "https://www.example.org/61a861b9-23a2-42d6-9915-e8e05031d7bd",
+      "doi" : "https://www.example.org/8a9ecef9-1b1f-4ec9-9505-f512bbcec1f0",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "MTP24htlxRlDSYO3",
-        "issue" : "BpZevLnGuZMFVoTFwB",
-        "articleNumber" : "dUYbHzm3xb44ScoHKC",
+        "volume" : "5qj8g4dtHoi",
+        "issue" : "TeDonzzkDY5Qn2Y5LL",
+        "articleNumber" : "nuFbCsxmDqwaJuB",
         "pages" : {
           "type" : "Range",
-          "begin" : "Kqu6sqMaStar3FqH1V",
-          "end" : "cC217zuPZf"
+          "begin" : "mr848atr723g9U",
+          "end" : "IXzznhH51GH0o7Ekf"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/587e852b-a982-42c9-8cf0-b5dcb08ca45f",
-    "abstract" : "I6KXQ3tXdwMbwX12f"
+    "metadataSource" : "https://www.example.org/d10b196c-9ec4-4152-a3ad-2494a37c7cee",
+    "abstract" : "A6hImA9Db1pJWYGC8NK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1ab902a5-dfd9-4f66-a06e-19bbecad8d4f",
-    "name" : "Vg1oWKiV3Pn6ZhC4Io",
+    "id" : "https://www.example.org/c81820db-1f98-4544-a318-290f0c787122",
+    "name" : "JuLs7wwvVw4EpaksS0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-09-01T06:24:05.290Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "R8giFMrY7GMsg8BU"
+      "approvalDate" : "1972-02-18T18:25:17.508Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "GUrOv8ma4PO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0b368959-9c9b-4e84-b41b-317ef568fbe9",
-    "identifier" : "aQ6aamGiiWvwGGzb2h7",
+    "source" : "https://www.example.org/bd992eee-ca85-4076-92f8-2466aa645c6b",
+    "identifier" : "MLKA8nWa8bFFq",
     "labels" : {
-      "cs" : "EwG57LrFi5mM"
+      "da" : "v3tqgbrmnbu"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 390771923
+    },
+    "activeFrom" : "2012-07-28T19:06:18.977Z",
+    "activeTo" : "2018-01-10T00:33:42.386Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d1901c35-1ee4-4452-8744-9d48128e53d2",
+    "id" : "https://www.example.org/f7162f79-8c5f-4d36-8bc4-8a9ce57e2401",
+    "identifier" : "Bmqnp4iwGSItNw",
+    "labels" : {
+      "bg" : "AdDfo8D3yjmm"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1125438573
+      "amount" : 1167024313
     },
-    "activeFrom" : "2019-09-25T19:11:50.879Z",
-    "activeTo" : "2023-08-10T11:59:21.217Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/05b46671-e35d-4401-870e-190bacee600c",
-    "id" : "https://www.example.org/f62c5004-fbfb-499d-94b9-fff3ef09e21c",
-    "identifier" : "JS1ccm4JKSU",
-    "labels" : {
-      "pl" : "TEoH60zfHoGohBwQM"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 3434327
-    },
-    "activeFrom" : "1996-03-11T08:00:34.050Z",
-    "activeTo" : "2016-06-05T12:29:04.471Z"
+    "activeFrom" : "2020-06-04T19:04:08.278Z",
+    "activeTo" : "2023-06-29T18:04:18.457Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "xjzo7TALQ2jC79WRJ",
-    "value" : "8l5MEkc6BRl4"
+    "type" : "CristinIdentifier",
+    "value" : "832716781",
+    "sourceName" : "jr73gyssqrifoh1t73@9hnuva95gp5qpv6g95o"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/f8f42c6f-48e6-45a7-a248-1d57387bd31d",
-    "sourceName" : "douy9y6sfxlil@zjk5maqgdpqv04"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "550875743",
-    "sourceName" : "wfqk0vmraunv@gcphmuyvpd"
+    "value" : "https://www.example.org/6f1eec24-f94c-4830-a8af-de20502a14f2",
+    "sourceName" : "puclwzvw8xw@5kdwvwgtyex"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "dTnbK0jyE5L",
-    "sourceName" : "osujd9rqonqrcntdo@ygyh916pksxqasa9z"
+    "value" : "IytfjzNMNMZGCVEb",
+    "sourceName" : "o8uxm5pufrlrduhpw@y0dw8usth2getjxh"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "Bh8yUbGnRRcJzO5ba4",
+    "value" : "dQ1b2bMU2PmY"
   } ],
-  "subjects" : [ "https://www.example.org/5e7a962e-99af-4ea5-bab0-c982b4d27496" ],
+  "subjects" : [ "https://www.example.org/825c979f-a477-4737-a37f-62560d2d2344" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "314a7ecd-bac9-4cf2-b83e-3f59545af437",
-    "name" : "aLNyftvR3DzMn",
-    "mimeType" : "Z78ulaNEjW2Wco7dJZ",
-    "size" : 763538514,
-    "license" : "https://www.example.com/m7bil0tqv1b9oh91",
+    "identifier" : "8296ad6a-35ae-4743-b8ad-84fbd5615f38",
+    "name" : "UktpOnCd9TX9mS17D",
+    "mimeType" : "yOfvVMis87",
+    "size" : 845170814,
+    "license" : "https://www.example.com/ntzxsyrz64vrcsuo",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "bfTFTsh2aise"
     },
-    "legalNote" : "gm0eZq9cRZZ",
-    "publishedDate" : "1988-06-14T19:23:56.415Z",
+    "legalNote" : "4sHSfoGNswk",
+    "publishedDate" : "1984-10-01T04:27:55.512Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "170757794@iUjZAL6NlNyweiQ",
-      "uploadedDate" : "2021-06-18T17:20:45.060Z"
+      "uploadedBy" : "361026887@YRL3oInkqCGy",
+      "uploadedDate" : "1973-05-08T04:49:10.934Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qzl2cEKEmLQT53B",
-    "name" : "qln9aA1HDFaZU7KaF",
-    "description" : "1SNiIiCVAyK7dDPvu"
+    "id" : "https://www.example.com/5CReKN6zZSL5OUe",
+    "name" : "THrNSACgjmOgf0TiTmR",
+    "description" : "3lNFB39eiAaPGRQZBa"
   } ],
-  "rightsHolder" : "lWA1Zosscb09N2V",
-  "duplicateOf" : "https://www.example.org/7d0f095d-9945-41c6-9f08-da8fd8a00a7f",
+  "rightsHolder" : "0PnTpOCkT9lA",
+  "duplicateOf" : "https://www.example.org/0e2104b5-dcfa-4916-8237-2bfe8224ca31",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "eszt6AnVk7hEqYY6"
+    "note" : "ag2YadCpGF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ZZsHSKOA1eM",
-    "createdBy" : "LMqXS33kLQRsjRVTF1",
-    "createdDate" : "1997-09-21T17:27:36.565Z"
+    "note" : "QBBYgKlkjY6zPC3GmAU",
+    "createdBy" : "rxr7xY6QpE8g",
+    "createdDate" : "1987-03-28T15:35:20.713Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/06b64f73-5ff1-4b9e-85a2-2e9355cd0dd5" ],
+  "curatingInstitutions" : [ "https://www.example.org/a5d1952b-5295-4d90-9692-ccc0f647a5c1" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "A30so1qmqGSiX2zcl3U",
-    "ownerAffiliation" : "https://www.example.org/974de8c6-bdbc-41f6-873b-e3e8a471dbb8"
+    "owner" : "0qoK8HI53D0HRiSOkFn",
+    "ownerAffiliation" : "https://www.example.org/ee1a5010-60e5-41d9-aa59-13d0645e0194"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/314f13c4-4ee9-4263-a0ce-f7bf4fc0833a"
+    "id" : "https://www.example.org/cc59a461-5d7b-4f4d-ab30-912bc8be36cf"
   },
-  "createdDate" : "1977-11-21T17:57:18.659Z",
-  "modifiedDate" : "1995-01-04T17:32:23.172Z",
-  "publishedDate" : "2016-05-07T10:25:39.693Z",
-  "indexedDate" : "1994-08-26T18:47:37.541Z",
-  "handle" : "https://www.example.org/b9643d2a-e71e-4fe0-b3a3-297f129402eb",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/150654cb-b465-458f-97e1-b3cfe5fbf5bd",
+  "createdDate" : "1984-05-15T11:49:20.757Z",
+  "modifiedDate" : "2017-06-19T22:31:03.012Z",
+  "publishedDate" : "1985-06-09T18:25:29.040Z",
+  "indexedDate" : "2004-03-02T13:01:44.861Z",
+  "handle" : "https://www.example.org/6c39f701-b3e5-4279-85d0-8b4d8bbeeae8",
+  "doi" : "https://doi.org/10.1234/magnam",
+  "link" : "https://www.example.org/c4b6b4f6-657e-45ad-9485-3cea1db2e106",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WFam1Ms8xjInoxaZ",
+    "mainTitle" : "Rgfhejn4ms5L97l7e",
     "alternativeTitles" : {
-      "en" : "tRnXEuTAiMvG209jc7k"
+      "zh" : "FlDRMhvzDOwKJp"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1GEpfYcenoygAqJFwr",
-      "month" : "tZgZfns6tnlZjb6jF",
-      "day" : "fHHXxD8w7pHYTM"
+      "year" : "HmmebyHMnh662",
+      "month" : "QHwt6c6EST",
+      "day" : "a4KAx65TukQnuWA7c3i"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8f8cf78e-48e8-40b6-8fe2-2549a6af4bda",
-        "name" : "fuWNVTCYNem",
-        "nameType" : "Organizational",
-        "orcId" : "feZARsMeesIyb8dEq",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/6766ac74-c67d-476c-b603-8ab50d793d35",
+        "name" : "L0hNTAbSVlInQ",
+        "nameType" : "Personal",
+        "orcId" : "TgLJbjjtN41",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MHGIqex3HRDFrsNpe",
-          "value" : "sSpBn0m8G8Dx7bzRu1Y"
+          "sourceName" : "V4VOmu15OgWTb3Gl",
+          "value" : "FAClDCckOo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "E6RJMbP5t7itB",
-          "value" : "d1wyQfEkhil5N"
+          "sourceName" : "41jKbjETd65Mv0r9oBn",
+          "value" : "oBp9qBx0aXkB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/34e1968e-c3fd-4b37-a63b-30bc6127ac24"
+        "id" : "https://www.example.org/2fa5e212-3ff6-48c1-b0fc-81b072fa163d"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5375768a-510a-47bc-8e44-7c04e2b80be6",
-        "name" : "DnZBeVFXiMwtIl75M",
+        "id" : "https://www.example.org/51194047-d90a-4198-884b-dbe599b90ce8",
+        "name" : "4bEXeU7LpQEhE",
         "nameType" : "Personal",
-        "orcId" : "AVTLvSoIgaCI",
-        "verificationStatus" : "Verified",
+        "orcId" : "P8JLVBAmnSkCTGIJT7",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wfS3fv17Ge",
-          "value" : "nkOEGMARhp5U"
+          "sourceName" : "3BF6tflHXfhfA",
+          "value" : "Nu0OCWkpXoGcv1v4MY9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1dlzAZvmhRAF",
-          "value" : "fvdyR6A9fD02Ysw"
+          "sourceName" : "t5ViSYpxbxs2F1H1H",
+          "value" : "QFU2Uj1NLEC1kmZ23"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1b799279-5c11-4d2b-9f3a-2f9a3a20ad05"
+        "id" : "https://www.example.org/e122657e-463f-4fc0-9622-7bd81dbf7ccf"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "kNlpEe5sDeV"
+      "sv" : "S818w9H1AijCmRGWW"
     },
-    "npiSubjectHeading" : "Q7O90hq5kjdaGNFx",
-    "tags" : [ "DmyEp1OxD2XYWVlsiVJ" ],
-    "description" : "WF7g61kPcFQg",
+    "npiSubjectHeading" : "C0XYVT1T0b1JhAy9bup",
+    "tags" : [ "3SyolUPABilLE" ],
+    "description" : "ymyPkBStZDV58zY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "MS70xBLJpSHr",
+        "label" : "SrIh13nGl3Q5scVBYkX",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "qPP1oI1AlY",
-          "country" : "bsFYHUqiGaT"
+          "label" : "W330Ke4qARDkjUb",
+          "country" : "HHtxkgUHOMu37Oo"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1983-09-28T10:28:46.816Z",
-          "to" : "2008-12-31T08:44:45.386Z"
+          "from" : "1979-08-31T06:18:32.078Z",
+          "to" : "2019-08-08T01:57:54.073Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/hudtFDgrd3H"
+          "id" : "https://www.example.com/pUtuigDfa9zpcifE"
         },
-        "product" : "https://www.example.com/OVg6th7Zoqimvbf7"
+        "product" : "https://www.example.com/bk9CwhnE55RT5aQ"
       },
-      "doi" : "https://www.example.org/74b59e98-a68a-4eb8-a8fc-b493d7e777b7",
+      "doi" : "https://www.example.org/7f69a7fc-c82f-45bb-898b-c5770e3607d4",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -122,106 +122,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8d963ddb-cedf-4df8-9ada-31688fd93519",
-    "abstract" : "VSNtqae2T2PkDgpp"
+    "metadataSource" : "https://www.example.org/437b6a92-0dbd-4f33-905d-d880d0b9aef2",
+    "abstract" : "6SD0vE8sfCZYqY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7dc3dd59-d177-4411-be4f-419888063dbc",
-    "name" : "umFXAd0oGuhtBNnR",
+    "id" : "https://www.example.org/5d04cad0-32ba-4c62-a558-67fbc79771aa",
+    "name" : "aa1qXCbw2jy7bCAZ1P",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-02-07T18:15:32.665Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2009-01-16T15:39:22.323Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "Y2BYN2UAxQ"
+      "applicationCode" : "7w0FLa7uLEktHw0"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f517c3c6-4875-4781-9bb1-26c093877f72",
-    "identifier" : "v9UMymqL1APY",
+    "source" : "https://www.example.org/a832cf96-c6f7-47be-bd5c-cd3c1bc6e0ef",
+    "identifier" : "uj9OOg0AAiOm6PsKeJ",
     "labels" : {
-      "el" : "hHbvmhGIX5Iw"
+      "is" : "92gFeP74bGqgefGyGk"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1774923232
+      "amount" : 219712850
     },
-    "activeFrom" : "1997-04-23T17:34:07.251Z",
-    "activeTo" : "2013-01-11T03:00:09.204Z"
+    "activeFrom" : "1992-05-11T03:04:53.814Z",
+    "activeTo" : "2014-07-29T15:46:59.060Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dd464c35-d375-4892-9613-81b51c828d37",
-    "id" : "https://www.example.org/72d7b193-24dd-4a53-810f-d9d740d05ade",
-    "identifier" : "XTvULESbHYrzmTwSxE",
+    "source" : "https://www.example.org/bc79f854-51d4-490e-ae68-e705d584a50b",
+    "id" : "https://www.example.org/27315a12-d844-493d-8dbc-0d8e2fea20ac",
+    "identifier" : "O0c4le8fD4",
     "labels" : {
-      "pl" : "r2j3t0Ij5ibxraTW"
+      "zh" : "PGw4eCSOdk"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2075309798
+      "currency" : "EUR",
+      "amount" : 1375057532
     },
-    "activeFrom" : "2009-02-25T10:40:08.581Z",
-    "activeTo" : "2010-12-23T13:32:07.076Z"
+    "activeFrom" : "2010-03-05T08:42:39.115Z",
+    "activeTo" : "2021-05-30T01:15:14.319Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/9c5351a6-2bd9-4d57-84bf-54fec39cd106",
-    "sourceName" : "p1qzeao4edpsgfxs4w@ym8oy12e8ltmoy"
+    "type" : "CristinIdentifier",
+    "value" : "665815466",
+    "sourceName" : "nocpoebkyz217v1utaz@cf2eduk1cgeqnbd"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "SHmWIWKdYWUzCQIpMi",
-    "value" : "pBcEdsVoehE"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "875878734",
-    "sourceName" : "vbdfmixu63@f3eqmdb9vcqlhxx2bw"
+    "sourceName" : "87tRFVmrLZCbiqZ2yVl",
+    "value" : "Vs8o168efz9"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "gemP5QHnMZ5CAkywrlS",
-    "sourceName" : "qovmtypmoqg8ly@qaiuuz5wav"
+    "value" : "SktrBTuW1vK",
+    "sourceName" : "onbyqdny9n@tdixqjpa46quint8"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/61754fb6-3dab-4328-8e6e-24ac8a1cae5b",
+    "sourceName" : "ih6cocun2qa7@pwuoazffjhs2jqdjt7"
   } ],
-  "subjects" : [ "https://www.example.org/c06a5ef7-824b-41f1-8bbb-ee7fbcb67423" ],
+  "subjects" : [ "https://www.example.org/e7ea68bd-9150-4095-94d1-4331ae15bce7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "823d9cea-65c5-4016-9f71-56fdbe59241b",
-    "name" : "RDtA3AKLLepIGA",
-    "mimeType" : "0rXnTxyY14X3TcgYbX",
-    "size" : 529663811,
-    "license" : "https://www.example.com/rzgxrrujrcy",
+    "identifier" : "5185e9fb-bee9-4fb2-8bbc-9b75e9f0218e",
+    "name" : "OXclY2mG1SZv",
+    "mimeType" : "HhgFBrUFUqRu8NTiB",
+    "size" : 2119496244,
+    "license" : "https://www.example.com/qtvyvef2y09qnr",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "MqYRMOKqftxyfW5",
-    "publishedDate" : "1982-12-07T06:10:13.772Z",
+    "legalNote" : "WEx1FA6TuKkMU8",
+    "publishedDate" : "2004-01-29T09:38:00.369Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "537287744@CKiGlKRxPV",
-      "uploadedDate" : "1975-05-12T07:39:28.489Z"
+      "uploadedBy" : "971439636@oUJtOYVATGRT",
+      "uploadedDate" : "1993-04-18T08:57:28.773Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2sUYPX0tYN",
-    "name" : "Kzn3U6FWeyLkq",
-    "description" : "8ri9N4ofOCF7"
+    "id" : "https://www.example.com/5IoTUXmV3vo9gYNp00i",
+    "name" : "RjRCST1alVGREuJ",
+    "description" : "2wxAFn9lRWii3B5"
   } ],
-  "rightsHolder" : "Fc2FisOHJSE3L",
-  "duplicateOf" : "https://www.example.org/e1407c15-aaf1-4a48-a56e-febf6a9151f3",
+  "rightsHolder" : "XdtEoHJ3eF",
+  "duplicateOf" : "https://www.example.org/8db351a2-57c0-4816-8e29-420d4d6f904a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dGTpzHBYKI52BDq7Ub"
+    "note" : "ILMErfbcCxVLWSOeH"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "qcZLoSFITyIhOt",
-    "createdBy" : "JBcNZ6S57faIZq3F0ju",
-    "createdDate" : "1984-12-26T09:20:25.902Z"
+    "note" : "JXagpgIE7rp",
+    "createdBy" : "pPrAjQ9p2Chx0FP",
+    "createdDate" : "1973-09-12T04:22:15.238Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/69be4c98-e57b-4efc-b956-8356e284ec47" ],
+  "curatingInstitutions" : [ "https://www.example.org/049d70d3-1f42-48f6-ad58-4d46699d3e3d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "328vQVBgXMc",
-    "ownerAffiliation" : "https://www.example.org/c5c9cc49-dbe2-4577-99d1-340aaeabc1d4"
+    "owner" : "9Og0jJKyt4NLLk3",
+    "ownerAffiliation" : "https://www.example.org/b3b76d9f-f159-4521-9c62-3180598c4b12"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9e3a55c9-ef11-41ec-a3f7-fa35b4ff380f"
+    "id" : "https://www.example.org/a5629f2a-d1e7-42d7-a2c2-15eea378db44"
   },
-  "createdDate" : "2013-12-14T21:04:53.906Z",
-  "modifiedDate" : "2013-01-18T12:10:36.654Z",
-  "publishedDate" : "2023-05-06T09:53:20.401Z",
-  "indexedDate" : "1989-04-27T18:58:56.859Z",
-  "handle" : "https://www.example.org/56ac4983-6917-4253-a16d-8c508fff2437",
-  "doi" : "https://doi.org/10.1234/velit",
-  "link" : "https://www.example.org/d4bc630f-ce18-4444-a953-ebb4e8a74422",
+  "createdDate" : "1979-01-18T00:49:46.615Z",
+  "modifiedDate" : "1992-08-14T03:38:16.172Z",
+  "publishedDate" : "1993-09-04T01:55:49.939Z",
+  "indexedDate" : "2007-05-20T17:56:10.971Z",
+  "handle" : "https://www.example.org/71d149ee-89a2-4f68-9213-b2d43091b427",
+  "doi" : "https://doi.org/10.1234/quasi",
+  "link" : "https://www.example.org/a319aaa8-edff-4d98-97a9-cfbc6d8aa17f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uE5050gnvfk",
+    "mainTitle" : "aIc7npy8QCQD6Jdl",
     "alternativeTitles" : {
-      "nl" : "Azg8eDKeQKLBp"
+      "da" : "3qCvgE4K6a"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "mFXtGaaKaeepTh4",
-      "month" : "viibWuC1LjyVe1",
-      "day" : "hVhFvPFeME"
+      "year" : "cyItL20LC09oL",
+      "month" : "SNQlHZyZ9MNfi02xDN1",
+      "day" : "OcivH9KmlfJepTXJw4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3351d87e-e63c-4bf2-8372-7b607404ebca",
-        "name" : "wgjh7F4WWDxk",
+        "id" : "https://www.example.org/f24c952a-85fe-4fe5-93cb-bb713587678a",
+        "name" : "1APgaGo8AOXgOdM",
         "nameType" : "Personal",
-        "orcId" : "oEHGZvppUl9iI",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "wlKAf5DrLvXoa",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v9aCIroZlqqy5MUe",
-          "value" : "LVgoPonqxgzfNNq"
+          "sourceName" : "2jvNmsvdoNr2ofh",
+          "value" : "6awbNeuxUoYz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "imTqyv4foFR",
-          "value" : "5PYI1XQdFIjXmE6W"
+          "sourceName" : "I4rS7X2tkCRkgZy",
+          "value" : "61UtOxMxIyDt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0e60135b-4311-4d0e-b06d-61919001ed3b"
+        "id" : "https://www.example.org/263baebf-26ce-4c96-b961-93ca30ffc8ef"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "RoleOther",
+        "description" : "L0CiiatBdsCqTSh"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,229 +63,227 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/77b237bc-0f78-4a36-8f47-cb0d35eb2b42",
-        "name" : "ZNX9Ai64I3QoOg2iASp",
+        "id" : "https://www.example.org/3be0cf70-f932-482f-a9be-ebf4573ccce5",
+        "name" : "8Ja3vn5Kp48",
         "nameType" : "Personal",
-        "orcId" : "pumD0vd1W0TGuDpn",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "DP8urZm0AM6Dn9lH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vp8k0N49JMLJ4HmtV",
-          "value" : "17tctUPTUM"
+          "sourceName" : "aTIH7RfOnDa9uc",
+          "value" : "2fIGHG4yzCVl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "roE2C8iyNe2NGcoxiYe",
-          "value" : "FsF2U0ulbWOhJC"
+          "sourceName" : "e1rKJN8BWaIXhSO",
+          "value" : "NDRSBC73FmYx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c21e4e38-5ac7-4467-8676-7fac514d493d"
+        "id" : "https://www.example.org/6b93ee15-41a7-4699-a410-25388932f191"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "o0umhdWbt4IkaYNoqlU"
+      "fi" : "cTZPNa92pzuf21FMP"
     },
-    "npiSubjectHeading" : "2AhDdlNxPl",
-    "tags" : [ "6lq8P40ssa5oKrwFE8x" ],
-    "description" : "oIYEYFQGjfaUJc",
+    "npiSubjectHeading" : "Ir2Fm3RNCzRRPouyxE1",
+    "tags" : [ "bn5GsG0sLNkJmEO" ],
+    "description" : "a0K3v5Z1ye",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/508ce4b5-c8f8-4563-96e6-3f958c65dc7c",
+      "doi" : "https://www.example.org/c930e7ef-0bfd-4727-89ca-bf5e49c36890",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Poetry"
+          "type" : "Translation"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "1ICDHKYSy4z",
+            "name" : "sWkHEY0MaNvdbEvh",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "19MU3rnWyd2",
-            "month" : "v7diksswu8T4fbgzzkV",
-            "day" : "3nT1b7wAw4efh0Wu"
+            "year" : "mfRGYwHGFy82uba",
+            "month" : "PW7swuZ1xfNNihm",
+            "day" : "QBiG0r56XDkpa37NED"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "p8J1IqdutckfI2",
-              "end" : "dj2EtIWbRAS19oNEC"
+              "begin" : "YqylY7aVsoQH6YZSoF",
+              "end" : "OjMeZwmPRhcAPG5rfF"
             },
-            "pages" : "3ysVOTWYv9idbRUS7pX",
+            "pages" : "4py8RNA59p2INtA",
             "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
-            "type" : "Audiobook"
+            "type" : "Podcast"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "LrDvjwypKDpNYNTLlnr",
+            "name" : "l00YlrtHFg16FV",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "wsx8j2thzWCTCkl0",
-            "month" : "v7al07tXDcqhmYp0",
-            "day" : "OEXHvkSODNBK"
+            "year" : "3ocFznsDCOcnLbWZRD",
+            "month" : "J1oejQU2Py4ZE",
+            "day" : "plS0Vw9QVyOa"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 1071876361
+          "extent" : 2064275266
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "LiteraryArtsPerformanceOther",
-            "description" : "e6XTgOmiI5Bayr"
+            "type" : "Play"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "itPy4jcInLgJsn",
-            "country" : "EZvn62ye3cYv"
+            "label" : "3wCCIWki4TED18",
+            "country" : "7YqYhIDxaEv"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "xES6cpEE6HyB1",
-            "month" : "S8s8XtlY3mJ6xc7",
-            "day" : "MjT3ONRLLJM4A3hK2Ik"
+            "year" : "gqKgrRvUhhFe2fE",
+            "month" : "HNXt51usbrVY4NZ4N9",
+            "day" : "fpp98v1nZBWZAsEa0vb"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/R1h3GhB3ve",
+          "id" : "https://www.example.com/3cUE06t6fMgf7",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "USFQ799Woc55xD2cb",
+            "name" : "1sdkCvFEDmvp",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "rswrlaa3aE2",
-            "month" : "wkytnFYzuC1Zd96gBxp",
-            "day" : "SwdBMRhzA6"
+            "year" : "z4F5YN6qvo7jmzU1Mo",
+            "month" : "sp7HuyimrWQKWbUMCg",
+            "day" : "doeQIg3hlyT3WCEAH0R"
           }
         } ],
-        "description" : "Yi7vjUNuThtZQ0TK1OK",
+        "description" : "Mioku0bUARaArVizG6w",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2699f32a-d1a8-4223-b895-aa1a8c137c14",
-    "abstract" : "PgKUy27Es0af6pyrywl"
+    "metadataSource" : "https://www.example.org/5812eade-ba9e-48eb-85df-5f8be8697f90",
+    "abstract" : "3oP4hKbe3KXrU2gOzh2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ae3e21c5-9642-4a95-9cb8-025572f1573a",
-    "name" : "IYz4eEMlzwC2",
+    "id" : "https://www.example.org/fe350173-8a1a-42c6-8a0f-78d1c468fc64",
+    "name" : "CBe6M2CX1XrS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-10-27T12:57:01.679Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "zntfzR3Ck1sveP"
+      "approvalDate" : "2011-02-12T14:20:40.681Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "6UdlzOABBnzxpGeRf"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5ba4caa6-8f2b-4a2b-9c1f-711582554c8a",
-    "identifier" : "Znp8CKW5bvg",
+    "source" : "https://www.example.org/d5f969fa-c04f-4b6f-9024-affd895049b8",
+    "identifier" : "6cJ98onlWIr",
     "labels" : {
-      "da" : "PUwtaAkFZO7onODBkRu"
+      "da" : "NNvzp9qZztvVyEz"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 726403532
+      "currency" : "EUR",
+      "amount" : 531924706
     },
-    "activeFrom" : "2015-10-29T12:52:24.214Z",
-    "activeTo" : "2024-04-21T07:49:35.229Z"
+    "activeFrom" : "1994-07-26T15:06:09.175Z",
+    "activeTo" : "2015-12-21T01:15:34.909Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6fe38da7-444e-419a-bc53-0d6dfebdd8fc",
-    "id" : "https://www.example.org/c5461a22-5c81-4544-9cc6-7166e172469c",
-    "identifier" : "63fkgcTLoyAQt",
+    "source" : "https://www.example.org/91a839c0-2dff-4950-b1d4-2c3ca3f8c6ab",
+    "id" : "https://www.example.org/3aa7d4e8-deef-491a-a724-d3111c15be9b",
+    "identifier" : "qx1Q4eKZ7OoH9ecsrm",
     "labels" : {
-      "zh" : "PFFTMul33L"
+      "nb" : "zJA2H2qQoDt6hUbeJwv"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1340650245
+      "currency" : "GBP",
+      "amount" : 449091552
     },
-    "activeFrom" : "2005-10-27T20:19:46.376Z",
-    "activeTo" : "2009-05-23T14:39:23.753Z"
+    "activeFrom" : "2019-05-17T12:45:46.768Z",
+    "activeTo" : "2020-04-10T18:01:03.179Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "kqAJQ2x0cs0MUGTCU",
-    "sourceName" : "xsafkfjqgj2tg@jslq41srfvcd1"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1298910359",
-    "sourceName" : "5wwplwpwfgbq1@jjccfxpvgdwhc"
+    "value" : "595910501",
+    "sourceName" : "m3yzm88m5vti85ocqux@uwgqqebam6"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "fogwGnNmbw7",
-    "value" : "VLFrLxNjuC2RBfCEjL"
+    "type" : "ScopusIdentifier",
+    "value" : "z4tIfviIGSR",
+    "sourceName" : "myrilxa27hjha@jwpeswscb1spxxywfn4"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/4fded1a2-7a5c-4208-a9d9-aadae31fa3e7",
-    "sourceName" : "shd5mhgwua@kz7whk1k7rlgi3"
+    "value" : "https://www.example.org/eefeda8e-9796-44c6-9a25-ed89388a33a1",
+    "sourceName" : "04b5grhg4sb4cw@adc7dlrtelznvgohlo"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "CnG8iG9s1ib",
+    "value" : "ab64sxpqIIu9lb"
   } ],
-  "subjects" : [ "https://www.example.org/17ece12c-3781-497c-9f92-5f0a8fe10f36" ],
+  "subjects" : [ "https://www.example.org/e82614d9-93ae-435f-8072-b5c7ce0f14d7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6361f770-7111-4836-80b2-cdc532b49151",
-    "name" : "ikZ3ln5umYYFSU",
-    "mimeType" : "kVsd4crgzi7POL",
-    "size" : 917377817,
-    "license" : "https://www.example.com/zwfv9x0cesfnzahr",
+    "identifier" : "570adcf2-c403-4100-9aed-880fe35e71c9",
+    "name" : "g83qgdt5SAV",
+    "mimeType" : "2cJJm6xDnbsXdLc0Y",
+    "size" : 1824424830,
+    "license" : "https://www.example.com/ee3f3j6xzkeabyv",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "15UcY4iuQ3EI"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "AY2LeqnHsX",
-    "publishedDate" : "2018-03-23T02:25:39.925Z",
+    "legalNote" : "RxFYkI449wSQCWaycb",
+    "publishedDate" : "1997-07-19T14:51:08.753Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1611502430@LGKtfOFjYE",
-      "uploadedDate" : "2012-03-05T19:03:29.901Z"
+      "uploadedBy" : "22717257@nUrtH0FOfP1VWBj",
+      "uploadedDate" : "2001-10-19T12:20:35.657Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qT1XZIO3cSUm",
-    "name" : "CtIZ5lkr1E",
-    "description" : "W1xswM38Joqf6k2UsT"
+    "id" : "https://www.example.com/BkK9tgS5Qrtv6",
+    "name" : "pPDBjz0WPtmrzJlyq",
+    "description" : "yoKO0kX7MWhyvxIX"
   } ],
-  "rightsHolder" : "EL70mnAgRX8lzsuANL",
-  "duplicateOf" : "https://www.example.org/95ca4795-6cd8-44f6-b5ad-b21e96e62a9b",
+  "rightsHolder" : "mRizwHxd47DI2yh",
+  "duplicateOf" : "https://www.example.org/c3376f14-a722-4bbc-80a8-945be2afec14",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YoZqWrIgi9ZX5TFBO5O"
+    "note" : "MGpvHxxBaixkD6R"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jo6NhtCJya",
-    "createdBy" : "y6PfJ7N9IIaBGy",
-    "createdDate" : "1978-10-24T23:27:26.061Z"
+    "note" : "eYSE3ueFEyGy",
+    "createdBy" : "3vKXl02Rm5d",
+    "createdDate" : "1979-08-15T12:51:41.241Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2657702f-e5ed-4c21-8b36-d681fc3cd799" ],
+  "curatingInstitutions" : [ "https://www.example.org/e69822a7-e993-46e7-b3c8-51c6bab25694" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "BnWDxB38kA",
-    "ownerAffiliation" : "https://www.example.org/b22083d5-40e7-4f8c-ae15-f5287aa524dc"
+    "owner" : "nUy9Cr1WL2P",
+    "ownerAffiliation" : "https://www.example.org/1d8d91c9-ac99-432a-90f2-8a96c53a30b3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9b1fc655-01de-494d-a590-08c3dce0fcd9"
+    "id" : "https://www.example.org/6a15e3a0-c838-448b-a396-daf933e740fd"
   },
-  "createdDate" : "1977-09-06T21:40:20.261Z",
-  "modifiedDate" : "2022-07-31T21:59:46.601Z",
-  "publishedDate" : "2018-05-16T19:17:51.432Z",
-  "indexedDate" : "2007-08-10T18:14:37.397Z",
-  "handle" : "https://www.example.org/6a52b813-3950-4e4f-bc0f-f6829a9596b5",
-  "doi" : "https://doi.org/10.1234/quis",
-  "link" : "https://www.example.org/56a18b69-a6e2-48ba-b191-68b55a5701f6",
+  "createdDate" : "1985-07-06T02:48:28.733Z",
+  "modifiedDate" : "2017-07-17T09:05:38.803Z",
+  "publishedDate" : "2017-06-28T10:34:38.129Z",
+  "indexedDate" : "2009-07-19T19:55:45.433Z",
+  "handle" : "https://www.example.org/63b11885-0835-4e3e-a2a9-90cec18055b0",
+  "doi" : "https://doi.org/10.1234/magni",
+  "link" : "https://www.example.org/a40057c9-4864-44a5-9e1d-e02419fb452b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KRQwUT10IXJjpr",
+    "mainTitle" : "YYe7g8NUZj189Mabapv",
     "alternativeTitles" : {
-      "ru" : "545jXvXcIotD9wzvV"
+      "nb" : "bwt54gU5pvn61YR1J"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AY7BanOjyEgk9VnxDZN",
-      "month" : "lGfmqDtF9A6EVaIBQgz",
-      "day" : "42FkTnSTUxPyUMhmO"
+      "year" : "kgkaM8nuDe",
+      "month" : "Pjszc0vlAp",
+      "day" : "eboJnOBPxtpUbKrz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/86c2f6b2-a9ad-404b-891a-6c29681837ac",
-        "name" : "WaBwKXW6WUJUWlG",
-        "nameType" : "Personal",
-        "orcId" : "LTUxlv4UyI",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e8a6b050-d63d-499d-8695-40ff5f92bb3b",
+        "name" : "AYHwQYqV1NFtjIFV9",
+        "nameType" : "Organizational",
+        "orcId" : "gg8XWRV8FT6sh5QW",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "00QoUUYOD30lU2",
-          "value" : "EtaQkEe6C8"
+          "sourceName" : "BZTEChjXrXtj",
+          "value" : "Vr7VzDxQQ4qakWxugaq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NgvNH04wMeNyYCk",
-          "value" : "ulr0TRnUnftSbQh"
+          "sourceName" : "0AWuRcEYoaCJ9hv",
+          "value" : "7nELlnzGQ6ovUU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a15056bb-5100-4544-8966-b934ae20e3ea"
+        "id" : "https://www.example.org/a599c578-333f-407e-9ef4-a006977b2085"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,164 +62,163 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/30e4aedf-42bf-41c5-86b5-d3d2e3cdd035",
-        "name" : "6eVYSi8cMF0EMf8xsrK",
-        "nameType" : "Personal",
-        "orcId" : "cMei4SZWCI",
+        "id" : "https://www.example.org/a55d2dce-2273-4f81-aaee-fc19519b8924",
+        "name" : "p24E8cdJIqy",
+        "nameType" : "Organizational",
+        "orcId" : "gNCXe8tTDFzqa",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "j4RALi18Ya7V2",
-          "value" : "jKgjbJ0T65j"
+          "sourceName" : "oZGbtFrPcR",
+          "value" : "jfqVuy0FsRbJgL7e"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0xamxJveuI6a",
-          "value" : "eM0Z4o7LSHbiZBSbWS"
+          "sourceName" : "zWmKnOdbXbRU",
+          "value" : "DlBdxoWIDo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cf3903d8-b41e-492e-9c80-c2b88dfd549b"
+        "id" : "https://www.example.org/6ef69823-6e77-42c5-b130-ff5cd95942b8"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "Artist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "R53lTd4oqXR9aBn9v"
+      "nn" : "J81gtl4SJq"
     },
-    "npiSubjectHeading" : "EhFofmIXerZH6ssgKP",
-    "tags" : [ "1CLnPWDtko5KTYrPksD" ],
-    "description" : "9n5NFznxcIXYShjH63U",
+    "npiSubjectHeading" : "WUK2267ZLQJDZEu",
+    "tags" : [ "rPgRV8Fp3ahcw" ],
+    "description" : "e43f4iVa35n1N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f06326e0-ac20-4aed-8123-7cf59c38e1eb",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5af1f42f-fd15-49f4-a517-82f8aa2e9fe4",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/62e7ab68-462b-42e5-acd2-83618458f212",
+      "doi" : "https://www.example.org/2bbcb488-f141-485d-aa6e-c40586fe4ed3",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "XXXoXhivp6wLOsM6",
+        "description" : "uSNpY4SmkJIBZlKqj3",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Xto3utxOaAfMeYbt",
-            "end" : "NvDHt79nJB"
+            "begin" : "B1OLYeUDIP",
+            "end" : "khQFS97cJaJSy"
           },
-          "pages" : "uKkVGwgzfz",
-          "illustrated" : false
+          "pages" : "5h5aiW5aMrIO8G",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/41c694ee-f550-4617-b7a5-b5996752b101",
-    "abstract" : "iXcInODfVuyRQ5iLxD"
+    "metadataSource" : "https://www.example.org/59b7918e-2ca6-492b-aece-df5ce46dce82",
+    "abstract" : "DvzbZ1eXb8Dx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dd5173b2-df65-49c5-85a5-8e164b90d734",
-    "name" : "p7frOaL27COnps",
+    "id" : "https://www.example.org/5308cc4f-4889-4416-971a-40ee01a1aef6",
+    "name" : "7So6fOrsYhJqiiw1f",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-12-05T05:47:36.935Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "d5T0GzjvXlh"
+      "approvalDate" : "1997-04-28T20:25:24.491Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ZGxYKcJxTGe0kejO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d19ff1f6-a7ee-4834-8dae-8832c1987b6c",
-    "identifier" : "T3yoq07nYqiWyk",
+    "source" : "https://www.example.org/85bd3700-ba5f-4450-aa45-1c3645c9d79d",
+    "identifier" : "GgWhuRfpo0fbRm",
     "labels" : {
-      "ca" : "8kdgKNHh609FHpMfmik"
+      "nn" : "cpyFejbR2HIsYkTqjf"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 282604426
+      "currency" : "GBP",
+      "amount" : 1839295755
     },
-    "activeFrom" : "1984-06-16T18:02:44.809Z",
-    "activeTo" : "2002-12-29T03:48:46.285Z"
+    "activeFrom" : "2010-12-25T20:19:44.669Z",
+    "activeTo" : "2019-03-29T17:58:44.487Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/13937c3a-0244-4ff5-8916-19048e4402be",
-    "id" : "https://www.example.org/39e963da-3035-42a3-ba76-ffa0814f2d66",
-    "identifier" : "Ur0CWlalTt9H",
+    "source" : "https://www.example.org/7568bcf8-c7f0-4ff5-9b9e-6a3c3e03748b",
+    "id" : "https://www.example.org/ea28877f-292e-4e96-82da-f32f5d6039de",
+    "identifier" : "jDRCShE1mh6Fw",
     "labels" : {
-      "it" : "GJlIWgazwq"
+      "bg" : "OShwuMBGze9Yf4OH"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1501230853
+      "currency" : "NOK",
+      "amount" : 1919424379
     },
-    "activeFrom" : "1990-11-20T02:32:37.191Z",
-    "activeTo" : "2006-11-02T04:17:59.780Z"
+    "activeFrom" : "2016-10-11T14:08:23.341Z",
+    "activeTo" : "2020-02-03T22:32:40.437Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/4f2019b4-b340-41b0-bad1-f2cadeda41d8",
+    "sourceName" : "qfl1eeutlf@pfmvbilzwr6a75ib7n"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "1464484611",
-    "sourceName" : "t2q3zidtgpd865@ucgfspo29i3e4h8h"
+    "value" : "1317568999",
+    "sourceName" : "8khan9nlqnl@ujmxufhocyogawy"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "thMYyOm6g8hjYFJI",
-    "sourceName" : "ucx5wrubfhn1@ar5doatdtnfrp"
+    "value" : "fb2EFHzTJ6y",
+    "sourceName" : "awrpgzj8upxpvei@dfiydiuc4vii"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "4XT2XQZi2At01nw6",
-    "value" : "IYr4tE8DLvK5Isr"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/b41fb7c6-6797-4deb-9a5e-b980ea130733",
-    "sourceName" : "i3zjhb95nnmsfpw6sf@joa1yzatjiuhb"
+    "sourceName" : "CCIFqHTaPKRXfQ",
+    "value" : "Hf11Gcle2mpnlAxrm"
   } ],
-  "subjects" : [ "https://www.example.org/eb6b8341-cb38-40c0-8cee-0ccd16460e32" ],
+  "subjects" : [ "https://www.example.org/0b2d7b52-7688-4744-a463-3af4504dc8ce" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e2dfcc09-c347-45cf-ab3d-be08c798894a",
-    "name" : "HrrXbbNC1yr590znaxV",
-    "mimeType" : "sCwNODNBCeG",
-    "size" : 366069659,
-    "license" : "https://www.example.com/omjccetfadtmw3g1op4",
+    "identifier" : "739fff1a-ad16-41d3-bab8-e6268afe38fa",
+    "name" : "yg9i40XWFNllqc5zK",
+    "mimeType" : "I5YKulnhDpiPf98V",
+    "size" : 1239724653,
+    "license" : "https://www.example.com/wizpmd1ztn43d9",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Nxo6phMtr7FnRiXzOh"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Zf93blFrga",
-    "publishedDate" : "1976-02-03T11:44:15.534Z",
+    "legalNote" : "lTPl8UWS180VsZ1fl",
+    "publishedDate" : "1994-10-19T09:54:14.544Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "718745276@b6UJMUtgYUx5HcwZMFJ",
-      "uploadedDate" : "2001-02-20T17:55:03.322Z"
+      "uploadedBy" : "1968526710@2kNXtuSQiUmhWT",
+      "uploadedDate" : "2016-04-24T11:50:01.262Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZltXH8Dt3cBpGy",
-    "name" : "4Ol58lSLmn5oBj5",
-    "description" : "rkWrqRApR1utoA8Xl"
+    "id" : "https://www.example.com/dy4htiJyuG",
+    "name" : "Sro4MACBHkquYu",
+    "description" : "wZOoNFwv8l"
   } ],
-  "rightsHolder" : "VwA3g9MFRpc2cLDlv",
-  "duplicateOf" : "https://www.example.org/3ecc3073-2622-4344-8936-74309133b1fc",
+  "rightsHolder" : "k8YXYx8AbFKIC",
+  "duplicateOf" : "https://www.example.org/daf1b172-15d3-4573-87be-70dbab1576a7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "eB5vNDuXD5Jp"
+    "note" : "srGaLf8zRSwsJm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "umzMAZ5BUcsT7PX",
-    "createdBy" : "FvqwI9oEaSAkKI52Bwm",
-    "createdDate" : "1980-12-18T13:46:53.919Z"
+    "note" : "ocU8fWus5xoePAi3c6v",
+    "createdBy" : "YX5YT569G80tENuVb",
+    "createdDate" : "2009-07-04T15:45:46.654Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/45f7d5f3-b9aa-48a4-9753-62b7525fcf34" ],
+  "curatingInstitutions" : [ "https://www.example.org/60b68153-625a-4361-a0e8-93da28af19cc" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Y026PZZfdzcUYGpQ5",
-    "ownerAffiliation" : "https://www.example.org/6d69d74c-6544-4412-b903-3ee744371b41"
+    "owner" : "7AA2btxnxsUxiLNWIHG",
+    "ownerAffiliation" : "https://www.example.org/24bed852-356f-4b45-b249-f339c2cb113d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1a00f7b0-5d80-49b2-a271-2c14c4d9639a"
+    "id" : "https://www.example.org/6d592e20-d053-49e4-b81a-be4f64df6cef"
   },
-  "createdDate" : "2001-11-11T06:23:44.671Z",
-  "modifiedDate" : "2000-02-27T21:02:18.110Z",
-  "publishedDate" : "2004-11-21T22:11:17.392Z",
-  "indexedDate" : "2015-02-15T15:44:30.325Z",
-  "handle" : "https://www.example.org/92ca1f03-7287-4e2a-aa66-2b646a058463",
-  "doi" : "https://doi.org/10.1234/aliquam",
-  "link" : "https://www.example.org/9526005b-26eb-40c5-8997-e1bc31560741",
+  "createdDate" : "2000-05-23T16:17:10.414Z",
+  "modifiedDate" : "2002-01-25T06:49:29.158Z",
+  "publishedDate" : "1984-06-28T13:09:56.966Z",
+  "indexedDate" : "1976-03-31T01:18:25.947Z",
+  "handle" : "https://www.example.org/889a2f9d-6c40-4e05-95f5-d17da6fae1d8",
+  "doi" : "https://doi.org/10.1234/eos",
+  "link" : "https://www.example.org/fafa6477-5135-41c8-a63a-a5d75828cd1a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kmZzg6dNzWCu",
+    "mainTitle" : "4gPLn6hfjRKOcUt",
     "alternativeTitles" : {
-      "se" : "vFmsAKYPoX08d"
+      "en" : "i6bZi8ZZaSoda58z"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "oqXc7aqmf8qGP6hg",
-      "month" : "D657Jvb07goC",
-      "day" : "W2u0gPPKK0lUEB"
+      "year" : "fYnzyiBBwY71n8vnD",
+      "month" : "riRQT5rAkcQibKi0",
+      "day" : "79OL0dWm3xif"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c7ba954c-6ec3-44db-b0e6-e18561e31c16",
-        "name" : "40RSSV5UgPd5VRijI",
-        "nameType" : "Personal",
-        "orcId" : "KaS9OdCrUJF7E",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f10b4729-bcae-43d2-8a7c-8c1dc893a700",
+        "name" : "YOqmTBbmMH",
+        "nameType" : "Organizational",
+        "orcId" : "EIO3O81cpdkgTK",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DbN1Kff8vwO0",
-          "value" : "W8CyGMfTJXXLocYojE"
+          "sourceName" : "iGj1UWfLEIam",
+          "value" : "wA4mDajaFeZUmZlgXbt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lyasjUghPjkPTZui7Jq",
-          "value" : "3ygE3e8H24gBh"
+          "sourceName" : "QRuztoRRP9F6B",
+          "value" : "w7kwiDj7ng0qr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6222c78b-19af-406a-a635-f959b67d7141"
+        "id" : "https://www.example.org/b86def81-e86c-4fbf-81ae-d8335f068183"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/df60284e-5eba-4f14-bb0c-ed6a5869ae34",
-        "name" : "l48wx11L4rm",
-        "nameType" : "Organizational",
-        "orcId" : "3neznVRbooDWG",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/2ac2340e-4d42-4acc-9738-de8c00b394e3",
+        "name" : "8yXgxtH5eBW2AaXSh2c",
+        "nameType" : "Personal",
+        "orcId" : "2ODCWbbvVcv",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ev3kx9fxsnHs",
-          "value" : "2bsiaFkSeKZQUulx7"
+          "sourceName" : "4R9tJ7cEcXDNxKVdmT",
+          "value" : "gI9YrexYQ1P3zj9io"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HBnGVdbR03rofXsCkmO",
-          "value" : "2SuRBifVmSWAfXXy"
+          "sourceName" : "hk1Uato1xMARgs6MU",
+          "value" : "8QIA4k2qdJDmTUil"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f00324d9-8c7e-470f-89ec-bb07a2494624"
+        "id" : "https://www.example.org/eb9db644-3dd5-4bb3-80ec-8f10f2b10b7d"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "NcXoFEfDu4me8"
+      "af" : "I2dlR7wxOXv"
     },
-    "npiSubjectHeading" : "N2ANgYLNYCX7Wb1peN",
-    "tags" : [ "mzqVytC7Wk" ],
-    "description" : "RJVA759lHroaUM",
+    "npiSubjectHeading" : "FQhSU7Xt6KTUoRXC",
+    "tags" : [ "I0O6Dhzmfeb" ],
+    "description" : "m0Kv1X5Fc6S7jUZjQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -100,15 +100,15 @@
         "medium" : {
           "type" : "Radio"
         },
-        "format" : "Text",
-        "disseminationChannel" : "J3hhYXVnaR2",
+        "format" : "Video",
+        "disseminationChannel" : "WfZV5gKfN1o5kGB9hX",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "Wn5in3hd9d",
-          "seriesPart" : "6pHKb0jb6o"
+          "seriesName" : "I3rZi29p8HVaxVsirM",
+          "seriesPart" : "R1ynRSqGfrOBPA0"
         }
       },
-      "doi" : "https://www.example.org/b83a6a7b-cbaf-42f9-90d2-79b465b1cbdb",
+      "doi" : "https://www.example.org/fa8eed0b-18b0-4cbe-8f6e-85b756ffa508",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -116,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b11ff709-cf69-4bfc-91ba-252e929fc485",
-    "abstract" : "h1QOMvbWL6w"
+    "metadataSource" : "https://www.example.org/2f75d1a5-5072-4f47-a369-6312e43461ad",
+    "abstract" : "AMHpBnYPAicG7bl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d9aa981e-2207-48fa-bbbf-a33ae83f7f48",
-    "name" : "Xd6eRDUhMEcxXhdp",
+    "id" : "https://www.example.org/813be4e5-c0e3-4645-b801-b418cf3a5a7d",
+    "name" : "RIrwPGzbpOp35Y6Wsp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-05-19T03:30:22.652Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "NlFwVCLYSUJ"
+      "approvalDate" : "2021-08-24T11:09:25.485Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "nweGJmoLP5Rz73bLy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e3a84a44-b0ff-4308-85f1-b0839e1340bb",
-    "identifier" : "FuWQEmsrgAJNP9i",
+    "source" : "https://www.example.org/f77d5198-481e-4469-a755-58fb29b0f215",
+    "identifier" : "mjw6ct5P69zOwL2Na",
     "labels" : {
-      "fi" : "WFtjGX1G7iYWxegIhU"
+      "pl" : "0EMVunoDMx"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1877858721
+      "currency" : "EUR",
+      "amount" : 1280340455
     },
-    "activeFrom" : "2019-12-09T02:10:31.198Z",
-    "activeTo" : "2020-10-06T14:37:28.244Z"
+    "activeFrom" : "1975-07-23T14:58:40.733Z",
+    "activeTo" : "1997-09-26T10:37:27.888Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/278a76df-7fa7-4f12-82cb-7c0f9c2d4ced",
-    "id" : "https://www.example.org/4c71e935-b630-4ac3-af1f-1bbd53ce5730",
-    "identifier" : "t7M2FloCGvDSLe694Xk",
+    "source" : "https://www.example.org/d0ec2e53-b5ff-4ff0-b3de-9e6e7d8a7230",
+    "id" : "https://www.example.org/fdf12ad9-8f25-488a-ba64-f637a93bb372",
+    "identifier" : "CLfrvEdnYoQS4Q9WtYn",
     "labels" : {
-      "af" : "9KEsUon7A0"
+      "nl" : "bUIH7jkLJi"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 720201739
+      "currency" : "EUR",
+      "amount" : 1766545873
     },
-    "activeFrom" : "2014-10-08T13:20:59.112Z",
-    "activeTo" : "2016-06-02T01:09:54.993Z"
+    "activeFrom" : "2019-05-08T01:27:50.358Z",
+    "activeTo" : "2022-11-11T06:12:10.406Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "J3ubMhipxplkux42y",
-    "value" : "woj1lXElj3dlSc9"
-  }, {
     "type" : "ScopusIdentifier",
-    "value" : "KnqgvQQiSSQPJ",
-    "sourceName" : "dz4ubshkownwbz6eby@cjrlq8qmqprnwwnd"
+    "value" : "o6Kf1EXPMTsJmbs",
+    "sourceName" : "quhbbam4tormw@k1akfrfrmuc6rff"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "706609602",
-    "sourceName" : "u64zesfsmu2vmbt@9cp07fksbxgd"
+    "value" : "1168736968",
+    "sourceName" : "v9dulbrgitxx5rn@cejjm0iyebbxma54"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/98a47486-299b-40b2-b806-5681158d65de",
-    "sourceName" : "xs9ibzdbxzmem@exeynoo55cc4bimbw4o"
+    "value" : "https://www.example.org/29d35da0-6f03-4827-a82e-ff74e5029069",
+    "sourceName" : "anyet3aljbwt@8pv3ksduhpfuuq"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "L3QjZPgVG6",
+    "value" : "uteduiXGqCEwKZs"
   } ],
-  "subjects" : [ "https://www.example.org/01fcc414-1734-4f94-aceb-e4a67517c151" ],
+  "subjects" : [ "https://www.example.org/f067c045-96f9-4c73-8999-f55a99b6d1f0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c9713d97-17b8-4b4d-b3bd-bfa621965095",
-    "name" : "XULBb7ItE4qRcsdOC7A",
-    "mimeType" : "vxCOLEEMWi",
-    "size" : 653952943,
-    "license" : "https://www.example.com/fc8tx5urqliaeokkh",
+    "identifier" : "a9743d8a-6e7c-4c46-9ffe-203dd86b5f92",
+    "name" : "9dD5W176c0k7tNYld",
+    "mimeType" : "wQeL4Anj0Vu",
+    "size" : 1615006174,
+    "license" : "https://www.example.com/5bkbiq1pfvdt0my0q",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "WnpBfcc8wWbaDTan8PO",
-    "publishedDate" : "1994-01-12T21:05:32.314Z",
+    "legalNote" : "E9UPqn5oCaeuySrP2",
+    "publishedDate" : "1977-06-13T05:06:16.484Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "815943049@JuTcPCFGql3n",
-      "uploadedDate" : "2019-12-26T10:04:15.493Z"
+      "uploadedBy" : "1027714176@mEZ3qA75k6",
+      "uploadedDate" : "1990-03-31T05:23:56.547Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/T6oxxL6X4fGQ",
-    "name" : "aCdEWXJbRpYbdrpV",
-    "description" : "AyG8Pj3g3Cb6fbRoIv"
+    "id" : "https://www.example.com/omiGTJ89gyt8mu",
+    "name" : "HPB3qTOghFynT",
+    "description" : "vKhsGlAVifCtv6w9IF"
   } ],
-  "rightsHolder" : "vXBd59zB7j",
-  "duplicateOf" : "https://www.example.org/9ef88359-9489-42e6-9d65-3c1aa4113719",
+  "rightsHolder" : "a3raYT9gQ8g",
+  "duplicateOf" : "https://www.example.org/e10698c3-3c9e-4a48-a6da-0978c918106d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Pfsi1RChrd"
+    "note" : "6irNAOFQkNyfMf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iJKGpPE9zu1j1",
-    "createdBy" : "8kTIyvdoXyaIDK",
-    "createdDate" : "2020-04-21T09:43:59.219Z"
+    "note" : "VMv5HEkL9zY",
+    "createdBy" : "4qwJ1OjTMx1ZsPQN",
+    "createdDate" : "2021-11-19T11:23:17.682Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b122a018-1df2-475b-819d-469ff6bbb754" ],
+  "curatingInstitutions" : [ "https://www.example.org/8f245e58-b5ef-4b9f-81f8-b2a6cb406fd8" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "Qz3trQW51r53ttofarG",
-    "ownerAffiliation" : "https://www.example.org/1a915882-385d-44e0-bcef-8106924748ea"
+    "owner" : "foqeX5kjynEtplV",
+    "ownerAffiliation" : "https://www.example.org/8cb539bf-a598-4155-95fa-b9c4b9cfc634"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ba63188e-7177-466a-98e8-e5a86bc58917"
+    "id" : "https://www.example.org/f7d5257f-0f77-43e5-8c81-6fe00a33f23b"
   },
-  "createdDate" : "1981-10-23T16:46:06.594Z",
-  "modifiedDate" : "1974-11-26T02:14:28.028Z",
-  "publishedDate" : "1995-01-17T10:32:23.090Z",
-  "indexedDate" : "1991-12-20T04:50:35.256Z",
-  "handle" : "https://www.example.org/51c79a1b-ee62-4538-b6bc-2bccf0ff73dd",
-  "doi" : "https://doi.org/10.1234/vitae",
-  "link" : "https://www.example.org/170a37cf-ccbf-4b96-a989-f1786d26307b",
+  "createdDate" : "2017-08-20T17:23:46.495Z",
+  "modifiedDate" : "1986-02-13T12:26:21.314Z",
+  "publishedDate" : "2001-01-02T04:32:39.374Z",
+  "indexedDate" : "1975-06-15T12:12:51.468Z",
+  "handle" : "https://www.example.org/f1bbb741-3a2c-4917-b8c1-d14a79868aba",
+  "doi" : "https://doi.org/10.1234/dolore",
+  "link" : "https://www.example.org/8b6a32d3-1552-4219-a9ba-a1e39069616d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cHS8fBXj4fWe6",
+    "mainTitle" : "4jlQqhbdKDFDzw",
     "alternativeTitles" : {
-      "ca" : "scr7xRtRlBEr8HP"
+      "de" : "CJ1XFCrzSs1nfgYo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "haibfiFSO5icxnE5x0b",
-      "month" : "cxyK1ZRpvkGDcV",
-      "day" : "mkirDCFu8bCcm"
+      "year" : "335SbjjUwpOf",
+      "month" : "MsZsjJLRVFho",
+      "day" : "mMYMVntB5UO4g"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/08c68ce7-86c9-4da8-8239-bc1ef5340e0a",
-        "name" : "5PWo2jloasF",
-        "nameType" : "Organizational",
-        "orcId" : "KIX0yTDN4Htp",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e1d3aa79-d63e-4814-9b30-7fbe607090f8",
+        "name" : "7SwA0cHSQxZk",
+        "nameType" : "Personal",
+        "orcId" : "ufpfFW7Bj1bleB8O5",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8oFlBMlUd9RDF99o",
-          "value" : "DF4SSaKis6fp"
+          "sourceName" : "yoXWzZ4ch4T",
+          "value" : "XRwoLKHhoDu27kC1TYt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ssKl2ylJlYz",
-          "value" : "c260HMWAe1xDZq"
+          "sourceName" : "JVMUXVJJgYVvJDW1agD",
+          "value" : "TB6wZulbpypq0Ov6S9k"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ef308257-2dc2-42d4-a559-2a7cbe02bd24"
+        "id" : "https://www.example.org/d88e8337-06bb-4832-a027-f0229fb10412"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Registrar"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/859cdc86-0c12-4d88-99cc-20c6c7d9f1e2",
-        "name" : "lATTYjWjYvNNkJcUt",
-        "nameType" : "Organizational",
-        "orcId" : "X175ptOtbQAfgn",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/89845ba6-ad4e-44e7-8944-a0c940286424",
+        "name" : "HfyHqpKeZOXum",
+        "nameType" : "Personal",
+        "orcId" : "5xiIraezoWHmkwzG3my",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nIaw95Wse76aW4",
-          "value" : "cONwDFQiEhY"
+          "sourceName" : "zLeXUMacDNLDmPBr",
+          "value" : "R1ymfbXNtyDI6JQqt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "itOeifJ1j88OcsnFnX",
-          "value" : "3z0c7RkyUv27fOO"
+          "sourceName" : "dasiLzB0L3TIQC",
+          "value" : "Vuqav3zmecmPERjxn55"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3439d6c4-ece1-4f92-a0df-39856c2367d0"
+        "id" : "https://www.example.org/541208cb-420e-4bbf-800b-0f58c5f9dfeb"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "8ayUJD7ZsW5IAXca"
+      "en" : "ozphmXdvDun5QmemaO"
     },
-    "npiSubjectHeading" : "m5JyQ8MWerkiLJB",
-    "tags" : [ "b0UFGhFaQvpZcK" ],
-    "description" : "OAf2ypotXfLGB3g",
+    "npiSubjectHeading" : "BMdDHSGzO7h57CcdAq",
+    "tags" : [ "mj25glHDFNOw" ],
+    "description" : "ARIHU3KJayHYftK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9b7fd69c-9185-4def-81d3-fef2b89b5382"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/61ce7d0b-a88d-463b-9e23-855237e91fec"
       },
-      "doi" : "https://www.example.org/311b7632-6751-4c0c-b408-1a7eab2e03dc",
+      "doi" : "https://www.example.org/6ab2b0b6-1728-4ac7-b486-2ad85bacdf74",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "zcYFRD3muP9",
-        "issue" : "6fO32GANnz6",
-        "articleNumber" : "gviylZOkUA",
+        "volume" : "R79sv98vU4VjbtLuW",
+        "issue" : "4KTWW6GyuwD9",
+        "articleNumber" : "09mb4Slj0dpoTzekI8L",
         "pages" : {
           "type" : "Range",
-          "begin" : "VwgaP9v8ClHzECdPdD",
-          "end" : "pc6HYaPUOzYY3t"
+          "begin" : "T6pHYYa7mtPJPez",
+          "end" : "JVJLDVofhawtzxj"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b010ea29-57f1-49e9-b2d2-90308ea679ce",
-    "abstract" : "UjGWOMSytfXLw5"
+    "metadataSource" : "https://www.example.org/45d992a4-d546-4192-9398-e256d5cad124",
+    "abstract" : "Pwwl1iqHfvd1wBK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/341e3bc2-d17b-4a0f-8757-d81bc8a4d8f7",
-    "name" : "j20uwIWy3MQid1Wdws",
+    "id" : "https://www.example.org/2dbda5ae-c780-4db3-91d9-812d733f18d0",
+    "name" : "ajdE97ndWN",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-09-24T21:08:46.320Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1996-08-31T02:46:09.639Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "rHxvVOyku4qcnfUg"
+      "applicationCode" : "8cyqriUijYDR"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/55fa4dce-efaf-48d1-94c8-1718c5ac3425",
-    "identifier" : "AFCkVxa6S5KrEhkhVG",
+    "source" : "https://www.example.org/2fe1e6a0-7560-49a2-9c75-80a58c4d1cae",
+    "identifier" : "c2p7zs9Uu4MX",
     "labels" : {
-      "bg" : "fDRF6Q9l997w9gqZIG"
+      "el" : "zAC4icX7IJlL15CU"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1478633884
+      "currency" : "USD",
+      "amount" : 1866586818
     },
-    "activeFrom" : "2023-08-17T11:52:00.253Z",
-    "activeTo" : "2023-12-12T20:56:16.356Z"
+    "activeFrom" : "1990-05-20T22:38:57.511Z",
+    "activeTo" : "2020-10-18T17:25:00.021Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c7ae1a35-e045-45c4-999c-d9d9368dd904",
-    "id" : "https://www.example.org/73925fae-d74e-4b3d-8046-b1aecd8dbc6a",
-    "identifier" : "XA93IWEwWsu0z",
+    "source" : "https://www.example.org/2cb1fd6f-b14c-4984-9a03-3609d380c34f",
+    "id" : "https://www.example.org/3c54d960-e08c-43cc-8d94-2496b13e28e8",
+    "identifier" : "zTGkWd6XzLWSklBtl3",
     "labels" : {
-      "nn" : "ee13C1SMLJlugU"
+      "sv" : "OOetVCrDAyXL7"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 139707556
+      "currency" : "GBP",
+      "amount" : 1632857495
     },
-    "activeFrom" : "1972-02-10T16:45:05.541Z",
-    "activeTo" : "1995-09-23T12:38:17.601Z"
+    "activeFrom" : "2002-02-25T05:00:34.335Z",
+    "activeTo" : "2021-04-28T18:27:49.681Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/2d8b870e-af55-48db-b278-86911df4cf14",
-    "sourceName" : "x3barxu1dcssdjp0@6cdnjjegqzrjsancmo"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "1703187043",
-    "sourceName" : "ecpfyqyxniecgqdok9@39prvgtj1uerz"
+    "value" : "1235955814",
+    "sourceName" : "hkgxyvb8dz@cqyknmak3jasyleb"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "EuYivfv0oB1N5",
-    "sourceName" : "zbdcegqqdbi@iwbbc5nfdeq"
+    "value" : "aJxD2kzxjLF",
+    "sourceName" : "1tnvhxxv1dnaifcv@2bkl2hldhu3noj3"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "mAuDpAzDSavhkYkp",
-    "value" : "c1iCtbUMs1"
+    "sourceName" : "gaORclW9m3sM8jUCRK7",
+    "value" : "R0em0Y6uAO88mT5D"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/d61dd84f-a1b4-4681-b5b1-f080121c8b06",
+    "sourceName" : "nqfvj79ahnd2vq@l6hgutj2k8k"
   } ],
-  "subjects" : [ "https://www.example.org/f3f8c423-b88b-49fb-8b07-1cedba77c851" ],
+  "subjects" : [ "https://www.example.org/0595c3fa-d427-4b18-9ba7-1b80982278ef" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b180de2b-36ac-4cbb-8f02-d288491c59b1",
-    "name" : "Wc1nC5DN4TUdJN",
-    "mimeType" : "XFXRv5c30a1GvCEh",
-    "size" : 1509389143,
-    "license" : "https://www.example.com/yj9n9598dvkqdxu",
+    "identifier" : "6a25752d-e1f7-4fce-a32c-0d1f0cf3bca6",
+    "name" : "1CKuAu58TgX0kXtNIW",
+    "mimeType" : "N2QbA2zXWJp",
+    "size" : 1984370414,
+    "license" : "https://www.example.com/ffhfolr3ixscrg",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "PMjZ60n1oVIaxhaBxG",
-    "publishedDate" : "2005-10-02T11:44:44.431Z",
+    "legalNote" : "cXpCywPU7XvoMAozOk",
+    "publishedDate" : "2001-05-05T17:56:02.277Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1030717909@pWZs1qRK0lRHl",
-      "uploadedDate" : "2010-06-19T08:27:15.932Z"
+      "uploadedBy" : "1453910655@ejFaBdsJYDkxh",
+      "uploadedDate" : "1979-05-29T11:13:26.035Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ekaJJw1CbEPs4U",
-    "name" : "LInc3uGXuUqneEQ",
-    "description" : "p5Ml11wRRo"
+    "id" : "https://www.example.com/PkpDyqms62tNWX",
+    "name" : "5nEJClxxo8St",
+    "description" : "qZjoDEAp7Gr"
   } ],
-  "rightsHolder" : "Kbnmi4eHE2MIjD",
-  "duplicateOf" : "https://www.example.org/e7443064-81cf-46ba-9c92-2752d68bac44",
+  "rightsHolder" : "IS1X7M0wbGLA6DS",
+  "duplicateOf" : "https://www.example.org/9404af36-00c1-496e-821b-e69146503f2d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Yk17e8FBBdXfJCZPqm"
+    "note" : "ifda6EWWDWGG8RSn"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "e0PuBfrGeTTUQqn",
-    "createdBy" : "OZSnv957171",
-    "createdDate" : "2022-12-21T17:42:30.825Z"
+    "note" : "2krdD0HAhFUn",
+    "createdBy" : "UFLnv1x4GPzoky",
+    "createdDate" : "2021-01-20T07:35:07.731Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8d8d42ba-1e1d-4a01-920c-7727ad794a85" ],
+  "curatingInstitutions" : [ "https://www.example.org/6f5929fa-ce06-4b7e-97b4-7fd3b2cf980d" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Bj4WpmDZfq1miMh8",
-    "ownerAffiliation" : "https://www.example.org/481c7ceb-c810-4ac3-8a1e-ef658d8f1ea2"
+    "owner" : "euT34JNLf13QqagGukM",
+    "ownerAffiliation" : "https://www.example.org/9eb972aa-d20b-49aa-aefb-3a185b447ff5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a06e54e3-68cd-4f8d-bfbc-89bab3261132"
+    "id" : "https://www.example.org/88e5664d-8312-43bd-953d-4a2a669fe3ee"
   },
-  "createdDate" : "2019-02-17T20:34:06.337Z",
-  "modifiedDate" : "1991-05-09T02:39:10.877Z",
-  "publishedDate" : "1984-07-19T05:49:05.992Z",
-  "indexedDate" : "1990-08-01T17:32:14.385Z",
-  "handle" : "https://www.example.org/0738a60b-1ec0-4c35-bca1-9273c1cb96a0",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/09d50198-ca5a-42bc-aa9f-e50b4cc1b8f5",
+  "createdDate" : "2008-07-20T02:51:29.242Z",
+  "modifiedDate" : "1981-02-12T20:01:09.943Z",
+  "publishedDate" : "1984-11-28T20:18:56.248Z",
+  "indexedDate" : "2017-12-12T10:45:30.494Z",
+  "handle" : "https://www.example.org/3e382894-956e-4e39-b6f0-ce78651afcbf",
+  "doi" : "https://doi.org/10.1234/architecto",
+  "link" : "https://www.example.org/b85b7a07-80f6-4aa4-8ebb-1ca84f5279fe",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0m4guBFFVIVcFyP9",
+    "mainTitle" : "I83cBllXcCsPlmxJe6",
     "alternativeTitles" : {
-      "bg" : "S75uNFN2pJNF3j"
+      "en" : "JrgByEA2DInEdwlS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PopwD1gNLi8",
-      "month" : "zH7aOfCDSkgCdq",
-      "day" : "EXRBnT5dSLJ3CD0G8QU"
+      "year" : "dxL5M0fMfr",
+      "month" : "0s2RPq8ZaItip413kMp",
+      "day" : "5n8DO1O58P97kp2tEG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2bdbf6f0-6cf0-4374-b253-16c174d7136f",
-        "name" : "9IUeM4I9EN2W",
+        "id" : "https://www.example.org/6a281e91-da2e-411d-955a-be7e9884652a",
+        "name" : "WLbPiaKSVx",
         "nameType" : "Personal",
-        "orcId" : "cCKoadESlNIn",
+        "orcId" : "bsv7ytQvKYMlX",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AwlkjT9HK3nUX56FA8G",
-          "value" : "IfwHcxp5o2B"
+          "sourceName" : "SayIrmxPQbM79va9c",
+          "value" : "ZiWTvUiTLG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5Gc8pVLcYP",
-          "value" : "y2Z7RVgyJk6rD"
+          "sourceName" : "uTmhrLTtpUu",
+          "value" : "o0kPhwsEWo3r8UIrW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4fd382e8-47b3-4b54-a2c5-6fef8ab3f174"
+        "id" : "https://www.example.org/bc97d6ed-4bcf-4825-bb9b-67645f47486f"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/79512595-63fa-4430-a112-090475c8df88",
-        "name" : "dFAYAvzlGs07fST",
+        "id" : "https://www.example.org/de44be44-2e12-446c-938d-121ca46e5f5d",
+        "name" : "wmEW0JtAvzggZZ",
         "nameType" : "Organizational",
-        "orcId" : "v6oSNOdb9or0h1h",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "VHaLgDekraCrVaxfH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0eWOeOm5973",
-          "value" : "stfX5k24rYf4"
+          "sourceName" : "uAGBEJlNlI",
+          "value" : "mkpmG7VoYTCcYJXs1It"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6r2Y7JgV9LFlbik",
-          "value" : "IBWG06cJM4"
+          "sourceName" : "xvtNp6wCLUEf",
+          "value" : "IGFQwJPzqkEEcGQDSW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e6124116-0a40-4619-8632-b0ca6677fc57"
+        "id" : "https://www.example.org/59c9bc74-709b-41ad-80bf-ad6556bc7c77"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "uB7YScCm1YV"
+      "da" : "EGtiUFxQWY"
     },
-    "npiSubjectHeading" : "Vsjn5vAiEva6p",
-    "tags" : [ "sawoGlh3i4" ],
-    "description" : "4hWwcXgr5BBgpG6sJC",
+    "npiSubjectHeading" : "jJUxTHo9Bh8fRd9bbw9",
+    "tags" : [ "5jH9xXXDHeI15LcSp" ],
+    "description" : "YokxF2O7aSq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -100,15 +100,15 @@
         "medium" : {
           "type" : "Radio"
         },
-        "format" : "Text",
-        "disseminationChannel" : "qak4lWM9jl7aL4d14v",
+        "format" : "Video",
+        "disseminationChannel" : "UiiLDso7FKYt8nNiaJN",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "zLLRj1G5AJvD7bEMX",
-          "seriesPart" : "jRAc34wnq88h"
+          "seriesName" : "2hicPLASNmM",
+          "seriesPart" : "SZjhsh2DfM4YCIK"
         }
       },
-      "doi" : "https://www.example.org/315bf44d-b75b-440f-92bb-3f625ef593af",
+      "doi" : "https://www.example.org/2a673b7b-a229-421a-878b-71f83cda9b52",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f4c340aa-6eef-4edc-8963-14504a6e107a",
-    "abstract" : "VXpl0alTDcB56BxN"
+    "metadataSource" : "https://www.example.org/280d383f-fef2-4341-acfe-89b9f6d2077e",
+    "abstract" : "riIb8Di6KfZ8AP6Np1C"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3eada757-a883-41fc-afec-e052b3713e9e",
-    "name" : "pqvwSRDNW7swwNr",
+    "id" : "https://www.example.org/e734fb0e-11cf-42bc-a66a-d51a0c46d7b0",
+    "name" : "L9bLweNTe0iawAT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-03-16T13:40:14.576Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2024-04-30T07:23:15.433Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "xdwqbxBeB7w6fYi"
+      "applicationCode" : "utbPsDaRmy4R43UCW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ecd2e64d-8421-42ea-b668-7b1b7b3812b2",
-    "identifier" : "3HYcplBdDvOr2",
+    "source" : "https://www.example.org/cc862466-0fe1-4f48-bb52-e1c86b52d67b",
+    "identifier" : "ONTsH78F5c8SO8dVt",
     "labels" : {
-      "nl" : "XTO4xo880b"
+      "da" : "o4cAWbbhnccHF21D0"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1093304639
+      "currency" : "NOK",
+      "amount" : 1711367496
     },
-    "activeFrom" : "1991-03-03T06:59:12.477Z",
-    "activeTo" : "2008-04-10T19:23:01.729Z"
+    "activeFrom" : "2020-01-06T03:40:37.386Z",
+    "activeTo" : "2021-08-01T16:55:18.309Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b867e11b-c1c3-442e-83bf-0361785a847c",
-    "id" : "https://www.example.org/3103146e-1bd5-4d07-90c3-e3ecaf47aa5f",
-    "identifier" : "TSlZfFFHTDk1",
+    "source" : "https://www.example.org/132c0384-8bd0-4e45-a5d2-06a7e0d64a99",
+    "id" : "https://www.example.org/97f869b0-6a78-4cfd-b358-ac9350e839ed",
+    "identifier" : "4of1z36iEXbud",
     "labels" : {
-      "de" : "TzpfkbBrntyWrkTvkmg"
+      "bg" : "nBzxVkq43G8rY"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 160124893
+      "currency" : "EUR",
+      "amount" : 1720402497
     },
-    "activeFrom" : "2003-07-30T09:22:49.493Z",
-    "activeTo" : "2017-06-25T18:05:43.025Z"
+    "activeFrom" : "1990-08-19T11:03:09.109Z",
+    "activeTo" : "2009-04-12T14:52:11.339Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/df20cc9d-3bf6-4d61-9d0b-944c9a9caff1",
-    "sourceName" : "o9e1mgbjvo@alcnadtcxgko"
-  }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "iIll7Xaa3gRoz",
-    "value" : "cCWXdYK10RwUyJFAtL"
+    "sourceName" : "c26PZLwmSTrdK9oSRw",
+    "value" : "1HNELbx3wS"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/f35da05c-2661-4ef0-8f41-3410d1594e57",
+    "sourceName" : "0e1xhqcbjwckb5v@xlsoikzwvq6ti"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1928281859",
-    "sourceName" : "5s6sntehfvnum7@c7hgzyjbh2l88hvcjk"
+    "value" : "235946727",
+    "sourceName" : "jludx9vslvj@qivt6mdvyg181obtzz"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "KYY3dFc5HjT",
-    "sourceName" : "hknibve37evj@bf5dn6mip6ywla824t"
+    "value" : "jMhfeZf6GJCKDjkayQ",
+    "sourceName" : "85n8lg7f5im8@brlrw0wa28kjy"
   } ],
-  "subjects" : [ "https://www.example.org/a12ecb09-e7bc-4365-8951-e7a8fdee0cf9" ],
+  "subjects" : [ "https://www.example.org/1b5c4399-d4c9-4a2a-a8ff-b6b3b2a3758a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "074a769f-e071-43d1-bbee-64d93baa5d84",
-    "name" : "oJwQAwQurVT4rgJNvOc",
-    "mimeType" : "IYuCnhXl3Nu",
-    "size" : 1767399509,
-    "license" : "https://www.example.com/7eza2g612unt12nidur",
+    "identifier" : "6597d305-ff1c-4bf3-bbf4-791e0464f263",
+    "name" : "HOKX73eGIl",
+    "mimeType" : "iz8VweHMjrb",
+    "size" : 1132254317,
+    "license" : "https://www.example.com/qcyrr5yx82mhwfkrz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ID0dBYLVzFbi9",
-    "publishedDate" : "2024-02-12T17:33:40.675Z",
+    "legalNote" : "akDJfFxkKbAYTis",
+    "publishedDate" : "1976-01-04T20:50:49.734Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1505018130@XM46KYd48iJhBgwXy",
-      "uploadedDate" : "1989-07-11T19:04:28.736Z"
+      "uploadedBy" : "1607692150@ZsODpBsSjzw",
+      "uploadedDate" : "1980-04-29T19:03:36.131Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/rGfpHfC8IBYzw9VQVIM",
-    "name" : "93cA1c7acZ6Vhnye8",
-    "description" : "A6NCrFMKElBh"
+    "id" : "https://www.example.com/0gYpJheREtTk",
+    "name" : "t1bPER4DKf",
+    "description" : "RQRuXCGXu4rAo7P"
   } ],
-  "rightsHolder" : "yjcB1HMkZ9",
-  "duplicateOf" : "https://www.example.org/9ce36467-29c2-4ba1-b047-5e6e4c227cc0",
+  "rightsHolder" : "ecpPJeYMxM",
+  "duplicateOf" : "https://www.example.org/fd940f73-1fec-4295-96bb-e64c42aa4785",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KaKn15hxZYdbO7tDX"
+    "note" : "ExWF3Xn2eLOyjM"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "r88FuqVBQkh",
-    "createdBy" : "q4UFZvsrIauVisNMgH",
-    "createdDate" : "1984-01-23T06:12:39.904Z"
+    "note" : "GrBU0cwdOXLrA6fj95b",
+    "createdBy" : "aAZgPX5ps1y6FJ",
+    "createdDate" : "1977-07-04T12:31:06.986Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9be1a951-9239-4e34-9bf1-e1c2b80075d6" ],
+  "curatingInstitutions" : [ "https://www.example.org/e6ce29d1-4935-4c97-8be2-f6504c596dfc" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "S2smmuz2RvdEWF",
-    "ownerAffiliation" : "https://www.example.org/ba2494c2-3262-4b49-b913-7322cbc86b29"
+    "owner" : "GNLxtIS6hBOVsYmwh",
+    "ownerAffiliation" : "https://www.example.org/d7e031b6-7f8a-4f6f-89eb-9ec4d1ca11cb"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b568dfe6-7bf3-4fe7-a45d-bf8e52167763"
+    "id" : "https://www.example.org/2ebaf4a0-cb2c-4c14-b5ca-ddb46cce1454"
   },
-  "createdDate" : "2020-10-11T19:42:02.105Z",
-  "modifiedDate" : "2010-05-10T22:05:47.281Z",
-  "publishedDate" : "1972-09-15T03:41:42.587Z",
-  "indexedDate" : "1989-06-09T07:34:41.935Z",
-  "handle" : "https://www.example.org/ea90fa04-cabf-463a-828f-16c117316eab",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/c7aa2edf-41d6-485e-8319-0eb6b2bd00c8",
+  "createdDate" : "2015-10-31T14:42:30.687Z",
+  "modifiedDate" : "2006-10-16T19:22:34.546Z",
+  "publishedDate" : "2009-09-06T11:08:47.544Z",
+  "indexedDate" : "1989-10-03T08:08:46.687Z",
+  "handle" : "https://www.example.org/cb6a4d60-f27a-4433-a981-a22c4f2608e8",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/f9a7fe3b-4a66-4248-8a01-3b6ee77e6757",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2rPeOnpQDDwOlRxst9",
+    "mainTitle" : "nuw867iQsA9hrnVHf",
     "alternativeTitles" : {
-      "zh" : "TmK0IwSElFy"
+      "ru" : "aXEV7JIOZKvhYOjC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Ydtf4gxjTV4VoDpH",
-      "month" : "VLn1ERN8dSgPIXe",
-      "day" : "d4xabmhg13s"
+      "year" : "ZBbcOxUu2t",
+      "month" : "fxP1zsYhxB4kOkDkUVm",
+      "day" : "geUA7Xa139ERWATGc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd2a0cbd-14a1-44bf-b932-8735e96b7c73",
-        "name" : "m59RU7sMSxiyB9G",
+        "id" : "https://www.example.org/5fccbfaa-b23f-4ce7-8cc8-64f20beb8737",
+        "name" : "sQXZCFWtmxfNxkWXDU2",
         "nameType" : "Organizational",
-        "orcId" : "dMNDpTljXz",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "AyuhnSIz28",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wHBARQgMYdD24F",
-          "value" : "nZWFKrONWLZT"
+          "sourceName" : "rHgjKqdViVB6lAjUlz",
+          "value" : "uekjZLk4R5A"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "C0dZdPB2rww",
-          "value" : "mEn10cwQj4DSHO"
+          "sourceName" : "2fQ5r5FOcEA",
+          "value" : "DtymvJk3TfG6B3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c216f5b1-96d6-4ab1-ac2c-6bcd31f9df6d"
+        "id" : "https://www.example.org/7fb73f3a-b04a-4707-a20c-5354465ef0b7"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4abd6354-d96e-46e5-a452-9cab862d5ad9",
-        "name" : "cCvDUFtKLm",
+        "id" : "https://www.example.org/63f86cbc-7c54-4f06-ac7e-c4e4dda3e4ad",
+        "name" : "Dilgrijm2TI5bxCjO",
         "nameType" : "Personal",
-        "orcId" : "GGPJunCfUaBN2cj",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ZcT9qIA1KoCzOO4Tc",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EZEyVCPbR2HYcRLZ",
-          "value" : "r47N4zhNnBEZ6SQVyQu"
+          "sourceName" : "Va7FDnw0Mp5cMCANPd",
+          "value" : "EC5bYsK398dp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NkYCMu9ZmSaz",
-          "value" : "HFFmJbcjNBbHWAGM"
+          "sourceName" : "HoOozxzJOLbSeJFznsE",
+          "value" : "O36GJRa7uHs5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8d882c73-e022-4611-ac9e-96a133f30e98"
+        "id" : "https://www.example.org/201546a4-6ee6-415f-b7a1-abd84b2478d5"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "DataCurator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "V6MWnVnols5JtSzZwA"
+      "da" : "92Pdc4FZIXOhxI"
     },
-    "npiSubjectHeading" : "Q3YEVCJQGKBpB8wo6",
-    "tags" : [ "dwbsmfzYN1y" ],
-    "description" : "hZxQNbzCNYYRjfgq",
+    "npiSubjectHeading" : "riF05nETE4JkBSly",
+    "tags" : [ "qRRWo3tOnElHeELEe" ],
+    "description" : "g88D39Dtc1qhwfDz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Internet"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "9peLjDfvlGhRpO",
+        "format" : "Text",
+        "disseminationChannel" : "8N5lXrSZb8hXu2YfUb",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "4dLw3oWkTZDlEwiShjq",
-          "seriesPart" : "dEl8HSGpxrw4IhVqL"
+          "seriesName" : "un3SJATu4fdrIjBCDT",
+          "seriesPart" : "N15lKvQ7gOrYgXnD"
         }
       },
-      "doi" : "https://www.example.org/6e2aff5b-a906-4b75-a49f-64a2ed887f0f",
+      "doi" : "https://www.example.org/2d8aa102-d20a-4eae-8e8f-2a2562e57d12",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,106 +116,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5225a05c-34e0-4d93-a57f-bcc0288998f3",
-    "abstract" : "jaGw2NpAKoq94"
+    "metadataSource" : "https://www.example.org/75d995e2-9113-4d0d-8bd9-ef470ec16196",
+    "abstract" : "h5DaUQIQvcKdlqWfM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a22ca51f-bd20-4fde-8a5a-aad0f5fdd2e0",
-    "name" : "hrPaBTAobFdECqsx",
+    "id" : "https://www.example.org/ade8114c-9a0d-4650-a532-67946c7a21e4",
+    "name" : "7ocYFSs9jZiFr8",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-06-06T15:26:09.234Z",
+      "approvalDate" : "1987-11-27T15:56:13.355Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "2ezamkuFs0Vh0Hii"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "xkRlolDCSgoGCqx4K7"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/63384499-1ba7-4e61-a542-9e66fdad10ee",
-    "identifier" : "olt9RsIqX1dfCUnGZ",
+    "source" : "https://www.example.org/1950056d-854b-4530-9f3f-b8d7cd5e29ff",
+    "identifier" : "xVRBpW97zvgxz",
     "labels" : {
-      "zh" : "RCV0MIiDOhJ"
+      "nl" : "WxUohX1osIANvv"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1558059522
+      "currency" : "GBP",
+      "amount" : 1541113072
     },
-    "activeFrom" : "2003-08-18T13:39:56.616Z",
-    "activeTo" : "2018-12-20T04:37:09.295Z"
+    "activeFrom" : "2023-11-07T07:25:26.011Z",
+    "activeTo" : "2024-04-23T03:33:50.421Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8ab6d4df-62fe-4ebb-bff1-271ef1ca93cd",
-    "id" : "https://www.example.org/846c6519-1a15-45ee-84e0-87c322c09fea",
-    "identifier" : "WM0KrKzfnvdnMTpRG0",
+    "source" : "https://www.example.org/6e3610bf-5617-4a70-97d7-52a2b623503e",
+    "id" : "https://www.example.org/f14824af-f5ca-4878-a7d8-fdaa42bf8982",
+    "identifier" : "u3NBXQDGqhIgla",
     "labels" : {
-      "el" : "yFgIePcOP3iVHXe"
+      "pt" : "XI78euURZZ0D"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 306748415
+      "amount" : 1309526119
     },
-    "activeFrom" : "1985-01-25T06:21:43.262Z",
-    "activeTo" : "1998-01-04T12:00:47.395Z"
+    "activeFrom" : "1975-04-26T14:31:44.774Z",
+    "activeTo" : "1999-10-20T23:51:52.958Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "tPsQUjIm5OJH",
-    "sourceName" : "hawejzgntkmggu5m@mb0r6uggqk7spefqdgf"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/5d7c8326-b1db-4149-8900-b779fb4ff524",
-    "sourceName" : "asbcitytc98uk9@dwxc9eqggx9"
+    "value" : "https://www.example.org/681d4e56-1a04-45ec-90f7-7c8ef96c988f",
+    "sourceName" : "oc5jhtzxpvzy6ul@aejs59fifjon"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "295751870",
-    "sourceName" : "vqlk3tjf42tsjz@m3xxbmuqfyfnphpz"
+    "value" : "1885874900",
+    "sourceName" : "altbizahjj2ocea@soin2boytlmo"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "y2EakOgkg7Og4",
+    "sourceName" : "bmelvi2m9g@q5hkhvxxo6x13l6mf"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "ClZov3vPwcmGT",
-    "value" : "wqJi6sh61dkvqCI"
+    "sourceName" : "3p5UTJJMrABU",
+    "value" : "PSl1uFmDLXQz9dl"
   } ],
-  "subjects" : [ "https://www.example.org/2bb422b7-59ee-4e78-a873-7de45b720590" ],
+  "subjects" : [ "https://www.example.org/17a40da3-def0-421c-9859-88374fbc3121" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dc96b88b-ae18-4520-911e-81505a8a5860",
-    "name" : "s7DhGQiBx6M0",
-    "mimeType" : "WK4lPE7HpWo0UA",
-    "size" : 676683404,
-    "license" : "https://www.example.com/mos3cqccl4l",
+    "identifier" : "35043a69-7efd-44d4-8df4-4cd14e6305dc",
+    "name" : "VNxpnCBrFD0KPxOHnBp",
+    "mimeType" : "Hp4gv9LPS04",
+    "size" : 1101991249,
+    "license" : "https://www.example.com/bps3kqy1zmb186k",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "XPfHBmchgbnh1rlC7fo",
-    "publishedDate" : "2016-10-02T05:44:44.089Z",
+    "legalNote" : "YRYygS4lwqYAOn4k",
+    "publishedDate" : "2020-03-26T05:37:51.068Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1397483936@eFnB1BBULqLadLvz9",
-      "uploadedDate" : "1982-08-05T12:13:07.090Z"
+      "uploadedBy" : "882549058@kvojh8jgZal8V03",
+      "uploadedDate" : "1977-09-22T20:29:51.124Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/94209FD4u1LzyqRq",
-    "name" : "VGf3hvHckYFK2c",
-    "description" : "vi7Cm917SAP4u"
+    "id" : "https://www.example.com/ybNxRlSu31pM",
+    "name" : "Kl7vjZx1IMDB",
+    "description" : "TdsG6BNNnORgSpXR"
   } ],
-  "rightsHolder" : "CI8KrMUPKRnTVH1",
-  "duplicateOf" : "https://www.example.org/d2041ad5-61bd-4da2-a120-08235b51af8b",
+  "rightsHolder" : "tRDM8LY9Y8rpUcBwSJC",
+  "duplicateOf" : "https://www.example.org/260fcf6a-c880-4d42-8ad9-fbd48d0bbcb5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lVRQUIOsL1lv"
+    "note" : "2FfRe5vZqP5iXUYPmwC"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kNb80FAVqtaekVqJt",
-    "createdBy" : "dN8PlCRuJoC",
-    "createdDate" : "1981-11-29T11:08:41.717Z"
+    "note" : "jd4PaDt4jrMtzlmpVV",
+    "createdBy" : "B9qjraVV0mg",
+    "createdDate" : "1994-01-27T21:50:52.816Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/12ca3980-eee8-4559-a683-1d73e2a825a4" ],
+  "curatingInstitutions" : [ "https://www.example.org/21165528-e90f-446a-87f3-043394823d95" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "4F031YTlNdU",
-    "ownerAffiliation" : "https://www.example.org/949d164c-e70f-44c8-a76c-195521c435a0"
+    "owner" : "2b2Bk88Qj7gvp5",
+    "ownerAffiliation" : "https://www.example.org/5cedce97-538e-4cd6-91c9-cd41ad94671d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eff5e402-d3e3-4fed-a894-e72397846042"
+    "id" : "https://www.example.org/fa169a69-ff58-443e-846e-73463a94d05c"
   },
-  "createdDate" : "1998-11-16T16:23:03.362Z",
-  "modifiedDate" : "1998-01-20T18:29:09.700Z",
-  "publishedDate" : "1998-10-02T22:10:00.321Z",
-  "indexedDate" : "1977-02-04T21:49:27.909Z",
-  "handle" : "https://www.example.org/783c0316-208e-4212-8e15-32f1bb5c3e3e",
-  "doi" : "https://doi.org/10.1234/harum",
-  "link" : "https://www.example.org/3e642c2b-2862-4903-88a3-7667871e8b04",
+  "createdDate" : "1991-01-17T04:40:58.458Z",
+  "modifiedDate" : "1982-07-24T15:51:20.695Z",
+  "publishedDate" : "1993-06-05T10:40:29.952Z",
+  "indexedDate" : "2019-12-09T16:56:30.283Z",
+  "handle" : "https://www.example.org/c0edb88c-6c63-489b-807a-17624492869a",
+  "doi" : "https://doi.org/10.1234/maxime",
+  "link" : "https://www.example.org/fe652c75-03f2-4575-bd48-2fb6969fda54",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "s53qLyZs9Gbc",
+    "mainTitle" : "khLRNNBYkzK54Yfe",
     "alternativeTitles" : {
-      "cs" : "v1IJhsVAHUK1jAeAt5"
+      "hu" : "ijTDnU1nvK72f"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ttiMdb100FQeat",
-      "month" : "AcMDgVuzz8N0uGN7bku",
-      "day" : "RszUGCvqx4"
+      "year" : "jDkIoZbsMj5Sv",
+      "month" : "NR7KicbgpdMfrpQu",
+      "day" : "xn8wRISw9SxiEzsCQC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/576b20d1-e921-4577-b18b-6d9a8c153ea5",
-        "name" : "cUolP1JjmGzUu8",
+        "id" : "https://www.example.org/784c71e9-73df-4799-ad8f-858f596e1a34",
+        "name" : "EY5eXQrB9oJbW9",
         "nameType" : "Organizational",
-        "orcId" : "Ap7984xPyq3OB4PDQxR",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "hFApoOpGAQ1BQmEX",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uSUfSBsBzu",
-          "value" : "y7R4aijcGOxrA9DB1"
+          "sourceName" : "xXOjLKzilqwkqxmbWx",
+          "value" : "lkNj6Q49I3LcVh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aePBOLglMfErCO",
-          "value" : "nWji5vVhmbKV"
+          "sourceName" : "5vDtucqfUhUp",
+          "value" : "7aNHhDXkqXResy4r"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/39019813-6b5a-4257-a5a2-366e3f6542b9"
+        "id" : "https://www.example.org/5a7ed636-5747-430c-9d73-3ea63f677d1e"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/45dd64cf-a6cd-4bf0-8847-b37f9ef1e20e",
-        "name" : "q3pYO2ui2s6CBbaiPK",
+        "id" : "https://www.example.org/38495833-ec77-47a6-a925-4810a26e58ef",
+        "name" : "ZvnKxzw0M8T5EGmDF",
         "nameType" : "Personal",
-        "orcId" : "hHOYBphRwwWlYoOsBJ8",
+        "orcId" : "c7jxss5WzkmV",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iEyvRfSgY5y",
-          "value" : "c7LDvMulM4ZQ"
+          "sourceName" : "sor90rxbez4fTQyWzL",
+          "value" : "Wt4bQLyjzqBiGYc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YGoPjRFAto8P",
-          "value" : "ULa6197VeoM0smyd"
+          "sourceName" : "4EHYgPZca85ROQgu4PI",
+          "value" : "SX3jJsxg51XQJqA60"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/22d13769-d01d-4344-ab65-ddf3e52612a7"
+        "id" : "https://www.example.org/0fad4355-397d-48ac-ac53-a1a2c31d01e2"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "Q6QJG6uIJN"
+      "da" : "S3oVmXnrcRyLmsNctiD"
     },
-    "npiSubjectHeading" : "ItC581QhLctN",
-    "tags" : [ "ct8Ol5kzd9zxSQ4P9" ],
-    "description" : "JgCvscnscvVkieG",
+    "npiSubjectHeading" : "f2eUUOMd6JrEty",
+    "tags" : [ "8WWMPyZcQdZDCM8ys7" ],
+    "description" : "38hrZnO8FHfntJeY6t",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Journal"
         },
-        "format" : "Video",
-        "disseminationChannel" : "MjHMWgWN1sVR7zUatH0",
+        "format" : "Sound",
+        "disseminationChannel" : "yW33kDECQnWgDveJrCl",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "neIUgNwV9xHR6I",
-          "seriesPart" : "5OZpJRxnh5x8eEj"
+          "seriesName" : "E9orBIUsOYf",
+          "seriesPart" : "6XYkjyTMVJXQ1A7"
         }
       },
-      "doi" : "https://www.example.org/d6973038-9860-4af2-b707-6a2851eae5d9",
+      "doi" : "https://www.example.org/12546e41-d54d-4f74-8eab-c03f4c9028c8",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -116,107 +116,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2ba65566-1023-466b-944d-c1025cb65b42",
-    "abstract" : "MUmd0o62TVo5S"
+    "metadataSource" : "https://www.example.org/0551f72c-08d4-45fa-a403-819f0366d1ba",
+    "abstract" : "Ki5K5r5mhh2f"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/06e47d2a-8443-440c-967b-1ff7a73b52b1",
-    "name" : "OronFsa3ZKKRVz4",
+    "id" : "https://www.example.org/42cc15c5-6dde-4fd4-abb7-bf98478b85c9",
+    "name" : "RKxVoqpJXPgK5u4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-03-09T08:39:11.575Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "v3JWH0OKQps57lt7Dp"
+      "approvalDate" : "1992-03-16T10:04:30.258Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "sgz6z3NZvkJ4qoMcLH"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4ae62a11-3efc-4ec7-9c42-eba53876bc1a",
-    "identifier" : "qLavMPiLGnAK",
+    "source" : "https://www.example.org/9c63b1ad-9179-4b85-a542-1761f5b01772",
+    "identifier" : "WVe12c8scr",
     "labels" : {
-      "fr" : "VfsXhtDBiHNcjg0"
+      "bg" : "UlLlf5js5jugFX"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1524399725
+      "amount" : 1666195155
     },
-    "activeFrom" : "1984-02-17T14:17:41.397Z",
-    "activeTo" : "2002-12-25T04:30:11.300Z"
+    "activeFrom" : "1999-06-23T17:52:34.796Z",
+    "activeTo" : "2008-02-27T09:01:24.577Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b6019812-ea0c-4472-b1d5-b85136695e0b",
-    "id" : "https://www.example.org/c6ee74b6-947d-46b9-bb74-033f3a01fe97",
-    "identifier" : "U4T5i2ExfEQ984",
+    "source" : "https://www.example.org/23be013f-8447-41d8-a61d-4caa67cec42b",
+    "id" : "https://www.example.org/c10413f6-370d-44d3-b2ea-8efff42e428a",
+    "identifier" : "1XaZV3uheHbc70e",
     "labels" : {
-      "da" : "xzXvsqdwELWg"
+      "da" : "qPGrFGIYk7tnYN0NaoY"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1678626080
+      "currency" : "GBP",
+      "amount" : 1842334496
     },
-    "activeFrom" : "2013-10-03T01:12:26.815Z",
-    "activeTo" : "2018-03-03T19:27:40.924Z"
+    "activeFrom" : "1980-11-04T09:20:45.469Z",
+    "activeTo" : "1995-04-20T04:50:58.826Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/222a023c-364e-411b-8900-4d05218830c0",
-    "sourceName" : "chqkhlia3jt@q2pmvg9hjrkcfhb"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "rZefXkmPwUsVU840h4",
-    "sourceName" : "rdprrcqdaghn@wcocganot6t"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "342558413",
-    "sourceName" : "oofbplceetjhzetrl@0wr6ewbcminuljl"
+    "value" : "2009535130",
+    "sourceName" : "s2yguvvmn6jzbc@o8hy3grwbeqmq389"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "4ugd9IHiCGaQ1Xk",
-    "value" : "eUuQZekFUDgD2Vo5mj"
+    "sourceName" : "OkMZ0FeGWW4l3Sqlfw",
+    "value" : "yxcvAnMXdXRbJF"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/100da99f-7685-4f95-9b24-6502c42c92b1",
+    "sourceName" : "fdaqofutj62v@jg6llvefapk"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "saNh1fQnPXyx9",
+    "sourceName" : "i5ozomkutfajbjqjwmw@ksbdnosxdg6ddxo6iq9"
   } ],
-  "subjects" : [ "https://www.example.org/2680ad96-59c7-41ef-9ff2-d36836beeb19" ],
+  "subjects" : [ "https://www.example.org/71d29869-d7ac-438a-b336-7923d0a7776e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "681d4117-3923-4575-9cd7-41903051c035",
-    "name" : "OOQ1Rkt3a9VvbkngqgP",
-    "mimeType" : "DkcGa7akqNA",
-    "size" : 1174389909,
-    "license" : "https://www.example.com/ysjwntbwa0ndh4k6i",
+    "identifier" : "e0c37689-f8ca-4d5b-8548-f62bee0b25e8",
+    "name" : "Lj4XEFKHj2WT",
+    "mimeType" : "AxJ7bknZVa0uyHbr",
+    "size" : 1267279417,
+    "license" : "https://www.example.com/qmporrqknmbiqw68oo",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "o9zhUR3RrQvF9sStq2"
+      "overriddenBy" : "YEDkHMLJ4rGE"
     },
-    "legalNote" : "UgbnWDOW8Ts2e4",
-    "publishedDate" : "1973-05-15T02:45:39.458Z",
+    "legalNote" : "XtzcKTYJlCfsy",
+    "publishedDate" : "1981-02-20T00:51:33.228Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1922710231@h7O1QPzUuwvDCN3ktR",
-      "uploadedDate" : "1981-07-19T17:07:17.004Z"
+      "uploadedBy" : "2001307702@vFon2g5xix",
+      "uploadedDate" : "1976-07-11T23:02:05.682Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/RaNdMEYJzRCk6X",
-    "name" : "YyMihAZoDEqoIkAW",
-    "description" : "ttJ6vqFpK3MnsN0aU"
+    "id" : "https://www.example.com/rbpNIFWRfdzIbsx",
+    "name" : "EknehRz1t2akehtC",
+    "description" : "MK2IcIHbk47xU"
   } ],
-  "rightsHolder" : "5IeBBqVHccMNTuIyR1o",
-  "duplicateOf" : "https://www.example.org/42b2d054-28b6-483d-a7a2-c3444efbb662",
+  "rightsHolder" : "4ldr1UWk5x6yNEX",
+  "duplicateOf" : "https://www.example.org/1132f6fc-2a18-4538-a136-6a23b4a81740",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ozlox8eSr14kA"
+    "note" : "Ex9fuHOPwbMt1v5I"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "uY9g2SKVkhPaEwJYcq",
-    "createdBy" : "MfV3Ls58uRfyW",
-    "createdDate" : "2023-07-31T17:43:07.222Z"
+    "note" : "ZKBYFddLA5hau6",
+    "createdBy" : "sls9RkryvG",
+    "createdDate" : "1972-05-04T10:47:06.577Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/24592ee7-759c-4ac0-814c-f67618d80422" ],
+  "curatingInstitutions" : [ "https://www.example.org/43dd98c3-ae57-41d8-a146-d3b683b12560" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "l5saT23lJgKGM",
-    "ownerAffiliation" : "https://www.example.org/6f270e02-c59b-4bb8-946d-2d6f8144f07e"
+    "owner" : "ijFuVNohLAciP7",
+    "ownerAffiliation" : "https://www.example.org/ccd5deb0-7194-4cbd-951b-2107da8e852e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9a5fc34c-85f1-4882-b50a-9b94b96d55d9"
+    "id" : "https://www.example.org/01664517-13e8-410a-abe8-947cf94042ee"
   },
-  "createdDate" : "1982-03-16T23:14:17.939Z",
-  "modifiedDate" : "1983-07-11T23:58:07.273Z",
-  "publishedDate" : "1987-08-26T09:22:43.656Z",
-  "indexedDate" : "1995-01-21T18:11:52.673Z",
-  "handle" : "https://www.example.org/6aede5ce-820e-4277-a4ae-7a10c9530acd",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/247899df-e94a-4dec-ae07-7f09b74fd901",
+  "createdDate" : "1998-10-01T22:11:03.274Z",
+  "modifiedDate" : "1975-04-27T12:17:58.131Z",
+  "publishedDate" : "2009-05-11T18:10:25.002Z",
+  "indexedDate" : "1971-01-23T12:04:31.107Z",
+  "handle" : "https://www.example.org/6ef9a0d7-e169-4c09-b0a2-d04c21910934",
+  "doi" : "https://doi.org/10.1234/eos",
+  "link" : "https://www.example.org/bf0698a2-d964-411a-988e-afe521e1edd0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Z5gLO50JK4WHJV",
+    "mainTitle" : "Qjw92mYPSQB4o5Ho1",
     "alternativeTitles" : {
-      "ca" : "UbN3DW5AiuiXSg"
+      "da" : "CySg7YNpMj0tk4yhC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "YLxbe3v9gRjLI",
-      "month" : "NSWpM8AF0XSp6bz",
-      "day" : "FyxEJzSFhfCGsOh"
+      "year" : "QGBEFhFreaMQY",
+      "month" : "WlLmsuuF3q0I4e",
+      "day" : "tSGSkb8wgBLWLhbalE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/69424ace-35e8-48f4-9617-ec2479617b6b",
-        "name" : "799xacmQugBo2ET",
-        "nameType" : "Organizational",
-        "orcId" : "daDs7WWXva",
+        "id" : "https://www.example.org/c336e371-29ef-4a88-aeaa-1d1eda62c9bd",
+        "name" : "1sjiXnCyMspR0",
+        "nameType" : "Personal",
+        "orcId" : "00z72hKdIGB8VEJRQS",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Yig5SLySFxS3",
-          "value" : "qdANj6oMg0NUWnqM0"
+          "sourceName" : "i9RSH9eOcSPj4o7DzM",
+          "value" : "leuoRf6AmEPyyBvAQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TrjUIffm2XRlei1Vdi4",
-          "value" : "8qaCWiwTVcpVKX0"
+          "sourceName" : "FgRkDpJ85IynbrBH",
+          "value" : "3aL0AmPpluZGgT7S"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/01dc8e7b-3a85-4cd8-aeaf-caab3bf8077b"
+        "id" : "https://www.example.org/74ecd8c4-cf4d-4963-942b-b1adb9323343"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,158 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b38bf2ce-226d-4ee2-9558-3755c377f398",
-        "name" : "XwRVgatmqoz6PMv",
+        "id" : "https://www.example.org/398bfd9b-2b02-4229-b9ab-0536671577c6",
+        "name" : "1K7xL8y8oG2zoNbZfeq",
         "nameType" : "Organizational",
-        "orcId" : "4clNpNoZbMEaAjRVW",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "OyWlezzmHi4ab3KsnD",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oLZUkTrxJQr1V2q",
-          "value" : "8RHQKL6eimqYcr9"
+          "sourceName" : "WGSwRPjreK9Ni",
+          "value" : "pVMhQilZsgnuc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JtwqxcDHxNfL0",
-          "value" : "PVXAh810A6s5Xz1fijO"
+          "sourceName" : "B5kfTtchCgeKsTFC20",
+          "value" : "q7HVO9rtSISGpk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/15d818ab-bbd6-46a4-a7b1-f9130ccbb12d"
+        "id" : "https://www.example.org/92bd2afd-f700-457e-b33b-7cc1ae5b00cf"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "Registrar"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "bL4YlEQ20uGu"
+      "bg" : "mJK31T69CW5Vbf"
     },
-    "npiSubjectHeading" : "rUTaYBgbs9j5Zs96",
-    "tags" : [ "cWxAlf8iNarY" ],
-    "description" : "TlNCIVYEsb",
+    "npiSubjectHeading" : "hBOCO7ocZZ",
+    "tags" : [ "cqZCHn9mhWVeP" ],
+    "description" : "OEZGjZLElTaXa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4461e284-e1d0-4905-b913-03c5eb79ca01"
+        "type" : "UnconfirmedMediaContributionPeriodical",
+        "title" : "oK6BIl7jl7DPNZTH",
+        "printIssn" : "7106-0863",
+        "onlineIssn" : "8088-3974"
       },
-      "doi" : "https://www.example.org/ab07d0a5-541a-45d9-b91c-709004799e2d",
+      "doi" : "https://www.example.org/2631d8a8-0a56-4511-98b3-f981745a4a1e",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "ifp2crMuFMVdL",
-        "issue" : "AgDUv4uNfiaLsmM4hRR",
-        "articleNumber" : "BjOchJmrVuZRw",
+        "volume" : "sEqubs7rzKwWIJj",
+        "issue" : "Ql2FI60qGFB",
+        "articleNumber" : "hzUHUdrz4ogqXUj288",
         "pages" : {
           "type" : "Range",
-          "begin" : "3oFsDON3a32",
-          "end" : "YiV4GegMGVMrWD"
+          "begin" : "6cM2DA7Lv4",
+          "end" : "g5MoPJkZrkXr"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/071f2275-ae79-44cc-bc29-f6e2e84f7f02",
-    "abstract" : "NzTvoelkqDeB"
+    "metadataSource" : "https://www.example.org/a26ce461-c870-435d-886f-89818b35b46a",
+    "abstract" : "R5C4yvqwnTgkrCD6gZ0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3a5ee6fd-bdf1-46bf-9def-0622ca2ef0dc",
-    "name" : "LeQBXlgn1f5c9",
+    "id" : "https://www.example.org/2492adc3-5c9c-41e1-895b-c696a3d31e73",
+    "name" : "qyvP9KaF7ZDrhUJs",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-04-08T10:12:44.882Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "wQXjkbNlj2"
+      "approvalDate" : "2003-04-19T23:51:58.229Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "GMo51KVbVDMDm0WX2hv"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e88a438c-1a43-49e2-a79f-d31d28808227",
-    "identifier" : "VaaJpM2G2HdNciur",
+    "source" : "https://www.example.org/af55945d-89fd-47bc-817d-68978e9df83f",
+    "identifier" : "BPPuhTHlGX9KKQ",
     "labels" : {
-      "de" : "JLRyhXd8HR0821sc"
+      "af" : "1y2elUB2GjUhX"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 870108989
+      "amount" : 1602486557
     },
-    "activeFrom" : "2011-09-15T20:45:55.788Z",
-    "activeTo" : "2014-09-29T00:59:21.840Z"
+    "activeFrom" : "1977-12-20T13:57:57.229Z",
+    "activeTo" : "2008-03-19T12:29:55.052Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/40a41f4c-99cf-4383-b0bc-130b79f9dd61",
-    "id" : "https://www.example.org/5aa324c0-689d-4239-af59-5bd25b0c890a",
-    "identifier" : "a1QdD1umRT",
+    "source" : "https://www.example.org/e2207615-0bc6-4293-8b0a-bdd76534861c",
+    "id" : "https://www.example.org/01e0e3a5-4104-4f8e-be53-8ba2429ce847",
+    "identifier" : "rN6kf6r0vCM",
     "labels" : {
-      "es" : "hyZJB2Q5QGOv0sth"
+      "it" : "aHkCAeCdvEMP"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 813462257
+      "currency" : "USD",
+      "amount" : 640170573
     },
-    "activeFrom" : "1987-11-13T01:03:09.006Z",
-    "activeTo" : "2004-03-15T10:49:05.331Z"
+    "activeFrom" : "2011-04-12T17:42:48.134Z",
+    "activeTo" : "2020-04-27T16:11:50.306Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "642099658",
-    "sourceName" : "yskm6igbsq0s0lbpq@ivbhh0rcm7w"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "N8u0nw5EHjXLOyO9o32",
-    "value" : "QWVBTBsnx1"
+    "type" : "ScopusIdentifier",
+    "value" : "SFvV8GxEaPLnX5kp",
+    "sourceName" : "dmebgjxvptodhaajbmg@hc2by7szdzljcvfaoud"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d7f0b13a-41c4-4a2d-8b10-03307ae1f6a5",
-    "sourceName" : "ps8seuvoqlgceks@haefk28315ikxgw"
+    "value" : "https://www.example.org/b1190e14-95ba-489a-9ce2-d1cf90f667ed",
+    "sourceName" : "e0gqwo61ho1@p93ikcc56aup2x9e"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "HDB8UNCpdLN5mQdtRP",
-    "sourceName" : "jrkpdnwb3qpjrgsu@dkum2cef02apglkj"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "4JFgQSeCMvgpMkULQ",
+    "value" : "r2kIRRqP5Ej"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "432868609",
+    "sourceName" : "wa8folbkjalaqwrdix@l0peagcxt3wbdil"
   } ],
-  "subjects" : [ "https://www.example.org/485fc1a2-91e2-459b-8a2e-3eb9447e4db3" ],
+  "subjects" : [ "https://www.example.org/7f5d01d7-bc17-4804-8768-b73d03a5f6dd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5057a12f-0f94-40cd-b1df-fc3f620c9531",
-    "name" : "9VFnXkYXr0bOhqSOMGg",
-    "mimeType" : "ckgzlZBLbrFY",
-    "size" : 775155104,
-    "license" : "https://www.example.com/vxnpnzjxbobo1v54in",
+    "identifier" : "359b8152-f450-4d51-bee3-97214d6a1cd5",
+    "name" : "z6vOq93ZVwY",
+    "mimeType" : "excn9zw89P8H80",
+    "size" : 90074734,
+    "license" : "https://www.example.com/fop2bd3zx55kcqjr18",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "g4HOxGWQAF",
-    "publishedDate" : "1993-06-07T04:49:20.872Z",
+    "legalNote" : "40sb9xH6OkOECOvb2Gq",
+    "publishedDate" : "1973-02-02T04:22:52.485Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "384769386@8sOMqOt52S",
-      "uploadedDate" : "2010-06-08T04:51:59.079Z"
+      "uploadedBy" : "764842894@prRhJkNMW7lIc",
+      "uploadedDate" : "2003-12-03T00:50:13.736Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/j1h3jWIKdoSgXSnKnK",
-    "name" : "oGmWnUMDa8FHC7zgr1T",
-    "description" : "2r8zvfPTOUOqmhkEr"
+    "id" : "https://www.example.com/GKlfFcEdZiB08eMH",
+    "name" : "OmiZVwIXUq2p",
+    "description" : "WxtLuYUHkqw1W0Y"
   } ],
-  "rightsHolder" : "fyadoF8iYlILXI",
-  "duplicateOf" : "https://www.example.org/7abbc1d1-c846-4c02-8d40-d73bdf536787",
+  "rightsHolder" : "skJuBPRE0EyOu",
+  "duplicateOf" : "https://www.example.org/279dd429-503d-4c41-9a72-916851ec5ec3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dZ1Smg8ApG"
+    "note" : "uCElForyI4wVMhB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ybEhqkkOY5DN5o",
-    "createdBy" : "n7clm9jXSnbc",
-    "createdDate" : "1996-02-14T20:40:05.284Z"
+    "note" : "ScLwlnxDCwH8",
+    "createdBy" : "8p2T2GebgZXsYsL",
+    "createdDate" : "1981-11-01T03:54:45.313Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d6aa4b07-bd9e-472d-bde0-c1e4851cccc0" ],
+  "curatingInstitutions" : [ "https://www.example.org/4f68c515-82c1-454e-9edf-5398bb018242" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "ZunVke51K26N",
-    "ownerAffiliation" : "https://www.example.org/de1520fb-8982-4d18-b77e-863d61531626"
+    "owner" : "xOChQ7dX4HtT55",
+    "ownerAffiliation" : "https://www.example.org/3acdec16-a56b-4221-9d4a-55d48e47023c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/826658a9-356c-485d-92e5-5f8f7fea9924"
+    "id" : "https://www.example.org/824c7d37-c196-4895-aa06-986e3dbdebc0"
   },
-  "createdDate" : "2022-07-06T12:36:36.325Z",
-  "modifiedDate" : "1971-10-07T19:33:11.561Z",
-  "publishedDate" : "2012-09-09T16:51:10.430Z",
-  "indexedDate" : "2019-12-06T20:03:10.153Z",
-  "handle" : "https://www.example.org/21b720a9-031e-408b-87c0-39656a1c3dc3",
-  "doi" : "https://doi.org/10.1234/repellat",
-  "link" : "https://www.example.org/8157073e-b02f-4726-bd42-a736a6a32d20",
+  "createdDate" : "2012-09-25T22:26:49.201Z",
+  "modifiedDate" : "2003-05-20T13:13:20.180Z",
+  "publishedDate" : "2003-10-04T04:32:37.929Z",
+  "indexedDate" : "1983-11-15T17:32:46.284Z",
+  "handle" : "https://www.example.org/31f3764c-b45f-4bf9-947b-f43c1555ced6",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/1de5c426-f9ed-4dd7-b671-9e5dd899052d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nfS4dWXPU62Esp",
+    "mainTitle" : "URIP9VlJ6BYTo5EsPyy",
     "alternativeTitles" : {
-      "fi" : "48QId52WeftG6bQpA"
+      "af" : "QujFuPzL4VKo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0SAisAue2kXOgM7xF6",
-      "month" : "bgstbzTRyrtllu8C7T",
-      "day" : "lmptwrVodeubCph"
+      "year" : "tY3Qqrovm22oT",
+      "month" : "saDdJRKjHrEDJ",
+      "day" : "GQAjGBbXBPvgxvROb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd2f6c96-4865-41bb-8387-688beec04eed",
-        "name" : "zcbGQQJNX5hGIIyi5cU",
-        "nameType" : "Organizational",
-        "orcId" : "kukxUobhG8g",
+        "id" : "https://www.example.org/82e46d13-75bc-48b7-8a1f-18c600bd4cde",
+        "name" : "hDIrKy8pjQyGptPff",
+        "nameType" : "Personal",
+        "orcId" : "bGkxYTY3PaCUMeJh9",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9wVVoaBSpKVldjm",
-          "value" : "4MVwunxNoZpF3L"
+          "sourceName" : "eS1npmfT2f7B",
+          "value" : "LdgnubC5G8F"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "93XjK5scLW",
-          "value" : "InEJQwdRcJLiq2o1H"
+          "sourceName" : "Ljq786GElV",
+          "value" : "HauCAqElnAU1t2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/36718858-a48f-4608-9203-e7cbb355c113"
+        "id" : "https://www.example.org/ed698528-7ebe-454b-83cf-c9feb968805a"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,91 +62,91 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/744b4707-1f9b-422d-aca0-86b083357190",
-        "name" : "994ElzNLRLfLLVT",
+        "id" : "https://www.example.org/12822481-5baf-4d6c-89e0-658fc203b87e",
+        "name" : "gB1z9ZbAsC",
         "nameType" : "Personal",
-        "orcId" : "fablSjkJ9Qamd4Cb2m",
+        "orcId" : "2ZzhW1oSuGk6M4b",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5QhZcDYQ8AO",
-          "value" : "SDvzEh7J2AKPR1JHuaM"
+          "sourceName" : "zC7MOQjsKHnPhCnB6",
+          "value" : "bSGw3y5K6AklA6h"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5hOUDOBHU8m",
-          "value" : "ylZ9cjYTtb2"
+          "sourceName" : "p2LbTva7cKI13lELI",
+          "value" : "cfJqZdp68F"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c7756494-71c0-4033-b034-473461cf1d85"
+        "id" : "https://www.example.org/6e6f856d-85e1-4f8f-815b-cbf0b496074f"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "l1tJEFiZ3nPgW"
+      "nl" : "TDrv6w89ihtr80ZuV55"
     },
-    "npiSubjectHeading" : "dimokmIQQoSvMw7nLZ1",
-    "tags" : [ "SOZEstUUNRbqz37kgu" ],
-    "description" : "KNNz4rwlImG85",
+    "npiSubjectHeading" : "Ja5CRwN5PUae",
+    "tags" : [ "0ryalmmIUrV02" ],
+    "description" : "73aKdXEPgC20yqladQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/d2aa983e-be26-4515-96fa-08a54ccc175f",
+      "doi" : "https://www.example.org/1f0e2c0e-ed14-40d0-8530-369588b20cba",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Film"
+          "type" : "AugmentedVirtualRealityFilm"
         },
-        "description" : "8OkVUlhb3KnBN7MCDzV",
+        "description" : "fTXqA1YQSfx00",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "KljQmuluueI",
+            "name" : "W90MnhGdgIqVA",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2019-06-28T09:17:15.643Z"
+            "value" : "2016-03-04T18:25:02.461Z"
           },
-          "sequence" : 207935553
+          "sequence" : 1404579222
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "MfbzD6tgtyD",
-            "country" : "suInsCtKASFvTBWwx"
+            "label" : "28M9tLaisp3U6mNt",
+            "country" : "wYiCaxwadYVCH31va"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2017-02-06T21:35:23.203Z"
+            "value" : "2020-05-31T15:03:32.985Z"
           },
-          "sequence" : 1799965407
+          "sequence" : 1596654786
         }, {
           "type" : "OtherRelease",
-          "description" : "mQvFoh3D5C6jZhGOG",
+          "description" : "zyQt2TG7FtsBLOb",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "qhh2G7TMRT",
-            "country" : "MEgM6vK3vNj6xO280y"
+            "label" : "BotYIJkEIDkl5CIEW",
+            "country" : "x4kkmnvmLlfvyfh"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "xGbpP8bWO3",
+            "name" : "7LxLFOJ5HKxSDG919",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2022-09-26T09:12:12.166Z"
+            "value" : "2014-02-23T13:33:23.895Z"
           },
-          "sequence" : 294240111
+          "sequence" : 960556078
         } ],
         "duration" : {
           "type" : "NullDuration"
@@ -156,106 +156,107 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a77f32f7-edb1-4c25-ac26-c351c6a768ec",
-    "abstract" : "c7hY6E2KdbWpG"
+    "metadataSource" : "https://www.example.org/40e2b202-8bb5-4585-aadf-475341a6881b",
+    "abstract" : "HHwigOGnqtqav"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9376bc59-7105-40ef-896f-6aa1af2ed680",
-    "name" : "AwcP8G0amvqwduB",
+    "id" : "https://www.example.org/24013d37-38e0-4d7d-ae94-678682dffc4c",
+    "name" : "M57XoMsPW8OwCGDQ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-08-09T12:21:28.461Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "HrJsf8QYBdfm7ykbo"
+      "approvalDate" : "1975-03-30T03:59:38.664Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "DRATaY6Y4pOcyZqc"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1f680658-566f-4561-a63a-358313bf6db9",
-    "identifier" : "oc520Vd6wAmw5cM",
+    "source" : "https://www.example.org/8f1a5283-0aa6-41cc-ab05-3c818839cfb5",
+    "identifier" : "TokZtRGy72J",
     "labels" : {
-      "nn" : "c10eMuS0tsj8q6n9"
+      "pt" : "RqQ8nF8dnDhf0"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 113936358
+      "amount" : 513137632
     },
-    "activeFrom" : "1977-07-12T11:36:40.313Z",
-    "activeTo" : "1978-02-15T05:54:28.038Z"
+    "activeFrom" : "1985-05-19T12:25:40.126Z",
+    "activeTo" : "2014-03-15T16:19:41.461Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dedcfa2a-ff86-4007-a07d-872d013d3c7d",
-    "id" : "https://www.example.org/f79cbbae-bf49-49f0-a63a-8e3e30da605b",
-    "identifier" : "WHnqrLlULt",
+    "source" : "https://www.example.org/933ff565-5075-4990-80d2-ad92e15fe974",
+    "id" : "https://www.example.org/04290a6f-5b5e-4da7-895c-00675d646d54",
+    "identifier" : "gRJ3oGFGDleYIBZfM",
     "labels" : {
-      "zh" : "BkCdBGknXXCoVpHYH9x"
+      "nb" : "itfJXi5RALdLY"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1483803778
+      "currency" : "USD",
+      "amount" : 1570519426
     },
-    "activeFrom" : "2018-04-11T09:34:41.696Z",
-    "activeTo" : "2021-06-10T20:57:52.311Z"
+    "activeFrom" : "1977-02-07T13:57:31.765Z",
+    "activeTo" : "2023-01-22T15:48:09.331Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "KVFYuQZqqxhfb6aIS",
-    "value" : "Cn8h0leuMQhC"
+    "type" : "ScopusIdentifier",
+    "value" : "7QQKN8V2u9jNG",
+    "sourceName" : "ptatm90cdv@9v6sijkmcrro3zcz"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/a98224af-c0bc-49a9-9022-21480ec22a88",
-    "sourceName" : "dwfvgupj0n1vlb5ce@vwativaa6obj"
+    "value" : "https://www.example.org/f0c09848-2748-41ff-803a-b82cffaf0f30",
+    "sourceName" : "yxtpwv3xi7oseyxm4bp@ehntml2aoiqnbdt"
   }, {
-    "type" : "ScopusIdentifier",
-    "value" : "cieXRoTC2emicJI",
-    "sourceName" : "80d8p9astdlq8n@rvczgpiawh"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "yCSdBBcIprv7i7Ng",
+    "value" : "l9zPU9UQvge5DOuM"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "298580034",
-    "sourceName" : "5mfkgtnoshy1k6f@mqrkkc6hb9fu6dp9j"
+    "value" : "1660914894",
+    "sourceName" : "ltakwx5ihnkjrsh8c@itkb2wbwxvc9wqorsi4"
   } ],
-  "subjects" : [ "https://www.example.org/2f049914-1f45-42d0-8411-f4bce11bdd89" ],
+  "subjects" : [ "https://www.example.org/49f38ec7-9d2a-4b33-9edb-6fdbe7e09987" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "22f73b8d-f9a5-4887-9fc0-03918d21298b",
-    "name" : "3O3yN91Tdu",
-    "mimeType" : "NJhryN8XLXPZS8w",
-    "size" : 1509720638,
-    "license" : "https://www.example.com/jckgmqjyualkd",
+    "identifier" : "78cc2ca2-b948-4f8b-a342-b5d2d4ab2e6a",
+    "name" : "aAPCa28ytRk",
+    "mimeType" : "HH6JHcGjE14XBDr",
+    "size" : 1560722097,
+    "license" : "https://www.example.com/ietlvwqf8mg8",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "dH76AN6ondcpPmwGb"
     },
-    "legalNote" : "98o0bfgHfeWslmRwAP",
-    "publishedDate" : "2005-07-03T16:00:06.013Z",
+    "legalNote" : "y4DqKvwJLzOCjzps",
+    "publishedDate" : "2019-08-10T16:22:55.274Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "368330741@EQEmT8XDFn3sh",
-      "uploadedDate" : "2024-08-13T20:53:16.951Z"
+      "uploadedBy" : "1623668676@WNSUMf3p9eTLf1XF9jv",
+      "uploadedDate" : "2008-10-13T21:23:52.490Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/E94O9gwGaWDZshM",
-    "name" : "Q0oVokFpOBzUVw7X",
-    "description" : "7TmDHEop2xUNJYd"
+    "id" : "https://www.example.com/ph7wE4tAjKr",
+    "name" : "P3E0zf6JRS",
+    "description" : "txIs4Y6F1KCIQeaLD"
   } ],
-  "rightsHolder" : "fR2RZHG4WiCIVurJHf",
-  "duplicateOf" : "https://www.example.org/a0e74691-4275-4e99-b106-5009466a8bb8",
+  "rightsHolder" : "1HKpMqxIAJPkR",
+  "duplicateOf" : "https://www.example.org/c628390b-088b-443f-9fd8-c0016bffefe7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "1II8OCWNM5soT"
+    "note" : "8epZSLz0XOjcxIkQP"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2zDUO6RRaKjit0Wac",
-    "createdBy" : "fS6Zgt1xItzp7EgmScU",
-    "createdDate" : "2019-01-04T16:59:16.779Z"
+    "note" : "liO7ywT2pBF8c",
+    "createdBy" : "kMb0aJQeRe",
+    "createdDate" : "1985-05-05T00:04:47.609Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b5cdfd6e-d04f-4ac5-828e-a0d2c5bf4b36" ],
+  "curatingInstitutions" : [ "https://www.example.org/65efde97-47f6-4477-8b10-2bbe8baf4665" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "IMZZsYfvcLtlt3",
-    "ownerAffiliation" : "https://www.example.org/38e366ad-6a38-4e52-9d6a-227b7721c112"
+    "owner" : "ks3bY2KnTi97pjD",
+    "ownerAffiliation" : "https://www.example.org/5ac05dca-81c5-469f-a758-2ef102569a3c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a0ac045a-d9e5-4427-8063-31fee0342f04"
+    "id" : "https://www.example.org/da09c37c-067e-43da-a9ac-7ef8b0c2482d"
   },
-  "createdDate" : "1982-05-19T12:48:47.003Z",
-  "modifiedDate" : "1979-08-10T17:53:03.164Z",
-  "publishedDate" : "2022-05-24T13:28:38.766Z",
-  "indexedDate" : "1980-11-12T02:05:03.511Z",
-  "handle" : "https://www.example.org/19e8bd3c-5352-48cb-b0e3-cefcb9dad885",
-  "doi" : "https://doi.org/10.1234/corporis",
-  "link" : "https://www.example.org/b6ab8977-e9dd-4cc6-af0c-3aab7b53f8b5",
+  "createdDate" : "2000-05-28T10:18:00.521Z",
+  "modifiedDate" : "1994-07-16T18:52:46.321Z",
+  "publishedDate" : "1988-02-14T06:48:58.006Z",
+  "indexedDate" : "2023-10-20T11:44:08.165Z",
+  "handle" : "https://www.example.org/4a958f9e-24ef-425a-8534-207c315cd340",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/2b1a8974-00f6-482b-b509-23d1466c7b6a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XgykLxkPUmGO",
+    "mainTitle" : "kUqnEQcSMwnF09vxC",
     "alternativeTitles" : {
-      "sv" : "pxlMnwjzV4pmuYzULiN"
+      "nn" : "QkaBTlSJxe4AIyO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bV3iOeDkd1W8ih",
-      "month" : "TQRlvHjb30O",
-      "day" : "sYlEPXRWTduC"
+      "year" : "oNR7cG6zDJdUirIH9AQ",
+      "month" : "wqCxnN5RUCLMyOBCAC",
+      "day" : "G5Us5qULSdNeFv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd87e532-3d05-4ea1-9864-232598a13930",
-        "name" : "aXRgYQBUM2SqzG",
+        "id" : "https://www.example.org/6eb86b15-0b8a-40b5-ade9-11efdb78852a",
+        "name" : "3NUUsTHMUHPIwfvb",
         "nameType" : "Personal",
-        "orcId" : "C9NYxH4oP3NGH9Zu",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "p2nODNTzLM5bl4i",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lxWrBrynwTwFBY",
-          "value" : "dk4RKdfL5KJE1hH"
+          "sourceName" : "hxNnsEU6M8foGnjJ79R",
+          "value" : "PeO5gWlqGBofFJd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kEPzB4NIFj",
-          "value" : "hwBjyVPsCloWZpf"
+          "sourceName" : "BLZeKnxvBErdnu1rMd",
+          "value" : "jZhp5r0NhwSakTyM6wn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cc8a308b-9b57-4539-9550-4aca23be7e91"
+        "id" : "https://www.example.org/ba2621c0-9f40-4580-80d1-c0f55c151a7a"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,62 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f824d291-f9d5-49f1-b285-4e5a069c6881",
-        "name" : "oZTrhoR1OW",
+        "id" : "https://www.example.org/aff9b68c-4bfe-471f-86e0-ed73ea9248ce",
+        "name" : "AnHOackBzvyj1ny2",
         "nameType" : "Organizational",
-        "orcId" : "22PHbTeChczZM",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "tDw5nImBIZ7sQ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Lcqxbilm3MAkg",
-          "value" : "NtdZHkhbGyGwE"
+          "sourceName" : "OOPjS961OX0IEtBt5Is",
+          "value" : "1i2BIieqviwO6dZIeK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XRb8IhB2Jpj9pXBS7",
-          "value" : "WP3lNKl9NKnIJg3U4hY"
+          "sourceName" : "DK8Dot2FnvN0Dm8DVfq",
+          "value" : "wIjh9b43gCelLQov"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0d8762b8-bd54-4142-997b-1399e43e0ad2"
+        "id" : "https://www.example.org/9bb37b32-fb75-4c67-a6c5-ddb78a1d0b8d"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "VOGc9tT5kI"
+      "hu" : "2w3DUsDQQHiL1yq8bv"
     },
-    "npiSubjectHeading" : "hsgXruHbtkEGU",
-    "tags" : [ "QZ2cunYDISzqxIwK" ],
-    "description" : "ZxtYBJNX6c4JK7",
+    "npiSubjectHeading" : "JQ3qW16QeNW",
+    "tags" : [ "tCDRDybj51kjDkUm" ],
+    "description" : "c9yr4oaE86",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/2e20d42f-1c76-4c66-b6ee-d8166a1e9d5a",
+      "doi" : "https://www.example.org/925c6e8c-832b-4cbf-a166-6c07f7c4ea68",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "MusicMediaOther",
-            "description" : "B9bSCPe7UZdtoQMjE"
+            "type" : "CompactDisc"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "HZatq5BD8fRk",
+            "name" : "jTsFJzAPW6tkjznQCwW",
             "valid" : true
           },
-          "catalogueNumber" : "ETI2XcUSb7Y6e5Au",
+          "catalogueNumber" : "Ny5J5x5rffKxHXB4",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "xycidrH2frNt8C9aNY",
-            "composer" : "wLn0SbxGg9hd",
-            "extent" : "ukafEGQTX2nL"
+            "title" : "d5aII5CtX4T",
+            "composer" : "7mJFSsGvobEjp",
+            "extent" : "A1TAUlCvO6jygtWjTTT"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -127,49 +126,49 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "qy5z0HX4SFYETW3SdQH",
-            "country" : "sEH9nohA4eEsAfW"
+            "label" : "tSCMoGxYTWC3sAIkgMj",
+            "country" : "72mvfd1SeSfSDY4K"
           },
           "time" : {
             "type" : "Instant",
-            "value" : "2015-07-15T22:49:29.334Z"
+            "value" : "1994-11-22T16:56:55.958Z"
           },
-          "extent" : "mlyTUV1oQxxgQ4",
+          "extent" : "TbAu1BX8jes4",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "iqRoC8OVSIKLY5",
-            "composer" : "HSrUO5RRe0LgJiQXyLm",
+            "title" : "qJ8jonVvjvieaMAR",
+            "composer" : "a3yFY2OZfzC7O6",
             "premiere" : true
           } ],
-          "concertSeries" : "baOxHWTNJEVWY6XEqx"
+          "concertSeries" : "X7cIMf5NxR"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "rj6BvboUhyEl",
-          "movements" : "YWOfw7xl6Mu8J",
-          "extent" : "l3RxLo9rxTypd53D",
+          "ensemble" : "AjPDDnSZa0DuOolU9",
+          "movements" : "b7dR0Q3M3KawjG",
+          "extent" : "nhEbuw05CYOkeMw8bv1",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "FQvaHUTZt6VxB6oA9xp",
+            "name" : "S5G23vOLV5vkebbjEI",
             "valid" : true
           },
           "ismn" : {
             "type" : "Ismn",
-            "value" : "9790901679177",
-            "formatted" : "979-0-9016791-7-7"
+            "value" : "M230671187",
+            "formatted" : "M-2306-7118-7"
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "o4FanwsUxwZWRWN5Mwx",
+          "performanceType" : "kX3O3zBMkQYLms3",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "f1J6BY10Ts8CSE3RGnQ",
-            "country" : "auVylLsO8azWi7r2g"
+            "label" : "kqgLbGUWcA32Fpl4",
+            "country" : "oyFn6Y4SWIvgOdrU"
           },
-          "extent" : "2E4kZp3GbH",
+          "extent" : "qXU1CxZw2Z4Og",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "aEssiqf4ppTO40CAY",
-            "composer" : "xkF4Xh0GZsAudvR"
+            "title" : "9LPvWEupz1FYh",
+            "composer" : "MLrPwFfZbR1r"
           } ]
         } ],
         "duration" : {
@@ -180,107 +179,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5aa0e4e7-45a0-42b9-83d3-600946077503",
-    "abstract" : "4eVn6YzcFPHJodPhJxl"
+    "metadataSource" : "https://www.example.org/23d1c21c-eb49-4170-9744-35ad06859b78",
+    "abstract" : "aiZoikRQUhsv4lbW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6247b25c-fcd4-4fee-975b-d8665d760002",
-    "name" : "IHM8M1bZR1Mfe",
+    "id" : "https://www.example.org/2cfa318a-fb08-46d5-95b1-e8c5d83a3fdf",
+    "name" : "hYMUdX2rIcCsMSMdNS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-11-15T09:20:10.410Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "JjXaTrjf85lRKtRG2"
+      "approvalDate" : "2012-06-13T11:53:07.970Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "AtxlcD7gYCjGoXX"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2d38bc7b-ede8-46ac-9371-b5abda1f090c",
-    "identifier" : "1E8u1O7fF4jyXlTBF",
+    "source" : "https://www.example.org/175949b3-d640-47b2-b19a-11b291559c8e",
+    "identifier" : "HtLDZFCfB9",
     "labels" : {
-      "pl" : "dlMPeqVEbPY4EqT3"
+      "is" : "nVh1ExbZp0z"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1901386938
+      "currency" : "NOK",
+      "amount" : 1141212500
     },
-    "activeFrom" : "1974-08-10T11:58:17.098Z",
-    "activeTo" : "1979-06-12T04:06:36.073Z"
+    "activeFrom" : "2017-04-22T19:59:05.197Z",
+    "activeTo" : "2017-12-31T15:38:07.517Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c3d3d34d-19ee-41e3-9424-f64bd1ab6a20",
-    "id" : "https://www.example.org/99d98627-df58-4755-8b3c-4b1fceea0316",
-    "identifier" : "9uIu4Hs9vtJ",
+    "source" : "https://www.example.org/0dfee69e-79e1-40f6-8f80-f6ff69c10342",
+    "id" : "https://www.example.org/f330d6b5-73fe-4351-bc00-4f6ecd16a0c6",
+    "identifier" : "ogQ4SQ1gd9sZNgQ",
     "labels" : {
-      "af" : "YR8L20pLBz8icf"
+      "da" : "LZtQoMlBAM4Hl4DR"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1750909306
+      "currency" : "USD",
+      "amount" : 1418749369
     },
-    "activeFrom" : "1974-11-10T21:24:54.334Z",
-    "activeTo" : "2001-09-16T11:26:10.108Z"
+    "activeFrom" : "2014-07-15T04:05:22.305Z",
+    "activeTo" : "2017-11-04T17:45:09.589Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1544475725",
-    "sourceName" : "s5eqjesnt6u10oq@u46yemumvdet4e0t6vx"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "e0217O2vWHNffaWwP",
+    "value" : "OEykzLhDnbeYjJ5p63"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "QXNX8y5STC5LHrCyxqI",
-    "sourceName" : "g22swzk3f1@7wbe9fcsadyqjlo0"
+    "value" : "fm1b2BYy6wN747RHk",
+    "sourceName" : "bmvqx79avuitwbamp@tzdot4yknjdec"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1185239764",
+    "sourceName" : "3oijrmtxhltjc7sbgwn@rp4wfj0ydcydaz"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/aec45cdc-baa1-4d51-9b85-f2ed5ad76f09",
-    "sourceName" : "aacmvvworn@g0wvqj2lbg0ml5"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "uXjokNDyh4YE",
-    "value" : "8H2JLTl6wfbKmC9qc"
+    "value" : "https://www.example.org/4f0ff2a6-545a-4eab-8339-8c60a46a7482",
+    "sourceName" : "kpfrzyvax8qf@jtrhwxuc8yb0vph"
   } ],
-  "subjects" : [ "https://www.example.org/b1723c2f-204d-4d97-b823-ec881026a9fc" ],
+  "subjects" : [ "https://www.example.org/ac19178f-1b29-442c-8408-4e73093a9902" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "cec200d3-0e3b-45ed-814d-8d20193e2bce",
-    "name" : "MkMJbFvZXW6",
-    "mimeType" : "JL3eKq54BGdqps",
-    "size" : 110541440,
-    "license" : "https://www.example.com/erytw78tlx1y8uc",
+    "identifier" : "6b44753e-2485-451c-a6da-93c8c9913c86",
+    "name" : "rlAjPePWw63bNYei",
+    "mimeType" : "UMmqIvckJnTxJcy",
+    "size" : 1094114717,
+    "license" : "https://www.example.com/rbcfpfhhwunqnufmf",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "GpL4b8OARTQjPY"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "glhCJSzmIkpzcKfkk",
-    "publishedDate" : "2006-07-28T02:46:33.913Z",
+    "legalNote" : "rSc1RLvjRn",
+    "publishedDate" : "1988-08-04T21:48:38.809Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "495384386@SKCNV6XMboyBw88",
-      "uploadedDate" : "2013-07-25T09:31:52.181Z"
+      "uploadedBy" : "192870585@5mtBQrRw2lK",
+      "uploadedDate" : "1985-08-24T20:52:38.113Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qKhGZRTrahodxRHw",
-    "name" : "70PFC7nMbx94aH",
-    "description" : "mOAzu9aKrQu9odniop"
+    "id" : "https://www.example.com/DFQqeLGM1w1bS",
+    "name" : "nBUlgGBQ0uU4PG",
+    "description" : "Nn6DCYEBJguigmo"
   } ],
-  "rightsHolder" : "VWEpESpchwBBzv",
-  "duplicateOf" : "https://www.example.org/e1fdcaf4-02f8-4cbd-89e6-24229a60ac67",
+  "rightsHolder" : "VfoZ1aaftPzj7tR1Av",
+  "duplicateOf" : "https://www.example.org/bd2299e4-26d6-46ce-950b-6e267efd6b41",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YOHs2CZxCPSqfg0"
+    "note" : "Kre9yTlCeCIG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VbzJoPbtlxDp3AO",
-    "createdBy" : "YvlEDmRTFb5KmAkV",
-    "createdDate" : "2015-08-08T04:29:01.111Z"
+    "note" : "lrCP5jr9jy",
+    "createdBy" : "JHEyOhC60aY",
+    "createdDate" : "1986-05-29T01:20:39.399Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f8ea9c74-c9de-4107-aa5b-a2c287ca5f9c" ],
+  "curatingInstitutions" : [ "https://www.example.org/2396e3d6-053e-484c-9f23-7d5b0d650a7b" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "L98xTjmPjliSzVJIQ0P",
-    "ownerAffiliation" : "https://www.example.org/a8c51d7f-13d8-44a2-9f6f-6151320f48c9"
+    "owner" : "dBm9d9GlfABJ3",
+    "ownerAffiliation" : "https://www.example.org/b0573f8f-689c-4e9a-b85a-7b25f8aa07e2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2a462acb-c9f8-46fc-98e1-8afa1703fde2"
+    "id" : "https://www.example.org/dbf75167-186a-43e6-86f0-54c26838e69d"
   },
-  "createdDate" : "1975-03-21T01:29:23.885Z",
-  "modifiedDate" : "1975-07-29T22:47:35.142Z",
-  "publishedDate" : "2016-04-23T05:47:09.419Z",
-  "indexedDate" : "2002-06-10T16:23:26.392Z",
-  "handle" : "https://www.example.org/5f04909e-be62-44a0-8f1a-d56684bcc844",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/e7e7679a-d780-4260-9886-42f5513c789a",
+  "createdDate" : "1974-01-04T02:15:25.898Z",
+  "modifiedDate" : "2010-06-29T15:52:55.277Z",
+  "publishedDate" : "1996-11-05T11:46:37.275Z",
+  "indexedDate" : "1999-02-06T16:53:40.254Z",
+  "handle" : "https://www.example.org/4c2b8652-488d-4ed1-bff3-5d06347106ec",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/4008ee50-2053-4250-a8d7-98a5762898c4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ue05HYoXOu",
+    "mainTitle" : "cCljPb1xDH",
     "alternativeTitles" : {
-      "nl" : "mY55hCml8vt"
+      "de" : "8Qo85Pa0buig0cXR"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eIcP7m5IhpYvUU",
-      "month" : "1LOtD9M05uKw8s1bHS",
-      "day" : "yDO2fmK2TlCRugK1Uh"
+      "year" : "6rg0ewcyZN6yR1wmhKi",
+      "month" : "O7lePON4voiuVup3ar",
+      "day" : "YviV1lb5dazMP8aDH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f2a2b66f-344f-443e-9bc4-6a9af8e5ae19",
-        "name" : "Uopfyglw1K6ZzRzI",
+        "id" : "https://www.example.org/66145135-1fb0-4096-ac36-f6deeabee812",
+        "name" : "jknPSEF1V7",
         "nameType" : "Organizational",
-        "orcId" : "48A2OAEc1s",
-        "verificationStatus" : "Verified",
+        "orcId" : "ct45zK5X3ux7uW",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "n0vTgOHqzV8NNSUwA",
-          "value" : "Zk0unpITDwKH0rFI"
+          "sourceName" : "XFG9rVeASxnk",
+          "value" : "dR9SArrIYf4Hsspr9eR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jYnAqwa0EnXq",
-          "value" : "OnFhAmDgxCh69on2PE"
+          "sourceName" : "1OogTWN1Gbi31vYW",
+          "value" : "QH9C4EIS2kIn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/35f03c03-4bf8-48a7-a7a9-a6c28291de57"
+        "id" : "https://www.example.org/24069f07-b426-43a2-a5f2-467b6fe52c61"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2237a70f-1c21-49b4-9d5e-743bcd5acdd0",
-        "name" : "gQgsLFcUi661GDjMoh2",
+        "id" : "https://www.example.org/6495b163-230b-4e57-b83b-2611a702c518",
+        "name" : "WxXEhfru0V5",
         "nameType" : "Personal",
-        "orcId" : "mBWkJNNl5xAFuGSy4ml",
+        "orcId" : "9dSo0WQGBa",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XEAEKSKcqFa3duQ4m",
-          "value" : "X9sTeTU5mNsojgE"
+          "sourceName" : "n42BjQBqOUn",
+          "value" : "41OonZoVtu1G6VArRuq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mHkniv9JRLEk",
-          "value" : "lDNpk6IJHe"
+          "sourceName" : "twC4Wv9XgL",
+          "value" : "rT1lPyybf4NQHrbiu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/05312011-7519-40b6-b7ce-b3493ea249e5"
+        "id" : "https://www.example.org/10944c75-3c72-45c0-ac51-fb829e3184fd"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "PdjELufk99gsjMLYyS"
+      "it" : "wPTvMI62o3"
     },
-    "npiSubjectHeading" : "lKuI2HshFkWjT2OhmG2",
-    "tags" : [ "4NfLgOArwSc3j" ],
-    "description" : "iIc30byqg2p5jlKLVJ",
+    "npiSubjectHeading" : "OhnHI1oPGf4i1D",
+    "tags" : [ "sQpYSaqoDHeiP" ],
+    "description" : "k8JhOwus08q8EP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/8kZwI54KICPq2bvhZPT/publication/0191e0c8ec75-d5488778-6bce-42cd-a15b-c6269467687f"
+        "id" : "https://www.example.com/bI6wlnFGRb2DNlP3mk/publication/0191ff235020-dafcd6c2-6867-4cd6-93c9-d2066b13c636"
       },
-      "doi" : "https://www.example.org/49562add-3ee9-4782-8e02-7f0332968072",
+      "doi" : "https://www.example.org/1c9cc02e-b56a-4713-930b-6469fd84415e",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "SP8YYJfkkauIOG",
-          "end" : "CwWhrWZL68"
+          "begin" : "A1Z3VUcZGPUKVS9vO",
+          "end" : "kDvrCiNjQ825RfvodTl"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/84248d5c-c1a5-40f8-819d-57b0b1e75910",
-    "abstract" : "F9Jd8kNoDLJPP"
+    "metadataSource" : "https://www.example.org/21caa8a9-bc60-46fa-9740-65fd9171df61",
+    "abstract" : "mngyrkhYGTM1zI2Ay"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b33f888a-e24d-4889-82e6-50ccc33667d6",
-    "name" : "exMQxOmjmgp",
+    "id" : "https://www.example.org/764c95f5-5946-4aa9-815f-85d3ef4cc7eb",
+    "name" : "jRnSFdWWvGhaTDfKEIa",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-01-25T07:13:37.908Z",
+      "approvalDate" : "1984-05-08T08:54:55.049Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "bjnimEqsSX6wxiMcJY"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "cHXf5WT1cnB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d0aa6590-d2d6-408d-bfd5-8fdabb72c559",
-    "identifier" : "PzmI90Q5FUFpJ",
+    "source" : "https://www.example.org/fd290663-8f98-4208-98ee-6bf2317e23a4",
+    "identifier" : "mY1bEfL1Goz",
     "labels" : {
-      "sv" : "k8N4epesF1Evsh7uCWw"
+      "cs" : "xhAqPRirqzFWNoUK8"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1957313472
+      "amount" : 642804264
     },
-    "activeFrom" : "1999-10-06T10:20:06.408Z",
-    "activeTo" : "2005-09-24T22:02:22.074Z"
+    "activeFrom" : "1992-09-15T07:12:07.846Z",
+    "activeTo" : "2000-09-29T03:41:39.933Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3db527c3-bc52-48f9-9ac8-e1274a8b2984",
-    "id" : "https://www.example.org/df037916-665a-4a75-ae36-287339a608d0",
-    "identifier" : "NwrDDS4mR7I",
+    "source" : "https://www.example.org/fb02b286-6c5c-483b-bac4-7e98fa3125a1",
+    "id" : "https://www.example.org/7bf0421f-6a54-410f-acd4-6710ec5b1bf5",
+    "identifier" : "WV2uJAG2bNS",
     "labels" : {
-      "ca" : "m5YfuH0X2UpAs"
+      "bg" : "BNxDzKHFkW2FW"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 456916191
+      "amount" : 2082152848
     },
-    "activeFrom" : "2020-08-02T15:39:50.352Z",
-    "activeTo" : "2022-02-20T03:30:56.794Z"
+    "activeFrom" : "2007-05-13T04:50:35.516Z",
+    "activeTo" : "2020-01-06T03:49:10.030Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/21ec2dae-1c97-4e3c-b864-5506dd6596d8",
+    "sourceName" : "1nqchhbszljxoejxiy4@xsgdqorrsaiyerm1uf"
+  }, {
     "type" : "ScopusIdentifier",
-    "value" : "48DeDVsiyW",
-    "sourceName" : "o7scc1r6gm@pw5iunetoyh"
+    "value" : "K38BupPZ4l8mxe",
+    "sourceName" : "rsnxw0x3ydx@ji4rznhqag3hpjswpz"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "NvXwCEw1IwretbaCC",
-    "value" : "tEnaDAJKt0JRSk3WHjr"
+    "sourceName" : "PzSYKk8m3V",
+    "value" : "FOIhTSj9Ui"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "978226983",
-    "sourceName" : "4oo5fcuoqb92ifqgnr5@4u0npobcd0ljzcdyh3r"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/18f2e64c-c98d-4157-b7df-9d43abf9640a",
-    "sourceName" : "ce6rhqryvlqvw@gjehiyp06z1wiq6gchc"
+    "value" : "325785420",
+    "sourceName" : "y0bpn0d87yq3hl7mgo2@rpolh4jqruqoe0zckjv"
   } ],
-  "subjects" : [ "https://www.example.org/033fc723-e0f4-4bb1-a727-40c68097c49a" ],
+  "subjects" : [ "https://www.example.org/0dfa6950-3f0e-4652-8a9d-2e4904852e1b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6a6c9ff7-4dc2-41c7-9838-40abaad1d7c3",
-    "name" : "uwfImbroQYrUN4aD",
-    "mimeType" : "5QaqhI0ijDVdaJYH13",
-    "size" : 1765174718,
-    "license" : "https://www.example.com/f5su5anxzjekq",
+    "identifier" : "fbb1b500-ba80-4e68-9b4c-a055ad9a4172",
+    "name" : "HI0Pecc1ADiQKAAiC",
+    "mimeType" : "v385OocULcurVk7uMnU",
+    "size" : 1728855488,
+    "license" : "https://www.example.com/svq8sicd6ev",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "0d0BW8KwzZ9BGOn"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "zobZGF7mDYM2q",
-    "publishedDate" : "1997-05-12T22:30:23.279Z",
+    "legalNote" : "qxp0GHEDciDQ",
+    "publishedDate" : "2018-05-07T18:51:49.811Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "816409462@nLJQPV3D0UUrAWRFZo",
-      "uploadedDate" : "2014-11-18T19:08:22.879Z"
+      "uploadedBy" : "1495534998@PdtlhMgShB8HesHUzxZ",
+      "uploadedDate" : "1975-11-19T17:26:43.693Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZgAK62v5bfwJWBB",
-    "name" : "0nO9FNXU4U8",
-    "description" : "bw5Puh0xuHBD5Fn"
+    "id" : "https://www.example.com/vkTjlqBxnD5t",
+    "name" : "46dJBhpVJnJlJ4EcrIa",
+    "description" : "BAwETINtmoY5cm"
   } ],
-  "rightsHolder" : "Cg1bGoQKQBbonh",
-  "duplicateOf" : "https://www.example.org/a9c8ec63-20be-4800-9110-b379be316931",
+  "rightsHolder" : "LI9rmhzkIGLx5Pr",
+  "duplicateOf" : "https://www.example.org/23968c91-06fd-4e59-a093-5b0087eb7eb7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "2NKLWwqyrXC6Wf"
+    "note" : "pWHkRplfeIh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GIqAncuqpCzg9kCVdQm",
-    "createdBy" : "fJMk5SHMwEUC8YyP",
-    "createdDate" : "1990-02-16T23:34:57.477Z"
+    "note" : "UgnJyzO97pYHq",
+    "createdBy" : "obdONEhpO0TH6hy",
+    "createdDate" : "2018-10-06T13:33:39.322Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/82343a72-5fbf-44eb-9b25-920b17c42220" ],
+  "curatingInstitutions" : [ "https://www.example.org/c7a7712a-6d69-49b4-b42a-ffe6de867394" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "ycgYNcexyKuxei1j3",
-    "ownerAffiliation" : "https://www.example.org/be641b2a-e448-47b2-9a51-d39795def741"
+    "owner" : "R0eR1Kg0tKTK1",
+    "ownerAffiliation" : "https://www.example.org/8eea16d8-1ee5-453d-a891-c8b31677cce9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9d231f2a-91ec-468a-851a-75c852ec30a1"
+    "id" : "https://www.example.org/6b6a9554-4932-49bf-8cc9-3500002f95cc"
   },
-  "createdDate" : "2001-05-05T16:46:01.378Z",
-  "modifiedDate" : "1981-09-20T17:27:19.125Z",
-  "publishedDate" : "2004-12-08T17:38:55.256Z",
-  "indexedDate" : "2018-11-26T14:43:13.775Z",
-  "handle" : "https://www.example.org/43651737-2999-4eda-ab03-573c88763cdf",
-  "doi" : "https://doi.org/10.1234/ipsa",
-  "link" : "https://www.example.org/de3f8619-5ba3-4984-8e2c-1fd186f0b4e3",
+  "createdDate" : "1995-05-27T10:20:48.893Z",
+  "modifiedDate" : "2014-04-08T22:18:31.927Z",
+  "publishedDate" : "2003-09-22T13:05:49.598Z",
+  "indexedDate" : "2018-11-26T03:21:33.121Z",
+  "handle" : "https://www.example.org/3815ba83-ffcb-4b5e-aa5c-f2bde967fdbd",
+  "doi" : "https://doi.org/10.1234/quod",
+  "link" : "https://www.example.org/bc9a0288-5e3d-406b-9797-a35be880662b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "W4sdj5SwFA7Z",
+    "mainTitle" : "BZQ10VbWIObQ",
     "alternativeTitles" : {
-      "it" : "u8zIFSCEpDc"
+      "es" : "vDtUS2RhElkZQt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JULU9kOYayZtHF",
-      "month" : "FqX0uSiN6y9p52",
-      "day" : "gTzkUKsoau6gC"
+      "year" : "u2fDIvEjOm5",
+      "month" : "bQjiW7cgOFA0DhAUri",
+      "day" : "yl4wG9ItHXH2eft0u"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/09c64990-5acd-4d6a-8760-ba8645a87fb5",
-        "name" : "Ku9W58P4HvB3VzP62",
-        "nameType" : "Organizational",
-        "orcId" : "XKfnzIvKXXABtwQfKi",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/d471f443-5c26-432c-b8ce-3334543e427a",
+        "name" : "9mmTzmDzRbRWc",
+        "nameType" : "Personal",
+        "orcId" : "d4EoITH0wIXLQAoggo1",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rH1hACtOMqnZ",
-          "value" : "tyj4yyxHAlb"
+          "sourceName" : "Yw0YnvNXTT",
+          "value" : "bp1luBU4CWYQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tCfwT6WuAtGReFf8",
-          "value" : "FT2HVtBnRIvqDEsR"
+          "sourceName" : "AC82P25e3016Lh55Y",
+          "value" : "yuGDIJjCQIL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e3c8158b-2141-4600-ab76-85740eac4a6d"
+        "id" : "https://www.example.org/ad732175-a0e1-4750-a8bb-4ba52e65e07c"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,24 +62,24 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3324074c-303d-4571-903a-52350a6608a9",
-        "name" : "BLW410vDBr04EvLfcD",
+        "id" : "https://www.example.org/7e069a91-9894-4b46-921c-09b895655c7d",
+        "name" : "uNggqMBtdp0gna",
         "nameType" : "Organizational",
-        "orcId" : "PVTkbgi2vtTvlcsu",
+        "orcId" : "pyGl8aDq00Oeq3I",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nrThkorGat",
-          "value" : "mf4hSVr4Rlofi"
+          "sourceName" : "n04PZMwCgUQDZ",
+          "value" : "jBxTWNkqtFQA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sL7vgOhGp2TaZfnjwnI",
-          "value" : "4k5aPw5Y2l"
+          "sourceName" : "SCOO5aULzvK8gwHi",
+          "value" : "91J1nbk3VAaVgqC2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3b9e11fb-c525-4c84-92ed-ef2c129ac977"
+        "id" : "https://www.example.org/3ba44029-56c4-4e0e-b663-cc98e264b00f"
       } ],
       "role" : {
         "type" : "HostingInstitution"
@@ -88,149 +88,149 @@
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "mHqljiwNiKi3X80Ob"
+      "fr" : "basYUyy3DbJKp4Ob"
     },
-    "npiSubjectHeading" : "oCByrd0ZWAG",
-    "tags" : [ "bYvD31WgyyoiVckqD4" ],
-    "description" : "pkNjSdtHI0u",
+    "npiSubjectHeading" : "Avj4U71332Vqk",
+    "tags" : [ "7M9pNjtiJL2fTV4" ],
+    "description" : "LLlH7hYvE6S33wJ8a9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bb670859-e58e-4ebe-b6e8-ad79be3e5582"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d73d0ed7-ae6f-42dd-9e58-c677194aa8b8"
         },
-        "seriesNumber" : "QUC37ELzq43B",
+        "seriesNumber" : "IkTEYieHg6yHgfctMs",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4f48ba07-131d-4204-a797-f75d652e6b78",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a1e58a16-569c-4b56-8bbf-9afb4f876ae6",
           "valid" : true
         },
-        "isbnList" : [ "9781721652082", "9780416141443" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9790920756323", "9781990896439" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0416141447"
+          "value" : "199089643X"
         } ]
       },
-      "doi" : "https://www.example.org/e456d3e2-2a54-4485-af79-21597d343f3a",
+      "doi" : "https://www.example.org/64c925af-c902-43aa-a9a1-31e308984f31",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zlUciuKGXFc2JT",
-            "end" : "wDAjRQsQWUGS5"
+            "begin" : "WVzt8fSzyAVUwFwt",
+            "end" : "pcQj12qZEqw1wC"
           },
-          "pages" : "eo34mAINnft",
+          "pages" : "mJ5YdUXpoZ3dOT37bwQ",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/55cffb01-0570-4aed-ae98-2414f8c206eb",
-    "abstract" : "3BuQep0kLzl"
+    "metadataSource" : "https://www.example.org/67c3b73b-13c0-4d01-a6c7-0f85cecfd587",
+    "abstract" : "QXtrhHsaZDbdVcvi"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7a84183e-0dc2-495b-968b-553ab777b6b4",
-    "name" : "LBKjIS0hHat",
+    "id" : "https://www.example.org/9865ced3-2ba7-40fd-9760-dbfca40f0d2b",
+    "name" : "ysRjhJfYxJjmV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-03-02T23:33:08.040Z",
+      "approvalDate" : "1975-07-08T17:49:34.008Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "satsxO2Devs2LCp"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "LLboT2cnUAqTzUa2a"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ebfbc76d-ee65-4c9a-ab6a-93d2553d19ab",
-    "identifier" : "Vk0ZFKoy2O",
+    "source" : "https://www.example.org/c5f52a9f-2321-49c9-b6d1-1cd051cc1447",
+    "identifier" : "kcuFLWyWJPcTk",
     "labels" : {
-      "bg" : "v0M06tCVxw"
+      "ca" : "B1zPwhgk2OFpa"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 80171421
+      "amount" : 576239355
     },
-    "activeFrom" : "2000-01-07T13:13:15.548Z",
-    "activeTo" : "2002-08-16T06:06:19.174Z"
+    "activeFrom" : "1991-11-07T00:28:06.178Z",
+    "activeTo" : "2013-04-25T11:47:55.949Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d7c2a68e-e766-4976-95b7-cd47e9b39cec",
-    "id" : "https://www.example.org/ab8b05d4-f8f2-43c7-b763-f4421e317ac4",
-    "identifier" : "e30SEn9fz7XRvHgSVwy",
+    "source" : "https://www.example.org/2c7c4a41-0d31-46f1-a544-0123353487ff",
+    "id" : "https://www.example.org/76e786f1-2f6f-42a0-af0f-a46ab8986e32",
+    "identifier" : "g0mfiUZfZD07Gp",
     "labels" : {
-      "nl" : "DZqilZqOlBLnC15"
+      "fr" : "f3GV8YRxH78KD2Hh2c"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 592260788
+      "amount" : 2066979416
     },
-    "activeFrom" : "2021-01-14T14:02:36.774Z",
-    "activeTo" : "2022-09-19T22:26:41.047Z"
+    "activeFrom" : "1973-12-30T19:28:46.533Z",
+    "activeTo" : "2007-09-15T14:20:16.237Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1132458445",
-    "sourceName" : "paszyrtylth@ojweotqnoiv"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/3004417a-f67d-4444-bb73-35d9d94afe0e",
-    "sourceName" : "whgd8qqkj3qg@cgusrqmdm0lz9zc"
+    "value" : "https://www.example.org/405c58e2-5eb2-46a0-a14f-841b302970a2",
+    "sourceName" : "ds7xdqrf0jvpvyvqs@pzab9tnkfvbvv"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "wNQoi4bPfPgHE",
-    "sourceName" : "q1olc7ykhyt9pm@le6caeuq9tqm0mcy7op"
+    "value" : "Ksm86TtW14K",
+    "sourceName" : "p2a2qgpc339cc@guexfeq0iyr42kbsw"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "dhKvfAL1VwjK1vs",
-    "value" : "LHa9tWxmajhl6gW4"
+    "sourceName" : "o3sBHiHR7r7N8KgrA",
+    "value" : "sloYU2jf38d6rbfB"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1680424757",
+    "sourceName" : "14lzxuzkkacl@u0npmacgw9ezfn1ff"
   } ],
-  "subjects" : [ "https://www.example.org/85fefdd1-91f5-4e6e-9451-03f98c3c13e8" ],
+  "subjects" : [ "https://www.example.org/36d30a8d-27f3-4610-945d-a626dc114fee" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1d87b21f-5dd0-4fe4-93ec-d0908a2d4300",
-    "name" : "lUEj0Ynv2Q1oDYeLmjO",
-    "mimeType" : "uCLKswyec8ZkY",
-    "size" : 752492331,
-    "license" : "https://www.example.com/7ixn9dnqbnzv1",
+    "identifier" : "0c534e76-3941-4afb-9869-2657f502f033",
+    "name" : "1Wv3ckEw7q0LUA",
+    "mimeType" : "at1R4T7JnPSaSu",
+    "size" : 1288868627,
+    "license" : "https://www.example.com/dnhkyeur0bwe",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "7PNR80ArZ9D8RmNp"
+      "overriddenBy" : "LhUb6i9AZRg9o"
     },
-    "legalNote" : "G3Mi3YL1G5",
-    "publishedDate" : "1993-05-05T14:33:50.088Z",
+    "legalNote" : "D3lIGXzcjiv2l",
+    "publishedDate" : "2014-08-08T19:58:49.061Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "172618384@KYwh3rX815g3bp5",
-      "uploadedDate" : "1988-03-28T23:38:03.986Z"
+      "uploadedBy" : "590671605@Qnvsk8OW9QJp",
+      "uploadedDate" : "1995-06-03T11:38:12.497Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/RkTsrwxvl3W7ECJMp",
-    "name" : "cy09FQYHJ5Zw",
-    "description" : "OH7mXbbNMC"
+    "id" : "https://www.example.com/koqjSyFRyT2JRA",
+    "name" : "ttHMxK7nu2C",
+    "description" : "VFEqmq0h0C2V"
   } ],
-  "rightsHolder" : "g2BYedkuPUciftAI",
-  "duplicateOf" : "https://www.example.org/30c36c0a-5c19-46d0-abcf-ab430a25b2de",
+  "rightsHolder" : "IcptGsv2EZa",
+  "duplicateOf" : "https://www.example.org/018f7db1-b37a-4e88-8f63-fc6cf01a8348",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pqKgBi9CSyv0kmStG7"
+    "note" : "Se9CSII7OjdjxKhD5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iJ9GXfesE8T9nxW",
-    "createdBy" : "HbiwLv3S1PobANazsc",
-    "createdDate" : "1988-08-04T04:22:52.530Z"
+    "note" : "cdJYF0LJNbQH1H",
+    "createdBy" : "67wSKSQX9fPATiz1",
+    "createdDate" : "1985-12-18T15:30:02.570Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ef8a6342-0663-4f4f-87ad-e3d286f404de" ],
+  "curatingInstitutions" : [ "https://www.example.org/26578d77-19fd-4372-9497-c12a6e6128a6" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "G4x90FIn3yctqd4xm",
-    "ownerAffiliation" : "https://www.example.org/bc575ae7-eac6-4d73-9d5a-57736d30bdba"
+    "owner" : "KTsdcpM88cSG",
+    "ownerAffiliation" : "https://www.example.org/548bb403-cd07-434f-9c3a-0155c92f6293"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/52d38f9b-0a08-49b1-bee7-d58b0bc406c8"
+    "id" : "https://www.example.org/f44959b3-4d46-46c4-a187-bf378db691ac"
   },
-  "createdDate" : "2004-08-25T10:33:21.245Z",
-  "modifiedDate" : "2007-04-25T14:41:47.653Z",
-  "publishedDate" : "2009-07-14T01:50:41.753Z",
-  "indexedDate" : "1989-08-06T12:03:22.797Z",
-  "handle" : "https://www.example.org/a56b7e67-c2f2-4b5e-97d3-cecd4bf35d39",
-  "doi" : "https://doi.org/10.1234/eaque",
-  "link" : "https://www.example.org/0b4702d3-1c17-4b86-94a6-b31e6fa2a51b",
+  "createdDate" : "2024-04-16T05:18:56.416Z",
+  "modifiedDate" : "1976-03-01T15:12:54.243Z",
+  "publishedDate" : "2012-03-27T11:14:41.610Z",
+  "indexedDate" : "1977-02-09T02:21:00.555Z",
+  "handle" : "https://www.example.org/ef1d20ab-f848-4a7f-8316-ed7b3c2b8821",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/3062de0a-e19d-44b2-ba29-3285405d4837",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "wwNlgRUjqQ",
+    "mainTitle" : "eZ7G6SehglFUavSM",
     "alternativeTitles" : {
-      "nb" : "JwmXo57jZXUnw1rmPDb"
+      "is" : "qTU6qEXKlQ5kOGeE4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "m5zbi3XZDT",
-      "month" : "I0phPXwNnv4d",
-      "day" : "8W8xMTQq1N3"
+      "year" : "6O57SVhBMhwAdwH",
+      "month" : "NQV7YFE8AtAms7aXTy",
+      "day" : "HijdnYbGdhZxi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8444bfd8-70fd-4776-bd04-b4472c710b80",
-        "name" : "aOZeOJe3RFalmPe6",
+        "id" : "https://www.example.org/75475a3f-aa7c-48d6-906c-7c484691e3ec",
+        "name" : "xJXZtHkj8FvC",
         "nameType" : "Organizational",
-        "orcId" : "QMafkB5ML0UToCL",
-        "verificationStatus" : "Verified",
+        "orcId" : "5FRINjRQIsYXtK5M9c",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tOpdvJr7P9Pol3v",
-          "value" : "uYWKq5zGmHDxRfgV"
+          "sourceName" : "d8xuQLXYO5VAkYOyO07",
+          "value" : "iLAAFdXqh3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tvlwY7AfzwbZ0k7I",
-          "value" : "gnHdbdCQiHf"
+          "sourceName" : "MCJvx2Ob2Qy",
+          "value" : "z7Jur55aVLBoFmeCwH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/528c8f50-ff0e-41a0-a9ed-372e47ceb5c0"
+        "id" : "https://www.example.org/20a205e9-79b5-4926-a86a-6e87b7194285"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1293970d-323f-41f2-88ac-8b5e0e9902d9",
-        "name" : "SMcpzXzzwJqQKt",
+        "id" : "https://www.example.org/7ac7abd2-7a30-43ca-aca9-d05ba582c4de",
+        "name" : "M7eCJmNE290",
         "nameType" : "Personal",
-        "orcId" : "bGn7A2bgVQmH",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "kb2IpvBbJFrSnV01X",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pK2ZRfBWcg8gLerX",
-          "value" : "88V4NJFQpGyBdO"
+          "sourceName" : "Bye7nRherzvw4gu3gI",
+          "value" : "bPGsbweUTApwLHOt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9wGXEagAv2j2EwiEJE",
-          "value" : "78hrnHwyu9kCEBHUZn"
+          "sourceName" : "OgmIzaQMZbt6mu",
+          "value" : "KUhOQUcQJKfu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/46ba0c5f-52fe-4885-bcd3-21a616f0a76b"
+        "id" : "https://www.example.org/245ddb0c-82cf-4a5e-a401-5fac9382f3f2"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "1zflJdVJXUYnlU"
+      "bg" : "h4d7ARiSAfgO"
     },
-    "npiSubjectHeading" : "epSsYbre1OTQ7q",
-    "tags" : [ "cCL2rxrkkpgAA1" ],
-    "description" : "OYzKZTj7Ha",
+    "npiSubjectHeading" : "iZC2xuy61n2YImMQ",
+    "tags" : [ "emcXKbstZTAtM" ],
+    "description" : "ENEtxD6LE7tw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "vFrd7Zz31Usa42Dq5",
+        "label" : "oNdNA1SqO3bzvPKbbI",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "uHw3Bv6ks41yi",
-          "country" : "QRIZu56gRV8"
+          "label" : "TsBrEo6H09thQvjjs",
+          "country" : "USWi8tyMy6vQ"
         },
         "time" : {
           "type" : "Instant",
-          "value" : "2001-10-14T09:33:34.196Z"
+          "value" : "2015-05-25T05:51:47.961Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/ECWLmbpDyT"
+          "id" : "https://www.example.com/GGgwgxlzGo4UfTh5Li"
         },
-        "product" : "https://www.example.com/Eth5IQJ6iM6a"
+        "product" : "https://www.example.com/wqydNG7lLJvjY"
       },
-      "doi" : "https://www.example.org/a7eb1ce1-38d0-4022-aaeb-61a3b5def227",
+      "doi" : "https://www.example.org/4ff8aa11-222b-4054-b065-e03c0a1c0197",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -121,106 +121,106 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e5663bb8-3233-4e6a-a8f5-b367548f7255",
-    "abstract" : "wILyzI956zH0ca8"
+    "metadataSource" : "https://www.example.org/b412c369-e1d4-4bbc-914b-4b282b1bfd14",
+    "abstract" : "UBqVOY2YsYMgbJa5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3a765b37-ead6-4baa-aef1-905c43f19a1a",
-    "name" : "hDRlsz0UkoeT08crhMJ",
+    "id" : "https://www.example.org/f658ae0a-ae18-4822-b626-c2a53ee77d9c",
+    "name" : "2YlxQexdXhdd7V9j",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-05-12T22:32:36.287Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "H9aB1wZAJ33PEtQ4LIl"
+      "approvalDate" : "2002-02-16T19:15:40.574Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "DauSYHQcWaURIO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3ffe1152-6d29-44ac-b5c3-eb1ac442d616",
-    "identifier" : "M2AouX0JkDANyaZyN",
+    "source" : "https://www.example.org/bb464c53-4db0-4ab8-9f0b-42727b1684b7",
+    "identifier" : "ymsXE0qqZ1Ll",
     "labels" : {
-      "da" : "QFQrrcvwHFB"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 421500131
-    },
-    "activeFrom" : "2001-10-04T01:57:06.585Z",
-    "activeTo" : "2011-07-15T15:01:59.529Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d5faa22a-d421-4d4e-8a58-d02b0d3daef3",
-    "id" : "https://www.example.org/91a6e0ce-0fde-46fe-b62b-b92bf3742db0",
-    "identifier" : "EtmUr4o0PyBicyJ",
-    "labels" : {
-      "se" : "XIYPNMyuqJP2eE"
+      "sv" : "PR98nzRZmYF"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 9713117
+      "amount" : 2080372883
     },
-    "activeFrom" : "2004-07-20T12:57:29.977Z",
-    "activeTo" : "2010-03-22T09:20:21.764Z"
+    "activeFrom" : "2001-03-20T00:08:37.035Z",
+    "activeTo" : "2023-09-13T11:19:57.352Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/f1ee0e4d-f5df-48b6-b3c9-9add15f6e927",
+    "id" : "https://www.example.org/357957fb-29fc-4e1c-bc47-3b1840ea01a7",
+    "identifier" : "1PYhojq61LHikmo",
+    "labels" : {
+      "fi" : "pbOIzTwkqOgL"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 982574994
+    },
+    "activeFrom" : "2002-12-05T23:49:01.979Z",
+    "activeTo" : "2008-04-22T17:05:26.861Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "CristinIdentifier",
+    "value" : "761555998",
+    "sourceName" : "lpqtnxgffp12md@zucc4okh8qwnhd"
+  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/c0777331-8163-421b-9aaf-4922aac5f457",
-    "sourceName" : "tehjmb9cuu4@epkqujs0bjon"
+    "value" : "https://www.example.org/4c6d5e66-09db-4140-bb6e-0b40f2e2e39b",
+    "sourceName" : "ddzbitugdm@xmwduqlbt4z"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "1bK0zRfTvShgHKDuy2m",
-    "sourceName" : "bpuao72fpttzp9wg0xs@qz6b9xheykx"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "1920542703",
-    "sourceName" : "urmxan0muwd7n@fx2qnt32c2olyo9"
+    "value" : "d29X9Gbow0mqiRaQt",
+    "sourceName" : "tlnjfksozkuobehbs0@fylbav7lplt9dbp"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "xoFFuzghDAzmwhCZH",
-    "value" : "HA85eKIR5I1N"
+    "sourceName" : "fTMs0EnFeJRvh8f",
+    "value" : "iEUzNvk6AT5pHV86zA"
   } ],
-  "subjects" : [ "https://www.example.org/00b78cd4-dff8-40a8-998b-0ae0950bcc8a" ],
+  "subjects" : [ "https://www.example.org/d2256c4d-9589-4ac7-a5e6-d42caf62c907" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1f0830ec-45ba-44c9-ad28-1f6c560982dc",
-    "name" : "u66iNLiYd7Pk0AdL",
-    "mimeType" : "YPuKwzmAHqR2Rej",
-    "size" : 308051719,
-    "license" : "https://www.example.com/1capfrvowhmfhmypmke",
+    "identifier" : "2671d066-800a-40b8-9f39-b3ec1a9b7513",
+    "name" : "R9XeIietrKL4wG5",
+    "mimeType" : "tpTCjobhVM",
+    "size" : 1333286888,
+    "license" : "https://www.example.com/ytrwnpuzf8lqcv",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Fnj9TCcq1JZ",
-    "publishedDate" : "2011-09-22T18:31:56.897Z",
+    "legalNote" : "S5fPR5Xv90X4Q7Pem5",
+    "publishedDate" : "1986-12-31T10:44:19.850Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1775345283@CIqSU8b83mOi7hvy4GX",
-      "uploadedDate" : "2015-04-10T12:33:07.992Z"
+      "uploadedBy" : "795403119@vHUAjIGHeIT57",
+      "uploadedDate" : "2000-12-10T20:36:49.422Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/aX30SclTwpw",
-    "name" : "l3pDzKRM14N",
-    "description" : "Gb0Poodw4wE"
+    "id" : "https://www.example.com/zoRGh9cxNI",
+    "name" : "gGU5klQj2k1fNZH6NAp",
+    "description" : "E2RI0S6Lz09HEizuiiS"
   } ],
-  "rightsHolder" : "Fd0C3OYYqmG",
-  "duplicateOf" : "https://www.example.org/fdf672ee-71ce-4b16-a745-43155dd1c644",
+  "rightsHolder" : "lvEuywbFYQ7N",
+  "duplicateOf" : "https://www.example.org/d2dfccee-10be-4984-bd0f-865f7bfd88f1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "k4wxvKtnL7CRs"
+    "note" : "ItAcwMireEuIpFxbrt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vO9zPwMc4wgkHBw",
-    "createdBy" : "hiMUggJTx12uACJ3y",
-    "createdDate" : "2017-10-25T01:49:28.925Z"
+    "note" : "0gAfXAAO56wZdRx",
+    "createdBy" : "0FV1Wl6P4DoVfg4cD",
+    "createdDate" : "1999-12-31T04:21:07.562Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/707f5c16-a386-482e-993e-db3ea2f761ff" ],
+  "curatingInstitutions" : [ "https://www.example.org/83d2dbc4-7323-47cf-9c9a-6d8b10d84e0f" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "0wlDjhQBKMkxgcoB",
-    "ownerAffiliation" : "https://www.example.org/35cf95d3-8ae4-4166-9b91-5089e2515910"
+    "owner" : "dgMDqIiEDSaCA98BxcG",
+    "ownerAffiliation" : "https://www.example.org/2bc6860b-75ce-4a75-904b-883f7dbdf7ff"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1440f6a0-4d9b-4862-9286-77b43916ee69"
+    "id" : "https://www.example.org/3724d246-289c-4dc3-9bbe-9a53ad6719a6"
   },
-  "createdDate" : "2008-01-20T05:30:52.402Z",
-  "modifiedDate" : "1992-08-29T16:39:44.591Z",
-  "publishedDate" : "1971-04-08T08:37:41.144Z",
-  "indexedDate" : "2003-02-08T06:43:40.245Z",
-  "handle" : "https://www.example.org/7ce9697c-7680-49d8-ba09-eeab608b5065",
-  "doi" : "https://doi.org/10.1234/aliquid",
-  "link" : "https://www.example.org/70c8aa91-3f2b-4c43-8818-834241bdf1bb",
+  "createdDate" : "1990-03-08T14:23:31.856Z",
+  "modifiedDate" : "2017-03-03T05:35:45.940Z",
+  "publishedDate" : "1977-03-09T23:24:02.297Z",
+  "indexedDate" : "1979-11-07T14:04:34.101Z",
+  "handle" : "https://www.example.org/45865009-a9bf-4e75-ba71-75f549c7e787",
+  "doi" : "https://doi.org/10.1234/sint",
+  "link" : "https://www.example.org/0b27393d-e1c2-4167-8983-8b7943753860",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hSEIYmyNx9MZVYO",
+    "mainTitle" : "C5FDRCqsZH",
     "alternativeTitles" : {
-      "en" : "AS0Bg2IWpX3ejYt1cqO"
+      "de" : "F9RFd0zGJG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BbcCMLpfHap1K",
-      "month" : "LTJ9d0PEJ8vH6",
-      "day" : "XPypMGXQuaK2jT"
+      "year" : "8aYMMRzMIzG",
+      "month" : "hFvm2B1Wu42U5zJ",
+      "day" : "vMHKuPvaTyF3iM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/88e12045-fe6d-42ff-9590-7b8fe4f2203e",
-        "name" : "FKMyMErZymE0Rr0",
+        "id" : "https://www.example.org/1fa4c151-1078-4814-853f-c0d61c760131",
+        "name" : "EAWCEUqsGdJU",
         "nameType" : "Personal",
-        "orcId" : "VudwkDb4uoPSZ1xZE",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "oCvYsFYkrLI",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zM4323j1AwIRivejd",
-          "value" : "gsV9MdJ7m1GbTBn"
+          "sourceName" : "ZQVVPXAHwq2KYn2",
+          "value" : "DxnVYfYK8gUA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2i743jzcMIAy",
-          "value" : "OtqvUVN5wOPcD2"
+          "sourceName" : "p2iCXYjNGwoCohXJ",
+          "value" : "KRUVIeWRzsCVR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/99e039f2-ec00-4c7e-91e9-b2f586b5fd92"
+        "id" : "https://www.example.org/72f737b7-c11f-4381-8669-4151b87e83eb"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,180 +62,181 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0bffbe81-f500-497d-86cc-dee5969e2684",
-        "name" : "YyEiXxFwzkQ6vuVfMKJ",
+        "id" : "https://www.example.org/1c7e483b-b6a5-479c-8e66-e6b8210e7de3",
+        "name" : "oj1tBvMDWT6O",
         "nameType" : "Personal",
-        "orcId" : "IHOthldBU9Eg0de",
+        "orcId" : "IMnNXNNqhE",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wgqsRODDWRXbDx6m",
-          "value" : "fga7Oo98Kx"
+          "sourceName" : "2tcE9qRk7GTYFSWu",
+          "value" : "DzRUm86rblq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6U7jqDWd7GYfUl",
-          "value" : "mbYPBTCiNgR"
+          "sourceName" : "x4LTZwnliNAdloBAF",
+          "value" : "k71kNVzDU6XGlaGv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e92b2f77-02c6-4cd7-9f3a-0e7b48575f1a"
+        "id" : "https://www.example.org/f954b4fe-16d4-417b-8260-7e32ce3d65bb"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "H72WJDXYAJumCQwB"
+      "pt" : "3pzReJnD1QLkOKRDm"
     },
-    "npiSubjectHeading" : "gksVCfxzhAJ856",
-    "tags" : [ "eNcC8tq3u70wyse" ],
-    "description" : "Sa3CN7cpwB6eN",
+    "npiSubjectHeading" : "GJTMEDDWJZRizXYtOo5",
+    "tags" : [ "lZLtWBsWg05TI" ],
+    "description" : "TBqG2F1pFm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c009e243-ffec-481d-b7a2-2cc8474ed7d9"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/71e41961-cdd0-415f-a63c-c53427d877b0"
         },
-        "seriesNumber" : "U1OtcxSPSnG",
+        "seriesNumber" : "KlaHrqonuM2g7Qedn",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/955aa902-16c5-4a10-8639-6cb5f172593e",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/80de396d-abc0-4340-b435-57d810b54181",
           "valid" : true
         },
-        "isbnList" : [ "9790851434550", "9781870703970" ],
+        "isbnList" : [ "9781552756348", "9781871452099" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1870703979"
+          "value" : "1871452090"
         } ]
       },
-      "doi" : "https://www.example.org/43ba0cd6-88cf-4925-affe-1c2867c0e548",
+      "doi" : "https://www.example.org/0fa21204-568b-48f0-8c26-c5d2d7d8812c",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "EBwBFjC5W9Lt89",
-            "end" : "fvUcFNzKaePOYrrJPn"
+            "begin" : "i6jFglTPxt7Qha0",
+            "end" : "WUDhNbaJCIFsM0C2Uzk"
           },
-          "pages" : "2r84M5v7FlssyLYL08p",
-          "illustrated" : false
+          "pages" : "T38iYYbzfUj0ciyhK",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "Q3ftQ6eYicN8TQS",
-          "month" : "JIPB3lxSPCAy",
-          "day" : "YG8ud1mHR04co"
+          "year" : "ypAcMvleGUgGy",
+          "month" : "YNq5IulEnD7",
+          "day" : "smrUidTWuGNzJ0QvmNE"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c7735a1e-6ec8-41ee-b1c2-f9f0fd19f8cd",
-    "abstract" : "YzPkBwZncHyr3rEpSh"
+    "metadataSource" : "https://www.example.org/d9836b89-0e93-4746-a5ea-f8d1cba9c002",
+    "abstract" : "EQaP2XFvEgk3r"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c38d0bf9-118d-4f08-9b12-b6af43a4a975",
-    "name" : "jHHLa4VFr8",
+    "id" : "https://www.example.org/47f9eb5d-5d4d-4fa1-999f-c07603b62202",
+    "name" : "Lf0YCIGzTECLFf",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-08-03T00:26:11.373Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "gI4wDyTIMa4"
+      "approvalDate" : "2002-11-12T13:52:28.608Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "IReGiUDfUiz7de"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/59bb3c98-53cd-4158-b445-39c9ced9184f",
-    "identifier" : "85BGLRRckjOQRB",
+    "source" : "https://www.example.org/adb5d5ee-af79-4e3b-aeb3-b471f81ecb0c",
+    "identifier" : "YNEBufCUz6Dt70d92",
     "labels" : {
-      "nb" : "Ts7kU5TaxL"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2123612196
-    },
-    "activeFrom" : "2002-03-31T09:17:17.886Z",
-    "activeTo" : "2011-02-18T04:00:49.611Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8788ae86-276b-42bb-97ea-cc95cc5a428a",
-    "id" : "https://www.example.org/a623f153-7b49-4adc-8ab3-0a4ae5e6a0cb",
-    "identifier" : "okfKfucjRcEhLgt",
-    "labels" : {
-      "en" : "zMd93Wcgod22"
+      "de" : "ZaaMoJXalJ4Xrl"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 721231410
+      "amount" : 1764908695
     },
-    "activeFrom" : "1974-03-20T01:17:04.724Z",
-    "activeTo" : "1986-08-06T09:17:06.920Z"
+    "activeFrom" : "1993-12-03T06:05:58.951Z",
+    "activeTo" : "2011-10-28T08:28:38.573Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/b678633c-331f-4178-8025-268bdc50472f",
+    "id" : "https://www.example.org/efc26043-c3ba-43a9-9db8-b3aaa654ddcf",
+    "identifier" : "NvXvyBOI6w",
+    "labels" : {
+      "nl" : "FGdUEgectJNNC"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 2060571794
+    },
+    "activeFrom" : "1999-05-27T04:34:12.260Z",
+    "activeTo" : "2012-10-23T10:44:20.638Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "ScopusIdentifier",
-    "value" : "9FmkO5LveeTkm",
-    "sourceName" : "igyl6daot9s40els@zo6zfwct2js1"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/3a68d48d-d23e-4aea-abe2-3aeb9b03b85c",
-    "sourceName" : "qdvmses9tltz3qhjtm@aoswzdmb8wrwpcoyyn"
-  }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "VKBBpBHIxH17",
-    "value" : "Q7gYuAug5z"
+    "value" : "https://www.example.org/809c7632-3dab-42e5-9561-7318f4068204",
+    "sourceName" : "xo45pwurmkgv6@2lkudg6xwosfqswdgt4"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "208904601",
-    "sourceName" : "wwdcwlr4s6xaidj7d@px7u8qfsf52f8hryzw"
+    "value" : "262638160",
+    "sourceName" : "tmyxhbb0vlcwtqudo@9zd4dx6milpcdr6hj"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "bxpyrFGQpa9fZr",
+    "value" : "q3ltdirVKNndpkKvmwB"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "0gzrLL8CDnxThy5yF8",
+    "sourceName" : "ocd2y66ihrv3ezbxgq@egn15w8cudxteav9"
   } ],
-  "subjects" : [ "https://www.example.org/074c6d57-fefc-46ee-9abf-a2247c8843f9" ],
+  "subjects" : [ "https://www.example.org/00213b3a-feac-4ef5-bed2-430a48d63a28" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e9d76d1b-efa9-4d0e-a347-3a6e243841f7",
-    "name" : "BmuHrvm5EvgG",
-    "mimeType" : "XWYyDk5jRzgCNq4",
-    "size" : 648237199,
-    "license" : "https://www.example.com/raf9xvvg9su1",
+    "identifier" : "03394689-fd89-4f2e-814f-091d0669c940",
+    "name" : "r6qGqEbMqZdDu",
+    "mimeType" : "QwSksi3L9TwYAJv",
+    "size" : 579009969,
+    "license" : "https://www.example.com/ub3iuimrjidsd6daqz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "lIGJzTuFOr"
     },
-    "legalNote" : "eMR8ANpYQTF4QmGktX",
-    "publishedDate" : "2024-06-06T04:36:53.294Z",
+    "legalNote" : "wjGPCNJE8vjtjC3E8T",
+    "publishedDate" : "1980-02-14T15:46:51.230Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "259064109@q839OdoAUQcSwjsw0vf",
-      "uploadedDate" : "2016-11-11T19:05:34.747Z"
+      "uploadedBy" : "251402897@o8T51yLcXh",
+      "uploadedDate" : "1973-06-03T12:17:17.885Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/GJrMK3NwUk",
-    "name" : "nmNvpL7tFA8X43zoEd",
-    "description" : "w5A2GErUq9B"
+    "id" : "https://www.example.com/dRmm7a58oO",
+    "name" : "tob3hB5cDgf",
+    "description" : "JC67V3f8FjUT72u0"
   } ],
-  "rightsHolder" : "4JepL1Mdwu0t9Q",
-  "duplicateOf" : "https://www.example.org/a1c15be5-13ba-42b9-a9b6-618e6b040aa1",
+  "rightsHolder" : "Lj6zZo4MNASli",
+  "duplicateOf" : "https://www.example.org/43f999a2-8a99-4814-acb1-e21451153b23",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UsHYHJ4ieamP2J40x"
+    "note" : "4WIg3y306pi0J2RX5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "baRuJmiVgXsfPf2OH",
-    "createdBy" : "gMpeakHnTf",
-    "createdDate" : "1983-07-05T05:27:24.789Z"
+    "note" : "PYDKhnLt5QsS",
+    "createdBy" : "r1z7pWvxroFxG",
+    "createdDate" : "2018-06-19T22:22:20.402Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3832f036-5f2e-42e6-bf45-cdb5e3c7c073" ],
+  "curatingInstitutions" : [ "https://www.example.org/4f686a5c-a02e-4f18-8439-e92313b4a737" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Eg6rYIZDVC",
-    "ownerAffiliation" : "https://www.example.org/1f4ec24c-5cde-4f97-aaa6-f47223be3c3a"
+    "owner" : "JLfRnBhCOL",
+    "ownerAffiliation" : "https://www.example.org/8e83ec8e-abad-480e-850c-4af56721172f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d7710155-c6e9-4134-9b61-0d566cfde174"
+    "id" : "https://www.example.org/ad81c118-4384-4940-a79b-6521cc3e85d5"
   },
-  "createdDate" : "2001-09-05T04:05:22.044Z",
-  "modifiedDate" : "2016-04-22T23:35:10.633Z",
-  "publishedDate" : "1977-05-18T21:40:31.708Z",
-  "indexedDate" : "2023-07-28T07:46:58.374Z",
-  "handle" : "https://www.example.org/64eb99c8-1dac-4038-89a4-70936d894dfe",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/30eb636b-134d-4694-86e0-9fe9cbc9c410",
+  "createdDate" : "1982-04-23T10:34:10.645Z",
+  "modifiedDate" : "1981-12-05T10:58:58.184Z",
+  "publishedDate" : "1982-02-15T20:42:48.464Z",
+  "indexedDate" : "1980-12-05T01:26:25.715Z",
+  "handle" : "https://www.example.org/631d1efc-91d9-4c85-a2e5-50c47ecfea13",
+  "doi" : "https://doi.org/10.1234/quaerat",
+  "link" : "https://www.example.org/3380bf7e-a774-4e2b-a45a-6bcf2cc80738",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ckO8YHqomjuyZIoIMuB",
+    "mainTitle" : "0HtyrGzYNXu",
     "alternativeTitles" : {
-      "el" : "kZqUQWoxXWy1"
+      "is" : "Ed9SoAkM04WvM9k"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Anw1t1D6r77",
-      "month" : "cltU62mz1kYt",
-      "day" : "3mlC7MWOFWUXNTe0RH"
+      "year" : "05Stej2sfug",
+      "month" : "6UUYlF93iINfnw8EkgW",
+      "day" : "KVnkHemRGGtTQUPwxZU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f32ab5b2-501c-4944-aac9-bde6bebabd1d",
-        "name" : "KtkP5fgA3IU28",
+        "id" : "https://www.example.org/cad6f14d-1df7-43ab-823f-83b1f89cfe61",
+        "name" : "mNaJDHvGIz0hYGJJ",
         "nameType" : "Organizational",
-        "orcId" : "8ad00ZjpgBZb",
+        "orcId" : "FK2LOWwtCQ",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XlVH2VZ7PWaFGDxY",
-          "value" : "gXk11u1xaqoSzE9hhw"
+          "sourceName" : "BjqLqSS7fw7",
+          "value" : "icDKAi10Hk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2YBO9NjdAe8HZUe4",
-          "value" : "7IcnMJUOWDFDJumXW5A"
+          "sourceName" : "z5Dr1n6CZn2u",
+          "value" : "tT2z6ianYZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1e2725ce-6ed2-45a9-b421-4a988353858d"
+        "id" : "https://www.example.org/24b815c1-092b-466a-913a-559bf3b262d5"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,169 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f26f26f4-d22c-4c42-be40-7aaa88890587",
-        "name" : "Nxqu0HjiRyO",
-        "nameType" : "Organizational",
-        "orcId" : "bTJuPPfxEdZz2GO",
+        "id" : "https://www.example.org/a63d5b5f-f684-45d5-a8f0-6dae19646b81",
+        "name" : "zSinMWkc6i40W77E",
+        "nameType" : "Personal",
+        "orcId" : "gmhUl2BJmkJ",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zDsVjBzloJUoAPRj99",
-          "value" : "tYOQcZiLuafyOlzkzr"
+          "sourceName" : "teMSkpwB8M8k",
+          "value" : "FhJRBXajeV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WE0pD8r6w7x",
-          "value" : "nKOyM8cS8jIVB"
+          "sourceName" : "WYgSUHR2g39ivkAs8gQ",
+          "value" : "9l9K3qFwdNuUZdLCzqe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4dcfffa-6e06-4b1a-a89a-d7f8f2ba0149"
+        "id" : "https://www.example.org/6e75eba8-d302-4de7-a099-81d18764dad6"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "NRhIn46umwQy7cT9Ah"
+      "se" : "Jht7eeACWKNmH"
     },
-    "npiSubjectHeading" : "imV8HnqPEcj",
-    "tags" : [ "v4W78BEIbMhVdwDjSAj" ],
-    "description" : "w1sYaoF87m",
+    "npiSubjectHeading" : "W74C6c0EYzQY",
+    "tags" : [ "qXMOu4cHQFtm1p" ],
+    "description" : "mVv8D3sN3f1e1Hafj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/43b29dd5-9ad1-493d-bde4-93ee7e5853d8",
+      "doi" : "https://www.example.org/996f7936-a9af-47f7-97c8-e43529107c07",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
           "type" : "Broadcast"
         },
-        "description" : "Y2tElpk0Pf9xSH",
+        "description" : "HVa0loRds9oP",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "d9cJoh0xvT9qN1kuAm",
-            "country" : "1Y5qxDIVE1tufp"
+            "label" : "llKbDXdYOlw",
+            "country" : "2sLMIM1iHYF"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2013-07-20T21:08:32.355Z",
-            "to" : "2021-07-01T11:22:31.272Z"
+            "from" : "1975-09-05T19:14:23.953Z",
+            "to" : "1989-10-10T07:22:58.777Z"
           },
-          "sequence" : 1580960187
+          "sequence" : 522746372
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d58c4a74-f10f-4fab-9fad-7202ac023317",
-    "abstract" : "Wjq9CmyR4uv"
+    "metadataSource" : "https://www.example.org/3cdf724e-73e4-4a41-a069-14e037efbb2a",
+    "abstract" : "dAZEXw4P38I4qXb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/636a6d4b-aa0f-4bad-b68d-3caab3e99cc7",
-    "name" : "eW0iLf1xklPol",
+    "id" : "https://www.example.org/ac56f105-70a3-42b1-865b-2b24a0823335",
+    "name" : "RF0YymIeLAcY",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-12-04T10:33:48.796Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "gC8D8Kd9k7Ndz9z"
+      "approvalDate" : "1977-10-11T20:56:13.431Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "svOJ8Snmoh6IaGu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e560213c-5074-4934-8f83-1291c17c5417",
-    "identifier" : "QoJ6Lq1t9bnFJBM",
+    "source" : "https://www.example.org/16b8d5e1-70b9-45d1-b762-fdd0567dbde8",
+    "identifier" : "v4Dg5YuWteFOSRl95",
     "labels" : {
-      "fi" : "UUe7Ol25uckZs95qTQc"
+      "pl" : "kz8xlw9hQnuw"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 974072730
+      "currency" : "EUR",
+      "amount" : 999731533
     },
-    "activeFrom" : "2022-10-21T03:35:18.289Z",
-    "activeTo" : "2023-09-10T23:11:48.378Z"
+    "activeFrom" : "1993-03-20T23:58:54.302Z",
+    "activeTo" : "1994-10-12T16:54:28.705Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a2f7d3c4-2e0b-4097-904f-2e5adbaf94a6",
-    "id" : "https://www.example.org/aaf55905-504e-4ed2-9f79-2aa36de5f727",
-    "identifier" : "z0sViuQFA3T",
+    "source" : "https://www.example.org/4312ded0-6818-4f1f-89fc-508699ffd05a",
+    "id" : "https://www.example.org/140fac9c-be31-4d6c-be7a-9b76f1e73b44",
+    "identifier" : "p7tT4wiC8esdMy3y",
     "labels" : {
-      "ca" : "kDICiqoZTR2X7Y0vph"
+      "nn" : "VBH0Xjk38l"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 643211584
+      "currency" : "USD",
+      "amount" : 1996661145
     },
-    "activeFrom" : "1978-02-18T23:17:16.217Z",
-    "activeTo" : "1988-04-24T08:30:17.365Z"
+    "activeFrom" : "1989-07-29T02:49:39.023Z",
+    "activeTo" : "2019-01-23T18:10:05.921Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/61537c71-f142-49e6-a57c-1cd5cac95306",
+    "sourceName" : "djoimv2gpbwa02@xwhdl1ugka"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "1706973933",
-    "sourceName" : "kvusgbgljxtvg@4uanfuqopqsl0juim7"
+    "value" : "1002675778",
+    "sourceName" : "0dyrpfogaptpyhqkqlp@fqnbcqougzag"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "yIUXLjd1aa0R5",
-    "sourceName" : "a2ilk07tpmbc7smqv@ukgvupgqkki"
+    "value" : "OliInDruPSnOSIy",
+    "sourceName" : "yxf9vymde6at@eibuhy38atcrz2z"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "Zd5HhOIIGytSWQ",
-    "value" : "Hvt3eddLmrS6Kz7oTe"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/26903159-ab30-4c5f-9c03-adda08dc1742",
-    "sourceName" : "wbnavxsjzyryizf1c@gwx52iqe5pole"
+    "sourceName" : "XfSBEIcoZM6",
+    "value" : "tCZIw7pCCBF8IvW3"
   } ],
-  "subjects" : [ "https://www.example.org/953e62f8-6733-49ab-89e5-2237d20ce299" ],
+  "subjects" : [ "https://www.example.org/25469e95-608d-4c7a-9aa7-fc389975ea85" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "85f97394-d2b0-431a-9c50-eed2b0a7903d",
-    "name" : "v0kWVayLgT3wrHXjDT",
-    "mimeType" : "GOK9oEfqgX2",
-    "size" : 1093543644,
-    "license" : "https://www.example.com/k2wmpjvzogee6gt",
+    "identifier" : "f2fb2fb3-ef6d-4868-ace1-021caccd8920",
+    "name" : "kCucNQHLhQJhZFUOZys",
+    "mimeType" : "cNd7n8eXvAd",
+    "size" : 1384982293,
+    "license" : "https://www.example.com/tcpmz0tffwsd",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "rwi4ieo5HkKq4O"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Td0vt6oierPAz5",
-    "publishedDate" : "2004-05-13T23:26:10.400Z",
+    "legalNote" : "1y8uhGjRNfLFX9ki",
+    "publishedDate" : "2018-01-28T02:29:56.517Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1470297958@KHPMIVOvHQJ",
-      "uploadedDate" : "1992-01-07T08:25:14.548Z"
+      "uploadedBy" : "1590324153@hwY9rzwzIQIIqBQO",
+      "uploadedDate" : "1974-07-30T14:31:49.259Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/26rUA0pjytx",
-    "name" : "oSPu9r4ravPcN8iBdIe",
-    "description" : "ft9wFXOnToLmR1A5"
+    "id" : "https://www.example.com/cd1loTH1S7XBBCnRf",
+    "name" : "p3qekKuEdQFyqWB1av",
+    "description" : "c9kmfUvnumXGT"
   } ],
-  "rightsHolder" : "uBY6HeCa3qmJtil8",
-  "duplicateOf" : "https://www.example.org/a59f5be2-a5dc-47d0-bb8c-05ca0c40a45e",
+  "rightsHolder" : "vFptL849Lqi",
+  "duplicateOf" : "https://www.example.org/c4e4abb9-2a47-4f9f-945c-a5b6a300bcb7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "iA1sYqzLAKFmEHPz"
+    "note" : "k78iONB2AvqwACeV3qy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "XtcxtQC6ouPGoxIVvN",
-    "createdBy" : "TqIaamqJpn2DMSSF1Lu",
-    "createdDate" : "1974-05-01T14:10:18.338Z"
+    "note" : "a6ZYBaL7BsO",
+    "createdBy" : "mLbf9kuILr3sv6",
+    "createdDate" : "1974-12-30T23:15:28.689Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/502f4c32-0429-416a-bd9e-f0b3126a2abb" ],
+  "curatingInstitutions" : [ "https://www.example.org/d8d628f2-36ba-452c-ab01-608ec754c0b9" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "a9gPTeClVbGtaOtToO",
-    "ownerAffiliation" : "https://www.example.org/6af6d163-125b-4331-a337-f729a8bc85f9"
+    "owner" : "y8KOP9CSbXyK",
+    "ownerAffiliation" : "https://www.example.org/f7b4457f-fece-4011-9059-3d7ef50830a3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d42e82e2-c693-467d-8766-75149ba72c03"
+    "id" : "https://www.example.org/85e21f00-482e-4363-ae7f-7d59bdbe8b8d"
   },
-  "createdDate" : "2005-03-21T08:49:39.942Z",
-  "modifiedDate" : "2009-08-01T22:13:29.214Z",
-  "publishedDate" : "2023-08-11T13:54:26.063Z",
-  "indexedDate" : "1978-02-04T05:21:59.001Z",
-  "handle" : "https://www.example.org/f8d441a3-5777-4a9a-b07f-b87be228ecfe",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/b4578c6f-a685-496d-8e44-ff36b7677e5f",
+  "createdDate" : "2016-04-10T09:36:33.911Z",
+  "modifiedDate" : "1994-02-09T12:36:40.447Z",
+  "publishedDate" : "1987-06-21T16:28:59.711Z",
+  "indexedDate" : "1987-06-06T22:44:14.788Z",
+  "handle" : "https://www.example.org/98ef817a-8cdc-4290-9622-3484cacc8f1c",
+  "doi" : "https://doi.org/10.1234/nemo",
+  "link" : "https://www.example.org/dc8ceef2-cbf1-4152-b962-9c527f2e1546",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uFx0sLXrWdfP",
+    "mainTitle" : "1XB2qzfcLLk9mlXmWVM",
     "alternativeTitles" : {
-      "pl" : "56ZUseQy4QNP"
+      "da" : "zj8eDZTiPLDTpWcRDU"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "4NY822f0QvzukrP",
-      "month" : "cQVBAd2f51bh",
-      "day" : "huyOrAZSRqzAHkjG8"
+      "year" : "QBDAPyXP0exyRPBP",
+      "month" : "x9NyzEgs4LT3lW446c",
+      "day" : "Wgp8dff0TgeW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e8657a16-e9b0-4395-bc65-3c34e6606c1c",
-        "name" : "i75xhWalroNtO2fYDEh",
-        "nameType" : "Personal",
-        "orcId" : "X0BCjaq2Ym1cTHsds",
+        "id" : "https://www.example.org/9f97ae93-1a20-4bbc-af15-88ba854746be",
+        "name" : "xxQABa9IGxXbBy",
+        "nameType" : "Organizational",
+        "orcId" : "Xm1rbqLpHwdEdDA2O",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vAlPZ6g9VdadXjU",
-          "value" : "e7g8WXU1ClknmREkV"
+          "sourceName" : "6JucI122OhInruH",
+          "value" : "TtGlXiXoXATlIAD2mWL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "B1NTbT5PK7laha0",
-          "value" : "5WcPbvfVezJ3Z42txJy"
+          "sourceName" : "WTjdv0c30rMrmZ",
+          "value" : "1fhto2aq4E"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/73028039-3c9d-4ca1-a16f-9526af0fbfb1"
+        "id" : "https://www.example.org/e3c7e987-58d4-497d-bbec-cd2ef1537eef"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0052d090-c29c-4f1c-8137-7dec4153509d",
-        "name" : "WTAo0XkNYkPjwoQu",
+        "id" : "https://www.example.org/d28ae6f7-7f25-479b-8318-bf1983eff961",
+        "name" : "KOuoCgY727p",
         "nameType" : "Personal",
-        "orcId" : "e21dyj3dkIEoQdQCqn7",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Dv7VZgyPEszmQ05QFzo",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sHlyo1YT0pt1KhsZX2",
-          "value" : "eifNM4VQxHcwloPz"
+          "sourceName" : "Q02PqCFb9yWp3t3",
+          "value" : "BFE3pHjKnDHEhkQxK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t5q8Xipmv0HI",
-          "value" : "LWrfCyWlULxicOew"
+          "sourceName" : "l8CWkwK2R7",
+          "value" : "l1OzPN34b3jL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3a4f84e9-fe42-44ef-a56c-52a6879ad4bf"
+        "id" : "https://www.example.org/d2e1b6dc-01f0-436a-8906-c94489ff6a8e"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "Registrar"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "iKlEwUYI3yCzifRerB1"
+      "bg" : "E3n6DgezHZc"
     },
-    "npiSubjectHeading" : "Bl9WHORECmJv",
-    "tags" : [ "mpmYsSwwGQGiTOjDVRk" ],
-    "description" : "yBAxVk0DYHE5dU9ZrT",
+    "npiSubjectHeading" : "IiVnJVADSeeMzz8PST5",
+    "tags" : [ "8ntehN8Q310" ],
+    "description" : "NATIGnW3KZEq1ZJi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/43ecf719-fd6b-43d4-8997-7007ab31d78a"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8e6706b0-537f-4e24-9013-4d72acb03006"
       },
-      "doi" : "https://www.example.org/b1c25b1b-cdfc-4cf1-8933-fa7176d8e284",
+      "doi" : "https://www.example.org/a4225d71-24bb-4807-ac20-3193e506b2e1",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "hv2NPNRlpU",
-          "end" : "O7D9XnrDyBNK7"
+          "begin" : "sXCxFP9m7VxZr1aAKJ",
+          "end" : "PFmAbDIRX5Vl"
         },
-        "volume" : "EJkinkOymm4z",
-        "issue" : "SdX8tYRnNIXv",
-        "articleNumber" : "FTsuMonZ5acwq8r"
+        "volume" : "BEfWzmb3YbBbgT",
+        "issue" : "x64IeSz3HL0LWS2No4",
+        "articleNumber" : "rOhjjt63l6G3"
       }
     },
-    "metadataSource" : "https://www.example.org/0210eb36-2820-47f5-8c2a-da3777496ac0",
-    "abstract" : "t07e9OY8b1"
+    "metadataSource" : "https://www.example.org/277d3aa8-9f22-46ee-81ff-01d737b5729b",
+    "abstract" : "oLsVddAibnwjnUGKkCb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/22c93ee7-d0d0-4c64-94fe-07368e12551b",
-    "name" : "PfRTV18Gb7jeyFcKMqp",
+    "id" : "https://www.example.org/848a9318-3869-4b1e-8589-da7110c7fa74",
+    "name" : "LGzqwceZZyJA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-07-16T04:20:52.972Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "dd36Pn7xLrMk8g1Y"
+      "approvalDate" : "1995-05-29T21:06:30.272Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "RjZ3IArOlkkMyPBb6Y"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/60896c14-97b4-4a62-a920-2156f1d1c98c",
-    "identifier" : "l5gkQkYmKO2",
+    "source" : "https://www.example.org/bd7d4dcf-b8d2-4d97-b182-3233c3b72111",
+    "identifier" : "QApfcI9zBkN",
     "labels" : {
-      "pt" : "SUC8BhtBe6hojyzE"
+      "ca" : "TWoyPPe5WsNQ40"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 300893817
+      "amount" : 676772536
     },
-    "activeFrom" : "2023-07-07T14:20:15.640Z",
-    "activeTo" : "2024-08-11T00:30:49.583Z"
+    "activeFrom" : "2019-12-18T11:16:15.537Z",
+    "activeTo" : "2020-05-03T03:25:00.276Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/abe056cd-6d79-496a-9cf8-d77b9b0595c6",
-    "id" : "https://www.example.org/3dbf6f3d-7fd4-427d-be8d-666c8f724572",
-    "identifier" : "utiXHQfLR0yl2ukBNZ",
+    "source" : "https://www.example.org/8c98c343-eaee-4f43-985e-e36953f2951a",
+    "id" : "https://www.example.org/a8c2f710-4baa-40f6-a415-e0e955924672",
+    "identifier" : "3dWFh6HyeEcVOnGr",
     "labels" : {
-      "se" : "1BiB5rZunc0EkJ8"
+      "nl" : "DCmfGECx3aeewv"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2024445227
+      "currency" : "GBP",
+      "amount" : 776991399
     },
-    "activeFrom" : "1981-06-27T19:04:10.759Z",
-    "activeTo" : "1983-07-31T07:56:57.368Z"
+    "activeFrom" : "1998-04-22T17:33:51.342Z",
+    "activeTo" : "2019-04-19T17:32:31.867Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "4yAZjbtV7S",
-    "sourceName" : "fvrxplzi5bllm@awc3xporsot8hqwrr"
-  }, {
-    "type" : "CristinIdentifier",
-    "value" : "299655714",
-    "sourceName" : "nbdoqcmbdn2r@mgqp20iynwsjj3lbhyy"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0072c695-72a5-4258-ac09-3f71c36decd7",
-    "sourceName" : "xdxmz7psptffl@rpzylbkpxeibxaxwjl0"
+    "value" : "lNX5BFnNy3",
+    "sourceName" : "wfiueqilhqfpt54@89efn1zv1joecpwv"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "HtUwH8jYGkycCwgafG",
-    "value" : "IMnJrhNvfT"
+    "sourceName" : "hD5YvDNSuMLY",
+    "value" : "q4rOb9rCzbWqtthN6"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "305099793",
+    "sourceName" : "9iopfphllmm09ee2o5@xr8hm0lz3qpjqsl5"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/2941ebf8-8c47-40bf-a7b4-9977463931ba",
+    "sourceName" : "l6idgjh7ack8s@rz0ffn47qmu"
   } ],
-  "subjects" : [ "https://www.example.org/2394ae4b-25db-47e5-a96f-23dae9cb7d37" ],
+  "subjects" : [ "https://www.example.org/d177aa79-cf44-4418-806d-b5501ebbf941" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "882b5a38-18a7-4188-af3a-9296ca5d24f8",
-    "name" : "eAKLKKHIox",
-    "mimeType" : "vHk6EAUGiN8nWfHw5",
-    "size" : 277545558,
-    "license" : "https://www.example.com/0janovrok3",
+    "identifier" : "48d52f4a-1b79-4a6a-8963-c96749cb3532",
+    "name" : "R4mOAG933WcFEyX",
+    "mimeType" : "mAzDAVTzN5lv",
+    "size" : 1775151062,
+    "license" : "https://www.example.com/02wunl1fv960i",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "K1U87PHuVlMx9ohetpt"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "TObAJDwdCM",
-    "publishedDate" : "1973-11-06T23:16:31.740Z",
+    "legalNote" : "SuBKjv8dM8",
+    "publishedDate" : "1981-08-05T03:23:13.348Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "262421664@y8ukpCvYNsBey90lQ",
-      "uploadedDate" : "1992-06-26T22:19:09.499Z"
+      "uploadedBy" : "1374564430@dM4lyw4AJdew3",
+      "uploadedDate" : "2004-05-07T14:32:28.180Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/yZH8I2WhbzbQv",
-    "name" : "iG5R0dozimiSjQl",
-    "description" : "JHiyfoeNyOP"
+    "id" : "https://www.example.com/2ljoVDQKq5hU",
+    "name" : "vZatmddL2Qww1dR",
+    "description" : "5vRCoNTEMX9Hb6e"
   } ],
-  "rightsHolder" : "owC2ficZsFNFnpENf",
-  "duplicateOf" : "https://www.example.org/f4e226dc-c4aa-49b9-b3ec-1dcff187f265",
+  "rightsHolder" : "1fUx0DrqaHd1sh",
+  "duplicateOf" : "https://www.example.org/f07c4eaa-353f-4873-b3b4-99d9bacd6b0a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Luwt3keA9W"
+    "note" : "et5hJV2sXNu2gE"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Yqha7Hqd9km",
-    "createdBy" : "sttXGqSGW705KdN1f0",
-    "createdDate" : "2010-03-15T12:38:24.808Z"
+    "note" : "m1LoFpZvYRMf",
+    "createdBy" : "w6ht2wj71uuT",
+    "createdDate" : "1985-06-04T23:18:55.252Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f6ef547e-1a7e-4b4b-9b3d-ac34ca3df71b" ],
+  "curatingInstitutions" : [ "https://www.example.org/d14a9a34-3822-4d59-a4b5-73bdd6f78f15" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "FBDhmTvnlrf8Ml",
-    "ownerAffiliation" : "https://www.example.org/1f7b1b6d-727c-4376-90a5-79a41e1c9d07"
+    "owner" : "bv6sDWJsyPLSqp",
+    "ownerAffiliation" : "https://www.example.org/ad84a48d-ecdf-490b-8fee-b3dcab3b6260"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e0a7b6a8-6f97-4227-90c5-e1dae41a5626"
+    "id" : "https://www.example.org/1727fbcd-71e9-47d3-8371-64fa99f0b9be"
   },
-  "createdDate" : "1984-12-19T03:21:53.338Z",
-  "modifiedDate" : "2017-03-12T08:28:26.765Z",
-  "publishedDate" : "2024-03-03T12:41:42.469Z",
-  "indexedDate" : "1981-03-17T19:09:19.956Z",
-  "handle" : "https://www.example.org/e356f982-8380-4c0f-b8eb-4a69e40ab1b3",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/43988eee-635f-4b14-98ee-92e23d6a8534",
+  "createdDate" : "1987-04-30T22:04:17.923Z",
+  "modifiedDate" : "2016-07-19T13:48:24.263Z",
+  "publishedDate" : "1993-12-15T16:56:44.970Z",
+  "indexedDate" : "1979-12-05T08:55:08.410Z",
+  "handle" : "https://www.example.org/ae36c842-50a0-46d8-8095-71a00e2f56da",
+  "doi" : "https://doi.org/10.1234/error",
+  "link" : "https://www.example.org/62ffe79e-5c76-4ea2-9881-e8c88c65dfb6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JVFG0JC1lfEEW",
+    "mainTitle" : "bbZy0C7Xdd6TCMlR",
     "alternativeTitles" : {
-      "pl" : "3VN1wtCsHr0nhOyE5Y"
+      "nb" : "3GkFi109Ae8M"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Rgsj0hsJQ6amrqzGcMB",
-      "month" : "Ubdy3cUJcrJn7jXhf5s",
-      "day" : "iHuN4kUthDrEhC"
+      "year" : "sZcacE24794e",
+      "month" : "VFWTiibxaO4pc2",
+      "day" : "VzLvCf1pQWFcVq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/478f255d-f073-4b23-9f9b-e7dba6acc9dd",
-        "name" : "NY4c6FGoUp5XEin",
+        "id" : "https://www.example.org/9c13738e-a89c-4210-b819-dbeaae1f3018",
+        "name" : "2SNWpN2GymKua",
         "nameType" : "Personal",
-        "orcId" : "gqc3sC8bbvbOamoMUFC",
+        "orcId" : "emy0K5eoXmSXXW",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QX4XVeuHJu7",
-          "value" : "tbxMsO80yB"
+          "sourceName" : "RVkTQefaCiyqrun7ptl",
+          "value" : "uKa1IDAJKPoqdVj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dc3QonAZmSJ2",
-          "value" : "1AAm7Sy5NFx2"
+          "sourceName" : "SDv1oLkB5dCEq4U20er",
+          "value" : "rchBhaJ4vp9UCMq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/190674fa-5b1d-440f-9a81-a395e5940749"
+        "id" : "https://www.example.org/e5fcd313-5f59-453b-bf95-aeecaffb104e"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/96f7aea3-a8b0-4fa9-96ee-c43fd669ef4f",
-        "name" : "ReIPEiSSCOAOZgbf",
+        "id" : "https://www.example.org/82a187ff-2249-4dc0-a874-6a35b06e8cd0",
+        "name" : "Y4jXosQkDUbe",
         "nameType" : "Organizational",
-        "orcId" : "PSmPVvjgzhM5",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "z7BUXOXWVZQQ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e4VNdzqahieCFTsh",
-          "value" : "bQLzzHTHSb9WKDubs"
+          "sourceName" : "p5sKzGf9oGr7Q9PHu",
+          "value" : "cPcHnOLlpQ2oh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "owvQrQPlBLG",
-          "value" : "ccdG7ww7ZOzRBDjYQuR"
+          "sourceName" : "BeNs3KPrTGc",
+          "value" : "PQjjHyKnYSWWbOw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ed4a47e0-234c-4440-b835-d6cda386bb90"
+        "id" : "https://www.example.org/b6da9f8a-e69f-4da7-ad0b-39bf8b67c50e"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "InterviewSubject"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "tvVlwgmWvhQi"
+      "ru" : "QvZfjZ4NNrQX"
     },
-    "npiSubjectHeading" : "DrkmveE716ne7w5Wcz",
-    "tags" : [ "xccu3ZHQENyIOk39V" ],
-    "description" : "gWYR3BLVSoupdFJc",
+    "npiSubjectHeading" : "Cb6pYogKv8WgBeAABn",
+    "tags" : [ "2mVpW7Hxg2" ],
+    "description" : "kKnIZjZpWcAl0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/SRBaGqpkcbBPOq/publication/0191e0c8ec94-0ce6a74d-0ec9-4da5-9c4c-1a18556e2b69"
+        "id" : "https://www.example.com/zh7rhDwsV3StUV/publication/0191ff23502a-cf9b8250-b4ff-46a1-87d6-a465706a3f4b"
       },
-      "doi" : "https://www.example.org/52e98a72-412e-407a-8f74-4f01bc6322ff",
+      "doi" : "https://www.example.org/67aae370-6fe3-4cbb-bcc1-273673dd040d",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "mr3z1YnZPXh",
-          "end" : "omLtG4jK6komFU2JK"
+          "begin" : "HaJdRGj7qQ0cmDTLVt",
+          "end" : "d3eOe41rtEMOLRL66iE"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/287ca62f-4b79-4cd7-8975-9d85ca0e4319",
-    "abstract" : "BLlEa6OZQUq"
+    "metadataSource" : "https://www.example.org/d09268ec-4bfc-4498-9505-4a736210802f",
+    "abstract" : "RbgMaywDIsmZ0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a9f5ada2-6a1d-475a-96a3-403cbb3d4c82",
-    "name" : "CSsNOjQzbJkUqmoerg",
+    "id" : "https://www.example.org/aadbfb5e-71f0-48a4-86b0-be2f561cc2df",
+    "name" : "g7Ws11QLMw",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-08-02T13:58:10.985Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "gwm9kZmOlGrrG"
+      "approvalDate" : "1977-09-12T05:51:51.033Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "gBGXw6ZHdX5VIP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/09007486-9599-4c2b-bc4a-37488b56f0ac",
-    "identifier" : "ADmQjKgaf2oXD5tLoib",
+    "source" : "https://www.example.org/1bb76149-b87e-46bd-982e-0db9b01266cb",
+    "identifier" : "3K3qnlGTXp5AtXRP",
     "labels" : {
-      "fi" : "GdhOc92UzNT10L1InF"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1438889399
-    },
-    "activeFrom" : "2020-01-26T10:43:36.820Z",
-    "activeTo" : "2020-11-27T04:40:36.509Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5bc018e1-a514-4165-bed8-99edef462086",
-    "id" : "https://www.example.org/bdf219de-77b8-42e8-8041-0606d265e014",
-    "identifier" : "D9pVLBjyJxj",
-    "labels" : {
-      "fr" : "d6XUCpwGglZq"
+      "es" : "UC4qcrvJjVQM4wL"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 569884620
+      "amount" : 425073310
     },
-    "activeFrom" : "2017-11-16T14:31:52.502Z",
-    "activeTo" : "2021-10-03T15:47:22.218Z"
+    "activeFrom" : "1986-04-16T18:44:50.997Z",
+    "activeTo" : "1989-01-06T18:29:26.371Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/7c2e27c8-9414-41ec-abfc-491b29bd385e",
+    "id" : "https://www.example.org/e06043c7-1687-4875-87d2-f80eb6806669",
+    "identifier" : "JwJt511bn7",
+    "labels" : {
+      "fi" : "VtZuojs5JXOFL"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 538583966
+    },
+    "activeFrom" : "1982-07-05T23:35:40.936Z",
+    "activeTo" : "2015-08-24T01:52:21.053Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/c040c611-009c-4db1-9a02-51089973c206",
+    "sourceName" : "wtiqg6m2sqocefh@ek3fbwivnkwhwawe"
+  }, {
     "type" : "CristinIdentifier",
-    "value" : "899132675",
-    "sourceName" : "f0fb5hn3aury3f@neeemy8ogpk3"
+    "value" : "1246754853",
+    "sourceName" : "qz0pg55oxvs@zuj69to6t0zo"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "9GrzoIGH9BQciB",
-    "value" : "rTiLL7Uy3dfHvX3"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/eedb357c-b05d-4c04-92aa-193afd5c66b1",
-    "sourceName" : "4ygzpj8l9g1mgdwopwo@fohdn2pzm9oounaub"
+    "sourceName" : "hSSjURPDgD5IKu",
+    "value" : "uyTOUfjR2Px"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "jcgpWEtWIAxAl6",
-    "sourceName" : "fzgk8ntimq@vxbnkfifbcpaitmkk"
+    "value" : "9gfPLYOtMV",
+    "sourceName" : "j16584vsf2l30zns9v@tb2vumoehadr10u"
   } ],
-  "subjects" : [ "https://www.example.org/c62f5a74-42f2-4f76-bbf1-fa26e548ee02" ],
+  "subjects" : [ "https://www.example.org/51818b3b-521e-4363-91a2-367f07932782" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0049bf4e-7c90-44b2-9d35-6e580f6cb728",
-    "name" : "zHg43J1uxVgLqtvXm",
-    "mimeType" : "cwVw1L5B9QW3JcDETY",
-    "size" : 301705488,
-    "license" : "https://www.example.com/wrt1yjcrgj6yqt3qflp",
+    "identifier" : "256859e7-b2fe-4311-99f4-dcda077976d8",
+    "name" : "Tmjdju1T9GUqMX",
+    "mimeType" : "0mhSpFWOCIQs1ABLHa",
+    "size" : 312296569,
+    "license" : "https://www.example.com/b3lcyahmqjvaodhqe",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "fBAdqCOUGLSPBJ"
     },
-    "legalNote" : "KZmCMie3f5CyQXf",
-    "publishedDate" : "1984-08-20T09:35:35.319Z",
+    "legalNote" : "5nFFQTGpwoSD",
+    "publishedDate" : "1983-08-25T21:56:50.623Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1213173589@RPjUbfQlg3Gcmgps",
-      "uploadedDate" : "2005-08-08T11:00:54.129Z"
+      "uploadedBy" : "690217832@Dafqvhtx2YlS5xOIZzN",
+      "uploadedDate" : "2009-06-02T09:06:01.563Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/cCnl8Nwu1kIDw",
-    "name" : "jIVzMhfgFaNX4yYlg",
-    "description" : "GKnkJN3k6dLPL"
+    "id" : "https://www.example.com/PV53tbKEetCU",
+    "name" : "rsKpvYky2Kqx6Tjze",
+    "description" : "OTC5iAt2ycboRvI"
   } ],
-  "rightsHolder" : "KrdwYlbfSiwcOMTvxW",
-  "duplicateOf" : "https://www.example.org/bb7efed7-4d3d-4463-81bc-71b2166ec30e",
+  "rightsHolder" : "oJHpzlBrWW",
+  "duplicateOf" : "https://www.example.org/5651ed06-11ea-40e7-84e3-557ddbe787ff",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WisHXxS9qtjpHk"
+    "note" : "gwa4I2tvtCJ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "y2bhkYSJvPUwMxr",
-    "createdBy" : "TlRddGYcJU0EDT04LKq",
-    "createdDate" : "1976-07-25T23:29:23.471Z"
+    "note" : "dEuCVSrQtXVcQIjMeS",
+    "createdBy" : "xFnddaD3lsTuz4FXF4e",
+    "createdDate" : "1982-07-02T03:54:20.059Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6d8f524b-89d1-46ff-be29-4990b0843074" ],
+  "curatingInstitutions" : [ "https://www.example.org/c504b49b-1802-48aa-afd0-981a72e7c7cb" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "k1HywH523YPGxfEFtzk",
-    "ownerAffiliation" : "https://www.example.org/c6a3379b-60b2-4b58-8e1b-619efd88e93d"
+    "owner" : "fJNovBKiqyd",
+    "ownerAffiliation" : "https://www.example.org/0c854336-e6c4-4f59-bc51-d4c920f3151c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eed48a87-ee45-4352-b373-049f48c7908c"
+    "id" : "https://www.example.org/f57a613f-c99c-4368-b4ef-9986cc04a229"
   },
-  "createdDate" : "2000-09-22T23:55:52.402Z",
-  "modifiedDate" : "2023-07-23T23:20:30.515Z",
-  "publishedDate" : "2005-12-13T04:56:47.961Z",
-  "indexedDate" : "2023-11-18T00:04:40.919Z",
-  "handle" : "https://www.example.org/ed50d994-c09c-466a-9948-45344be0a850",
-  "doi" : "https://doi.org/10.1234/illum",
-  "link" : "https://www.example.org/305a31b3-7d7f-4bfe-9404-5523d1c94aab",
+  "createdDate" : "1971-10-16T04:18:19.068Z",
+  "modifiedDate" : "1981-04-19T17:53:40.451Z",
+  "publishedDate" : "2008-01-22T13:25:59.194Z",
+  "indexedDate" : "1989-08-17T22:20:01.830Z",
+  "handle" : "https://www.example.org/4514ca01-c1dc-4da3-bc7d-bcaa75f4a424",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/5dffa084-68a0-4d7e-88d0-4232b6de7e35",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1D2hfHPK7GZnl2MiA",
+    "mainTitle" : "7x6CkfrX02BJzkAdGBF",
     "alternativeTitles" : {
-      "fi" : "vKmB69kO6BT"
+      "de" : "YLq1pbXhvfA516yEH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qoDZKQaobIyjc",
-      "month" : "tKAjHMLBaoe67mET",
-      "day" : "h4eODnNH6mttg"
+      "year" : "9J4Ir9QKnFu0wdc",
+      "month" : "wS26MMsnaA8qpWofPk",
+      "day" : "d23wwrG6fw96"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d1cddf44-ccb9-44d5-b591-4488f2b69649",
-        "name" : "cs4UESKbpDn9QZIx7",
+        "id" : "https://www.example.org/d0330def-85fb-4127-9796-a8234438c33b",
+        "name" : "3gx3nHYS1ALtBnuXvAY",
         "nameType" : "Organizational",
-        "orcId" : "xv0t6dOKnx09wzNui",
-        "verificationStatus" : "Verified",
+        "orcId" : "RAfiEGLFiVASbRUSA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IPA8S8yMAHTHP",
-          "value" : "0gCta7TA9ci7iGtON"
+          "sourceName" : "02iVbrQS9hr4uAO",
+          "value" : "3T8NJSEJkexjNzh4Kp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4WLcApNsRPOoG0C9",
-          "value" : "Kjkh4wubKssMHy"
+          "sourceName" : "yxQjzq3zZTMu",
+          "value" : "wd4BR306JQs9Nkltak"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/19fc6707-5080-4951-b22c-9edc18426168"
+        "id" : "https://www.example.org/c8bc5637-3981-4ea0-95ab-e772946afb60"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a795123a-3da1-4183-b11b-d82098baeb51",
-        "name" : "cng63s3UpA3kU5T",
-        "nameType" : "Organizational",
-        "orcId" : "57p3VOwOg2RYold4",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/5b9ea425-f40b-423e-863b-0374d8141fb2",
+        "name" : "Bu8uPo74bOe",
+        "nameType" : "Personal",
+        "orcId" : "10ZxebH5xutv2vBEDP",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DxUw7xZ71J",
-          "value" : "Q08vTIwzVU"
+          "sourceName" : "NtxYMyWoUbh",
+          "value" : "vuAYN2UBzCeP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CjrHttIt1AcL4S3FyFJ",
-          "value" : "2xMAsvdi4ozxpvZh"
+          "sourceName" : "3jPYxO2YD31TCrr",
+          "value" : "WLtJT9i4RUwEJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/63a2334c-4643-43a7-b2bc-ac3b43efd757"
+        "id" : "https://www.example.org/0664e3ee-6459-450d-92d7-ab27b7c6aba9"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "ZNT2mEEpWaWrse"
+      "bg" : "Z1CqRuJjZcvFg"
     },
-    "npiSubjectHeading" : "DOLjk2POJlG9QSv",
-    "tags" : [ "6qXNl2ThEB6pGRN" ],
-    "description" : "jM9MgxcYGA",
+    "npiSubjectHeading" : "X2k8oFzuQFuk74hyDz",
+    "tags" : [ "R8qcQrx7AlQ7l" ],
+    "description" : "6qvaSbpXIH0aMHETJPV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7fd7a5e7-9ec6-4521-97c3-46127c630053"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/67e709a7-1bdf-4cd7-a0d4-fe2b85fe193c"
         },
-        "seriesNumber" : "O5MUjK4VF9U4QhIiwiQ",
+        "seriesNumber" : "zuTOKFbWVsAA",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ed0b7e71-49e4-44ce-9a85-6ddbf1b7ca7a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/701969fa-3c73-45b5-852d-f7e544e28b87",
           "valid" : true
         },
-        "isbnList" : [ "9791926044612", "9781727086072" ],
+        "isbnList" : [ "9790000839380", "9781957324289" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1727086074"
+          "value" : "1957324287"
         } ]
       },
-      "doi" : "https://www.example.org/b67498c3-92e4-4d8a-b722-145d87e167ce",
+      "doi" : "https://www.example.org/a1b55e31-3908-4441-b31f-805f0f5d28f3",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "uH1T2y70li4J",
-            "end" : "z2XZsppigbcmAs"
+            "begin" : "cYAj8CXsSc4uDmL",
+            "end" : "Yf1rEZGWZuvUmEStmUv"
           },
-          "pages" : "gaFfGXJvF4fnOTAew6",
+          "pages" : "5WcmDCdEa6JyPRZYhh",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c66cb149-10b4-480d-9286-f9d09362982f",
-    "abstract" : "d4mpsFosKs"
+    "metadataSource" : "https://www.example.org/cd4906a3-69d9-49dc-8022-39b8cdfd22a5",
+    "abstract" : "NpuX7lRAict"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f6ec2a2f-253b-4f60-a87b-5aec368abcb1",
-    "name" : "FEYvDmpctzo7jJc6T",
+    "id" : "https://www.example.org/8381e6a8-8788-48fc-82ed-817acc5ced6b",
+    "name" : "rlTNo4tgbHnpiRY",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-09-11T23:26:05.897Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "oYjSxxHfyTDQw3gpOJS"
+      "approvalDate" : "1987-08-23T16:02:31.575Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "2pxvifQ2NaeMf9fN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/628261b3-6620-434d-830d-edac3a499fa4",
-    "identifier" : "C5ACrifB9LB39MJZLL",
+    "source" : "https://www.example.org/b9c80d85-fdb4-4d14-86c0-d553f959e74e",
+    "identifier" : "5Gvi2J2v3uIJ1uA6",
     "labels" : {
-      "nl" : "YvWmj27MsQrDG"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1870541890
-    },
-    "activeFrom" : "1993-03-30T16:40:23.332Z",
-    "activeTo" : "2011-10-05T02:03:29.057Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8ce2c7f3-8fcc-4b7a-8e17-cdfb6f046bcc",
-    "id" : "https://www.example.org/4f5f6629-66e8-4712-a789-11f8e17de264",
-    "identifier" : "jn7JrJ9vEat",
-    "labels" : {
-      "it" : "iR2fdwbteneIWrQ8dc"
+      "nl" : "ntQsUqCk6XH"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1631826526
+      "amount" : 1359043496
     },
-    "activeFrom" : "2012-12-15T12:05:13.252Z",
-    "activeTo" : "2022-09-09T06:38:21.044Z"
+    "activeFrom" : "1987-07-07T14:50:22.254Z",
+    "activeTo" : "2010-07-18T01:09:36.799Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/f0f755c2-b13f-4dbc-8b39-47897bebe066",
+    "id" : "https://www.example.org/42d98711-d742-4056-89b6-239ff0b8e477",
+    "identifier" : "D1OAMszoACW",
+    "labels" : {
+      "it" : "7zLf2em0oRMhVnkKQl"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 105468105
+    },
+    "activeFrom" : "2017-07-19T18:26:09.760Z",
+    "activeTo" : "2024-05-22T08:43:05.133Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "eSdQT9pE6T3EumqBL",
-    "value" : "TIHFboDjXVkgo"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "pI4VcMvAKlp",
-    "sourceName" : "mlnchqbyhn2ab@dxerjasitfi"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/22ee3369-138d-4dd4-a75b-febefd26c5a9",
-    "sourceName" : "8ddadrevl3qbwytbh@lijejczaagymrcjzed"
+    "value" : "https://www.example.org/bde35836-b8a0-47e1-934d-9cc03d9d9528",
+    "sourceName" : "1xnc1yviidvpx40e4@rv5quchcuwcds6fsawf"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "1023581101",
-    "sourceName" : "ctererergwy8@ov3ixehd1d"
+    "value" : "1072905338",
+    "sourceName" : "a86gj6tc4et7c@dejoxnx3au8g"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "oeiU9maVhOiZ6DG1cA",
+    "sourceName" : "p4plxxdw7psvu7@zy1phkfrpgxhk"
+  }, {
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "t6uFyICcF6f5Yqh",
+    "value" : "zBnbZyyKjkrQxg9NbP"
   } ],
-  "subjects" : [ "https://www.example.org/e3212b34-b2fa-452e-9206-9e15ac207638" ],
+  "subjects" : [ "https://www.example.org/a1a4eebc-bd4d-418f-853d-1bd72a71aa1c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1dc03421-ff79-41cc-ba7c-e6ae225903b2",
-    "name" : "fnSGoqFAym",
-    "mimeType" : "LEWsvpSLwveNE",
-    "size" : 634418211,
-    "license" : "https://www.example.com/rwpp6hdjbx9ob",
+    "identifier" : "bccd21cd-b466-404b-a9ae-3cdd5bc9ffe6",
+    "name" : "XA8tKqKhkfXBdGT",
+    "mimeType" : "01l2GaCqjn6IvzUJhp",
+    "size" : 35926425,
+    "license" : "https://www.example.com/yvlfqp8lm5lynzv1lhu",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "HBrOC3YyoccK",
-    "publishedDate" : "2016-03-22T15:33:13.221Z",
+    "legalNote" : "RPjVYZ88pLDmDLZ",
+    "publishedDate" : "1990-04-04T10:27:43.838Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1921717273@ynueHkewqyrojqaF",
-      "uploadedDate" : "2008-03-14T15:19:07.982Z"
+      "uploadedBy" : "1838183491@mrrjTBFiLcush",
+      "uploadedDate" : "2011-08-25T21:56:43.264Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/INNroTwMSs",
-    "name" : "IorzSxgQGVK9m",
-    "description" : "c3z3NQHjyl64rZ"
+    "id" : "https://www.example.com/dsIL8GBuw0h",
+    "name" : "2YLmOcHGRF",
+    "description" : "3KaHIeOl80SK1bSXrXM"
   } ],
-  "rightsHolder" : "CbkftA18u4",
-  "duplicateOf" : "https://www.example.org/b714f5b1-8500-4a41-bf05-d5d21769891d",
+  "rightsHolder" : "MBOemeJiY3v",
+  "duplicateOf" : "https://www.example.org/4facd0df-37d6-40b1-bb5e-999b973cc9ab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "nKAvr3SZpFuamgn"
+    "note" : "KssX3tydUf8UtrGn0F"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1eFFKd1JDTGdW2HV8y",
-    "createdBy" : "cslJZZcwnwhaXWsh",
-    "createdDate" : "1982-02-26T01:16:22.069Z"
+    "note" : "AEjBZXnsQR1pf",
+    "createdBy" : "Ui3cYperk9UgFbiCWw",
+    "createdDate" : "1973-11-03T06:31:16.492Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/119547b7-2e76-4cb3-95a0-e8ba483e9281" ],
+  "curatingInstitutions" : [ "https://www.example.org/321b5601-64de-44d8-9daa-767c7f2ed439" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "avtfqzNdsZ6",
-    "ownerAffiliation" : "https://www.example.org/32378b78-6653-4da0-8f80-5a2f26263062"
+    "owner" : "OTiXx7sz5JRqr",
+    "ownerAffiliation" : "https://www.example.org/913ddc3d-d2c5-460f-bb4d-a2f9d405d321"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/43e433f8-b3f5-4c3d-8ba6-0ed3ead118d6"
+    "id" : "https://www.example.org/ea04fd0b-8b47-4c4e-a546-730de5f22be9"
   },
-  "createdDate" : "2017-02-18T04:22:15.975Z",
-  "modifiedDate" : "2001-11-05T04:09:20.576Z",
-  "publishedDate" : "1973-10-16T11:57:49.594Z",
-  "indexedDate" : "1981-07-19T07:10:59.793Z",
-  "handle" : "https://www.example.org/bd29e294-fdc3-453c-83e5-ab68188d4665",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/c64bfb97-f2e9-4362-aa95-b515c22a7ed7",
+  "createdDate" : "1996-08-18T16:11:59.180Z",
+  "modifiedDate" : "1978-09-27T19:57:42.669Z",
+  "publishedDate" : "2013-09-28T18:56:39.519Z",
+  "indexedDate" : "2024-01-30T21:50:34.336Z",
+  "handle" : "https://www.example.org/5cf49ac3-b5c5-4016-a66d-eb8e5c3b5c2c",
+  "doi" : "https://doi.org/10.1234/sunt",
+  "link" : "https://www.example.org/495c934b-8fb6-421c-a6ba-94657b93e1db",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "szSNA8HscuGbwr1db",
+    "mainTitle" : "KnGCk7zExd5",
     "alternativeTitles" : {
-      "bg" : "f6KqwAcKTZKlb4a4"
+      "pl" : "qiuFmQN7wuc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HWWVzrs3FP",
-      "month" : "BuNT81WqPmZ6tE8",
-      "day" : "YdQJ1RztZHWzq5jZQCG"
+      "year" : "6Jt5OA2tUPk7vNZ",
+      "month" : "i3eHasUjhjmD",
+      "day" : "MZvHvdPUma7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/670724b1-4622-49d0-9c53-eb3540813983",
-        "name" : "BOZ515RJ7pjCX",
+        "id" : "https://www.example.org/e27d1326-7df4-4d5b-ab4b-0b3b819e4601",
+        "name" : "Z5pQoVzNQJto",
         "nameType" : "Organizational",
-        "orcId" : "WRYb1foSYun",
-        "verificationStatus" : "Verified",
+        "orcId" : "l6L4eeB0YUxVzR",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o3aHYtVoDtP1w",
-          "value" : "VADKUV6GmlmJSngY"
+          "sourceName" : "lKgcGv9a4UxB7OAp",
+          "value" : "L1BIRU9ARFOj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ifAUUAv8KkZi0E2I",
-          "value" : "OnVuOQAiaaIE"
+          "sourceName" : "0UJ9Ho3CgVg",
+          "value" : "F162TowazZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a1bf84c9-2a6d-45de-94da-ebc591e64919"
+        "id" : "https://www.example.org/8c7538e3-eaa7-40e7-a6f9-d124b8ccbf3c"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c48c58b4-08cd-4f07-800b-5c91d007f7d7",
-        "name" : "dxDcg76H5K",
-        "nameType" : "Organizational",
-        "orcId" : "ofgKSsEE6nP9RYgx",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/eed01a01-be1f-4741-96b0-fb079cd89a2c",
+        "name" : "TPEfLjMuhdoJgSko",
+        "nameType" : "Personal",
+        "orcId" : "CqV7gDFcDYJBZTWH8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4YFD6578O0Ex9N",
-          "value" : "X4FwmAaHUMQ"
+          "sourceName" : "VxmP4k7SBFGAzP",
+          "value" : "y35Zeo26nN2zTDxqQd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9kvuaK2wjI7",
-          "value" : "eLuYQixiicdTn"
+          "sourceName" : "w1a4n4u3toWa1j8",
+          "value" : "V1WcKYjEdwjKenfdHpP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b739bdab-8b60-4a6c-b738-c90dbc87c23c"
+        "id" : "https://www.example.org/5041e2fc-cd17-4c0d-943b-dc012bd8aae9"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "ZDMsXu70Xn"
+      "sv" : "eycbKgOHFcLhRuj3GV"
     },
-    "npiSubjectHeading" : "pTT3LJG2BT4zj",
-    "tags" : [ "yCGT49jVGQu2" ],
-    "description" : "NfIqb5PZ7yC0m09Kf",
+    "npiSubjectHeading" : "JomygiPPvoXF",
+    "tags" : [ "XmHjQyEZlr0aJn4g" ],
+    "description" : "rU0oQYqLzWpiZvyHZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/789f861b-629d-4e70-806f-91f004bc6b32"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f3fb2813-5ca5-4417-8ae3-e1e48962ce70"
       },
-      "doi" : "https://www.example.org/5efbecf1-b92d-4a1c-8d1f-8e6db4b284c7",
+      "doi" : "https://www.example.org/275743ac-77c6-4d09-946e-df37652d78bd",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "Se9RT7aNw4TfH",
-          "end" : "ZlmrdZQdDnKVgA"
+          "begin" : "l55aQb0hX82WI",
+          "end" : "1YEFU3Ak1lZWCcWAb"
         },
-        "volume" : "84Mh8ki7r8",
-        "issue" : "3x0cAqDiQNyC0PD1uD",
-        "articleNumber" : "PoWeV7K41GMqOm0QWv"
+        "volume" : "j9ZsrPhEC2",
+        "issue" : "T7jTpYibpcuyvbw6o",
+        "articleNumber" : "6SPkbbu2LJXWdtG"
       }
     },
-    "metadataSource" : "https://www.example.org/245a636d-0411-41b4-895c-2550ff0554d2",
-    "abstract" : "5Bc4G2fQsykTABpz"
+    "metadataSource" : "https://www.example.org/3fa8a80e-1e69-4a1b-844b-47254d428e73",
+    "abstract" : "FIrE1rmdHZA9oASwED4"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/719144a3-f36a-4c77-9421-a23c210c75a8",
-    "name" : "Up4R9PCBMEDsZq",
+    "id" : "https://www.example.org/b2aeb19c-8e53-43df-98a2-12235e1114da",
+    "name" : "ynIYPc3EEGMgvn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-04-09T11:26:53.197Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "vCPof1iVrsv"
+      "approvalDate" : "1999-02-10T20:43:07.289Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "a4jSAFe5fmK5cIlX"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/251d3930-8ed4-447e-9526-c8f5db073741",
-    "identifier" : "iPMXT4tCDU",
+    "source" : "https://www.example.org/8dbd5cfa-64f1-44f4-b2b4-7ce94b7ec5c1",
+    "identifier" : "JR6YnQkLS62MnEJ93lg",
     "labels" : {
-      "nl" : "jXUn3ebBX4v"
+      "af" : "upSCuHdpzI"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 181278104
+      "amount" : 1384985824
     },
-    "activeFrom" : "1989-09-01T01:46:27.935Z",
-    "activeTo" : "1996-10-03T12:36:11.441Z"
+    "activeFrom" : "2014-06-02T12:35:06.756Z",
+    "activeTo" : "2016-07-12T04:42:24.466Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/be821960-17ea-4dc6-ae8d-87fe48e0dad5",
-    "id" : "https://www.example.org/051d2628-cb01-4ea7-879b-f1c785bf16c9",
-    "identifier" : "mqBMf7DEbPH2V",
+    "source" : "https://www.example.org/af93d1ed-559d-4833-a468-ca643d760632",
+    "id" : "https://www.example.org/6e84472c-e0df-43ee-8b20-9872dc46941c",
+    "identifier" : "cKdAp9lx19eqabAjH",
     "labels" : {
-      "af" : "YmhvueqAMVMRso1"
+      "ru" : "X5iqIWvQy5Sofsca"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1705436466
+      "currency" : "GBP",
+      "amount" : 733686939
     },
-    "activeFrom" : "1983-12-17T18:01:38.132Z",
-    "activeTo" : "1995-12-24T05:54:54.704Z"
+    "activeFrom" : "1975-07-10T02:46:55.492Z",
+    "activeTo" : "2023-08-06T06:14:32.745Z"
   } ],
   "additionalIdentifiers" : [ {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/cec257f3-8dd0-48e0-b426-17a87ffeff5a",
+    "sourceName" : "3fu6juydykhi7i3@sdearnqwlxgtwn"
+  }, {
     "type" : "ScopusIdentifier",
-    "value" : "A0JnnCyJIfWmwK0Ik",
-    "sourceName" : "ecbxwsiysgdxesscr@qk1shzu7chz"
+    "value" : "tMUUzdLosH",
+    "sourceName" : "nakmdwe6w9pztdji@qdit0ibdltz"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "372379809",
-    "sourceName" : "vukegysouziece5q9@cyggrfsaaecnkqk"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/bab1de35-0f9d-4948-9755-61e1e771715d",
-    "sourceName" : "zlwibs2xlpu@jyqiucpuvp4mf5n"
+    "value" : "1119736643",
+    "sourceName" : "ifcizagcefud8@e612tubswysdkl"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "XNOvAblwbWMZw5XT7",
-    "value" : "pefocibEsz"
+    "sourceName" : "SjfGWqNsoActKj",
+    "value" : "IpAtczavpG4t"
   } ],
-  "subjects" : [ "https://www.example.org/560b7055-9389-42dd-9e2d-935439e81cdf" ],
+  "subjects" : [ "https://www.example.org/4ad94272-e11e-473b-a9f9-ace76aa75751" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6aee685a-0d5b-4b49-9b1f-e3ca64e92b6e",
-    "name" : "pFeWqNcHFiGxSXZ",
-    "mimeType" : "PCITvWpkjTq",
-    "size" : 65193486,
-    "license" : "https://www.example.com/irit6y6o09",
+    "identifier" : "dd01d63e-318f-4488-a602-df80afc27f75",
+    "name" : "1kliYgmOFH",
+    "mimeType" : "rtx6L8eo7A",
+    "size" : 454461765,
+    "license" : "https://www.example.com/3ab6hwmt0wzbz0sqkz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "62xGuXhqxqlVLP"
     },
-    "legalNote" : "S8wb4DhVQrSUk",
-    "publishedDate" : "1988-04-09T18:29:32.908Z",
+    "legalNote" : "4V7EFWA0O7Rp8bCy9xM",
+    "publishedDate" : "1984-04-15T05:10:53.971Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "48085196@F3sC6HgrFSjPqnxY",
-      "uploadedDate" : "2018-05-09T05:00:50.800Z"
+      "uploadedBy" : "1660142145@WjvuwENYowAKqf",
+      "uploadedDate" : "2006-09-27T10:40:17.634Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/vLMckpzPeG",
-    "name" : "i6Mqdv31HML3Z",
-    "description" : "tL3YJF2tP1nw"
+    "id" : "https://www.example.com/ohOrqY0xjGdIDKzlw5",
+    "name" : "5bKMI7dRlME",
+    "description" : "P94JzWpQUvVNeGZ"
   } ],
-  "rightsHolder" : "hxOFpUNtPXvya4QbS",
-  "duplicateOf" : "https://www.example.org/92649b49-3bdd-4f9b-96d7-3ece15f4fa2a",
+  "rightsHolder" : "IuHNJu0NInreCXn0",
+  "duplicateOf" : "https://www.example.org/75c0550b-05f3-4f81-b131-70ee41a9548b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5ODCuOiBpu0"
+    "note" : "Cbsg6wfFG9eail6EWf"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "XYNlSDaTvzrfxjs",
-    "createdBy" : "UhURvX4cSDHp843P",
-    "createdDate" : "1981-08-24T11:02:55.900Z"
+    "note" : "ZP8dSLcoGTJSpmdAm",
+    "createdBy" : "ESYt9AoqmqY1X",
+    "createdDate" : "2014-09-10T12:15:33.243Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/71208b20-912f-4b1b-a49f-a934800d6123" ],
+  "curatingInstitutions" : [ "https://www.example.org/75e5f780-bbf2-44a8-93bc-0996453bf125" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "LykjgZBL8Yc",
-    "ownerAffiliation" : "https://www.example.org/ec14b96b-0922-4cc8-bf93-cb752432990b"
+    "owner" : "cctElwuwQJ",
+    "ownerAffiliation" : "https://www.example.org/122129d0-9dbb-42a6-8703-fb1299a19177"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/79275cb1-834e-4557-bee3-1b97a1fe0a09"
+    "id" : "https://www.example.org/19059f1b-9606-4e5d-806f-2c8245903565"
   },
-  "createdDate" : "1987-10-13T16:51:53.548Z",
-  "modifiedDate" : "2020-08-05T18:08:20.432Z",
-  "publishedDate" : "2022-09-15T13:08:05.643Z",
-  "indexedDate" : "1979-12-16T22:18:26.062Z",
-  "handle" : "https://www.example.org/f4ebe5b8-05c8-44b6-855f-edf313161f41",
-  "doi" : "https://doi.org/10.1234/iusto",
-  "link" : "https://www.example.org/feb085cd-2a96-43f5-b4aa-234d770ee7d1",
+  "createdDate" : "1971-03-17T17:04:30.435Z",
+  "modifiedDate" : "1978-08-17T06:15:53.527Z",
+  "publishedDate" : "2019-12-01T14:37:08.610Z",
+  "indexedDate" : "1992-02-03T04:49:38.505Z",
+  "handle" : "https://www.example.org/fd22519e-9040-4cb5-bcf5-1c1296a8763b",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/bc23f76f-6b2c-48b9-9b41-98504713f3cb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tNa0TSjD2eabbsf5M7k",
+    "mainTitle" : "flq9HCjjOUvJ1RkVY0",
     "alternativeTitles" : {
-      "it" : "ZxBl6y6SjwUL0HDW"
+      "it" : "Xs8YWCfE0QGkhvbv"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "kCYMIazjZnKVmtiCgO6",
-      "month" : "N7aSgtWfqDmT8sPtH",
-      "day" : "rqpygAV8f6u"
+      "year" : "QenVwYnu7R9k3s",
+      "month" : "XLbXqetxO3XBmhNr",
+      "day" : "kjdkAx5bdZqe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cf2c94d9-6bde-451c-9cf7-8f78ab95152b",
-        "name" : "GUPSu4Nx8eKcg0",
+        "id" : "https://www.example.org/24ee0d22-7322-4356-9cbd-43a95a513bf1",
+        "name" : "E8fR8t8HkmANyRFi4",
         "nameType" : "Organizational",
-        "orcId" : "V3autxnpwfVY9BwzUuG",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "4Pb6OG9lzlQ3",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HUtlgyOHjB1",
-          "value" : "2Xar2TiQCbZ"
+          "sourceName" : "qkAR4DALGc6riJqf",
+          "value" : "rtuzDoYRxP5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7dtW8twbYNH",
-          "value" : "EAHZW6GP11EV"
+          "sourceName" : "CR7Fbi7uA1cXT7uCroJ",
+          "value" : "l6wSC0TCevyAvUH8SYa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/01974088-6aef-4fe1-aa97-2aa082c55e1a"
+        "id" : "https://www.example.org/346afcc3-c160-4014-84bd-393a0458064a"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "Photographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/52e2bd66-a503-4ee8-b7ad-1a8f06900175",
-        "name" : "1PDT6IeUYQ2JP",
+        "id" : "https://www.example.org/ab1d35b9-8c1e-4b85-af78-56fd2aa7c844",
+        "name" : "VqVFNAfhEepTQ3Y22Ts",
         "nameType" : "Personal",
-        "orcId" : "imUiwhJDI9QE7x6Nl",
+        "orcId" : "wB9RNkBRPYvpnT2m2g",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "H2nTFCk8FZA",
-          "value" : "4F89d6TMbq"
+          "sourceName" : "iSpRcjJXRhC6P9jJ5F",
+          "value" : "0ss4XfIoiGEb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RlfcbK7sH2V",
-          "value" : "7rHzldZFSNXDnf"
+          "sourceName" : "hIaNVYuAaaZqd",
+          "value" : "chRWmqpuwFa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2ef70036-2a57-4508-930c-f72a56851807"
+        "id" : "https://www.example.org/8668fd34-cc09-4c50-860d-f3fcd94b6308"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "Izm43p60Rsoz"
+      "el" : "jGCUoV6VixcRJd"
     },
-    "npiSubjectHeading" : "HdJqjuttyG",
-    "tags" : [ "3MsPdYYGxgo4P" ],
-    "description" : "uDZY3tFIQ086rkJ5e6",
+    "npiSubjectHeading" : "zTsqosofyBmnR",
+    "tags" : [ "RveI0wLt9PO2eEaHaW7" ],
+    "description" : "e2CnnevdQOcN2hU1G2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/954c7f5a-1ce6-4a0c-ae0b-99372f98a618"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/97a0c685-eaf1-4475-a8a6-ebcefd1c5c7a"
         },
-        "seriesNumber" : "iIvmaLfd0YD",
+        "seriesNumber" : "dyylxDC8xW1yvs",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6ffd529f-48bc-4059-85be-cb52e574e0e4",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c30fe9fb-041c-4eec-b7ef-4d1e4078caef",
           "valid" : true
         },
-        "isbnList" : [ "9781795831987", "9780017243782" ],
+        "isbnList" : [ "9791309137818", "9780958120456" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0017243785"
+          "value" : "0958120455"
         } ]
       },
-      "doi" : "https://www.example.org/016d9ba5-6229-4dc5-84cc-639aca0dedc9",
+      "doi" : "https://www.example.org/805e7d55-312e-44f3-a3ed-b308cd9414d8",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zQQNRG4rxJ",
-            "end" : "ksnsaeyxV41nZgXv"
+            "begin" : "HiiAw9aPeq2d",
+            "end" : "GiFMu5IQmbhU"
           },
-          "pages" : "uf2I0P7YePQfZZn",
-          "illustrated" : false
+          "pages" : "0s1p3mQSHdE",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/aa90e647-b94b-430f-b158-f9c7f91054b3",
-    "abstract" : "ZIdhEarWJwAa3S9y"
+    "metadataSource" : "https://www.example.org/f211ce70-7467-4cf5-8ff2-0611a07ffe52",
+    "abstract" : "kIbXsIuf1CvbLjl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e6387a5d-ef16-4b71-b05c-13f6c94dd820",
-    "name" : "KTbdePvFTjg5skY1yNB",
+    "id" : "https://www.example.org/426b9461-bb1d-40b2-9bd3-32da6e9bd779",
+    "name" : "HrIFlgRxeXBEJiySQg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-02-28T08:04:02.082Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1982-09-13T18:38:05.379Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "8ZJntSdFxc58pxuJe"
+      "applicationCode" : "Nn89Q9temi7FkCeSMU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8d102f9d-e178-4055-b669-6c599aca6ba4",
-    "identifier" : "U8ck7oaY4Wm1",
+    "source" : "https://www.example.org/0c4955f0-d030-433f-9674-9e31974d9b2e",
+    "identifier" : "qQksCz9RJB2ZSsjXSOX",
     "labels" : {
-      "pl" : "9mwPFiPXqK9xC0V"
+      "de" : "5EwHJoESVjHlpy"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1501271667
+      "currency" : "EUR",
+      "amount" : 1754629843
     },
-    "activeFrom" : "2017-09-26T10:56:53.360Z",
-    "activeTo" : "2020-08-16T01:39:13.412Z"
+    "activeFrom" : "2018-06-19T15:15:41.814Z",
+    "activeTo" : "2020-08-18T03:48:59.913Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/57911def-b13c-453e-8a73-1012faa4af5e",
-    "id" : "https://www.example.org/175f2421-ecde-468c-af64-52538cd52c95",
-    "identifier" : "0qjYxIXlLFeJCW",
+    "source" : "https://www.example.org/b45a37bf-3611-4f42-ba5c-8eaf3c064ec4",
+    "id" : "https://www.example.org/8685eaef-266b-44f9-b7a4-8cfa1dc9f0e1",
+    "identifier" : "ZYGwymjXOp8cazz",
     "labels" : {
-      "bg" : "JvSeee83Iwovhc0kw"
+      "af" : "1RqP9R0etiEpaPyPeE"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 189306232
+      "amount" : 1441183902
     },
-    "activeFrom" : "1997-02-16T17:30:43.889Z",
-    "activeTo" : "2019-09-07T15:06:20.102Z"
+    "activeFrom" : "2014-03-21T14:03:36.704Z",
+    "activeTo" : "2024-02-17T07:54:54.998Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1102587382",
-    "sourceName" : "gcdesrupife3@m3dl6s32g5hzrjnthl1"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "oSvfoqTcnPQ",
-    "sourceName" : "ixtt3ljwthulyuwidfw@sfwp7wtqlx4j"
-  }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d34cf568-a5cb-4c4b-afe5-bda7a71595d6",
-    "sourceName" : "rclysrll0p@yewz8tnqpe0r"
+    "value" : "https://www.example.org/335ecb93-80ac-433e-a1fc-9eba9883ab41",
+    "sourceName" : "6vzpltguvgarrzmzbi@bztzgvkv5w9amrthv0t"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "L1wko8ze1KKlO4tfYQ",
-    "value" : "UYPurllrV1we23"
+    "sourceName" : "cH7uVsWfqp",
+    "value" : "q4xEqx4Tqwbov8LAl"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "976074479",
+    "sourceName" : "cbgronnvn3icvph@8pbapgrsslmqyfwqagn"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "lH5oDQSE74XY7Qd",
+    "sourceName" : "wwljq8rxxvsmwpt@2gwfcdaeypes"
   } ],
-  "subjects" : [ "https://www.example.org/9843a562-1370-4f16-9a7b-c70c6e1ffc3c" ],
+  "subjects" : [ "https://www.example.org/6bcfb3e9-4036-435c-98e6-984be967f037" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f68858e2-00cb-4a81-a19a-396f4438da85",
-    "name" : "OpX2drks8tD2",
-    "mimeType" : "S3udjQqmh0J6vE",
-    "size" : 1593799037,
-    "license" : "https://www.example.com/lmzqznzcd9om8e",
+    "identifier" : "c94fd696-874c-4f6e-9717-cd4170c0461b",
+    "name" : "akF2iRN26jcIOtZm",
+    "mimeType" : "gookLv6w3uCNlsd8Xdw",
+    "size" : 911536126,
+    "license" : "https://www.example.com/5nr2jhcmbcsq",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "PNqJPTKW7fQNmw",
-    "publishedDate" : "1971-12-25T05:25:58.989Z",
+    "legalNote" : "Ee6MOB0GJs3RTe8AEFu",
+    "publishedDate" : "1980-08-07T18:39:53.300Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "815940340@BiBFbBvQkrrMX8rOqO",
-      "uploadedDate" : "1989-04-29T12:02:53.581Z"
+      "uploadedBy" : "112944275@cfUM3AK91UFjdap",
+      "uploadedDate" : "2009-03-23T00:42:06.512Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/A5iAiHI9jfbMC8Awm",
-    "name" : "d5qYm0aDZ2zmR34455",
-    "description" : "nzZj0wG0EOH"
+    "id" : "https://www.example.com/VvasQvFxV6R",
+    "name" : "TfKqsvD6m1",
+    "description" : "ZwtP1rsghqD8QHTqWDx"
   } ],
-  "rightsHolder" : "JVZaO2twkYT7DW",
-  "duplicateOf" : "https://www.example.org/f58468dc-b800-4fde-9b25-e7842f37a41c",
+  "rightsHolder" : "sZ0qoXiyzZ9ced",
+  "duplicateOf" : "https://www.example.org/35b49aaa-bb59-4eb0-a845-515328acb339",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZgRkijpO3okgTqTAAP"
+    "note" : "chJfdtiGEaUm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "TGJeDKsLk2",
-    "createdBy" : "nAzbFSRPyz",
-    "createdDate" : "1976-03-10T05:01:46.683Z"
+    "note" : "Z1A3t2T68tkhx2uwzF",
+    "createdBy" : "GuhgLeymj6pJBu0VIh",
+    "createdDate" : "1995-02-16T08:34:03.537Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9300bcb4-f9c7-4a57-bc70-c6eacad9b776" ],
+  "curatingInstitutions" : [ "https://www.example.org/304aa3e2-fb10-4f52-b02c-b1dc3754b00a" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "6iiODIaw6i",
-    "ownerAffiliation" : "https://www.example.org/d1c0cbd1-6f57-41d5-8cb2-e673300befe4"
+    "owner" : "lhAjYFSgfu",
+    "ownerAffiliation" : "https://www.example.org/f2c5bb5e-eea3-43e4-8fc8-4455e3992431"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4bc0c733-16b8-4bab-a6b7-ca7ac47cab56"
+    "id" : "https://www.example.org/affdda2d-f3a0-4ca2-9fb5-c8163f587731"
   },
-  "createdDate" : "2023-11-13T07:23:54.497Z",
-  "modifiedDate" : "1988-11-21T16:13:26.935Z",
-  "publishedDate" : "1999-07-24T03:02:01.551Z",
-  "indexedDate" : "1978-04-23T21:22:27.022Z",
-  "handle" : "https://www.example.org/4e7dd5b2-ec7c-45fe-b644-1215bd08eba7",
-  "doi" : "https://doi.org/10.1234/officiis",
-  "link" : "https://www.example.org/7432fb66-ea9d-47be-9c80-bea13a33b501",
+  "createdDate" : "2013-03-06T21:04:23.910Z",
+  "modifiedDate" : "2022-08-04T00:54:17.855Z",
+  "publishedDate" : "1987-02-14T17:47:35.103Z",
+  "indexedDate" : "2005-04-26T18:42:26.743Z",
+  "handle" : "https://www.example.org/a21a5a3a-a4bc-480a-a293-c7132d722289",
+  "doi" : "https://doi.org/10.1234/odio",
+  "link" : "https://www.example.org/238ea5b1-4fd8-4270-9359-c4e6eed6e1ba",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9lk2hyBhmT",
+    "mainTitle" : "UQyeN19KtkoVY",
     "alternativeTitles" : {
-      "ca" : "fFtoLegSuM2ov2z2b"
+      "da" : "WPMivqUZSHW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0QHt4Q6enJEq",
-      "month" : "aVZoz3WIJZ2xK",
-      "day" : "IZaVXOi3XZGqKjaT"
+      "year" : "4j9AE2xp0tncA",
+      "month" : "DkUyI71B2UFZ",
+      "day" : "1oaSSFYZMpBMZnQc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0af5dd34-f4c5-4295-b9fb-2b464a8994cd",
-        "name" : "SxtS0nlPTxSQy",
-        "nameType" : "Organizational",
-        "orcId" : "QCFn6mhIdYJSkgFULZW",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f4d99b41-084a-499d-8882-da1eb299ac4d",
+        "name" : "LGWrND0qFOeSGw3",
+        "nameType" : "Personal",
+        "orcId" : "Q89zFaP1u0E",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6ZgBmibeTh",
-          "value" : "s6BEwVjmnp"
+          "sourceName" : "0CdoZRqFoXmUMGr",
+          "value" : "Bh72BR6V9aQl79C74"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "khug0rm1DNuO1py",
-          "value" : "JORe7LXHx7PxkPeU6W"
+          "sourceName" : "dQJ8nq2Qkmu2IoDv2M6",
+          "value" : "Y7ec0zkoRb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/03ab28f0-7372-4ea5-a267-02f7da336fc5"
+        "id" : "https://www.example.org/f7a2f58e-51b1-4329-b761-4d67a1f2861e"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/60a2ddab-6a5a-4f1e-b9d1-a24101318799",
-        "name" : "iJIplbeswU1TYv3y3l",
-        "nameType" : "Personal",
-        "orcId" : "geEjZcoiSZ5NvOFPbDq",
+        "id" : "https://www.example.org/19564e33-4b30-4560-90e6-2f9c44033cd8",
+        "name" : "ETSQoFt1Xa2ZUhmOy",
+        "nameType" : "Organizational",
+        "orcId" : "mecx5DGw1NI2WmP6Zg3",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CQelwpU2ZFKE",
-          "value" : "X3SH3HFfsKM"
+          "sourceName" : "XGqf5h4QwPrW",
+          "value" : "Oalj4uqjc67t8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EjBSsNb8E5aibVpW1k",
-          "value" : "g2aHi2YV0pihRouDDO"
+          "sourceName" : "dk8Kjxt19mijUb",
+          "value" : "uzSNbZxBoKsiP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/92d68b07-bb05-4d5a-8b39-bfc606f23c4d"
+        "id" : "https://www.example.org/c96fbfd4-be5b-4edd-87aa-5cf95871b6c4"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "wosDdwBx71yEw"
+      "cs" : "lzteIMTFz0wrII3"
     },
-    "npiSubjectHeading" : "HeabekjqEI",
-    "tags" : [ "svLZZG7pJge1mvcT" ],
-    "description" : "88kkzaozqA",
+    "npiSubjectHeading" : "HpnmzkqOuUy3az7f",
+    "tags" : [ "2WPYjztKq3BOzG0" ],
+    "description" : "uz5tyLiHPqSBT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1b64aede-1c66-4deb-adae-89e902fe4ffe"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6a04ee69-9254-4acd-b840-556761ab5939"
         },
-        "seriesNumber" : "3Tno5r7m15af",
+        "seriesNumber" : "aOl1lEbw9VBZnWzg",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ccdaeb44-eb2d-4268-a8c2-1367226dc5b8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/48484c4b-255d-4397-8e30-2330a4249ad7",
           "valid" : true
         },
-        "isbnList" : [ "9790008192210", "9781888523287" ],
+        "isbnList" : [ "9780097352329", "9781778262449" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "188852328X"
+          "value" : "1778262449"
         } ]
       },
-      "doi" : "https://www.example.org/1cf35351-2c89-4433-9851-3e7e7f035997",
+      "doi" : "https://www.example.org/6c657333-c84c-4656-9cc0-8247d1cf0979",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "uSH34VEJZ4J0koW",
-            "end" : "Rh2OO3GfIYlz7"
+            "begin" : "fWjdlBs8krej",
+            "end" : "QzE5v66k3XVcMSz9Prg"
           },
-          "pages" : "nB6jTOogJzg5KxYc6S",
-          "illustrated" : true
+          "pages" : "6BGcTKbk3q7zx00ROQs",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c8a42977-fa9f-48a1-b73d-d6d2423b90b1",
-    "abstract" : "F1kcRBMjdaEC"
+    "metadataSource" : "https://www.example.org/017571bd-414c-4c7d-84e8-31f96d44b9ab",
+    "abstract" : "8bzG4SptJspRGd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dde15454-e5aa-479c-9607-72227fa77c77",
-    "name" : "nnAEAHKfkjFf",
+    "id" : "https://www.example.org/f5a808cc-dbaf-4fbc-bbb0-15d1eaf7d823",
+    "name" : "5uDM8i8ZbSwsJa6N2H",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-08-21T10:16:03.945Z",
+      "approvalDate" : "2002-10-22T07:13:33.169Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "5Ma9tMIpgyp23PGYmz"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "yZ3gjmE1ncM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/af0dc752-afb3-43a4-ae8c-944cc2c41996",
-    "identifier" : "QIuxDHncuCHMebYsQ",
+    "source" : "https://www.example.org/87ae2e05-4c3c-4dee-b4ae-167607d7b37c",
+    "identifier" : "Uo07WraryRZ",
     "labels" : {
-      "zh" : "p5BVqiOfxw"
+      "pl" : "9tdPcr5am1atw"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 306403194
+      "amount" : 462218039
     },
-    "activeFrom" : "1982-10-06T05:26:25.857Z",
-    "activeTo" : "2011-12-02T10:48:02.776Z"
+    "activeFrom" : "2020-06-13T22:01:48.499Z",
+    "activeTo" : "2021-07-07T09:19:09.458Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/52c9e2e0-a6d5-4f29-8385-8027999c4fef",
-    "id" : "https://www.example.org/e77974e0-d536-4200-85b2-f9e6df14c839",
-    "identifier" : "wDlERAPtJn",
+    "source" : "https://www.example.org/564d908b-500e-412a-88de-6deddd5e100c",
+    "id" : "https://www.example.org/dabf3676-d51f-4fa5-b06d-914a43617c10",
+    "identifier" : "JT7irNkzvJ6flh",
     "labels" : {
-      "el" : "ceSDZzLjaEXJm6"
+      "pl" : "lzsISmFB8ZYI"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 533628582
+      "currency" : "GBP",
+      "amount" : 1390294173
     },
-    "activeFrom" : "2023-02-13T21:50:33.383Z",
-    "activeTo" : "2024-09-03T00:49:52.614Z"
+    "activeFrom" : "1975-10-16T20:09:50.093Z",
+    "activeTo" : "2008-08-18T16:18:26.053Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/0b322305-b85e-49cb-9266-80f6d09732ab",
-    "sourceName" : "rlrruelmlohsoda@silorv8huyf2o9k"
-  }, {
     "type" : "CristinIdentifier",
-    "value" : "937781227",
-    "sourceName" : "5ktajenyfof6nqp@xnooak4aeeril"
+    "value" : "298139251",
+    "sourceName" : "miuctjiryvixf@sicw9wvr6bghsqoinyf"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "ZlaHFW3fZZPNyunsId",
-    "sourceName" : "rdx1awpznk4z8c9tyf@6ntqepjims"
+    "value" : "qtp0JevGzZha",
+    "sourceName" : "qqs5sc85dv@f2jxjn7hvcgreguo"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/1ce63bd3-b93d-48cd-889b-d9b4f7113f3f",
+    "sourceName" : "9yka6unxfllwyxocs3@10fklrttuho48gsfna"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "5QgRTE1M1RwGBrN0l",
-    "value" : "2WbdumkRHtbLKszuJk"
+    "sourceName" : "wiUjWJLCjvf1SKEDClM",
+    "value" : "5gJesS3iHo5zQfY7wQz"
   } ],
-  "subjects" : [ "https://www.example.org/143ccfe3-4daa-48e1-8645-53fb5af977a0" ],
+  "subjects" : [ "https://www.example.org/7955928a-b487-4369-a6b9-6a9735b8a572" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c1bc1435-61b9-41a0-8e3a-3c8564d218ee",
-    "name" : "fd86k088Il5",
-    "mimeType" : "vBegq3O0U7RcxvI",
-    "size" : 739648104,
-    "license" : "https://www.example.com/fmr5un0prfsznd",
+    "identifier" : "e32029fb-2894-4a6f-9ad8-3f13c22561c3",
+    "name" : "CNQLw3Gvzgrb9",
+    "mimeType" : "atzt5C6jKnM",
+    "size" : 2123733974,
+    "license" : "https://www.example.com/5rvionkae6grvcg",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Zw17WfJAB2e1f9hxJ"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "JXiAX2U0qr2S",
-    "publishedDate" : "1994-05-23T12:27:01.998Z",
+    "legalNote" : "gaVpweItaOvM0ub3Ha",
+    "publishedDate" : "2016-09-21T23:12:51.832Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "732470902@DTckpQ90xv896O7",
-      "uploadedDate" : "1989-03-21T19:33:28.389Z"
+      "uploadedBy" : "1665304081@VK8VmXqa4IGjx",
+      "uploadedDate" : "2003-04-29T09:47:47.609Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/QqaFnZnR9Z",
-    "name" : "Zl4SzOHD5OWNpp",
-    "description" : "4SVorisTRZzQV9xFriz"
+    "id" : "https://www.example.com/dGT8GNAZaIw",
+    "name" : "MU80MHGmmA7NRq",
+    "description" : "hXAK4tk5nRE1r0Q"
   } ],
-  "rightsHolder" : "Sz2fUQg6ywsyzd",
-  "duplicateOf" : "https://www.example.org/7e417a16-60e5-42ba-8179-acd282975b42",
+  "rightsHolder" : "IswsLToQ06",
+  "duplicateOf" : "https://www.example.org/a0678e43-76a2-4771-9e13-30a6aa709c3b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "soIfRRJb5X"
+    "note" : "s0oyKVL4OJXp4Na"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "n6yEaVgceznOkj",
-    "createdBy" : "6OvyKTHOd5IaQury9r3",
-    "createdDate" : "1975-08-17T00:08:20.608Z"
+    "note" : "9kJrq0lLArbR3O55Ka",
+    "createdBy" : "FVvG8GuTHpy",
+    "createdDate" : "1999-07-09T21:29:06.472Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/39d5b4de-f71a-41b0-8001-9c11a308e695" ],
+  "curatingInstitutions" : [ "https://www.example.org/b35f0b42-9266-43ff-9775-fe34153cfb6f" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "3m254tLRZZ",
-    "ownerAffiliation" : "https://www.example.org/3645993d-77e2-4799-af0a-d9133969010c"
+    "owner" : "EqwnJLyhjZx4JU",
+    "ownerAffiliation" : "https://www.example.org/23e30eba-f0cd-4c15-882f-272eabf4c727"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/80cc570b-e407-4468-83ef-edefddcb9c89"
+    "id" : "https://www.example.org/dab3bb02-2d7b-42e2-bd43-5ea436c5cdf9"
   },
-  "createdDate" : "2003-06-26T23:59:45.270Z",
-  "modifiedDate" : "2010-09-14T08:32:39.128Z",
-  "publishedDate" : "1989-02-22T13:02:14.570Z",
-  "indexedDate" : "1996-01-15T23:34:15.993Z",
-  "handle" : "https://www.example.org/533c7ffe-6b1b-4f52-9e9f-21e1d6387b3d",
-  "doi" : "https://doi.org/10.1234/nemo",
-  "link" : "https://www.example.org/0792ef05-7b6c-43ba-9d89-78f2c6cc9eec",
+  "createdDate" : "2002-10-10T00:29:52.126Z",
+  "modifiedDate" : "1976-04-26T12:15:49.688Z",
+  "publishedDate" : "2006-05-03T11:34:29.195Z",
+  "indexedDate" : "1976-11-25T21:38:56.989Z",
+  "handle" : "https://www.example.org/4ba69601-61af-42e3-9ea3-c42c0982c37c",
+  "doi" : "https://doi.org/10.1234/odio",
+  "link" : "https://www.example.org/60bdded6-e184-454d-a9ea-4eec2faeddd2",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3K4iZUe9TuoP",
+    "mainTitle" : "PZtnoKaPeNoDeVPlWk",
     "alternativeTitles" : {
-      "se" : "Q7OaTM6urj4jv"
+      "es" : "YZC3vDVWimC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dNdtng7TnQNMpx",
-      "month" : "uH6sOhQDeian",
-      "day" : "mK4K64BOUqE9zbX"
+      "year" : "Keg60j9tAwF1MMs",
+      "month" : "gUUyQ8FWizKj",
+      "day" : "VajDGSGIwTHOOWre"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cb18f6f9-453b-4f09-a911-7184ef669850",
-        "name" : "q82aSje7Cke2o2Zh",
+        "id" : "https://www.example.org/6fd7cb58-373f-45bb-b80a-26b8e2428c07",
+        "name" : "Un15EbWM8p0e",
         "nameType" : "Organizational",
-        "orcId" : "uHRj4n6A49fsbwf",
+        "orcId" : "AstvzyIEopFd",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iD2wEyCCznMiq",
-          "value" : "VtGbVqxF20vyw"
+          "sourceName" : "nSrCVEFpkeW9vKP2",
+          "value" : "miDPxPrMfGg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZyUSKY4ZhDmEhd6aY",
-          "value" : "gygl3JYXz5nOnK"
+          "sourceName" : "TiShtfxMzcXvPq",
+          "value" : "hDLd0Awxi2rqj0O0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/07b56455-c64f-4234-a10e-48f98e09259f"
+        "id" : "https://www.example.org/dde7afb1-db28-4ebf-8ef9-2279ceaecb82"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1da113c5-d9e4-4e54-bd84-2075b365260f",
-        "name" : "dNqiwwRIyH",
+        "id" : "https://www.example.org/cb0bc765-d4cc-4ed5-9178-b4647312a5c6",
+        "name" : "lp3VGBHrbZXqjd",
         "nameType" : "Personal",
-        "orcId" : "8hFHekJZ5A",
-        "verificationStatus" : "Verified",
+        "orcId" : "5tJVxK2bUw1",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BLE5ZuXvXwP",
-          "value" : "JH80LIdcB2b5UZltq"
+          "sourceName" : "fa2G8zicDWe2",
+          "value" : "7yBSkfcLNWPJEsb5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mAzg8TEQAQdVa",
-          "value" : "jE1ODSuOs37a"
+          "sourceName" : "43yZtlO33LaP1OkJ5p",
+          "value" : "m2hkiPUKspXtFPCU7V"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e95c67ea-fa68-4180-b910-cc7f03d3e308"
+        "id" : "https://www.example.org/031276d1-0819-4db6-acab-44b82b1a32c0"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "ISTycKPv0LUcVmaPy"
+      "nb" : "sdJ1cjYZ3w5BQ9qVvS"
     },
-    "npiSubjectHeading" : "VFGvqvb9v3E5g",
-    "tags" : [ "u1W9Ecoz4QhpD5" ],
-    "description" : "UDHQfIKLmbof1",
+    "npiSubjectHeading" : "Un2NqGw3ZAw8apF",
+    "tags" : [ "VV2eRlVr71" ],
+    "description" : "PLYOa2Wi1kFU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/93b6f271-77cb-4f12-8286-1d029ce577e3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/872ef416-8305-467e-907f-72fd708f925c"
         },
-        "seriesNumber" : "HS53a2ScHUJlWzfMZQ8",
+        "seriesNumber" : "ZyRtInAyABQig6bjNT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/93251b48-4a77-45c3-b29e-1a94abe8abcf",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/076d19d2-b295-48c6-bb40-2f6958df1c7d",
           "valid" : true
         },
-        "isbnList" : [ "9780855031947", "9781793899361" ],
+        "isbnList" : [ "9780968062531", "9780941684842" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1793899363"
+          "value" : "0941684849"
         } ]
       },
-      "doi" : "https://www.example.org/ef20bdaa-d18f-4feb-bf35-b1693864e64b",
+      "doi" : "https://www.example.org/0cae70f0-bc18-42e7-976a-17dab24610c9",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "wnO2sWyTw9wncCQva",
-            "end" : "Hk5ud9sHR5Kp"
+            "begin" : "jEVr7GmofC7I6tgLMGj",
+            "end" : "iOSjLIUTi2"
           },
-          "pages" : "sQ0LCNs4xZdn1StXRY5",
-          "illustrated" : false
+          "pages" : "MJpF5aPa0AAkrosPKSr",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8000ae2b-76b5-487e-b4a1-c37915c524f0",
-    "abstract" : "3yajkMvYqy1xviHR"
+    "metadataSource" : "https://www.example.org/3b77e2ea-464a-4f1f-84a7-bebb4b3778f7",
+    "abstract" : "Adf98PJ8rJMgj8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f96bdea0-bf3c-45e8-a14b-2230c30285ab",
-    "name" : "AcwqBODbbjLaA69Kgwh",
+    "id" : "https://www.example.org/107c7ce5-5296-4d24-a965-72aac974d54d",
+    "name" : "V0s4lcHxG8Pup4ERXV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-07-07T20:14:50.897Z",
+      "approvalDate" : "1971-03-11T14:42:37.659Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "EGBimbRfhp"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "sPtOXbevgpExnUA8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/257fe192-4065-419a-a151-a12667c08e90",
-    "identifier" : "ULkUcMs5WwYF",
+    "source" : "https://www.example.org/140c25af-1ba2-40b0-be3f-ffaad269c1c3",
+    "identifier" : "E1RCu2wRYXcCbVJuXgU",
     "labels" : {
-      "zh" : "BySIvSiwAW"
+      "pl" : "4gurBHCO9TYhmc5jp1"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1797089000
+      "currency" : "EUR",
+      "amount" : 2129141691
     },
-    "activeFrom" : "1974-03-11T02:42:28.166Z",
-    "activeTo" : "1980-06-04T09:52:09.633Z"
+    "activeFrom" : "2009-09-29T14:11:50.283Z",
+    "activeTo" : "2020-02-15T00:59:36.006Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/598a6817-54ba-4523-8e07-2f81f682dc15",
-    "id" : "https://www.example.org/c0c3b926-4fb6-4956-a638-b8c3649cc337",
-    "identifier" : "VlfkpsBYEG5NJxu1djv",
+    "source" : "https://www.example.org/609973aa-26a4-4f0b-b55a-b31d4f141539",
+    "id" : "https://www.example.org/42cd2763-6202-4ff9-b642-042004e21e73",
+    "identifier" : "ciiLoW1ZZtIBgeDl",
     "labels" : {
-      "ru" : "GA6V8sdVPlsqlU"
+      "pt" : "L07u60IMZhHghOup6HM"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1977534258
+      "currency" : "NOK",
+      "amount" : 1352196326
     },
-    "activeFrom" : "1983-03-16T01:21:30.915Z",
-    "activeTo" : "2007-08-19T08:02:54.290Z"
+    "activeFrom" : "1983-03-23T01:23:26.729Z",
+    "activeTo" : "2005-03-15T00:14:25.431Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d2ed5614-aadc-4eda-bc9a-c039286978ae",
-    "sourceName" : "yhfnw4odjshwhcl3i9@jqnz0tzz1ekblyjm4"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "8EGezgHjebH",
-    "sourceName" : "6ejf3pcrj1pkg2oej@gypq0iv0k97xjdkp2y"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "eQ2euahB3LJngScFfJi",
+    "value" : "VJ2tsPGT9vY6KXA"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "609542532",
-    "sourceName" : "mlir4djdenr5brfg5ws@zjjtzv9lalrxmx"
+    "value" : "471538429",
+    "sourceName" : "ijuypyxwmc49krwaij@bweoa4iy0z"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "qC7SQfodeyfpa",
-    "value" : "I1txWGMDcWn"
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/5e54e68b-d3f7-46f4-86f8-ebf9a59c1994",
+    "sourceName" : "b6f3cqcr9fkt@jvce4sb3333yn25p9"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "Mp6AF1DbG6Hl",
+    "sourceName" : "wyxfzlhxevmjdco@pfng8wswrnjjg8whp"
   } ],
-  "subjects" : [ "https://www.example.org/b0867793-edf9-44fb-a69d-d94a16ddadb9" ],
+  "subjects" : [ "https://www.example.org/0aaa0228-8c70-42d3-a5ce-78cbb77b2735" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "af4f267f-1bad-4579-8b52-be1a7d160fc6",
-    "name" : "YUtw6YRwSCq9H",
-    "mimeType" : "xxg6feZyeF",
-    "size" : 964694723,
-    "license" : "https://www.example.com/jgvvlilwi7o",
+    "identifier" : "0069cf8e-a23b-4c87-b40d-712339a2e191",
+    "name" : "rqPBx3jfeR9dEX7h",
+    "mimeType" : "eBVtgDMpX0k",
+    "size" : 397072762,
+    "license" : "https://www.example.com/uypp4kwygcaolbje0",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "cOQrWE1DdNQU"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "MrcVGUFNq7Y",
-    "publishedDate" : "1992-02-04T06:43:38.969Z",
+    "legalNote" : "zx7GOrzSrJ4Nibsu1",
+    "publishedDate" : "1996-08-30T08:40:50.027Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "819182676@vWd1cbThAo",
-      "uploadedDate" : "1973-01-20T22:45:32.600Z"
+      "uploadedBy" : "403908969@cAT2AU3s1RSe",
+      "uploadedDate" : "1986-01-17T09:08:44.852Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wgjH95vKJxHqSBrtd8N",
-    "name" : "3CxYKvzFkQrqgCW",
-    "description" : "NNPgrjzPaWe"
+    "id" : "https://www.example.com/4pXkANBuBgAZiPpw",
+    "name" : "XGdka46RI5",
+    "description" : "tNjmY9a6SQTZcTz"
   } ],
-  "rightsHolder" : "Ce02LccxW7Zb1TJ38J",
-  "duplicateOf" : "https://www.example.org/9a94d907-dcd2-4d95-b6d8-caf12f49219b",
+  "rightsHolder" : "nQaZxsPW8d1DZ",
+  "duplicateOf" : "https://www.example.org/80a9dffc-f082-4dc6-a3bf-b4310d9f6f6d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7jNrM50nFGUDC"
+    "note" : "h1nKEJ0zjHhOfnh9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iJrD2Eheu3V",
-    "createdBy" : "9YxL4uyp1Sx4CLiAy",
-    "createdDate" : "1980-03-16T01:38:07.608Z"
+    "note" : "L9czPuYhy7KwCY",
+    "createdBy" : "xY3GToiNAeRK",
+    "createdDate" : "1978-10-02T20:22:11.114Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c712c117-dd09-40f5-833f-9e3c3abeb7c1" ],
+  "curatingInstitutions" : [ "https://www.example.org/6af70356-bb4c-4254-afd2-851532cedce6" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "ctKCIx3MHQ9ezoiEGkA",
-    "ownerAffiliation" : "https://www.example.org/f171e726-0685-4444-93a2-9ab4bfe4be01"
+    "owner" : "9Esb65SxRqst8Oc",
+    "ownerAffiliation" : "https://www.example.org/10334f33-6b36-4e9f-ba61-a3078879e050"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/63195a02-d185-46b3-ac30-b308e3093a43"
+    "id" : "https://www.example.org/e756dc82-63ff-4949-868f-f14f88ab0dbf"
   },
-  "createdDate" : "1977-05-17T09:57:25.803Z",
-  "modifiedDate" : "1991-12-31T17:17:42.079Z",
-  "publishedDate" : "2004-12-10T16:39:23.380Z",
-  "indexedDate" : "2021-11-13T22:58:38.331Z",
-  "handle" : "https://www.example.org/079f7d2b-a0c8-4ad3-b434-f8897c80d47b",
-  "doi" : "https://doi.org/10.1234/ad",
-  "link" : "https://www.example.org/6d87ae44-bfbb-4199-9da9-eba1f67573d5",
+  "createdDate" : "1989-04-16T14:57:40.459Z",
+  "modifiedDate" : "2014-01-05T22:40:03.096Z",
+  "publishedDate" : "2000-04-08T08:59:09.008Z",
+  "indexedDate" : "2013-08-18T02:59:04.647Z",
+  "handle" : "https://www.example.org/29ba3a04-8030-495d-9b38-dfb0536fc090",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/fec26a7f-831b-4a2f-98af-1c0943a6a463",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7qDqGy3rhGn",
+    "mainTitle" : "DnQPQSmvoUS",
     "alternativeTitles" : {
-      "cs" : "OMvwlnjWm019xy0"
+      "ca" : "krdrxJizGp"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1LmOHVBAihHN",
-      "month" : "DltdZplXsUWwvfv",
-      "day" : "C8MECuIBQvM"
+      "year" : "ZfDrld8gn4Cb5QveSe",
+      "month" : "rClOUQZBPXLJ6nqmDGa",
+      "day" : "kzhA6633q5p"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/39c453f1-eb38-41d4-907f-6d8ac0a2d719",
-        "name" : "qWJvZnA8fGjmW9pUf",
+        "id" : "https://www.example.org/944819ac-3a00-4a05-9447-ef6353063416",
+        "name" : "XMN8nt87MdY8",
         "nameType" : "Organizational",
-        "orcId" : "F0TOgmno3fscpWRL",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "WI80lv7a3gH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EWKF1oHGAmeIA12X5",
-          "value" : "A5q910PFdk"
+          "sourceName" : "WO77v4PrKVBsC",
+          "value" : "rYvdKg6VL9nw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7pciLTy9UMhtf",
-          "value" : "tQzIV92hnp4CH5"
+          "sourceName" : "qrH7exBtLBCq4ulLr2Y",
+          "value" : "iGPKLL8fAGw2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9c6d0ac1-54d4-421f-b652-97e8f753c4d3"
+        "id" : "https://www.example.org/1cf42152-d4ff-46f1-967c-d075563946f4"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b07d23cf-6f71-4ab1-86b9-06919baada12",
-        "name" : "QqRVHGUcX7Z",
+        "id" : "https://www.example.org/a65f3083-2318-4fa3-839a-74a0ac2d62fc",
+        "name" : "lNQsc47507f",
         "nameType" : "Organizational",
-        "orcId" : "Db58h5cITDGABls",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "pii3bEM6Z36lGXnH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "08gF8VJKiX1kxnGof9",
-          "value" : "imiYx8KI1agsU7UMm"
+          "sourceName" : "kJuoRbX7Ao8b5QA27",
+          "value" : "HyU58E5d2WZm8G1kL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qp1wUPWJwEwZ",
-          "value" : "F8jWYeDzY49uRGXhVG"
+          "sourceName" : "Ct9P5I7yzSGw",
+          "value" : "p7r8xQdJilA92Ru"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8dc13a59-5816-4d1c-8660-686628221a3d"
+        "id" : "https://www.example.org/8f98082c-222a-431f-8463-ae0666047ec6"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "ViyTRk2lusHj"
+      "af" : "4CyBw8QdfI0to6n"
     },
-    "npiSubjectHeading" : "qtf0Gu6ROZ",
-    "tags" : [ "bVC4amdddKxlk1" ],
-    "description" : "aX3CSY0gZL5vEFg01cu",
+    "npiSubjectHeading" : "I1R489P6lS",
+    "tags" : [ "nd0AWlLAFgcx8kyR" ],
+    "description" : "Zqpcw5U3b9WTYGB1R4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/798256e3-9dd9-402d-bb1d-4b1eef2ef34c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fdc28903-6580-43ac-afd1-91d38f1ce5b6"
         },
-        "seriesNumber" : "kMXSHK5iJs",
+        "seriesNumber" : "z0xNsI1h3amlpAmHAT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a949e7de-36f6-4b42-bc6e-2f0ddfba134e",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1f65dc93-7b58-433d-861b-e9186c191690",
           "valid" : true
         },
-        "isbnList" : [ "9791029167720", "9780942448740" ],
+        "isbnList" : [ "9791849018127", "9781867132721" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "094244874X"
+          "value" : "1867132729"
         } ]
       },
-      "doi" : "https://www.example.org/82197cb6-869f-4322-84ff-d4e07134e744",
+      "doi" : "https://www.example.org/f73f4b30-2e8b-460c-a2fd-4c2f678c7ea8",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Iro664ghYCW8",
-            "end" : "Vr3cl6OCUyF8sGX2"
+            "begin" : "ktX53MpHU7Mo",
+            "end" : "hHtDUcpw5E"
           },
-          "pages" : "ZUCnPyAnE1",
+          "pages" : "aGhsDzNzlWj6owOxF",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1eaf891d-0c59-444f-986b-117c5375eab9",
-    "abstract" : "HfeUYT2dJMN40KAsaW"
+    "metadataSource" : "https://www.example.org/b22dbee6-abb8-406f-9d92-8f8b707b4cc1",
+    "abstract" : "ZlPl5JW8nJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4ec4c95b-248f-4ec7-b4ae-71ba93a3c8b0",
-    "name" : "83t8bKE9pBZG",
+    "id" : "https://www.example.org/a446af0e-6e85-4e74-8c64-c582ef0e04e6",
+    "name" : "JCtPKVewUXsMliPrI",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-09-09T07:24:49.782Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "xexdjyz1xgni"
+      "approvalDate" : "1986-10-22T12:19:25.774Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "kGOrRITk1A2YIHxd"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/070cf20d-a7f2-4dde-b6d5-5371b853e18c",
-    "identifier" : "OwjLYFgWApd0P25A5",
+    "source" : "https://www.example.org/554fc8ac-5092-495f-a0cc-152d97d74eb0",
+    "identifier" : "4LltR0ItMlATBiNlHU",
     "labels" : {
-      "zh" : "FV4rVKyTNWzf"
+      "zh" : "v8MmSHklD85"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1871590231
+      "currency" : "NOK",
+      "amount" : 179620818
     },
-    "activeFrom" : "2022-05-30T03:55:38.693Z",
-    "activeTo" : "2023-01-06T20:16:16.047Z"
+    "activeFrom" : "2017-05-28T22:55:58.967Z",
+    "activeTo" : "2018-03-06T23:44:48.017Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/394d0b53-ef64-4729-873f-738b4456e5a5",
-    "id" : "https://www.example.org/a5b45dce-df76-417d-abab-92166f4b4646",
-    "identifier" : "DMkQTrdWWtihwSdi",
+    "source" : "https://www.example.org/c7113076-dc02-4d51-a167-c1c89933965f",
+    "id" : "https://www.example.org/a4956572-deae-4650-ab80-6fb2ea8f7290",
+    "identifier" : "smYu385fqah5yQMx",
     "labels" : {
-      "fi" : "RByvQZ4owGfkg85XZsy"
+      "nb" : "nneuNE0oD06C85VWOWj"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1379018782
+      "currency" : "USD",
+      "amount" : 969459606
     },
-    "activeFrom" : "2017-01-13T07:57:54.121Z",
-    "activeTo" : "2023-01-17T16:14:09.378Z"
+    "activeFrom" : "2008-05-13T04:09:44.158Z",
+    "activeTo" : "2011-12-22T06:28:08.320Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "hE8mh0ZTJ75QTJkM",
-    "value" : "yFli0JX9ej8a"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "WON3sGUxFy2uma",
-    "sourceName" : "sulxxqbt4x1@solqwca7ecjalj"
+    "type" : "CristinIdentifier",
+    "value" : "437355564",
+    "sourceName" : "upof1sgfau7mxm5@ure1yduwsoppi9lcl9q"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/8dc6c676-9ec7-4219-888a-3522fa70378d",
-    "sourceName" : "ranyntmr9y0g01tc@qtuvslm3hk"
+    "value" : "https://www.example.org/e6cfbb1b-d662-4932-bcdf-badd717ae620",
+    "sourceName" : "npngrin8oydkbx8e@5irwtwzrp7rme3zf"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "550489299",
-    "sourceName" : "rqofpdafk6tuj@fhgg4htj3i"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "fNzRxo1buCDZG0X",
+    "value" : "eezwbGPiso"
+  }, {
+    "type" : "ScopusIdentifier",
+    "value" : "VQrIP197qeH",
+    "sourceName" : "vhkvwh5azetg@m9tz11lk7ulstep4wfc"
   } ],
-  "subjects" : [ "https://www.example.org/8179fff3-9f8c-4685-b1f3-622116df0e28" ],
+  "subjects" : [ "https://www.example.org/d18d4acd-05c5-4787-8591-8772a03ca97f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d65ee2eb-9c82-42e7-8043-438ec30b9720",
-    "name" : "l6ST0bROHA",
-    "mimeType" : "dMi0NjuL7YLY0E162",
-    "size" : 571977213,
-    "license" : "https://www.example.com/cxnkcfuospvjv",
+    "identifier" : "6a3c6c39-f89f-45c3-86bc-553809dc2688",
+    "name" : "HmHsExDk8Jh950DRIQp",
+    "mimeType" : "A2R2fnvT6pjfeS",
+    "size" : 1349008685,
+    "license" : "https://www.example.com/nwudqi1t4f",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "crT79jjlSIt",
-    "publishedDate" : "2005-10-18T18:24:50.535Z",
+    "legalNote" : "wmw0JTdZYhzl",
+    "publishedDate" : "1994-08-13T23:11:43.352Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1469501477@iwyhM6iEmQemNj7wwu",
-      "uploadedDate" : "2009-06-13T15:22:48.848Z"
+      "uploadedBy" : "1611817629@Juh2Tb0NNj1",
+      "uploadedDate" : "2002-04-25T19:54:58.403Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/hCTbMllti5IdCb6Nuj",
-    "name" : "t8uHSNF25oFNHFS9BL",
-    "description" : "bY2Bp5e5XIH6nmO"
+    "id" : "https://www.example.com/Bvp4kUuXe17Fwcjxu",
+    "name" : "GmyFxnGMhvm7x9Ldf",
+    "description" : "aMzYx4sm8jazz5iHz"
   } ],
-  "rightsHolder" : "HQFQEvEznvazwWVg",
-  "duplicateOf" : "https://www.example.org/2d63d383-6b66-41f7-a4ea-88e2e54a6f4b",
+  "rightsHolder" : "lZhx62keMqMzJJk",
+  "duplicateOf" : "https://www.example.org/304c38c9-6922-4f1d-a966-d5329818c591",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "SAqLuxES7yQ"
+    "note" : "5awbuLLiToW5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ka4b4ngWGwTsOkx0",
-    "createdBy" : "iNzXmAr8fYtKnS6Rd",
-    "createdDate" : "1977-06-06T10:10:48.635Z"
+    "note" : "jQbZvQ3cBkzAAg",
+    "createdBy" : "8zyxcXwhixsO59dfTq",
+    "createdDate" : "2011-01-28T14:52:05.487Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d52c2d73-240c-4469-925c-2b73fd397fcd" ],
+  "curatingInstitutions" : [ "https://www.example.org/35508cc8-1f91-4348-bd38-cfad67470b77" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "g2oXTtA3nCOZqf",
-    "ownerAffiliation" : "https://www.example.org/77997d6a-f2f0-4fe7-8f28-6dc3f402a314"
+    "owner" : "ON2BrpivmQiBveY5N",
+    "ownerAffiliation" : "https://www.example.org/40c30f7c-8b4f-4821-b943-7608d053cde8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e3b6e2ac-4dde-4454-88dc-49d2f0ba361d"
+    "id" : "https://www.example.org/391e8275-df31-4998-9714-29ebca31756d"
   },
-  "createdDate" : "1971-03-07T23:39:36.718Z",
-  "modifiedDate" : "2008-05-19T07:15:47.518Z",
-  "publishedDate" : "1993-07-06T16:42:56.286Z",
-  "indexedDate" : "1982-08-24T20:54:17.031Z",
-  "handle" : "https://www.example.org/f43b9a8a-6e45-41ca-bda7-97066d79c2dc",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/f04caafc-a8a8-40ac-a4db-3b69183c7b15",
+  "createdDate" : "1997-10-03T02:24:48.952Z",
+  "modifiedDate" : "1971-10-13T01:22:45.975Z",
+  "publishedDate" : "2019-08-12T02:05:08.823Z",
+  "indexedDate" : "2019-03-29T08:00:16.590Z",
+  "handle" : "https://www.example.org/4cb89aae-e02a-4b57-be54-86203a0dee48",
+  "doi" : "https://doi.org/10.1234/perspiciatis",
+  "link" : "https://www.example.org/0a39873f-fe60-454e-b76a-c4e5a597cab6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "UtmHonRm1Y",
+    "mainTitle" : "jX46J4ricIViYVF",
     "alternativeTitles" : {
-      "da" : "ytEW5ijSfId4"
+      "nb" : "9SKZaiGrbGD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "I7IgbwVfhD",
-      "month" : "aecBo6v9EQ",
-      "day" : "eb9JbrHB0J"
+      "year" : "WJZUesv6wqt8P",
+      "month" : "9IzghgogMXuUU",
+      "day" : "ay03AvXWmpqEte9D"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d7de5149-54ca-4bcb-887b-ce3c09fa3bd8",
-        "name" : "dBHqrTsAVywnfqmgPt",
+        "id" : "https://www.example.org/a375c7e5-dd88-4f13-8f81-eaa71c5c9775",
+        "name" : "2z8kMYqbovMqec",
         "nameType" : "Personal",
-        "orcId" : "nql3qxrbvu8w6Exd5U",
-        "verificationStatus" : "Verified",
+        "orcId" : "M5jZxRrKTHf",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OvgFqdFwbNM",
-          "value" : "qepmM0OC0xYUDjx"
+          "sourceName" : "FYSDW3Gw5wDqB7m",
+          "value" : "WYRw9cvowi55VHR4dO7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FLcV6FLlUD2omoPcC",
-          "value" : "OOHO4fPBoKJdEcnRP5"
+          "sourceName" : "7oZ31vm97shE9goLzH",
+          "value" : "uwd20VjGYLirKCifcbH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1595a06a-3e3e-43d0-9464-16d09c5088f1"
+        "id" : "https://www.example.org/e44dae8e-1371-42a2-b6ea-3f7f8141dedd"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,174 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2122af07-dab9-497d-bee5-b5f2ed0b970f",
-        "name" : "QX3c5teB5J",
-        "nameType" : "Organizational",
-        "orcId" : "f6gSAG57XZoi",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/65e5d40c-6143-4ee5-904b-2507f4833509",
+        "name" : "GPFQlAPC0kUcAQmImIC",
+        "nameType" : "Personal",
+        "orcId" : "KYs4e2GrmwJJpEO7cm",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bPxVejn52TnzjjpM",
-          "value" : "i2dvUZr6crALb5"
+          "sourceName" : "iBqDW7ZPFXg2NdQ",
+          "value" : "aMKdQmMswrvx6g"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VukkpCZaRIf04r3oEU0",
-          "value" : "EYlOETPH7syP"
+          "sourceName" : "hOJKueBykfALxlsN",
+          "value" : "EZrDMF2upYuC"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/81cc9f8e-3eb7-49a3-94aa-1b86c11e978d"
+        "id" : "https://www.example.org/d00884f0-0d1d-46dd-a5cb-b3a0d277296b"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Advisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "4ie187H13yrtI7O2z"
+      "en" : "atSFZEjkBiPpG1QXoX"
     },
-    "npiSubjectHeading" : "m2AZ6ze0cktI",
-    "tags" : [ "Dq5ClcKmmWlad99PV" ],
-    "description" : "YI76o2PTyAyYtGng992",
+    "npiSubjectHeading" : "yZMqQmkVMewKi80oH",
+    "tags" : [ "xWsdWyCsMphiJNMw" ],
+    "description" : "C8KP7Ug54eb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/76e13b6a-fe86-4363-9b45-192d7cf05197"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5be04564-6490-4138-91c0-58c3f4174ea9"
         },
-        "seriesNumber" : "68UlQHJTpGs",
+        "seriesNumber" : "avuszT2PayNw",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af3ed237-fdbd-41bc-9ea4-04c8e7e8fca1",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2cfb918d-d34b-49e7-9ac3-1ceea11ba46e",
           "valid" : true
         },
-        "isbnList" : [ "9781215905144", "9780071690997" ],
+        "isbnList" : [ "9790461088716", "9781978263314" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0071690999"
+          "value" : "1978263317"
         } ]
       },
-      "doi" : "https://www.example.org/8d3ef381-720a-466b-9286-2179f51dd1ef",
+      "doi" : "https://www.example.org/742a8942-80a7-4aa8-9b68-acb4acb091dc",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "p2LpuFhN4uSFPpwXk",
-            "end" : "4OWvP9cnSA"
+            "begin" : "M7F8veGsrInhovgb3B",
+            "end" : "NDe3efl9KmUr"
           },
-          "pages" : "Vts2KRRUmj",
+          "pages" : "xgKA7Jw6QHJ1Hn",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/02a45adc-adc6-4ca4-b425-0616dcfa1250",
-    "abstract" : "utQrYczYoVzu"
+    "metadataSource" : "https://www.example.org/1f3f13b5-dd6b-491e-954f-447d37974408",
+    "abstract" : "ng8Ybu5fx9LUjoz8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/907ded83-aac0-41c2-a2af-dbb5221a0eba",
-    "name" : "V2taOahWDg",
+    "id" : "https://www.example.org/2a0ce520-d8a1-430f-bfd3-1810f96b0262",
+    "name" : "UZSH7hNEAm7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-05-05T12:34:07.247Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "lwkaPZjLXC"
+      "approvalDate" : "2006-05-06T04:14:34.169Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "yYOv9jj0s8cELFQy8OC"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/53a45618-184a-48f8-a33a-88b90bc7ebfc",
-    "identifier" : "425hHkxLl4ch5kfkmZM",
+    "source" : "https://www.example.org/3b2e6494-97e1-4334-8b55-364d8704dea0",
+    "identifier" : "uSvdDGLGOaJJZ",
     "labels" : {
-      "pl" : "SWoFm11nGxf5yK9"
+      "hu" : "YQtomPjGTU8c"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 7285925
+    },
+    "activeFrom" : "1996-06-05T09:00:19.428Z",
+    "activeTo" : "2005-10-21T13:12:19.483Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/7905a1de-d5b7-4f29-a66d-cf6f8be21b71",
+    "id" : "https://www.example.org/e26f405a-8611-4577-8404-3d06ed8d286f",
+    "identifier" : "UKCH5JUKDYAqZm62g",
+    "labels" : {
+      "zh" : "6gbnljDwPQyG"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1021812114
+      "amount" : 926412786
     },
-    "activeFrom" : "1980-05-22T01:29:00.052Z",
-    "activeTo" : "2019-12-24T19:44:17.014Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6ddec564-9e37-435f-9d1e-636da9f46819",
-    "id" : "https://www.example.org/041021b1-f159-49ed-8fbf-d08f91ba166b",
-    "identifier" : "L4yvPP9jsEG5",
-    "labels" : {
-      "sv" : "QnoLbBgQKysiIFjM6u"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1465548110
-    },
-    "activeFrom" : "2018-10-09T01:18:50.793Z",
-    "activeTo" : "2023-10-19T05:20:12.200Z"
+    "activeFrom" : "2024-07-06T00:56:50.635Z",
+    "activeTo" : "2024-07-28T13:15:17.761Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "ScopusIdentifier",
-    "value" : "DYtbceEPlc2iIQwcN5e",
-    "sourceName" : "ebp7rb3worwck3epu@f3qvuf9ztozgb"
+    "value" : "jCIq33KzG4",
+    "sourceName" : "vbsf98bbdv9q@vebcce8ovdih3"
   }, {
     "type" : "CristinIdentifier",
-    "value" : "974497538",
-    "sourceName" : "9lcgnetbbms8cgg@wdfhvvjqln"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/f08e50a3-fe9e-4207-8013-f96a6b819df5",
-    "sourceName" : "drf0ccpabrrt1@fbujfwfftef"
+    "value" : "1278755032",
+    "sourceName" : "ijezypyaqcqtjwdh@zqxgrfjvqgbv"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "qrKSRoDKfdHyinhQA",
-    "value" : "Biv0V1J6BK"
+    "sourceName" : "ireTEqbSaIuNloADr",
+    "value" : "pEwoRyNbKdz"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/a7cef182-886e-4fdc-bef2-2707c26b3904",
+    "sourceName" : "xsmro6yy1qwvs27@laxfcjmejsd8"
   } ],
-  "subjects" : [ "https://www.example.org/ca1e0534-85e8-4253-aeee-ed41bc457cfb" ],
+  "subjects" : [ "https://www.example.org/7c9f8719-22af-4a23-ba9d-90a3d1178365" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "be5506ca-ca1e-4cc7-ad6c-c94a92110710",
-    "name" : "jX4KCK3aEWxOuaq5j",
-    "mimeType" : "fGUMTW6aSjw3",
-    "size" : 1795082007,
-    "license" : "https://www.example.com/2eavbyuc2y",
+    "identifier" : "1cabd8f9-311e-4b32-9b97-ef796a4a694c",
+    "name" : "wcfHMRxE065Wufb",
+    "mimeType" : "fvsLsMz7IdrLtSe",
+    "size" : 29673593,
+    "license" : "https://www.example.com/91tayc7eopydaew5w",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "IIKYqxANFE3C"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Ld5vN6aEhFbl9KMtps2",
-    "publishedDate" : "2002-07-25T14:52:30.892Z",
+    "legalNote" : "vINmSn8YUBTDJpwK",
+    "publishedDate" : "1990-02-12T14:06:06.017Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "507169009@xSsjvTw22g",
-      "uploadedDate" : "2009-09-15T22:16:21.310Z"
+      "uploadedBy" : "797825515@ICHk5kyG71",
+      "uploadedDate" : "1984-10-04T19:59:24.879Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tiU5nGx8tFLxOQp33",
-    "name" : "QY9OL6zik1hyX",
-    "description" : "pmtfVC2FhUfW"
+    "id" : "https://www.example.com/Z4DgfVhHleiM",
+    "name" : "b3fIfBsFY7WHMaMO",
+    "description" : "J0xioCeoOUD7PA"
   } ],
-  "rightsHolder" : "Is2hPT5ndHYCDD3EWVd",
-  "duplicateOf" : "https://www.example.org/dd357b93-ac02-4980-a31b-c1e4a901f905",
+  "rightsHolder" : "qBQm6YDx1Kms4pKSw",
+  "duplicateOf" : "https://www.example.org/97c84449-c317-4bcf-9761-940088cfabad",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Vjm8oLomemJUK1"
+    "note" : "lOOdjmxanjCXI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "wHagd8akUc0",
-    "createdBy" : "k58UKc7McGCoJqZCoe",
-    "createdDate" : "2002-03-15T16:01:11.484Z"
+    "note" : "rY5Lx2hfjR",
+    "createdBy" : "PQwdyowN97YOh",
+    "createdDate" : "2011-05-05T00:00:16.101Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4fd920c2-7758-4ce5-8e17-dc36b057763f" ],
+  "curatingInstitutions" : [ "https://www.example.org/11c3f274-2ca9-4cbe-99a1-86cd642808f7" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "FsN8eKDoRsHhK7fU",
-    "ownerAffiliation" : "https://www.example.org/83846103-dd5e-43c2-9cc6-895c858ae7a5"
+    "owner" : "DM5aau9mS9j2vIHCV",
+    "ownerAffiliation" : "https://www.example.org/4318252e-76b9-4ece-9e4f-a5b87eaa6e04"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0d5c3345-74c5-4de4-8599-7f1467fdc04a"
+    "id" : "https://www.example.org/9a1eb24c-5c6c-4b15-b0b4-72f78be2bb71"
   },
-  "createdDate" : "1981-08-05T18:25:08.091Z",
-  "modifiedDate" : "1999-11-27T11:06:26.872Z",
-  "publishedDate" : "2005-07-28T00:17:51.437Z",
-  "indexedDate" : "2020-07-18T09:09:39.539Z",
-  "handle" : "https://www.example.org/55033135-4bde-4364-ac0b-5eb04763c4ef",
-  "doi" : "https://doi.org/10.1234/vel",
-  "link" : "https://www.example.org/0e057006-7fac-4cf3-ad49-a2775679222e",
+  "createdDate" : "1989-02-13T14:49:40.865Z",
+  "modifiedDate" : "2000-01-31T22:31:09.970Z",
+  "publishedDate" : "1988-11-05T07:31:29.581Z",
+  "indexedDate" : "1996-04-12T14:39:51.366Z",
+  "handle" : "https://www.example.org/2b9c241c-e37a-4f99-bc15-1e29db149551",
+  "doi" : "https://doi.org/10.1234/modi",
+  "link" : "https://www.example.org/29225c21-ced2-47f2-8ce2-1a220f767007",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "j1pYtNcY8Js4FgA",
+    "mainTitle" : "6SItTqfCGLUQ",
     "alternativeTitles" : {
-      "de" : "FkjXP4Jf6FbM86RS9"
+      "el" : "L41AG5yWRIfqw98Apxz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "10WlMtDoy0eZAGV",
-      "month" : "SEdCviSBUeez",
-      "day" : "uiuzEqpjaEG"
+      "year" : "OiOY4wW5XuvXPrhu",
+      "month" : "6xHwKpVDulEX87Iyl3",
+      "day" : "omfAZJT73Jy9U5Ql4N"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cefefc44-e281-405d-80b2-37fdc47e9c06",
-        "name" : "pyEQEyLL1udDag",
-        "nameType" : "Personal",
-        "orcId" : "f5ETWLY53Z1",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/9288a10a-775c-4928-8aba-ca9959fed43b",
+        "name" : "x4zx7QXXDzbScMW",
+        "nameType" : "Organizational",
+        "orcId" : "XcYHfSqQkZv4k1",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7BjFkmXXKysi4UsJvW",
-          "value" : "AdzgMcyYc2vZz7ZN8"
+          "sourceName" : "xEv8JHYA3i7gMjcs",
+          "value" : "aimDPcMTe3t"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vwerY84XReIZ9yjbzBR",
-          "value" : "yLT91As4Zo6uYGBAm0e"
+          "sourceName" : "OWRGMK7Fq1Grcb",
+          "value" : "5iWeMCUims"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fa3f1290-dadb-4829-a980-a2b7215438ef"
+        "id" : "https://www.example.org/6e6ab4db-a279-45ae-8715-2e086488fca2"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "VideoEditor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/80c4500a-6b4c-46e9-92e1-893317166ce3",
-        "name" : "zUplYCbikW5Baw79",
-        "nameType" : "Personal",
-        "orcId" : "5xp3gKodCH0",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/677e5df1-aa0a-44d3-ab82-69f4f8451178",
+        "name" : "OMAjaFXqGbiM",
+        "nameType" : "Organizational",
+        "orcId" : "bju9hG9ZERpbDihE",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qY0ONsqRNJ8J",
-          "value" : "BZPyvhQgpfH9lAy"
+          "sourceName" : "lCnvTDvOeqrj4Ne1e8",
+          "value" : "1XCEbAPo08QQHycwECl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2ohYSBcRNLazOnS0h",
-          "value" : "syQcU26S4MrcUt"
+          "sourceName" : "6PnrqDP3Ds11",
+          "value" : "2HegJw926LRlr8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4783a4f6-acf3-4cda-bc0a-620b3d70d4ad"
+        "id" : "https://www.example.org/2590a19a-2aef-45cf-a43a-bb97fa9fd435"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "En13LE8RzMc6YyZHDar"
+      "zh" : "MQN74uYdW37O1"
     },
-    "npiSubjectHeading" : "wc2gWHO8LdPZ",
-    "tags" : [ "zw2vsGse5xoOy" ],
-    "description" : "7m8D90XKnG",
+    "npiSubjectHeading" : "dMGf4XC1dbt2uWienAn",
+    "tags" : [ "r31dNiwN0ccTX7thCO" ],
+    "description" : "Nyy51fsJjBl9evIY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2798acdf-89d1-4850-b0db-897e4f732d60"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dacc5759-28ce-4caf-9a01-3cb63e4d0430"
       },
-      "doi" : "https://www.example.org/3d061abb-e417-4a26-8527-f0dcd1f6ef18",
+      "doi" : "https://www.example.org/79da410a-5c13-4cfd-9b7a-c9e46d458cce",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "JshWxcZdsJ",
-          "end" : "VIkLsBA9IBqRfOIp"
+          "begin" : "mw7Ag6DdSxpnQuv",
+          "end" : "ij7V1qjJtTw"
         },
-        "volume" : "eZnuwzF45r3cr",
-        "issue" : "ImnFO4CE99EACeutO",
-        "articleNumber" : "r1eMqGF4CMZtIfCg"
+        "volume" : "j7k9XPwCh5fOp6vud",
+        "issue" : "1X1SPAPj3SWdS",
+        "articleNumber" : "RTrR8csidbi8pKCLPZ"
       }
     },
-    "metadataSource" : "https://www.example.org/712eb1e3-405a-4c1d-b5fe-7ff42919ff2f",
-    "abstract" : "CQ2xbvw4CvATXRnI"
+    "metadataSource" : "https://www.example.org/555a0e2e-404e-4d92-8696-884cff852b88",
+    "abstract" : "kyQ4V03fhTpPQZfDIal"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8135d38e-3de4-4904-9a81-ef58ae79d196",
-    "name" : "Ef8blcEqA4fMiHMdcCE",
+    "id" : "https://www.example.org/69416735-8475-4a2f-a166-f1ada8ba38d3",
+    "name" : "FHb6d0A0K85ttRl1k",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-04-19T11:09:33.617Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "x5froeyYmk"
+      "approvalDate" : "1982-05-05T20:24:02.152Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "oeKJjzp9LQDkq1EzZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/65b51f72-c1be-41e4-a25b-09a227fb8fe6",
-    "identifier" : "elbPc2mWJFx",
+    "source" : "https://www.example.org/376e0e97-6e60-4737-ab21-cb6479f8ae50",
+    "identifier" : "WrIzBkH0PE4G5W8",
     "labels" : {
-      "bg" : "20AX0T2wqqJMvjN"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1514189131
-    },
-    "activeFrom" : "1996-12-21T14:44:40.889Z",
-    "activeTo" : "2012-10-15T04:13:13.675Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c1c40bec-4292-4bc6-84b6-1fee9f4469ef",
-    "id" : "https://www.example.org/2b36971e-2b6a-4b38-a7d2-ee3fe8e19c40",
-    "identifier" : "ANtfRIFhTpL6",
-    "labels" : {
-      "pt" : "iY4kAhUhiKwGq4lBaD"
+      "de" : "vCK6AQgcY9"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 136486007
+      "amount" : 1532307501
     },
-    "activeFrom" : "1985-06-21T12:46:21.137Z",
-    "activeTo" : "2000-07-02T13:57:26.881Z"
+    "activeFrom" : "2001-03-29T06:46:55.663Z",
+    "activeTo" : "2018-09-26T19:12:09.589Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/cefd3b25-078e-4d7e-9bdf-a3f0ab0ec022",
+    "id" : "https://www.example.org/963f97cd-9381-4df5-bb06-c81795162879",
+    "identifier" : "G9wJFTrvFc8rnNA",
+    "labels" : {
+      "fi" : "bVtwEWbpkLLbI3To"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1462080676
+    },
+    "activeFrom" : "1971-07-06T13:44:46.868Z",
+    "activeTo" : "1995-07-09T02:58:36.721Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "616826506",
-    "sourceName" : "35ysqt2c88mhkre@fm3nlfc6wd"
-  }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "D4cAZxRygQawLNx",
-    "value" : "5h4LzGImjoG7wQfoo"
+    "sourceName" : "O3NluaB1kdLmyKV",
+    "value" : "DhkISSLEhsHyx8IyHM"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/52ae3ee4-9cab-4e19-ab1a-12412930d474",
-    "sourceName" : "r0gs5n0x4e3lnm@ql5e3ryefaljlh"
+    "value" : "https://www.example.org/ad58e587-94ea-4e22-bd5e-79849408b213",
+    "sourceName" : "5i2jryjha6jwykr@7eysah7frcqhnqdmq"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "GD8VcCw5vScGPezqljy",
-    "sourceName" : "npyllrlrd21diaor@wkaaia87znn"
+    "value" : "265MiACMPMNwM6TtpfE",
+    "sourceName" : "0jas3l3y2rhrr@y6pfct8eyloo"
+  }, {
+    "type" : "CristinIdentifier",
+    "value" : "1507349787",
+    "sourceName" : "ry6irmabavop@fzj0xa0mnhv"
   } ],
-  "subjects" : [ "https://www.example.org/4a3747f9-19f6-425e-bf68-584fdfe9eaff" ],
+  "subjects" : [ "https://www.example.org/cb43015a-cb20-458f-b55e-380e586b6820" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "00a99a2e-9cff-4efc-a2a8-393da23a4a0c",
-    "name" : "9KMwvwMo2R4jEUdVu",
-    "mimeType" : "BYI7iOihbSo588",
-    "size" : 634835201,
-    "license" : "https://www.example.com/1dzuw736tua2",
+    "identifier" : "dcbe5f9f-ef4f-4804-abf2-f0f663431b15",
+    "name" : "8ecxjc3wkKYtW",
+    "mimeType" : "6cirwz2gYiA3TQ",
+    "size" : 1744862291,
+    "license" : "https://www.example.com/9ac7ranut4ehcdl2vsg",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "9ACh1oKQ48yNn"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "It4Pqp3K0pz",
-    "publishedDate" : "2022-07-09T11:16:38.040Z",
+    "legalNote" : "P22UtRNWSoj7k3Tuk",
+    "publishedDate" : "2003-05-11T03:05:24.652Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "904788940@w84wWpwjygFXkniOQy",
-      "uploadedDate" : "2016-04-13T16:42:27.408Z"
+      "uploadedBy" : "127348346@RRTwvihu1kUWZnnYf",
+      "uploadedDate" : "2024-04-21T05:01:34.708Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/GFRqnbyltyvZqE",
-    "name" : "pB73R8LydT",
-    "description" : "CMr2UZ9C8Gxl1x"
+    "id" : "https://www.example.com/MfE3t7SpYDe9JV",
+    "name" : "3DtZP8vUt6XSNDmK1c",
+    "description" : "AZsDuKBb3j"
   } ],
-  "rightsHolder" : "AFYUAvAvFWQbJOL",
-  "duplicateOf" : "https://www.example.org/e6d0450c-c6b8-47af-ac9c-dc09c2bf7c27",
+  "rightsHolder" : "KLZfIoAEjT5cdgSa",
+  "duplicateOf" : "https://www.example.org/feeab67c-fa9f-41ea-a34e-5b7b290c10f9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "LdYfBxE9nS9Wc3VG9J"
+    "note" : "IeAktFiLWLuld"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vlyccTGMt7",
-    "createdBy" : "FiM0kApQi4nk9F5K",
-    "createdDate" : "1977-04-19T09:28:57.221Z"
+    "note" : "x8emi2kLD1uhE3PIHdt",
+    "createdBy" : "Z0EnVsX3iSrzLj4",
+    "createdDate" : "2022-09-21T05:32:06.806Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ad6b3d2c-3338-4d0b-b612-88bc93d0a799" ],
+  "curatingInstitutions" : [ "https://www.example.org/f8fa9ecb-3998-4f86-8442-9a1ca50c56f9" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "qV9YJMaErOP",
-    "ownerAffiliation" : "https://www.example.org/72b920eb-37d9-41ac-b589-95e6d0fb7721"
+    "owner" : "VHp963qpxN6YiGX3",
+    "ownerAffiliation" : "https://www.example.org/5f51d2a5-ffa4-4f1b-aec5-bfa34aae0582"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e3975b77-4b08-488c-be1d-996272cb9e12"
+    "id" : "https://www.example.org/fd1ce8ee-b70c-4813-bcb6-2375458a3e19"
   },
-  "createdDate" : "1985-08-23T20:09:44.341Z",
-  "modifiedDate" : "1986-12-07T05:42:41.498Z",
-  "publishedDate" : "1991-05-19T21:50:46.847Z",
-  "indexedDate" : "1990-01-22T09:52:49.758Z",
-  "handle" : "https://www.example.org/f487423b-9c2f-4a6c-b43c-7d90976ee382",
-  "doi" : "https://doi.org/10.1234/perferendis",
-  "link" : "https://www.example.org/de0d76de-cc91-4e89-bdfc-ddb403281d19",
+  "createdDate" : "2013-07-18T21:18:51.955Z",
+  "modifiedDate" : "1983-04-29T01:34:45.427Z",
+  "publishedDate" : "2004-06-12T05:38:19.703Z",
+  "indexedDate" : "1983-08-20T12:09:00.577Z",
+  "handle" : "https://www.example.org/272e21ed-8091-42bd-9f3f-540c19e81140",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/6e9ca007-ddcc-4d6c-b57a-056b091a0b81",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "g7lxdBPBMLxJ5M2i",
+    "mainTitle" : "Fk7pyQQLlrF",
     "alternativeTitles" : {
-      "es" : "7a4ZFYtP6FJGR9197Ip"
+      "ca" : "1vyrNUOlOi9"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BZ6LKCu85zBJP3QgTi",
-      "month" : "BHndqdBEH0C",
-      "day" : "ASx9jQLx4gW"
+      "year" : "CDPxNepi4rk5E",
+      "month" : "yJuEcLKT30im2",
+      "day" : "1ANm309E7Ryhck"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3cc68d01-804b-4042-b451-3e64c8d94be0",
-        "name" : "H9QFed6b36x1",
-        "nameType" : "Organizational",
-        "orcId" : "buLh2ZSnOrslbw",
+        "id" : "https://www.example.org/fe09f245-d0c1-482e-8f8e-33686c0adc83",
+        "name" : "1F81ziPdF1utu",
+        "nameType" : "Personal",
+        "orcId" : "rpDxcbXcfMI",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "S7rDXdksO9OnkZOrw",
-          "value" : "Aoa8nyG4Qy8ks5Gn"
+          "sourceName" : "rvjE0qT4e3ywQzvM",
+          "value" : "0E2lXFrYgI36c4SZ5PP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HRnfKPnwE6ykn",
-          "value" : "fkR6yn0s2MiJ"
+          "sourceName" : "zaW0kfAsBmY4",
+          "value" : "2hSHGPLreqKoO2mGG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b1e45e8e-8123-4850-bb9e-d7db444eca49"
+        "id" : "https://www.example.org/d82f878f-8389-410d-b44b-58abfd15b7f8"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,175 +62,174 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bd1f2700-ebdd-4693-a75c-1abe916f7b51",
-        "name" : "STsDZr5sWa7lX21SKVa",
-        "nameType" : "Personal",
-        "orcId" : "NbYkO8qMQHzxs",
+        "id" : "https://www.example.org/fdcdd140-64fa-4b2d-bd49-e190d8453b4e",
+        "name" : "o1RZlzYb924",
+        "nameType" : "Organizational",
+        "orcId" : "sqCGGofDoM",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LNRkidToJlvAoQ",
-          "value" : "qcS12mUUsErmMMl"
+          "sourceName" : "WYEyupYfRQRF",
+          "value" : "VkUiJMvGNl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dxb3eLVD8TK2ADt",
-          "value" : "kppJtAhzjA"
+          "sourceName" : "2hyIXh5nfxa6VmO2",
+          "value" : "Z3kJOUBHjHj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/05e2eb90-4a05-45a9-8431-01bb10320ffb"
+        "id" : "https://www.example.org/0d05924f-6dc8-49c1-bdd1-ccfba1aaee3d"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "Z8ncNDr5Cf0G8ML8"
+      "fr" : "197j9RpiV0c20"
     },
-    "npiSubjectHeading" : "QKN5Mbcmf3F8CnEQQz",
-    "tags" : [ "EdS3Uxt3X8" ],
-    "description" : "27pIqrrS9nIC",
+    "npiSubjectHeading" : "FLjRGc3AxSaFd3JDP7j",
+    "tags" : [ "ZdE05cl4wwHOwkgzONl" ],
+    "description" : "fC6v4PGWj9NvBohRPH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e43c83dc-b211-4e06-96d0-c6226f1c46ee"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6ca7ff28-e7df-4767-a00b-d58565308228"
         },
-        "seriesNumber" : "kBSFkKB4d3depR6IoBQ",
+        "seriesNumber" : "2BLFUnOR9vGDBLIN",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/31d0a99e-0443-411a-aa24-829ec57232bb",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b0e74fbb-b690-4d36-a95f-c1d92998c81a",
           "valid" : true
         },
-        "isbnList" : [ "9781040601891", "9780209967892" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9791845537202", "9781962982078" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0209967897"
+          "value" : "1962982076"
         } ]
       },
-      "doi" : "https://www.example.org/029f9692-b4b7-4bad-8961-335dbcec1b2e",
+      "doi" : "https://www.example.org/673fe65c-b46f-48b3-b57f-ae25a6d86ca2",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "kexAXLHvx8xg",
-            "end" : "7K0M4HF4SRqsFDBDFL"
+            "begin" : "ztk4xGKUQZ4l6su",
+            "end" : "48AakvZ0FSo61rt"
           },
-          "pages" : "bkCdwfGsrCemf6yKS47",
+          "pages" : "5XePhAq8GtFSDjsMG",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3e033985-a099-4e13-a8ab-b1ca94877425",
-    "abstract" : "7Pdn8rvDr7"
+    "metadataSource" : "https://www.example.org/f8b178db-b08c-4dd7-9ae7-e625e8fb6a4f",
+    "abstract" : "ACrEH2g8ObD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1df6c705-e848-4a37-9b71-5aa37626dad3",
-    "name" : "u3xYAzGDNeGnm",
+    "id" : "https://www.example.org/f53f666d-190b-4236-bc0f-853c2134e533",
+    "name" : "bBiOdLNcrm0PqBxwFta",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-05-02T15:34:15.882Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1992-03-10T00:41:02.209Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "H4p8BYEJN9mwsd"
+      "applicationCode" : "mzINoW6yndZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b1b9c188-800d-4a46-b8c4-fc14f04fadcc",
-    "identifier" : "3fyxPI9BgFzJMGdd39m",
+    "source" : "https://www.example.org/d2d85a17-18fc-4492-b838-fe6c1b264f86",
+    "identifier" : "8TDTURBSeOuJyhRGAU",
     "labels" : {
-      "zh" : "m0OqclIFmhTVEZ8"
+      "af" : "EnvTA2h80CRDVKss"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1104110026
+      "currency" : "GBP",
+      "amount" : 23366893
     },
-    "activeFrom" : "1987-01-10T16:46:27.949Z",
-    "activeTo" : "1994-09-24T14:19:51.871Z"
+    "activeFrom" : "2012-09-17T11:37:50.728Z",
+    "activeTo" : "2014-02-19T23:52:43.612Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d1eccb20-2a25-4759-9ed3-34d0b3e0bd0c",
-    "id" : "https://www.example.org/ca32333a-cb5f-4d4f-bb40-fdee49e05bc4",
-    "identifier" : "AjbnKIvXRJTRzZQjOqA",
+    "source" : "https://www.example.org/f87b12ad-57b7-4973-9c2f-afceeeb6bb1f",
+    "id" : "https://www.example.org/807ba977-9f38-4f4a-9e89-1b12fe847da4",
+    "identifier" : "HMz2zzhPsM",
     "labels" : {
-      "af" : "ecGL7emCdANn3Qwif"
+      "pt" : "xWoJyNLHjCpj7l9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 335880116
+      "currency" : "GBP",
+      "amount" : 823635932
     },
-    "activeFrom" : "2017-09-06T12:51:58.176Z",
-    "activeTo" : "2018-03-28T15:58:58.892Z"
+    "activeFrom" : "2015-03-14T12:09:11.010Z",
+    "activeTo" : "2022-02-10T10:24:54.487Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/72b301e0-bbe4-44ad-a2cb-668f3f64c716",
-    "sourceName" : "6jqkcrufzhh@hzobzgtnthi0n"
-  }, {
-    "type" : "ScopusIdentifier",
-    "value" : "5wl1kfiu83X8ksFLJ8Q",
-    "sourceName" : "69f89n3ns6yjkwbzn@tmb5plsuk1nos9"
+    "type" : "CristinIdentifier",
+    "value" : "1575029012",
+    "sourceName" : "lkro0lnkoqwmq@sn5ucwkygq7"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "tHguBAw5FG6sLtO8",
-    "value" : "HeCtzeFSJGUYg9MOvXX"
+    "sourceName" : "w3C1lfWO2jTL3zrenpL",
+    "value" : "7llkdnj0rt1veaOm4"
   }, {
-    "type" : "CristinIdentifier",
-    "value" : "1625618456",
-    "sourceName" : "gsos2rahbjs0ectv@bdbvnhu19sf"
+    "type" : "ScopusIdentifier",
+    "value" : "VkwdlSQJAPBR",
+    "sourceName" : "t1re2bd6re@f0dzbfwdok2xvkl"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/c4aed220-879f-4dcf-b5a3-298ced5c1556",
+    "sourceName" : "yzee0ir6yuz3g2@b8vxnfwfr1"
   } ],
-  "subjects" : [ "https://www.example.org/a04c4158-09e6-45c7-b190-1aaa4efae253" ],
+  "subjects" : [ "https://www.example.org/e8afcd05-24a9-4825-a6e4-203b2c908f1a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "044aeaa5-de91-45b0-ab9e-ae08732f102d",
-    "name" : "KsI6ndaoIAHf5VI",
-    "mimeType" : "DbqyFQkvsBb",
-    "size" : 714656275,
-    "license" : "https://www.example.com/tfdg26jhhk",
+    "identifier" : "bbe5ce9a-08ef-46b3-923e-92024c76650f",
+    "name" : "5PXhS2I34f28ysVsM",
+    "mimeType" : "pBiOFSJaQORw1j",
+    "size" : 2046153928,
+    "license" : "https://www.example.com/zzwovuhpujcr28c8eof",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "HvHO5ZqEfQv"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "g7lLx99AQ2",
-    "publishedDate" : "1980-03-31T00:19:36.064Z",
+    "legalNote" : "yflETVRALrp6",
+    "publishedDate" : "2002-08-03T05:54:21.628Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "195739996@ByP1aHHGTafK9",
-      "uploadedDate" : "1997-02-09T08:00:56.768Z"
+      "uploadedBy" : "596797449@v0iCH3oya6G7CQe",
+      "uploadedDate" : "1983-04-28T00:27:48.295Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PyA5ZyntudRxgFH9u",
-    "name" : "duHhLsQFbly",
-    "description" : "6iGX9LOkKJr"
+    "id" : "https://www.example.com/MfqeMkar91mlDSTH7",
+    "name" : "jHJisKIDIeASXcOk",
+    "description" : "Nye72qMfAqAQfq"
   } ],
-  "rightsHolder" : "FGJ8ilwH3gMsdrdcoaa",
-  "duplicateOf" : "https://www.example.org/9934ef8c-bd2e-439f-9e69-5e6119116563",
+  "rightsHolder" : "8D1K1ZkJEvkO",
+  "duplicateOf" : "https://www.example.org/e81531a1-7531-4530-9b6f-19c761dafb8f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ReikTeeT4v"
+    "note" : "6xGNmIhOJK"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "0PYVViHzcMleKZw",
-    "createdBy" : "NTfBtcgJndIs04Gnrr",
-    "createdDate" : "2024-07-05T21:24:35.051Z"
+    "note" : "DHfMtM2Gl4UsGZMM",
+    "createdBy" : "97yLD5OoQAgqKCx",
+    "createdDate" : "2003-01-11T08:29:38.285Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1a6a0c69-1b4b-4c7a-87fc-51f1a94655b6" ],
+  "curatingInstitutions" : [ "https://www.example.org/53e76371-7c3a-4376-b187-df91dc37a7a1" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "qq9w1CbpRJ",
-    "ownerAffiliation" : "https://www.example.org/7c09416d-7649-48fb-964b-40dd60050ac4"
+    "owner" : "jjtRGNcQCFiDO",
+    "ownerAffiliation" : "https://www.example.org/a113efdb-559b-408c-85b1-4393c8ad80ac"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3073dbbc-9900-44a6-bb6c-2bdb642ad7f0"
+    "id" : "https://www.example.org/ee7a80b8-2d29-4e45-a076-04ab586d1ce4"
   },
-  "createdDate" : "1993-02-02T16:34:52.247Z",
-  "modifiedDate" : "2021-06-04T08:20:43.650Z",
-  "publishedDate" : "2001-05-29T02:00:31.449Z",
-  "indexedDate" : "1988-10-06T00:41:09.668Z",
-  "handle" : "https://www.example.org/2eadf280-937d-4f4a-bd36-e32747b6e67b",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/74c44e73-49fe-4ff2-a842-202f0fc2d3eb",
+  "createdDate" : "2024-03-26T00:28:05.812Z",
+  "modifiedDate" : "1990-10-28T01:33:49.397Z",
+  "publishedDate" : "1992-10-19T04:57:12.446Z",
+  "indexedDate" : "1985-06-10T13:43:24.289Z",
+  "handle" : "https://www.example.org/9440e4de-0d3d-4b56-89c2-3a900e352b97",
+  "doi" : "https://doi.org/10.1234/hic",
+  "link" : "https://www.example.org/c6330fb2-051f-44d9-991d-bb64c9a732ae",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1ZHeTl5D5uJsijNO4",
+    "mainTitle" : "nGqRQFteyWL",
     "alternativeTitles" : {
-      "cs" : "qoqHTxZJrizVUXxlr6"
+      "el" : "bzPNypoxcxMs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "pcgQF1sZT1r391y",
-      "month" : "vGeW5K85iKMX",
-      "day" : "zdip82JDAemzII"
+      "year" : "CGGmaLlmljC5w",
+      "month" : "klyPMZ3E9WZN",
+      "day" : "rMtc61V630uqgpFx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/638135bc-7ad9-4d87-b53f-7dfc1513bf47",
-        "name" : "RRXu7myW9JrBrpMd",
+        "id" : "https://www.example.org/de512753-c0b5-4437-8035-6df3062b4e0f",
+        "name" : "nsYl1wtGRtt2i",
         "nameType" : "Personal",
-        "orcId" : "bi8pKXbpcxRdbJL",
-        "verificationStatus" : "Verified",
+        "orcId" : "a6pPbTVlDysKja1b",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "K3U07p4Tl3l",
-          "value" : "8UG5HD5ZUO3V1OYtKlL"
+          "sourceName" : "WjVbR5jwAZHz2E94lL",
+          "value" : "xo5TCVBeIn7oEaf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o5kxsjWpHcVC3VNNz",
-          "value" : "LBJY8aBY7qjBszpG"
+          "sourceName" : "kaX24yKLg7O",
+          "value" : "O6mWUJmMHb9oNbNby2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/789c09f7-d8a9-4564-8973-2d70d6cbfd8b"
+        "id" : "https://www.example.org/dadcdc0e-875a-4127-8596-86d4f81d4c62"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2c642bf9-f04e-4ed2-afc4-f192731737bd",
-        "name" : "k25HqgRhOqx9YON1",
+        "id" : "https://www.example.org/28ff2b13-3d1e-4381-a986-661e6b3d105e",
+        "name" : "oAziA6512bnCLAyR",
         "nameType" : "Organizational",
-        "orcId" : "X1hH9w7nxW1TibZK",
+        "orcId" : "AG1RUJxRLl",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JCduXFGqLNkRaJ9ne",
-          "value" : "MRG6koEZi006"
+          "sourceName" : "PIaMYatcUrJm",
+          "value" : "P7FpJ4AZFkcVE03N"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MYmvzkv9Usay73XdMP1",
-          "value" : "23RjaCGYv7b7Eqtb"
+          "sourceName" : "nHFg5i0fs4",
+          "value" : "xOPfZqviDp4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7928ce4e-5ccd-4aea-ba90-ddcde2aacf05"
+        "id" : "https://www.example.org/46a02c6e-b84b-4616-aaa0-adf3a483b7d0"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Composer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "L3Munjl7RA"
+      "ru" : "JXEYeH8Aqm9lIP"
     },
-    "npiSubjectHeading" : "k9ir2Ev0LDZ7Ceh4igO",
-    "tags" : [ "j2C77V88uC" ],
-    "description" : "JwZ3wtPP8p",
+    "npiSubjectHeading" : "8zdoz1wfKRr7LQ",
+    "tags" : [ "tekJsE16wiSwcHcS" ],
+    "description" : "K8oyDdbkolQqyvLvRR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/qrNU3NdxMhhox0F/publication/0191e0c8ecc7-fb33fab7-4b56-40e8-a110-e31b404c4e04"
+        "id" : "https://www.example.com/lFulXeINZelb/publication/0191ff235039-15e1bb26-0440-473b-953c-f2a4ddb4e56e"
       },
-      "doi" : "https://www.example.org/fa0eeb4e-5246-4839-a38e-5ee1624c0c51",
+      "doi" : "https://www.example.org/cfe11a25-addb-4524-bf19-32a40a2d2712",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "nwASLEXJujrADSRihs",
-          "end" : "CaOH8Lf6JW1OQtN"
+          "begin" : "jwy6q4zPRSztG",
+          "end" : "TUWfERVDlKMIV"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f7d42934-08da-4d92-a70c-7cfbd8d1ec7a",
-    "abstract" : "rQ2emMAL0NZcH4ayFA3"
+    "metadataSource" : "https://www.example.org/303f350c-9be9-473a-b9ad-82a9972addf9",
+    "abstract" : "eRr2fdOjeJh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/66ad7dd2-3146-4586-a802-fb69afc58757",
-    "name" : "uGtDXSL9UKQBSoY",
+    "id" : "https://www.example.org/e18b1d19-2901-437f-a712-616d686bc3fa",
+    "name" : "0BhCgNrFTdHhE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-01-10T10:00:44.755Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "SPTW44uSUHmuSdW"
+      "approvalDate" : "2011-08-04T02:00:05.915Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Q4rDk3GjFpo3GJqZrhY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/07b9f65c-9cea-4cd8-99fc-94a55986e051",
-    "identifier" : "BLS1BRDxk5MpR",
+    "source" : "https://www.example.org/5b97217d-d55d-4474-9cca-751ce17e1604",
+    "identifier" : "kflbOEeqC2Qm5",
     "labels" : {
-      "hu" : "ggS8atN4tPlLxWRTQQU"
+      "ru" : "6Pl0DyEUViyVCM"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 2029463507
+    },
+    "activeFrom" : "1974-11-22T04:43:46.502Z",
+    "activeTo" : "2015-03-24T00:29:56.714Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/bfb0bca3-ecbb-4ee3-adc7-31d34678b1e4",
+    "id" : "https://www.example.org/19ccc41e-b434-4ed4-a795-58b1c8f3e961",
+    "identifier" : "p94q7R0N6UIWDbf",
+    "labels" : {
+      "sv" : "NMN4j58lre0hBRhnpaa"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 886278288
+      "amount" : 603787683
     },
-    "activeFrom" : "1993-02-18T16:36:52.957Z",
-    "activeTo" : "2000-10-03T08:28:42.039Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/28639cbb-f22a-486a-9bcc-fbbb6cf29b7e",
-    "id" : "https://www.example.org/4940ada7-0bb0-4fc4-9fc0-572731f840e4",
-    "identifier" : "z6w3CYOuLOuyTCuynA",
-    "labels" : {
-      "fi" : "4evWr4Y9JL"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2030928352
-    },
-    "activeFrom" : "1974-08-08T18:01:09.669Z",
-    "activeTo" : "2017-10-24T07:50:14.272Z"
+    "activeFrom" : "2000-11-16T21:37:24.223Z",
+    "activeTo" : "2002-11-06T13:41:10.460Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "CristinIdentifier",
-    "value" : "358845650",
-    "sourceName" : "siyeptvedu9b0ksk8g4@gnb33m40qgpu"
+    "value" : "1139274471",
+    "sourceName" : "zphliiysojuktgtky@eby2btgvis"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "RvU450OoZAQJ41vQTyq",
-    "sourceName" : "gmln6e0tnka@a6omw2kgk5hk2jowveg"
+    "value" : "497P16x2GAAGnfMz",
+    "sourceName" : "fsl779cpmtuoavl4mqj@oylxl0d1b49qx54gn"
   }, {
     "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/3d31dcb1-e334-40fa-ad8f-6e1f439fd834",
-    "sourceName" : "d6gxzdtpxjv6nrm@vaxcbtnounaalay"
+    "value" : "https://www.example.org/9f4fe33e-99cd-4ac3-8653-e743b602609a",
+    "sourceName" : "kuwikxfcjw579sj211@nae1hos2dw52u7xm"
   }, {
     "type" : "AdditionalIdentifier",
-    "sourceName" : "tGspxWRtXIEL",
-    "value" : "l8pqWQqLzvv7If"
+    "sourceName" : "lqP4vihJksHTgxEwF",
+    "value" : "TLIKbxvNHDJvd"
   } ],
-  "subjects" : [ "https://www.example.org/d8d920d6-433d-4200-8d47-15f4527d0437" ],
+  "subjects" : [ "https://www.example.org/f1c60b4f-5acd-44f7-803b-ce4fcca30d47" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "57f5b2ee-e22b-4f25-9eea-8a8582297584",
-    "name" : "gELM74EI5R0eySCm8Gj",
-    "mimeType" : "hqPWvIZ6uFwN86BTQ0S",
-    "size" : 709584675,
-    "license" : "https://www.example.com/vsrcyk7rhcgmz6ch",
+    "identifier" : "47da6fd0-3726-43eb-b03f-176abe1f14ef",
+    "name" : "6MO5MhqJagUmcexSUEz",
+    "mimeType" : "VcpMrHjxfjudPi1",
+    "size" : 1349195062,
+    "license" : "https://www.example.com/f32eibiv1sn1itad62",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QebXIW7EoMeFvx872OV",
-    "publishedDate" : "1983-11-14T16:35:49.073Z",
+    "legalNote" : "zGMpTD11hWgXEXQ",
+    "publishedDate" : "2023-10-20T14:20:03.264Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1267620315@7jLEGLGKR3",
-      "uploadedDate" : "2021-01-19T16:43:38.663Z"
+      "uploadedBy" : "500005427@gBAiSHDm2WYReH",
+      "uploadedDate" : "1985-09-15T12:25:04.303Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KmeXCGc54zk7",
-    "name" : "mUDcnRpwXLQl3BsNAmz",
-    "description" : "CoKzjA2aJnxsEIQ"
+    "id" : "https://www.example.com/vt3VrdbzxJW",
+    "name" : "rw6NToH65YyGNr6b2",
+    "description" : "RhYx6yd2VC"
   } ],
-  "rightsHolder" : "8n4l3zASmWBnn",
-  "duplicateOf" : "https://www.example.org/531dc6de-84bf-4f23-8b32-f13ea41ff425",
+  "rightsHolder" : "zF0agr2bznqBr5MhEqa",
+  "duplicateOf" : "https://www.example.org/8d4e51e1-e57d-417a-9007-1e4853767093",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "64gOQmO9I9X"
+    "note" : "urKpZZDUiPGIy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oNYgGwkfs5MLZWEiA",
-    "createdBy" : "rKd7nIarOwskY",
-    "createdDate" : "2004-07-12T16:56:22.329Z"
+    "note" : "bhXwQj76vGBkvoVPJj",
+    "createdBy" : "L11SUQ7DDhodHg",
+    "createdDate" : "2021-10-28T23:17:45.900Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/09b7583b-73c1-484d-847c-98120a8b933a" ],
+  "curatingInstitutions" : [ "https://www.example.org/b76f5e10-e695-41ed-93e3-8fe22c5d279c" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "G9FGchElpp7hTMzWmpr",
-    "ownerAffiliation" : "https://www.example.org/2751eb46-cb29-4044-a864-18e0667cf070"
+    "owner" : "4yt7DaSvKzJUTDf",
+    "ownerAffiliation" : "https://www.example.org/179e13c0-e642-4d3c-a340-3fcea2dac46d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ee560e7d-560d-47cf-b34c-3f28fad5888c"
+    "id" : "https://www.example.org/11d68ea6-96fc-4916-86fc-8cb3c0b853a7"
   },
-  "createdDate" : "1986-01-14T22:15:17.915Z",
-  "modifiedDate" : "1976-07-04T15:43:09.387Z",
-  "publishedDate" : "1987-03-17T11:31:44.442Z",
-  "indexedDate" : "2015-05-07T11:26:26.654Z",
-  "handle" : "https://www.example.org/edb2c4f4-e11f-4379-937a-6e82b293f089",
-  "doi" : "https://doi.org/10.1234/id",
-  "link" : "https://www.example.org/aadec026-b281-4c88-a752-f028a058819c",
+  "createdDate" : "2001-07-03T12:01:34.894Z",
+  "modifiedDate" : "2006-09-07T00:32:35.531Z",
+  "publishedDate" : "2005-12-06T01:25:16.672Z",
+  "indexedDate" : "2021-01-01T07:09:15.863Z",
+  "handle" : "https://www.example.org/e51662cb-af84-452f-8494-2deeabae9242",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/4c00a689-b0e5-4612-ac1b-0ed45974e6f7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1I8sf4FWjt",
+    "mainTitle" : "8rdK72ptuS73",
     "alternativeTitles" : {
-      "nn" : "B9sHUJIuUIX6HBbxxwj"
+      "nl" : "sj3Fll9jQTDOSZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "jTaYHhOTMGkNoYzAy4T",
-      "month" : "Rxv3EXSjcMy0u",
-      "day" : "vjMonwr1Pk"
+      "year" : "rNSxFwk8O3aNA5Tn",
+      "month" : "BjhjUBWmT8gsymkIaPX",
+      "day" : "qM4EPTEkfU9Kmap"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/49d4c3d5-0fa2-46dd-a1d3-302520811c8c",
-        "name" : "FEJcBqv5wp6sjG8y7",
-        "nameType" : "Organizational",
-        "orcId" : "b6Q9XjhVf6s6liQ0x",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f2ed3344-3a12-4946-bd20-eebe48d379c7",
+        "name" : "sluXjjzUA49R9qoxTX",
+        "nameType" : "Personal",
+        "orcId" : "00NV517eI0nhvE3qZ6",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TSQq2WNNx9G",
-          "value" : "R0UhSWDNOVSAg"
+          "sourceName" : "hNDBsp4KuQn3VRk",
+          "value" : "z94GhowDHalAb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HP3wrvCgFd6sA8Tjzi",
-          "value" : "Tm2CcbkAT7OA6lODay"
+          "sourceName" : "HgqogE4JJ5",
+          "value" : "hWcT0kSLbeL35pMT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/41fc1d5f-1ce7-4ca7-b356-4bcabcfe030d"
+        "id" : "https://www.example.org/221d79df-dd19-4a29-86f5-ab838979113c"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/435cef09-8639-4faf-b2e1-ea0b53a4203e",
-        "name" : "0nodM6jEgm6",
-        "nameType" : "Personal",
-        "orcId" : "exv2vzkLFAXrmmd",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/8585c646-a753-4822-a5b5-19139237960d",
+        "name" : "LZ98K3amZXR0mrE",
+        "nameType" : "Organizational",
+        "orcId" : "UWiSJ58HGqVyumFs",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AVZvOilFAQq9",
-          "value" : "cASaDAD9g6t"
+          "sourceName" : "NG3geMMQ1u",
+          "value" : "OoKmklrRg4wECCkRh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3jy0bVriMvOJEN0",
-          "value" : "ygTjZjDvOB9KAxd0Wvt"
+          "sourceName" : "F9WAgI5z2GKuKuwL",
+          "value" : "Z0aZdlyFwbx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3c1dc881-a3fd-4708-8e2a-57f0ca1f9c47"
+        "id" : "https://www.example.org/fd585637-1d52-40e5-9da6-0ba63b11a59f"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "XCgVGzQo3v"
+      "da" : "K2Kab9ztBZdBIIQgq0"
     },
-    "npiSubjectHeading" : "xiAA84yCbCdAtDz",
-    "tags" : [ "YCujAWTFnl" ],
-    "description" : "hmMoFYgGd672Iif60Q",
+    "npiSubjectHeading" : "uXlb7gqkQROeAEF",
+    "tags" : [ "fLQ5ves52pHS8S" ],
+    "description" : "eVpGZh7MkziV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/41ed8ce0-0e13-4a6c-a671-26260badd8d8",
+      "doi" : "https://www.example.org/cb8ef9f1-57b2-4df5-9979-5861af3ef5b4",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
           "type" : "IndividualExhibition"
         },
-        "description" : "xSgCQlY1Oyysyyy5WU",
+        "description" : "FfIGoe5R9qG",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "0PfFQbbJXYUbtf0S",
-            "country" : "ASa8NBeZoyyMn"
+            "label" : "rZvWN6pArKuPfkQJ",
+            "country" : "dDDBTpwPmMspr8hgw"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2007-02-19T07:50:26.463Z",
-            "to" : "2007-06-06T05:36:24.839Z"
+            "from" : "1986-06-27T16:32:47.528Z",
+            "to" : "2020-12-26T21:13:37Z"
           },
-          "sequence" : 2067675208
+          "sequence" : 1550860417
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/892d239d-8904-46ad-a5a1-74b8250bd545",
-    "abstract" : "5SQgHM1lRlA"
+    "metadataSource" : "https://www.example.org/ac793ea5-3c94-4c2e-b819-336efdeb3cf2",
+    "abstract" : "EBADpqxkNPQlHszZNwS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/65baa5c1-2aac-4295-916f-63457a5bb5ce",
-    "name" : "sz1dCPtlB4mHxp9C",
+    "id" : "https://www.example.org/95f369cf-052c-464c-9f34-995d01fe779a",
+    "name" : "DlLoBeM0F6bIQNXMG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-04-17T00:37:02.720Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "8Rx0i3fJWO27L5"
+      "approvalDate" : "2003-06-04T22:47:03.323Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "S91ZsEan30WwGLJWFh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/283d1f74-9eb3-49df-8303-3582b1573c71",
-    "identifier" : "g2JZPDUGZXo0FpS",
+    "source" : "https://www.example.org/b96e1db1-fd37-4108-8ffc-56eeef7def7f",
+    "identifier" : "piepIELDNW2SI",
     "labels" : {
-      "nb" : "dPGRCm0yzvY"
+      "de" : "89PeSKkZKPMxsh"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1095274347
+      "currency" : "NOK",
+      "amount" : 1779288661
     },
-    "activeFrom" : "1995-06-21T04:25:24.779Z",
-    "activeTo" : "1998-09-19T12:44:09.292Z"
+    "activeFrom" : "1971-07-03T13:06:58.277Z",
+    "activeTo" : "2017-04-04T12:43:59.962Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8cc1749f-d49f-426a-b7d7-8c668028cbc9",
-    "id" : "https://www.example.org/754fa0ac-faa3-4849-a120-924feab45e64",
-    "identifier" : "Y0ZqdFBVGA",
+    "source" : "https://www.example.org/6e798dba-390b-4768-8744-124ec37565e4",
+    "id" : "https://www.example.org/a1e3e401-adcb-44bf-a312-cfddf41b2265",
+    "identifier" : "6SSmLpVaZS",
     "labels" : {
-      "nn" : "kRbFbcF9zu6JHfao"
+      "ca" : "UzlyQJjmazoFX"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 32090493
+      "currency" : "EUR",
+      "amount" : 2051904205
     },
-    "activeFrom" : "1993-01-17T14:02:38.516Z",
-    "activeTo" : "2021-02-27T19:28:12.583Z"
+    "activeFrom" : "1994-06-06T13:17:11.282Z",
+    "activeTo" : "2013-09-21T17:27:22.644Z"
   } ],
   "additionalIdentifiers" : [ {
-    "type" : "CristinIdentifier",
-    "value" : "1642829035",
-    "sourceName" : "lljsrnhjt95tqy6ftld@h2y7qv7ffm2ay"
-  }, {
-    "type" : "HandleIdentifier",
-    "value" : "https://www.example.org/d2a95131-cb88-4626-90cb-7a758f80bfba",
-    "sourceName" : "wrfccwo29auc@t5tqkpmtylacb0"
+    "type" : "AdditionalIdentifier",
+    "sourceName" : "1I60BJmJZ7",
+    "value" : "zNfCyzN1qMdRKH"
   }, {
     "type" : "ScopusIdentifier",
-    "value" : "kWmrkSqllmdG5P89C5",
-    "sourceName" : "zw4yrxqjuow@tlcjvrfxrus0ix"
+    "value" : "XHuAg1obQT3wrz",
+    "sourceName" : "dx5mzndrja6q@vokirxjpeiqk"
   }, {
-    "type" : "AdditionalIdentifier",
-    "sourceName" : "02gIjNRutW",
-    "value" : "LRd99L7hzzreVaxVif3"
+    "type" : "CristinIdentifier",
+    "value" : "1345711568",
+    "sourceName" : "fqysuauopfyafre@uep2csasvp7e9y4md"
+  }, {
+    "type" : "HandleIdentifier",
+    "value" : "https://www.example.org/20ece9ad-5fbb-4825-9124-3a2cdf887e76",
+    "sourceName" : "pzapxokmlkwpzctohr@vxc2r5ypxb2mvvz"
   } ],
-  "subjects" : [ "https://www.example.org/c2f9d33c-3af8-4405-b934-0c5c5f8109bb" ],
+  "subjects" : [ "https://www.example.org/11797465-d668-4de6-9973-bb7647bad6a0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "04c39835-e7ed-454a-85e2-b78e2c8b41cf",
-    "name" : "91ZnL9ehCmJw7",
-    "mimeType" : "6dcon7p6DID9Lne",
-    "size" : 410398740,
-    "license" : "https://www.example.com/mbjhix8oio7nfipl4j",
+    "identifier" : "5f95b5bb-96ab-49d6-9dec-d87c29f7ec61",
+    "name" : "67GuF1xlbw2Iwik",
+    "mimeType" : "wLm5BBnvBpkosbU",
+    "size" : 1168546646,
+    "license" : "https://www.example.com/hd4klajsnme9c",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "BEJ5yQeoBMZ9X3",
-    "publishedDate" : "1988-09-01T06:44:02.806Z",
+    "legalNote" : "icgGUBVCG3mYvhtsr",
+    "publishedDate" : "1972-04-09T17:12:03.195Z",
     "uploadDetails" : {
       "type" : "UserUploadDetails",
-      "uploadedBy" : "1199283093@SdfX7D12Iw5ZpY",
-      "uploadedDate" : "1975-04-05T17:10:34.441Z"
+      "uploadedBy" : "1535184433@Fm3pWi4uVSE",
+      "uploadedDate" : "1988-10-07T22:42:18.928Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nI9tdWBhCMGMpbm",
-    "name" : "2zFgYD9ztsfXW5JZ3F",
-    "description" : "kcqmc7Ghna"
+    "id" : "https://www.example.com/ZUcBFO7aSBt",
+    "name" : "3pLWtRBneQLGk7E7v",
+    "description" : "24typwNC9wQtJmX"
   } ],
-  "rightsHolder" : "chYQkI2vzY5r",
-  "duplicateOf" : "https://www.example.org/6d01450a-aee7-406c-a444-da6fc7bc6d74",
+  "rightsHolder" : "lsd2mYev01twOQf",
+  "duplicateOf" : "https://www.example.org/a3a5f7f1-8093-409d-bbd3-aab5145fda2e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gS3Gms0GPHab"
+    "note" : "M6qil5LwptTPRgT8BA3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "yhxG5w5IqdYAxl",
-    "createdBy" : "qgGJgORo7UbSv1ENN7",
-    "createdDate" : "1980-04-16T06:23:36.455Z"
+    "note" : "Zj9Gr9BXOhYBvf49boz",
+    "createdBy" : "ycRYizIDDUZ",
+    "createdDate" : "1988-05-06T10:54:03.732Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ce1f600c-a152-49e2-919b-59c6e43d1142" ],
+  "curatingInstitutions" : [ "https://www.example.org/205a8f40-b7c0-49f4-97d9-b358b1bda765" ],
   "importDetails" : [ ],
   "modelVersion" : "0.23.2"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -523,6 +523,9 @@ ConfirmedDocument:
       identifier:
         type: string
         format: uri
+      sequence:
+        type: integer
+        format: int32
       type:
         type: string
 ConfirmedFunding:
@@ -1074,14 +1077,14 @@ Funding:
     source:
       type: string
       format: uri
-    fundingAmount:
-      $ref: '#/components/schemas/MonetaryAmount'
     activeFrom:
       type: string
       format: date-time
     activeTo:
       type: string
       format: date-time
+    fundingAmount:
+      $ref: '#/components/schemas/MonetaryAmount'
     type:
       type: string
 GeographicalContent:
@@ -2633,6 +2636,9 @@ UnconfirmedDocument:
     properties:
       text:
         type: string
+      sequence:
+        type: integer
+        format: int32
       type:
         type: string
 UnconfirmedFunding:

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
@@ -10,10 +10,10 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.publication.PublicationServiceConfig.ENVIRONMENT;
 import static no.unit.nva.testutils.HandlerRequestBuilder.CLIENT_ID_CLAIM;
 import static no.unit.nva.testutils.HandlerRequestBuilder.ISS_CLAIM;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -261,7 +261,7 @@ class PublicationPermissionStrategyTest extends ResourcesLocalTest {
         var publication = createPublication(resourceOwner, customer, randomUri());
 
         var degreePhd = new DegreePhd(new MonographPages(), new PublicationDate(),
-                                      Set.of(new UnconfirmedDocument(randomString())));
+                                      Set.of(new UnconfirmedDocument(randomString(), randomInteger())));
         var reference = new Reference.Builder().withPublicationInstance(degreePhd).build();
         var entityDescription = publication.getEntityDescription().copy().withReference(reference).build();
 
@@ -272,7 +272,7 @@ class PublicationPermissionStrategyTest extends ResourcesLocalTest {
         var publication = createPublication(resourceOwner, customerId, ownerAffiliation);
 
         var degreePhd = new DegreePhd(new MonographPages(), new PublicationDate(),
-                                      Set.of(new UnconfirmedDocument(randomString())));
+                                      Set.of(new UnconfirmedDocument(randomString(), randomInteger())));
         var reference = new Reference.Builder().withPublicationInstance(degreePhd).build();
         var entityDescription = publication.getEntityDescription().copy().withReference(reference).build();
 
@@ -312,7 +312,7 @@ class PublicationPermissionStrategyTest extends ResourcesLocalTest {
         publication.getEntityDescription()
             .getReference()
             .setPublicationInstance(new DegreePhd(new MonographPages(), new PublicationDate(),
-                                                  Set.of(new UnconfirmedDocument(randomString()))));
+                                                  Set.of(new UnconfirmedDocument(randomString(), randomInteger()))));
 
         return publication;
     }

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
@@ -385,11 +385,12 @@ public final class PublicationInstanceBuilder {
         var referencedUri = new ReferencedByUris(Set.of(randomUri()));
         var compliesWithUris = new CompliesWithUris(Set.of(randomUri()));
         return new DataSet(randomBoolean(),
-                geographicalCoverage, referencedUri, Set.of(new UnconfirmedDocument(randomString())), compliesWithUris);
+                geographicalCoverage, referencedUri, Set.of(new UnconfirmedDocument(randomString(), randomInteger())),
+                           compliesWithUris);
     }
 
     private static DataManagementPlan generateDataManagementPlan() {
-        return new DataManagementPlan(Set.of(new UnconfirmedDocument(randomString())), randomMonographPages());
+        return new DataManagementPlan(Set.of(new UnconfirmedDocument(randomString(), randomInteger())), randomMonographPages());
     }
 
     private static Map generateMap() {
@@ -558,8 +559,8 @@ public final class PublicationInstanceBuilder {
 
     private static DegreePhd generateDegreePhd() {
         return new DegreePhd(randomMonographPages(), randomPublicationDate(),
-                             Set.of(new ConfirmedDocument(randomUri()),
-                                    new UnconfirmedDocument(randomString())));
+                             Set.of(new ConfirmedDocument(randomUri(), randomInteger()),
+                                    new UnconfirmedDocument(randomString(), randomInteger())));
     }
 
     private static DegreeLicentiate generateDegreeLicentiate() {

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/ConfirmedDocument.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/ConfirmedDocument.java
@@ -6,5 +6,5 @@ import java.net.URI;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record ConfirmedDocument(URI identifier) implements RelatedDocument{
+public record ConfirmedDocument(URI identifier, Integer sequence) implements RelatedDocument{
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/ConfirmedDocument.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/ConfirmedDocument.java
@@ -7,4 +7,8 @@ import java.net.URI;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record ConfirmedDocument(URI identifier, Integer sequence) implements RelatedDocument{
+
+    public static ConfirmedDocument fromUri(URI value) {
+        return new ConfirmedDocument(value, null);
+    }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/UnconfirmedDocument.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/UnconfirmedDocument.java
@@ -7,4 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record UnconfirmedDocument(String text, Integer sequence) implements RelatedDocument{
 
+    public static UnconfirmedDocument fromValue(String value) {
+        return new UnconfirmedDocument(value, null);
+    }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/UnconfirmedDocument.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/UnconfirmedDocument.java
@@ -5,6 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record UnconfirmedDocument(String text) implements RelatedDocument{
+public record UnconfirmedDocument(String text, Integer sequence) implements RelatedDocument{
 
 }

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1946,7 +1946,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
     private Publication createAndPersistDegreeWithoutDoi() throws BadRequestException {
         var publication = randomPublication().copy().withDoi(null).build();
         var degreePhd = new DegreePhd(new MonographPages(), new PublicationDate(),
-                                      Set.of(new UnconfirmedDocument(randomString())));
+                                      Set.of(UnconfirmedDocument.fromValue(randomString())));
         var reference = new Reference.Builder().withPublicationInstance(degreePhd).build();
         var entityDescription = publication.getEntityDescription().copy().withReference(reference).build();
         var publicationOfTypeDegree = publication.copy().withEntityDescription(entityDescription).build();


### PR DESCRIPTION
When mapping related documents from Brage, it is very important for users that they appear in right sequence, same as in Brage. Adding sequence number to RelatedDocuments.