### PR TITLE
mapping scopus identifier

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -453,7 +453,7 @@ public class CristinMapper extends CristinMappingModule {
 
     private static boolean scopusIdentifierThatAlreadyHasBeenMapped(String sourceCode,
                                                                     AdditionalIdentifierBase additionalIdentifier) {
-        return sourceCode.toLowerCase(Locale.ROOT).equals(SCOPUS_IDENTIFIER_SOURCE_CODE_FROM_CRISTIN)
+        return SCOPUS_IDENTIFIER_SOURCE_CODE_FROM_CRISTIN.equals(sourceCode.toLowerCase(Locale.ROOT))
                && additionalIdentifier instanceof ScopusIdentifier;
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -40,10 +40,7 @@ import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.cristin.mapper.exhibition.CristinExhibition;
 import no.unit.nva.cristin.mapper.nva.CristinMappingModule;
 import no.unit.nva.cristin.mapper.nva.ReferenceBuilder;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
 import no.unit.nva.model.Contributor;
-import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
@@ -54,6 +51,10 @@ import no.unit.nva.model.PublicationNoteBase;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResearchProject;
 import no.unit.nva.model.ResourceOwner;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
+import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
+import no.unit.nva.model.additionalidentifiers.ScopusIdentifier;
 import no.unit.nva.model.additionalidentifiers.SourceName;
 import no.unit.nva.model.funding.Funding;
 import no.unit.nva.publication.model.utils.CuratingInstitutionsUtil;
@@ -89,6 +90,7 @@ public class CristinMapper extends CristinMappingModule {
                                                                    "bb3d0c0c-5065-4623-9b98-5810983c2478",
                                                                    "api.nva.unit.no",
                                                                    "22139870-8d31-4df9-bc45-14eb68287c4a");
+    public static final String SCOPUS_IDENTIFIER_SOURCE_CODE_FROM_CRISTIN = "scopus";
     private final CristinUnitsUtil cristinUnitsUtil;
     private final S3Client s3Client;
 
@@ -176,12 +178,6 @@ public class CristinMapper extends CristinMappingModule {
                    .withMonth(String.valueOf(publishedDate.getMonthValue()))
                    .withDay(String.valueOf(publishedDate.getDayOfMonth()))
                    .build();
-    }
-
-    private static String craftSourceCode(CristinSource cristinSource) {
-        return SCOPUS_CASING_ACCEPTED_BY_FRONTEND.equalsIgnoreCase(cristinSource.getSourceCode())
-                   ? SCOPUS_CASING_ACCEPTED_BY_FRONTEND
-                   : cristinSource.getSourceCode();
     }
 
     private URI extractHandle() {
@@ -421,11 +417,15 @@ public class CristinMapper extends CristinMappingModule {
             new CristinIdentifier(SourceName.fromCristin(getInstanceName()), cristinObject.getId().toString());
         var additionalIdentifiers = extractCristinSourceids(cristinObject);
         additionalIdentifiers.add(cristinId);
-        if (nonNull(cristinObject.getSourceCode())
-            && sourceCodeHasNotBeenMappedAlready(additionalIdentifiers, cristinObject.getSourceCode())) {
+        if (sourceCodeHasBeenMappedAlready(additionalIdentifiers)) {
             additionalIdentifiers.add(extractAdditionalIdentifierFromSourceCode());
         }
         return additionalIdentifiers;
+    }
+
+    private boolean sourceCodeHasBeenMappedAlready(Set<AdditionalIdentifierBase> additionalIdentifiers) {
+        return nonNull(cristinObject.getSourceCode())
+               && sourceCodeHasNotBeenMappedAlready(additionalIdentifiers, cristinObject.getSourceCode());
     }
 
     private String getInstanceName() {
@@ -444,7 +444,17 @@ public class CristinMapper extends CristinMappingModule {
     }
 
     private boolean hasIdenticalSourceCode(String sourceCode, AdditionalIdentifierBase additionalIdentifier) {
-        return additionalIdentifier.sourceName().equals(sourceCode);
+        if (scopusIdentifierThatAlreadyHasBeenMapped(sourceCode, additionalIdentifier)) {
+            return true;
+        } else {
+            return additionalIdentifier.sourceName().toLowerCase(Locale.ROOT).equals(sourceCode.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private static boolean scopusIdentifierThatAlreadyHasBeenMapped(String sourceCode,
+                                                                    AdditionalIdentifierBase additionalIdentifier) {
+        return sourceCode.toLowerCase(Locale.ROOT).equals(SCOPUS_IDENTIFIER_SOURCE_CODE_FROM_CRISTIN)
+               && additionalIdentifier instanceof ScopusIdentifier;
     }
 
     private Set<AdditionalIdentifierBase> extractCristinSourceids(CristinObject cristinObject) {
@@ -458,8 +468,22 @@ public class CristinMapper extends CristinMappingModule {
                        Collectors.toSet());
     }
 
-    private AdditionalIdentifier mapCristinSourceToAdditionalIdentifier(CristinSource cristinSource) {
-        return new AdditionalIdentifier(craftSourceCode(cristinSource), cristinSource.getSourceIdentifier());
+    private AdditionalIdentifierBase mapCristinSourceToAdditionalIdentifier(CristinSource cristinSource) {
+        return isScopusIdentifier(cristinSource)
+                   ? extractScopusIdentifier(cristinSource)
+                   : extractAdditionalIdentifier(cristinSource);
+    }
+
+    private static AdditionalIdentifier extractAdditionalIdentifier(CristinSource cristinSource) {
+        return new AdditionalIdentifier(cristinSource.getSourceCode(), cristinSource.getSourceIdentifier());
+    }
+
+    private ScopusIdentifier extractScopusIdentifier(CristinSource cristinSource) {
+        return new ScopusIdentifier(SourceName.fromCristin(getInstanceName()), cristinSource.getSourceIdentifier());
+    }
+
+    private static boolean isScopusIdentifier(CristinSource cristinSource) {
+        return SCOPUS_CASING_ACCEPTED_BY_FRONTEND.equalsIgnoreCase(cristinSource.getSourceCode());
     }
 
     private String extractNpiSubjectHeading() {

--- a/cristin-import/src/test/resources/features/GeneralMappingRules.feature
+++ b/cristin-import/src/test/resources/features/GeneralMappingRules.feature
@@ -14,12 +14,27 @@ Feature: Mappings that hold for all types of Cristin Results
       | Source Code Text | Source Identifier Text |
       | SomeCode         | Some identifier        |
       | Some other code  | Some other identifier  |
-      | SCOPUS           | Some third identifier  |
     When the Cristin Result is converted to an NVA Resource
     Then the NVA Resource has an additional identifier with key "SomeCode" and value "Some identifier"
     And the NVA Resource has an additional identifier with key "cristin@sikt" and value 12345
     And the NVA Resource has an additional identifier with key "Some other code" and value "Some other identifier"
-    And the NVA Resource has an additional identifier with key "Scopus" and value "Some third identifier"
+
+  Scenario: Cristin scopus sources is saved as Scopus identifier
+    Given the Cristin Result has id equal to 1
+    And the Cristin Result has a non null array of CristinSources with values:
+      | Source Code Text | Source Identifier Text |
+      | Scopus           | 12345                  |
+      | SCOPUS           | 12345                  |
+      | scopus           | 12345                  |
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a single Scopus identifier with value "12345"
+
+  Scenario: Cristin scopus sourceCode and CristinSource are saved as Scopus identifiers
+    Given the Cristin Result has id equal to 1
+    And the Cristin Result has a non null array of CristinSources with code "Scopus" and value "12345"
+    And Cristin result has source code scopus with value "12345"
+    When the Cristin Result is converted to an NVA Resource
+    Then the NVA Resource has a single Scopus identifier with value "12345"
 
   Scenario: CristinSource collides with sourceCode
     Given the Cristin Result has id equal to 12345
@@ -94,7 +109,7 @@ Feature: Mappings that hold for all types of Cristin Results
     Then the NVA Resource has a Publication Date with year equal to "1996", month equal to "null" and day equal to "null"
 
   Scenario: The Resources Publication Date is set to the Cristin Result's publication Date
-    Approximately 300 000 cristin entries have the publication date set.
+  Approximately 300 000 cristin entries have the publication date set.
     Given that the Cristin Result has published date equal to the local date "2001-05-31"
     When the Cristin Result is converted to an NVA Resource
     Then the NVA Resource has a Publication Date with year equal to "2001", month equal to "5" and day equal to "31"


### PR DESCRIPTION
Cristin often stores Scopus identifier as `kildeKode` and as an entry in list of codes `varbeid_kilde`.
Mapping it to single ScopusIdentifier.