### PR TITLE
Np 47907 rRecoveryBatchScanHandler, avoid event loop

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/QueueClient.java
@@ -8,7 +8,7 @@ public interface QueueClient {
 
     void sendMessage(SendMessageRequest sendMessageRequest);
 
-    List<Message> readMessages();
+    List<Message> readMessages(int maximumNumberOfMessages);
 
     void deleteMessages(List<Message> messages);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/queue/ResourceQueueClient.java
@@ -17,13 +17,12 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 @JacocoGenerated
 public final class ResourceQueueClient implements QueueClient {
 
-    public static final int MAXIMUM_NUMBER_OF_MESSAGES = 10;
-    public static final String AWS_REGION = "AWS_REGION";
+    private static final String AWS_REGION = "AWS_REGION";
     private static final int MAX_CONNECTIONS = 10_000;
     private static final long IDLE_TIME = 30;
     private static final long TIMEOUT_TIME = 30;
-    public static final String ALL_MESSAGE_ATTRIBUTES = "All";
-    public static final int WAITING_TIME = 20;
+    private static final String ALL_MESSAGE_ATTRIBUTES = "All";
+    private static final int WAITING_TIME = 20;
     private final SqsClient sqsClient;
     private final String queueUrl;
 
@@ -42,11 +41,11 @@ public final class ResourceQueueClient implements QueueClient {
     }
 
     @Override
-    public List<Message> readMessages() {
+    public List<Message> readMessages(int maximumNumberOfMessages) {
         var receiveMessageRequest = ReceiveMessageRequest.builder()
                                         .queueUrl(queueUrl)
                                         .waitTimeSeconds(WAITING_TIME)
-                                        .maxNumberOfMessages(MAXIMUM_NUMBER_OF_MESSAGES)
+                                        .maxNumberOfMessages(maximumNumberOfMessages)
                                         .messageAttributeNames(ALL_MESSAGE_ATTRIBUTES)
                                         .build();
         return sqsClient.receiveMessage(receiveMessageRequest).messages();

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
@@ -1,54 +1,14 @@
 package no.unit.nva.publication.events.handlers.recovery;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import java.time.Instant;
+import static java.util.Objects.isNull;
 import no.unit.nva.commons.json.JsonSerializable;
-import nva.commons.core.Environment;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
-public record RecoveryEventRequest(String topic, int messagesCount) implements JsonSerializable {
+public record RecoveryEventRequest(Integer maximumNumberOfMessages) implements JsonSerializable {
 
-    public static final String EVENT_BUS_NAME = new Environment().readEnv("EVENT_BUS_NAME");
-    public static final String TOPIC = "PublicationService.Recovery.Refresh";
-    public static final String MANDATORY_UNUSED_SUBTOPIC = "DETAIL.WITH.TOPIC";
     private static final int DEFAULT_MESSAGES_COUNT = 10;
 
-    public static PutEventsRequestEntry createNewEntry(Context context) {
-        return PutEventsRequestEntry.builder()
-                   .eventBusName(EVENT_BUS_NAME)
-                   .detail(RecoveryEventRequest.builder().build().toJsonString())
-                   .detailType(MANDATORY_UNUSED_SUBTOPIC)
-                   .source(RecoveryBatchScanHandler.class.getName())
-                   .resources(context.getInvokedFunctionArn())
-                   .time(Instant.now())
-                   .build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static final class Builder {
-
-        private String topic = TOPIC;
-
-        private int messagesCount = DEFAULT_MESSAGES_COUNT;
-
-        private Builder() {
-        }
-
-        public Builder withTopic(String topic) {
-            this.topic = topic;
-            return this;
-        }
-
-        public Builder withMessagesCount(int messagesCount) {
-            this.messagesCount = messagesCount;
-            return this;
-        }
-
-        public RecoveryEventRequest build() {
-            return new RecoveryEventRequest(topic, messagesCount);
-        }
+    public RecoveryEventRequest(Integer maximumNumberOfMessages) {
+        this.maximumNumberOfMessages =
+            isNull(maximumNumberOfMessages) ? DEFAULT_MESSAGES_COUNT : maximumNumberOfMessages;
     }
 }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryEventRequest.java
@@ -6,20 +6,49 @@ import no.unit.nva.commons.json.JsonSerializable;
 import nva.commons.core.Environment;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
-public record RecoveryEventRequest(String topic) implements JsonSerializable {
+public record RecoveryEventRequest(String topic, int messagesCount) implements JsonSerializable {
 
     public static final String EVENT_BUS_NAME = new Environment().readEnv("EVENT_BUS_NAME");
     public static final String TOPIC = "PublicationService.Recovery.Refresh";
     public static final String MANDATORY_UNUSED_SUBTOPIC = "DETAIL.WITH.TOPIC";
+    private static final int DEFAULT_MESSAGES_COUNT = 10;
 
     public static PutEventsRequestEntry createNewEntry(Context context) {
         return PutEventsRequestEntry.builder()
                    .eventBusName(EVENT_BUS_NAME)
-                   .detail(new RecoveryEventRequest(TOPIC).toJsonString())
+                   .detail(RecoveryEventRequest.builder().build().toJsonString())
                    .detailType(MANDATORY_UNUSED_SUBTOPIC)
                    .source(RecoveryBatchScanHandler.class.getName())
                    .resources(context.getInvokedFunctionArn())
                    .time(Instant.now())
                    .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String topic = TOPIC;
+
+        private int messagesCount = DEFAULT_MESSAGES_COUNT;
+
+        private Builder() {
+        }
+
+        public Builder withTopic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Builder withMessagesCount(int messagesCount) {
+            this.messagesCount = messagesCount;
+            return this;
+        }
+
+        public RecoveryEventRequest build() {
+            return new RecoveryEventRequest(topic, messagesCount);
+        }
     }
 }

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.events.handlers.batch;
 
-import static java.util.Objects.nonNull;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
@@ -30,7 +29,6 @@ import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.MessageService;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
-import no.unit.nva.stubs.FakeEventBridgeClient;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.ioutils.IoUtils;
@@ -48,7 +46,6 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
     private TicketService ticketService;
     private MessageService messageService;
     private FakeSqsClient queueClient;
-    private FakeEventBridgeClient eventBridgeClient;
     private RecoveryBatchScanHandler recoveryBatchScanHandler;
 
     @BeforeEach
@@ -59,9 +56,8 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
         ticketService = getTicketService();
         messageService = getMessageService();
         queueClient = new FakeSqsClient();
-        eventBridgeClient = new FakeEventBridgeClient();
         recoveryBatchScanHandler = new RecoveryBatchScanHandler(resourceService, ticketService, messageService,
-                                                                queueClient, eventBridgeClient);
+                                                                queueClient);
     }
 
     @Test
@@ -137,17 +133,9 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
     private static InputStream createEvent(Integer messagesCount) throws JsonProcessingException {
         var event = new AwsEventBridgeEvent<RecoveryEventRequest>();
         event.setId(randomString());
-        event.setDetail(createRequest(messagesCount));
+        event.setDetail(new RecoveryEventRequest(messagesCount));
         var jsonString = JsonUtils.dtoObjectMapper.writeValueAsString(event);
         return IoUtils.stringToStream(jsonString);
-    }
-
-    private static RecoveryEventRequest createRequest(Integer messagesCount) {
-        var builder = RecoveryEventRequest.builder();
-        if (nonNull(messagesCount)) {
-            builder.withMessagesCount(messagesCount);
-        }
-        return builder.build();
     }
 
     //TODO: Implement recovery for other entity types than publication

--- a/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/service/FakeSqsClient.java
@@ -27,8 +27,8 @@ public class FakeSqsClient implements QueueClient {
     }
 
     @Override
-    public List<Message> readMessages() {
-        int toIndex = Math.min(deliveredMessages.size(), 10);
+    public List<Message> readMessages(int maximumNumberOfMessages) {
+        int toIndex = Math.min(deliveredMessages.size(), maximumNumberOfMessages);
         return new ArrayList<>(deliveredMessages.subList(0, toIndex));
     }
 


### PR DESCRIPTION
Jira task: NP-47907 RecoveryBatchScanHandler - should not run in event loop if retry fails
With the current implementation, `RecoveryBatchScanHandler` will go into an infinite loop if a resource that ends up in DLQ is not successfully expanded on retry.

Change: 
- `RecoveryBatchScanHandler` does not emit new event for self-consumption
- `RecoveryBatchScanHandler` takes `maximumNumberOfMessages` as input