### PR TITLE
adding support to create ticket and message in one api call

### DIFF
--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/CreateTicketHandler.java
@@ -3,10 +3,8 @@ package no.unit.nva.publication.ticket.create;
 import static no.unit.nva.publication.PublicationServiceConfig.API_HOST;
 import static no.unit.nva.publication.PublicationServiceConfig.ENVIRONMENT;
 import static no.unit.nva.publication.PublicationServiceConfig.PUBLICATION_PATH;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
-import java.util.List;
 import java.util.Map;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.PublicationServiceConfig;
@@ -15,7 +13,6 @@ import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.service.impl.MessageService;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
-import no.unit.nva.publication.ticket.MessageDto;
 import no.unit.nva.publication.ticket.TicketDto;
 import no.unit.nva.publication.utils.RequestUtils;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -63,10 +60,10 @@ public class CreateTicketHandler extends ApiGatewayHandler<TicketDto, Void> {
     }
 
     private void persistMessage(TicketDto input, RequestUtils requestUtils, TicketEntry ticket) {
-        attempt(input::getMessages)
-            .map(List::getFirst)
-            .map(MessageDto::getText)
-            .forEach(text -> messageService.createMessage(ticket, requestUtils.toUserInstance(), text));
+        if (!input.getMessages().isEmpty()) {
+            var message = input.getMessages().getFirst().getText();
+            messageService.createMessage(ticket, requestUtils.toUserInstance(), message);
+        }
     }
 
     private void addLocationHeader(SortableIdentifier publicationIdentifier, SortableIdentifier ticketIdentifier) {

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -20,7 +20,9 @@ import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import static nva.commons.apigateway.AccessRight.SUPPORT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -849,6 +851,25 @@ class CreateTicketHandlerTest extends TicketTestLocal {
 
         assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
         assertThat(persistedMessage, hasSize(1));
+    }
+
+    @Test
+    void creatingTicketWithoutMessageShouldNotLogAnyMessages()
+        throws ApiGatewayException, IOException {
+        var publication = TicketTestUtils.createPersistedNonDegreePublication(randomUri(), PUBLISHED,
+                                                                              resourceService);
+
+        var request = createHttpTicketCreationRequest(
+            constructDto(GeneralSupportRequest.class), publication.getIdentifier(),
+            publication.getResourceOwner().getOwnerAffiliation(), randomUri(), randomString(), SUPPORT);
+        var logAppender = LogUtils.getTestingAppender(CreateTicketHandler.class);
+        handler.handleRequest(request, output, CONTEXT);
+
+        var response = GatewayResponse.fromOutputStream(output, Void.class);
+        var logMessages = logAppender.getMessages();
+
+        assertThat(logMessages, is(emptyString()));
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_CREATED)));
     }
 
     private PublishingRequestCase fetchTicket(Publication publishedPublication,

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -20,7 +20,6 @@ import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import static nva.commons.apigateway.AccessRight.SUPPORT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.everyItem;


### PR DESCRIPTION
Frontend today makes two calls when sending first message for GeneralSupportCase. It is not necessary. From now on it will be done in one call. 