### PR TITLE
updating publication comparator when importing publications

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -2,12 +2,14 @@ package no.sikt.nva.brage.migration.lambda;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static no.unit.nva.PublicationUtil.PROTECTED_DEGREE_INSTANCE_TYPES;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -27,10 +29,10 @@ import no.sikt.nva.brage.migration.model.PublicationRepresentation;
 import no.sikt.nva.brage.migration.record.Record;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
-import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
+import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
@@ -67,6 +69,7 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
     private static final String S3_URI_TEMPLATE = "s3://%s/%s";
     private static final String ERROR_SAVING_BRAGE_IMPORT = "Error saving brage import for record with object key: ";
     private static final Logger logger = LoggerFactory.getLogger(BrageEntryEventConsumer.class);
+    private static final String UIO = "uio";
     private final S3Client s3Client;
     private final ResourceService resourceService;
     private final UriRetriever uriRetriever;
@@ -427,7 +430,20 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         throws JsonProcessingException, InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
         var brageRecord = getBrageRecordFromS3(event);
         var nvaPublication = BrageNvaMapper.toNvaPublication(brageRecord, apiHost, s3Client);
+        validateRecordForImport(brageRecord, nvaPublication);
         return new PublicationRepresentation(brageRecord, nvaPublication);
+    }
+
+    private void validateRecordForImport(Record brageRecord, Publication publication) {
+        if (publicationShouldBeIgnored(brageRecord, publication)) {
+            throw new IgnoredPublicationException();
+        }
+    }
+
+    private boolean publicationShouldBeIgnored(Record brageRecord, Publication publication) {
+        var type = publication.getEntityDescription().getReference().getPublicationInstance().getClass();
+        return UIO.equals(brageRecord.getCustomer().getName())
+               && Arrays.asList(PROTECTED_DEGREE_INSTANCE_TYPES).contains(type);
     }
 
     private Record getBrageRecordFromS3(S3Event event) throws JsonProcessingException {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/IgnoredPublicationException.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/IgnoredPublicationException.java
@@ -1,0 +1,9 @@
+package no.sikt.nva.brage.migration.lambda;
+
+public class IgnoredPublicationException extends RuntimeException {
+
+    public IgnoredPublicationException() {
+        super();
+    }
+}
+

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.brage.migration.lambda;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
@@ -1,8 +1,11 @@
 package no.sikt.nva.brage.migration.lambda;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
@@ -12,12 +15,12 @@ import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.event.Lecture;
 import no.unit.nva.model.instancetypes.report.ConferenceReport;
 import no.unit.nva.model.pages.Pages;
+import nva.commons.core.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 
 public final class PublicationComparator {
 
     public static final int MAX_ACCEPTABLE_TITLE_LEVENSHTEIN_DISTANCE = 10;
-    public static final int MAX_ACCEPTABLE_CONTRIBUTOR_NAME_LEVENSHTEIN_DISTANCE = 5;
     public static final int ALLOWED_PUBLICATION_YEAR_DIFFERENCE = 2;
     private static final LevenshteinDistance LEVENSHTEIN_DISTANCE = LevenshteinDistance.getDefaultInstance();
 
@@ -84,11 +87,11 @@ public final class PublicationComparator {
         if (existingContributors.isEmpty()) {
             return true;
         }
-        return atleasOneContributorMatch(incomingPublication, existingContributors);
+        return atLeastOneContributorLastNameMatch(incomingPublication, existingContributors);
     }
 
-    private static boolean atleasOneContributorMatch(Publication incomingPublication,
-                                                     List<Contributor> existingContributors) {
+    private static boolean atLeastOneContributorLastNameMatch(Publication incomingPublication,
+                                                              List<Contributor> existingContributors) {
         var incomingContributors = incomingPublication.getEntityDescription().getContributors();
         return existingContributors.stream()
                    .flatMap(contributor -> containsContributor(incomingContributors, contributor))
@@ -97,15 +100,21 @@ public final class PublicationComparator {
 
     private static Stream<String> containsContributor(List<Contributor> incomingContributors,
                                                       Contributor contributor) {
-        var name = contributor.getIdentity().getName();
-        return incomingContributors.stream()
-                   .map(Contributor::getIdentity)
+        var lastName = getLastName(contributor);
+        return isNull(lastName)
+                   ? Stream.empty()
+                   : incomingContributors.stream()
+                         .map(PublicationComparator::getLastName)
+                         .filter(Objects::nonNull)
+                         .filter(lastName::equals);
+    }
+
+    private static String getLastName(Contributor contributor) {
+        return Optional.ofNullable(contributor.getIdentity())
                    .map(Identity::getName)
-                   .filter(value -> levenshteinDistanceIsLessThan(
-                       value,
-                       name,
-                       MAX_ACCEPTABLE_CONTRIBUTOR_NAME_LEVENSHTEIN_DISTANCE)
-                   );
+                   .map(name -> name.split(StringUtils.SPACE))
+                   .map(nameArray -> nameArray[nameArray.length - 1])
+                   .orElse(null);
     }
 
     private static boolean levenshteinDistanceIsLessThan(String left, String right, int distance) {


### PR DESCRIPTION
When berging publication from Brage with existing publication in NVA, comparing last name of contributor instead of whole name value. Multiple cases where contributors from Cristin have full names including middle names, but Brage contributors have first name and last name only. 

+ 

Ignoring student thesis from UiO when importing from Brage