### PR TITLE
fixing academic commentary + converting contributorCristinIds to Set

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/utils/CuratingInstitutionsUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/utils/CuratingInstitutionsUtil.java
@@ -4,7 +4,6 @@ import static java.util.Objects.nonNull;
 import static no.unit.nva.publication.utils.RdfUtils.getTopLevelOrgUri;
 import java.net.URI;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,12 +22,12 @@ public final class CuratingInstitutionsUtil {
     private CuratingInstitutionsUtil() {
     }
 
-    public static Set<CuratingInstitution> getCuratingInstitutionsOnline(Publication publication, UriRetriever uriRetriever) {
+    public static Set<CuratingInstitution> getCuratingInstitutionsOnline(Publication publication,
+                                                                         UriRetriever uriRetriever) {
         return getVerifiedContributors(publication.getEntityDescription())
-
                    .flatMap(contributor -> toCuratingInstitutionOnline(contributor, uriRetriever))
                    .collect(Collectors.groupingBy(SimpleEntry::getKey,
-                                                  Collectors.mapping(SimpleEntry::getValue, Collectors.toList())))
+                                                  Collectors.mapping(SimpleEntry::getValue, Collectors.toSet())))
                    .entrySet()
                    .stream()
                    .map(entry -> new CuratingInstitution(entry.getKey(), entry.getValue()))
@@ -43,7 +42,7 @@ public final class CuratingInstitutionsUtil {
                                                   Collectors.mapping(SimpleEntry::getValue, Collectors.toSet())))
                    .entrySet()
                    .stream()
-                   .map(entry -> new CuratingInstitution(entry.getKey(), new ArrayList<>(entry.getValue())))
+                   .map(entry -> new CuratingInstitution(entry.getKey(), entry.getValue()))
                    .collect(Collectors.toSet());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/EditorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/EditorPermissionStrategyTest.java
@@ -8,7 +8,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.model.CuratingInstitution;
@@ -165,7 +164,8 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var requestInfo = createUserRequestInfo(randomString(), randomUri(), getAccessRightsForEditor(),
                                                 randomUri(), editorInstitution);
         var publication = createNonDegreePublication(randomString(), randomUri()).copy()
-                              .withCuratingInstitutions(Set.of(new CuratingInstitution(editorInstitution, List.of(randomUri()))))
+                              .withCuratingInstitutions(Set.of(new CuratingInstitution(editorInstitution,
+                                                                                       Set.of(randomUri()))))
                               .withStatus(UNPUBLISHED).build();
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/NonDegreePermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/NonDegreePermissionStrategyTest.java
@@ -133,7 +133,7 @@ class NonDegreePermissionStrategyTest extends PublicationPermissionStrategyTest 
                               .withStatus(PublicationOperation.UNPUBLISH == operation ? PUBLISHED : UNPUBLISHED)
                               .build();
         var curatingInstitution = randomUri();
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, List.of(randomUri()))));
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, Set.of(randomUri()))));
         var requestInfo = createUserRequestInfo(curatorUsername, institution, getAccessRightsForThesisCurator(),
                                                 cristinId, curatingInstitution);
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);

--- a/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permission/strategy/PublicationPermissionStrategyTest.java
@@ -304,7 +304,7 @@ class PublicationPermissionStrategyTest extends ResourcesLocalTest {
 
         return publication.copy().withEntityDescription(entityDescription)
                    .withResourceOwner(new ResourceOwner(new Username(randomString()), randomUri()))
-                   .withCuratingInstitutions(Set.of(new CuratingInstitution(topLevelCristinOrgId, List.of(randomUri()))))
+                   .withCuratingInstitutions(Set.of(new CuratingInstitution(topLevelCristinOrgId, Set.of(randomUri()))))
                    .withStatus(PUBLISHED).build();
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -942,7 +942,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
                               .build();
 
         resource.getEntityDescription().setContributors(List.of(randomContributor(List.of(affiliation))));
-        resource.setCuratingInstitutions(Set.of(new CuratingInstitution(topLevelId, List.of(randomUri()))));
+        resource.setCuratingInstitutions(Set.of(new CuratingInstitution(topLevelId, Set.of(randomUri()))));
         var publishedResource = publishResource(createPersistedPublicationWithoutDoi(resource));
 
         var updatedResource = resourceService.updatePublication(publishedResource);
@@ -986,7 +986,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
                               .build();
 
         importCandidate.getEntityDescription().setContributors(List.of(randomContributor(List.of(affiliation))));
-        importCandidate.setCuratingInstitutions(Set.of(new CuratingInstitution(topLevelId, List.of(randomUri()))));
+        importCandidate.setCuratingInstitutions(Set.of(new CuratingInstitution(topLevelId, Set.of(randomUri()))));
 
         var persistedImportCandidate = resourceService.persistImportCandidate(importCandidate);
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -919,7 +919,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
                    .filter(Organization.class::isInstance)
                    .map(Organization.class::cast)
                    .map(Organization::getId)
-                   .map(id -> new CuratingInstitution(id, List.of()))
+                   .map(id -> new CuratingInstitution(id, Set.of()))
                    .collect(Collectors.toSet());
     }
 

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationContextBuilder.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationContextBuilder.java
@@ -82,6 +82,7 @@ public class PublicationContextBuilder {
             case "JournalReview":
                 return randomJournal();
             case "AcademicMonograph":
+            case "AcademicCommentary":
             case "Encyclopedia":
             case "ExhibitionCatalog":
             case "NonFictionMonograph":

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -255,7 +255,7 @@ public final class PublicationGenerator {
                    .withAssociatedArtifacts(AssociatedArtifactsGenerator.randomAssociatedArtifacts())
                    .withPublicationNotes(List.of(randomPublicationNote(), randomUnpublishingNote()))
                    .withDuplicateOf(randomUri())
-                   .withCuratingInstitutions(Set.of(new CuratingInstitution(randomUri(), List.of(randomUri()))))
+                   .withCuratingInstitutions(Set.of(new CuratingInstitution(randomUri(), Set.of(randomUri()))))
                    .build();
     }
 

--- a/publication-model/src/main/java/no/unit/nva/model/CuratingInstitution.java
+++ b/publication-model/src/main/java/no/unit/nva/model/CuratingInstitution.java
@@ -7,28 +7,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CuratingInstitution(URI id, List<URI> contributorCristinIds) {
+public record CuratingInstitution(URI id, Set<URI> contributorCristinIds) {
 
     @JsonCreator
     public static CuratingInstitution create(@JsonProperty("id") URI id,
-                                             @JsonProperty("contributorCristinIds") List<URI> contributorCristinIds) {
+                                             @JsonProperty("contributorCristinIds") Set<URI> contributorCristinIds) {
         return new CuratingInstitution(id, getContributorCristinIds(contributorCristinIds));
     }
 
     @JsonCreator
     public static CuratingInstitution create(String id) {
-        return new CuratingInstitution(URI.create(id), Collections.emptyList());
+        return new CuratingInstitution(URI.create(id), Collections.emptySet());
     }
 
     @Override
-    public List<URI> contributorCristinIds() {
-        return nonNull(contributorCristinIds) ? contributorCristinIds : Collections.emptyList();
+    public Set<URI> contributorCristinIds() {
+        return nonNull(contributorCristinIds) ? contributorCristinIds : Collections.emptySet();
     }
 
-    private static List<URI> getContributorCristinIds(List<URI> contributorCristinIds) {
+    private static Set<URI> getContributorCristinIds(Set<URI> contributorCristinIds) {
         return nonNull(contributorCristinIds) && !contributorCristinIds.isEmpty() ? contributorCristinIds
-                   : Collections.emptyList();
+                   : Collections.emptySet();
     }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/PublicationInstance.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/PublicationInstance.java
@@ -12,6 +12,7 @@ import no.unit.nva.model.instancetypes.artistic.literaryarts.LiteraryArts;
 import no.unit.nva.model.instancetypes.artistic.music.MusicPerformance;
 import no.unit.nva.model.instancetypes.artistic.performingarts.PerformingArts;
 import no.unit.nva.model.instancetypes.artistic.visualarts.VisualArts;
+import no.unit.nva.model.instancetypes.book.AcademicCommentary;
 import no.unit.nva.model.instancetypes.book.AcademicMonograph;
 import no.unit.nva.model.instancetypes.book.BookAnthology;
 import no.unit.nva.model.instancetypes.book.Encyclopedia;
@@ -68,6 +69,7 @@ import no.unit.nva.model.pages.Pages;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
+    @JsonSubTypes.Type(name = "AcademicCommentary", value = AcademicCommentary.class),
     @JsonSubTypes.Type(name = "Architecture", value = Architecture.class),
     @JsonSubTypes.Type(name = "ArtisticDesign", value = ArtisticDesign.class),
     @JsonSubTypes.Type(name = "MovingPicture", value = MovingPicture.class),

--- a/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
@@ -445,7 +445,7 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
         var publication = PublicationGenerator.randomPublication();
         publication.setPublisher(createExpectedPublisher(wireMockRuntimeInfo));
         publication.setDuplicateOf(null);
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(RandomDataGenerator.randomUri(), List.of(
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(RandomDataGenerator.randomUri(), Set.of(
             RandomDataGenerator.randomUri()))));
         var userInstance = UserInstance.fromPublication(publication);
         var publicationIdentifier =

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -854,7 +854,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                    .stream()
                    .map(UpdatePublicationHandlerTest::getAffiliationUriStream)
                    .flatMap(Set::stream)
-                   .map(id -> new CuratingInstitution(id, List.of(randomUri())))
+                   .map(id -> new CuratingInstitution(id, Set.of(randomUri())))
                    .collect(Collectors.toSet());
     }
 
@@ -1767,7 +1767,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                                                                                        IOException {
         var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
         var curatingInstitution = randomUri();
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, List.of(randomUri()))));
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, Set.of(randomUri()))));
         resourceService.unpublishPublication(publication);
         var input = curatorWithAccessRightsRepublishedPublication(publication, randomUri(), curatingInstitution,
                                                                   MANAGE_RESOURCES_ALL);
@@ -1786,7 +1786,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
         var curatingInstitution = randomUri();
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, List.of(randomUri()))));
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, Set.of(randomUri()))));
         var input = curatorWithAccessRightsRepublishedPublication(publication, randomUri(), curatingInstitution,
                                                                   MANAGE_RESOURCES_ALL);
 

--- a/schema-org-metadata/src/main/resources/subtype_mappings.ttl
+++ b/schema-org-metadata/src/main/resources/subtype_mappings.ttl
@@ -23,6 +23,7 @@ nva:ReportBookOfAbstract rdfs:subClassOf schema:Report .
 nva:MediaPodcast rdfs:subClassOf schema:PodcastEpisode .
 nva:BookMonograph rdfs:subClassOf schema:Book .
 nva:AcademicMonograph rdfs:subClassOf schema:Book .
+nva:AcademicCommentary rdfs:subClassOf schema:Book .
 nva:Encyclopedia rdfs:subClassOf schema:Book .
 nva:ExhibitionCatalog rdfs:subClassOf schema:Book .
 nva:NonFictionMonograph rdfs:subClassOf schema:Book .

--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -126,13 +126,13 @@ public final class TicketTestUtils {
         return persistPublication(resourceService, publication);
     }
 
-    private static List<URI> getContributorIds(Publication publication) {
+    private static Set<URI> getContributorIds(Publication publication) {
         return publication.getEntityDescription()
                    .getContributors()
                    .stream()
                    .map(Contributor::getIdentity)
                    .map(Identity::getId)
-                   .toList();
+                   .collect(Collectors.toSet());
     }
 
     public static Publication createPersistedDegreePublication(PublicationStatus status,

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/create/CreateTicketHandlerTest.java
@@ -94,7 +94,6 @@ import nva.commons.logutils.LogUtils;
 import nva.commons.logutils.TestAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -788,7 +787,7 @@ class CreateTicketHandlerTest extends TicketTestLocal {
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PUBLISHED, resourceService);
         var curatingInstitution = randomUri();
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, List.of(randomUri()))));
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, Set.of(randomUri()))));
         resourceService.updatePublication(publication);
         var requestBody = constructDto(PublishingRequestCase.class);
 

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
@@ -636,7 +636,7 @@ public class UpdateTicketHandlerTest extends TicketTestLocal {
         var publication = TicketTestUtils.createPersistedPublicationWithUnpublishedFiles(
             PublicationStatus.PUBLISHED, resourceService);
         var curatingInstitution = randomUri();
-        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, List.of())));
+        publication.setCuratingInstitutions(Set.of(new CuratingInstitution(curatingInstitution, Set.of())));
         resourceService.updatePublication(publication);
         var ticket = TicketTestUtils.createPersistedTicket(publication, GeneralSupportRequest.class, ticketService);
 


### PR DESCRIPTION
BatchScan is failing cause AcademicCommentary is not added to JsonSubtypes of InstanceType. 

- Adding AcademicCommentary to JsonSubtypes of InstanceType.
- Converting contributorCristinIds in CuratingInstitution to Set instead of using List.