### PR TITLE
using funding code english when generating funding id

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinGrant.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinGrant.java
@@ -39,6 +39,7 @@ public class CristinGrant {
 
     public static final String IDENTIFIER_FIELD = "finansieringslopenr";
     public static final String GRANT_SOURCE_CODE_FIELD = "finansieringskildekode";
+    public static final String GRANT_SOURCE_CODE_ENGLISH_FIELD = "finansieringskildekode_engelsk";
     public static final String GRANT_RERERENCE_FIELD = "finansieringsreferanse";
     public static final String YEAR_FROM_FIELD = "arstall_fra";
     public static final String YEAR_TO_FIELD = "arstall_til";
@@ -55,6 +56,9 @@ public class CristinGrant {
 
     @JsonProperty(GRANT_SOURCE_CODE_FIELD)
     private String sourceCode;
+
+    @JsonProperty(GRANT_SOURCE_CODE_ENGLISH_FIELD)
+    private String sourceCodeEnglish;
 
     @JsonProperty(GRANT_RERERENCE_FIELD)
     private String grantReference;
@@ -89,7 +93,7 @@ public class CristinGrant {
                           + UnixPath.PATH_DELIMITER
                           + FUNDING_SOURCES
                           + UnixPath.PATH_DELIMITER
-                          + urlEncode(sourceCode));
+                          + urlEncode(sourceCodeEnglish));
     }
 
     private Instant convertDateToInstant(Integer yearOrNull) {
@@ -104,13 +108,13 @@ public class CristinGrant {
         return shouldHaveId()
                    ? UriWrapper.fromUri(NVA_API_DOMAIN)
                          .addChild(VERIFIED_FUNDING_PATH)
-                         .addChild(sourceCode.toLowerCase(Locale.ROOT))
+                         .addChild(sourceCodeEnglish.toLowerCase(Locale.ROOT))
                          .addChild(grantReference)
                          .getUri()
                    : null;
     }
 
     private boolean shouldHaveId() {
-        return NFR_SOURCE_CODE.equalsIgnoreCase(sourceCode);
+        return NFR_SOURCE_CODE.equalsIgnoreCase(sourceCodeEnglish);
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -168,7 +168,7 @@ public class CristinMapper extends CristinMappingModule {
     private static List<CristinContributor> sortCristinContributors(List<CristinContributor> cristinContributors) {
         return cristinContributors.stream()
                    .sorted(Comparator.nullsLast(Comparator.naturalOrder()))
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private static PublicationDate convertToPublicationDate(LocalDate publishedDate) {
@@ -217,7 +217,7 @@ public class CristinMapper extends CristinMappingModule {
     private List<CristinLocale> getValidCristinLocales() {
         return Optional.ofNullable(cristinObject.getCristinLocales())
                    .map(list -> list.stream().filter(this::doesNotContainInvalidInstitutionCode))
-                   .map(stream -> stream.collect(Collectors.toList()))
+                   .map(Stream::toList)
                    .orElse(List.of());
     }
 
@@ -258,7 +258,7 @@ public class CristinMapper extends CristinMappingModule {
 
     private List<Funding> mapToNvaFunding(List<CristinGrant> grants) {
         return grants.stream().map(CristinGrant::toNvaFunding)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private void assertPublicationDoesNotHaveEmptyFields(Publication publication) {
@@ -278,13 +278,13 @@ public class CristinMapper extends CristinMappingModule {
 
     private List<ResearchProject> extractProjects() {
         if (cristinObject.getPresentationalWork() == null) {
-            return null;
+            return List.of();
         }
         return cristinObject.getPresentationalWork()
                    .stream()
                    .filter(CristinPresentationalWork::isProject)
                    .map(CristinPresentationalWork::toNvaResearchProject)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private Organization extractOrganization() {
@@ -345,12 +345,12 @@ public class CristinMapper extends CristinMappingModule {
                    .map(cristinContributor -> attempt(() -> cristinContributor.toNvaContributor(cristinIdentifier,
                                                                                                 s3Client)))
                    .map(Try::orElseThrow)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private List<URI> generateNvaHrcsCategoriesAndActivities() {
         if (isNull(extractCristinHrcsCategoriesAndActivities())) {
-            return null;
+            return List.of();
         }
         List<URI> listOfCategoriesAndActivities = new ArrayList<>();
         listOfCategoriesAndActivities.addAll(extractHrcsCategories());
@@ -369,7 +369,7 @@ public class CristinMapper extends CristinMappingModule {
                    .filter(CristinHrcsCategoriesAndActivities::validateCategory)
                    .map(categoryId -> HRCS_CATEGORY_URI + HRCS_CATEGORIES_MAP.get(categoryId).toLowerCase(Locale.ROOT))
                    .map(URI::create)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private Collection<URI> extractHrcsActivities() {
@@ -379,7 +379,7 @@ public class CristinMapper extends CristinMappingModule {
                    .filter(CristinHrcsCategoriesAndActivities::validateActivity)
                    .map(activityId -> HRCS_ACTIVITY_URI + HRCS_ACTIVITIES_MAP.get(activityId).toLowerCase(Locale.ROOT))
                    .map(URI::create)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private PublicationDate extractPublicationDate() {
@@ -522,7 +522,7 @@ public class CristinMapper extends CristinMappingModule {
     private List<String> extractTags() {
         var tags = extractCristinTags();
         if (isNull(tags)) {
-            return null;
+            return List.of();
         }
         return tags.stream()
                    .flatMap(tag -> Stream.of(tag.getBokmal(), tag.getEnglish(), tag.getNynorsk()))

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -503,7 +503,7 @@ public class GeneralMappingRules {
     @Then("publication should have a nva Fundings:")
     public void publicationShouldHaveANvaFundings(List<Funding> fundings) {
         var nvaFundings = scenarioContext.getNvaEntry().getFundings();
-        assertThat(nvaFundings, containsInAnyOrder(fundings.toArray()));
+        assertThat(nvaFundings, containsInAnyOrder(fundings.toArray(Funding[]::new)));
     }
 
     @And("that the Cristin Result has published date equal to the local date {string}")
@@ -583,14 +583,15 @@ public class GeneralMappingRules {
         affiliations.get(0).setRoles(List.of(cristinRole));
     }
 
-    @Given("that Cristin Result has a grant with properties finansieringsreferanse {string} and sourceCode {string}:")
+    @Given("that Cristin Result has a grant with properties finansieringsreferanse {string} and sourceCodeEnglish " +
+           "{string}:")
     public void thatCristinResultHasAGrantWithPropertiesFinansieringsreferanseAndSourceCode(String fundingReference,
                                                                                             String sourceCode) {
         scenarioContext.getCristinEntry()
             .setCristinGrants(
                 List.of(CristinGrant.builder()
                             .withGrantReference(fundingReference)
-                            .withSourceCode(sourceCode)
+                            .withSourceCodeEnglish(sourceCode)
                             .build()));
     }
 

--- a/cristin-import/src/test/java/cucumber/utils/transformers/CristinGrantTransformer.java
+++ b/cristin-import/src/test/java/cucumber/utils/transformers/CristinGrantTransformer.java
@@ -2,6 +2,7 @@ package cucumber.utils.transformers;
 
 import static java.util.Objects.nonNull;
 import static no.unit.nva.cristin.mapper.CristinGrant.GRANT_RERERENCE_FIELD;
+import static no.unit.nva.cristin.mapper.CristinGrant.GRANT_SOURCE_CODE_ENGLISH_FIELD;
 import static no.unit.nva.cristin.mapper.CristinGrant.GRANT_SOURCE_CODE_FIELD;
 import static no.unit.nva.cristin.mapper.CristinGrant.IDENTIFIER_FIELD;
 import static no.unit.nva.cristin.mapper.CristinGrant.YEAR_FROM_FIELD;
@@ -12,7 +13,7 @@ import no.unit.nva.cristin.mapper.CristinGrant;
 
 public class CristinGrantTransformer {
 
-    private static final int CURRENTLY_MAPPED_FIELDS = 5;
+    private static final int CURRENTLY_MAPPED_FIELDS = 6;
 
     @DataTableType
     public CristinGrant toCristinGrant(Map<String, String> entry) {
@@ -21,12 +22,14 @@ public class CristinGrantTransformer {
         }
         var identifier = entry.get(IDENTIFIER_FIELD);
         var sourceCode = entry.get(GRANT_SOURCE_CODE_FIELD);
+        var sourceCodeEnglish = entry.get(GRANT_SOURCE_CODE_ENGLISH_FIELD);
         var yearFrom = nonNull(entry.get(YEAR_FROM_FIELD)) ? Integer.parseInt(entry.get(YEAR_FROM_FIELD)) : null;
         var yearTo = nonNull(entry.get(YEAR_TO_FIELD)) ? Integer.parseInt(entry.get(YEAR_TO_FIELD)) : null;
         var grantReference = entry.get(GRANT_RERERENCE_FIELD);
         return CristinGrant.builder()
                    .withIdentifier(identifier)
                    .withSourceCode(sourceCode)
+                   .withSourceCodeEnglish(sourceCodeEnglish)
                    .withYearFrom(yearFrom)
                    .withYearTo(yearTo)
                    .withGrantReference(grantReference)

--- a/cristin-import/src/test/resources/features/GeneralMappingRules.feature
+++ b/cristin-import/src/test/resources/features/GeneralMappingRules.feature
@@ -329,16 +329,16 @@ Feature: Mappings that hold for all types of Cristin Results
     Then an error is reported.
 
   Scenario: Mapping cristin Funding with NFR should create nva Funding with id set.
-    Given that Cristin Result has a grant with properties finansieringsreferanse "3013" and sourceCode "NFR":
+    Given that Cristin Result has a grant with properties finansieringsreferanse "3013" and sourceCodeEnglish "NFR":
     When the Cristin Result is converted to an NVA Resource
     Then the publication should have a Confirmed Nva funding with identifier equal to "3013" and id equal to "https://api.test.nva.aws.unit.no/verified-funding/nfr/3013"
 
 
   Scenario: When CristinGrants year from and / or year to is present they are mapped.
     Given that Cristin Result has grants:
-      | finansieringslopenr | finansieringskildekode | arstall_fra | arstall_til | finansieringsreferanse |
-      | 619                 | EU                     | 2005        | 2006        | SCP8-GA-2009-233969    |
-      | 3013                | KI                     |             |             | 456                    |
+      | finansieringslopenr | finansieringskildekode | finansieringskildekode_engelsk | arstall_fra | arstall_til | finansieringsreferanse |
+      | 619                 | E                      | EU                             | 2005        | 2006        | SCP8-GA-2009-233969    |
+      | 3013                | K                      | KI                             |             |             | 456                    |
     When the Cristin Result is converted to an NVA Resource
     Then publication should have a nva Fundings:
       | identifier          | activeFrom           | activeTo             | source                                                      | label |
@@ -348,9 +348,9 @@ Feature: Mappings that hold for all types of Cristin Results
 
   Scenario: When CristinGrants should not be url encoded twice
     Given that Cristin Result has grants:
-      | finansieringslopenr | finansieringskildekode | arstall_fra | arstall_til | finansieringsreferanse |
-      | 17157               | MILJØDIR               | 2005        | 2006        | 17011442               |
-      | 10228               | EC/H2020               | 2005        | 2006        | 642080                 |
+      | finansieringslopenr | finansieringskildekode | finansieringskildekode_engelsk | arstall_fra | arstall_til | finansieringsreferanse |
+      | 17157               | MILJØDIR               | MILJØDIR                       | 2005        | 2006        | 17011442               |
+      | 10228               | MILJØDIR               | EC/H2020                       | 2005        | 2006        | 642080                 |
     When the Cristin Result is converted to an NVA Resource
     Then publication should have a nva Fundings:
       | identifier | activeFrom           | activeTo             | source                                                                 | label |


### PR DESCRIPTION
`finansieringskildekode_engelsk` is a funding code which is used in cristin-api. This is the code we should use when generating funding id. 