### PR TITLE
Persisting completed pub req in single database transaction

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -341,9 +341,7 @@ public class PublishingRequestCase extends TicketEntry {
     public PublishingRequestCase persistAutoComplete(TicketService ticketService, Publication publication,
                                                      Username finalizedBy)
         throws ApiGatewayException {
-        var ticket = this.persistNewTicket(ticketService);
-        ticket.complete(publication, finalizedBy).persistUpdate(ticketService);
-        return (PublishingRequestCase) ticket.fetch(ticketService);
+        return (PublishingRequestCase) this.complete(publication, finalizedBy).persistNewTicket(ticketService);
     }
 
     private static PublishingRequestCase createPublishingRequestIdentifyingObject(

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -127,6 +127,7 @@ public abstract class TicketEntry implements Entity {
         ticketEntry.setCreatedDate(now);
         ticketEntry.setModifiedDate(now);
         ticketEntry.setIdentifier(identifierProvider.get());
+        ticketEntry.setFinalizedDate(nonNull(ticketEntry.getFinalizedDate()) ? now : null);
     }
 
     public SortableIdentifier getResourceIdentifier() {
@@ -264,7 +265,7 @@ public abstract class TicketEntry implements Entity {
 
     public final TicketEntry persistNewTicket(TicketService ticketService) throws ApiGatewayException {
         // this is the only place that deprecated should be called.
-        return ticketService.createTicket(this);
+        return ticketService.createNewTicket(this);
     }
 
     public final TicketEntry markUnreadByOwner() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -265,7 +265,7 @@ public abstract class TicketEntry implements Entity {
 
     public final TicketEntry persistNewTicket(TicketService ticketService) throws ApiGatewayException {
         // this is the only place that deprecated should be called.
-        return ticketService.createNewTicket(this);
+        return ticketService.createTicket(this);
     }
 
     public final TicketEntry markUnreadByOwner() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
@@ -79,7 +79,7 @@ public class TicketService extends ServiceWithTransactions {
      * @deprecated Use TicketEntry#persist instead.
      */
     @Deprecated(since = " TicketEntry#persist")
-    public <T extends TicketEntry> T createNewTicket(TicketEntry ticketEntry)
+    public <T extends TicketEntry> T createTicket(TicketEntry ticketEntry)
         throws ApiGatewayException {
         var associatedPublication = fetchPublicationToEnsureItExists(ticketEntry);
         return createTicketForPublication(associatedPublication, ticketEntry);

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
@@ -79,7 +79,7 @@ public class TicketService extends ServiceWithTransactions {
      * @deprecated Use TicketEntry#persist instead.
      */
     @Deprecated(since = " TicketEntry#persist")
-    public <T extends TicketEntry> T createTicket(TicketEntry ticketEntry)
+    public <T extends TicketEntry> T createNewTicket(TicketEntry ticketEntry)
         throws ApiGatewayException {
         var associatedPublication = fetchPublicationToEnsureItExists(ticketEntry);
         return createTicketForPublication(associatedPublication, ticketEntry);

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -742,13 +742,13 @@ public class TicketServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void finalizedDateShouldBeSetAfterCreatedDateWhenAutoCompletingTicket() throws ApiGatewayException {
+    void finalizedDateShouldBeEqualCreatedDateWhenAutoCompletingTicket() throws ApiGatewayException {
         var publication = TicketTestUtils.createPersistedPublicationWithUnpublishedFiles(DRAFT, resourceService);
         var ticket = (PublishingRequestCase) PublishingRequestCase.createNewTicket(
             publication, PublishingRequestCase.class, SortableIdentifier::next);
         var completedTicket = ticket.persistAutoComplete(ticketService, publication, new Username(randomString()));
 
-        assertThat(completedTicket.getFinalizedDate(), greaterThan(completedTicket.getCreatedDate()));
+        assertThat(completedTicket.getFinalizedDate(), is(equalTo(completedTicket.getCreatedDate())));
     }
 
     @Test


### PR DESCRIPTION
Persisting completed PublishingRequest in two transactions causes sometimes processing of EventBridge events in unwanted order. Event with completed ticket is being proceeded before event with new ticket. It causes that search index is not updated with latest image of database entry. 

- Persisting completed PublishingRequest in single database transaction. 