### PR TITLE
adding more log messages when updating ticket + refactoring

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
@@ -3,6 +3,7 @@ package no.unit.nva.publication.utils;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.SUPPORT;
+import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -17,6 +18,7 @@ import no.unit.nva.publication.model.business.UnpublishRequest;
 import no.unit.nva.publication.model.business.UserInstance;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 
 public record RequestUtils(List<AccessRight> accessRights,
@@ -45,20 +47,20 @@ public record RequestUtils(List<AccessRight> accessRights,
         return Arrays.stream(rights).anyMatch(accessRights::contains);
     }
 
-    public SortableIdentifier ticketIdentifier() {
-        return Optional.ofNullable(pathParameters().get(TICKET_IDENTIFIER))
+    public SortableIdentifier ticketIdentifier() throws NotFoundException {
+        return attempt(() -> pathParameters().get(TICKET_IDENTIFIER))
                    .map(SortableIdentifier::new)
-                   .orElseThrow(() -> new IllegalArgumentException(missingPathParamErrorMessage(TICKET_IDENTIFIER)));
+                   .orElseThrow(failure -> new NotFoundException(missingPathParamErrorMessage(TICKET_IDENTIFIER)));
     }
 
     private static String missingPathParamErrorMessage(String value) {
         return String.format(MISSING_PATH_PARAM_MESSAGE, value);
     }
 
-    public SortableIdentifier publicationIdentifier() {
-        return Optional.ofNullable(pathParameters().get(PUBLICATION_IDENTIFIER))
+    public SortableIdentifier publicationIdentifier() throws NotFoundException {
+        return attempt(() -> pathParameters().get(PUBLICATION_IDENTIFIER))
                    .map(SortableIdentifier::new)
-                   .orElseThrow(() -> new IllegalArgumentException(
+                   .orElseThrow(failure -> new NotFoundException(
                        missingPathParamErrorMessage(PUBLICATION_IDENTIFIER)));
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/utils/RequestUtilsTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/utils/RequestUtilsTest.java
@@ -25,7 +25,6 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
-import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
@@ -48,12 +47,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class RequestUtilsTest {
 
     private ResourceService resourceService;
-    private UriRetriever uriRetriever;
 
     @BeforeEach
     public void setup() {
         this.resourceService = mock(ResourceService.class);
-        this.uriRetriever = mock(UriRetriever.class);
     }
 
     public static Stream<Arguments> ticketTypeAndAccessRightProvider() {
@@ -71,17 +68,23 @@ public class RequestUtilsTest {
     }
 
     @Test
-    void shouldThrowIllegalArgumentWhenExtractingMissingPathParamAsIdentifier() throws UnauthorizedException {
+    void shouldThrowNotFoundExceptionWhenExtractingMissingTicketIdentifier() throws UnauthorizedException {
         var requestInfo = mockedRequestInfoWithoutPathParams();
 
-        assertThrows(IllegalArgumentException.class,
-                     () -> RequestUtils.fromRequestInfo(requestInfo).publicationIdentifier());
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(NotFoundException.class,
                      () -> RequestUtils.fromRequestInfo(requestInfo).ticketIdentifier());
     }
 
     @Test
-    void shouldReturnIdentifiersFromPathParamsWhenTheyArePresent() throws UnauthorizedException {
+    void shouldThrowNotFoundExceptionWhenExtractingMissingPublicationIdentifier() throws UnauthorizedException {
+        var requestInfo = mockedRequestInfoWithoutPathParams();
+
+        assertThrows(NotFoundException.class,
+                     () -> RequestUtils.fromRequestInfo(requestInfo).publicationIdentifier());
+    }
+
+    @Test
+    void shouldReturnIdentifiersFromPathParamsWhenTheyArePresent() throws UnauthorizedException, NotFoundException {
         var requestUtils = RequestUtils.fromRequestInfo(mockedRequestInfo());
 
         Assertions.assertTrue(nonNull(requestUtils.publicationIdentifier()));


### PR DESCRIPTION
- Adding log message when user is not allowed to fetch ticket.
- Removing UriRetriever from UpdateTicketHandler - is not in use?
- Minor refactoring in UpdateTicketHandler and RequestUtils - throwing not found exception when identifiers from path params can not be converted to sortable identifiers (we do it other places and serve 404 NotFound via API).
   
