### PR TITLE
Np 47374 setting sequence number to related documents

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
@@ -517,12 +517,13 @@ public final class PublicationInstanceMapper {
     }
 
     private static Set<RelatedDocument> extractUnconfirmedDocuments(Record brageRecord) {
-        return Optional.ofNullable(brageRecord.getPart())
-                   .orElseGet(Collections::emptyList)
-                   .stream()
-                   .sorted()
-                   .map(UnconfirmedDocument::fromValue)
-                   .collect(Collectors.toCollection(LinkedHashSet::new));
+        var values = Optional.ofNullable(brageRecord.getPart())
+                                 .orElseGet(Collections::emptyList);
+        var relatedDocuments = new LinkedHashSet<RelatedDocument>();
+        for (int i = 0; i < values.size(); i++) {
+            relatedDocuments.add(new UnconfirmedDocument(values.get(i), i + 1));
+        }
+        return relatedDocuments;
     }
 
     private static MonographPages extractMonographPages(Record brageRecord) {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
@@ -517,8 +517,7 @@ public final class PublicationInstanceMapper {
     }
 
     private static Set<RelatedDocument> extractUnconfirmedDocuments(Record brageRecord) {
-        var values = Optional.ofNullable(brageRecord.getPart())
-                                 .orElseGet(Collections::emptyList);
+        var values = Optional.ofNullable(brageRecord.getPart()).orElseGet(Collections::emptyList);
         var relatedDocuments = new LinkedHashSet<RelatedDocument>();
         for (int i = 0; i < values.size(); i++) {
             relatedDocuments.add(new UnconfirmedDocument(values.get(i), i + 1));


### PR DESCRIPTION
When importing phd degrees from Brage, we should present related documents in the same order as in Brage. Attempting to achieve it by setting sequence number.
