### PR TITLE
fixing bug

### DIFF
--- a/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
@@ -10,8 +10,9 @@ public enum TicketDtoStatus {
     NEW("New"),
     PENDING("Pending"),
     COMPLETED("Completed"),
-    NOT_APPLICABLE("Not Applicable"),
-    CLOSED("Closed");
+    NOT_APPLICABLE("NotApplicable"),
+    CLOSED("Closed"),
+    REMOVED("Removed");
 
     private static final String INVALID_TICKET_STATUS_ERROR = "Invalid ticketDto status. Valid values:  ";
     private static final String SEPARATOR = ",";

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoStatusTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoStatusTest.java
@@ -1,6 +1,9 @@
 package no.unit.nva.publication.ticket;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Arrays;
+import no.unit.nva.publication.model.business.TicketStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -12,5 +15,12 @@ class TicketDtoStatusTest {
     void shouldThrowExceptionWhenInputIsUnknownValue() {
         Executable executable = () -> TicketDtoStatus.parse(UNKNOWN_VALUE);
         assertThrows(IllegalArgumentException.class, executable);
+    }
+
+    @Test
+    void shouldParseAllValidTicketStatuses() {
+        assertDoesNotThrow(() -> Arrays.stream(TicketStatus.values())
+            .map(TicketStatus::toString)
+            .map(TicketDtoStatus::parse).toList());
     }
 }


### PR DESCRIPTION
Ingen har utvidet TicketStatusDto til å støtte nye ticket statuser. 
Listing av ticket feiler da vi ikke klarer å servere tickets med status NotApplicable og Removed til frontend.

Dette fikser problemet.