### PR TITLE
Use uriRetriever in resource expansion

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -77,8 +77,7 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public ExpandedDataEntry expandEntry(Entity dataEntry) throws JsonProcessingException, NotFoundException {
         if (dataEntry instanceof Resource resource) {
             logger.info("Expanding Resource: {}", resource.getIdentifier());
-            var expandedResource = ExpandedResource.fromPublication(authorizedUriRetriever,
-                                                                    resource.toPublication(resourceService));
+            var expandedResource = ExpandedResource.fromPublication(uriRetriever, resource.toPublication(resourceService));
             var resourceWithContextUri = replaceInlineContextWithUriContext(expandedResource);
             return attempt(
                 () -> objectMapper.readValue(resourceWithContextUri.toString(), ExpandedResource.class)).orElseThrow();


### PR DESCRIPTION
None of the uris for expansion on a `Resource`/`Publication` require `AthorizedBackendClient`, we reduce traffic against Cognito a lot by changing to uriRetriever without auth