### PR TITLE
mapping of commentary from Cristin

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/BookBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/BookBuilder.java
@@ -4,6 +4,7 @@ import static no.unit.nva.cristin.mapper.CristinSecondaryCategory.isMonograph;
 import java.util.Set;
 import no.unit.nva.cristin.mapper.nva.exceptions.UnsupportedSecondaryCategoryException;
 import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.instancetypes.book.AcademicCommentary;
 import no.unit.nva.model.instancetypes.book.AcademicMonograph;
 import no.unit.nva.model.instancetypes.book.BookAnthology;
 import no.unit.nva.model.instancetypes.book.Encyclopedia;
@@ -48,7 +49,7 @@ public class BookBuilder extends AbstractBookReportBuilder {
         } else if (CristinSecondaryCategory.EXHIBITION_CATALOG.equals(secondaryCategory)) {
             return new ExhibitionCatalog(createMonographPages());
         } else if (CristinSecondaryCategory.ACADEMIC_COMMENTARY.equals(secondaryCategory)) {
-            return new AcademicMonograph(createMonographPages());
+            return new AcademicCommentary(createMonographPages());
         } else {
             throw new UnsupportedSecondaryCategoryException();
         }

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -28,7 +28,7 @@ Feature: Book conversion rules
       | POPVIT_BOK        | PopularScienceMonograph |
       | OPPSLAGSVERK      | Encyclopedia            |
       | UTSTILLINGSKAT    | ExhibitionCatalog       |
-      | KOMMENTARUTG      | AcademicMonograph       |
+      | KOMMENTARUTG      | AcademicCommentary       |
 
   Scenario: Cristin Result "Academic monograph" is converted to NVA Resource with Publication Context
   of type "Book"


### PR DESCRIPTION
When importing publication from Cristin
And publication main category is Book
And publication second category is Commentary
Then import publication as Book -> AcademicCommentary 