### PR TITLE
Channel client error response handling

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/model/IndexDocumentWrapperLinkedData.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/IndexDocumentWrapperLinkedData.java
@@ -208,6 +208,9 @@ public class IndexDocumentWrapperLinkedData {
     private InputStream processResponse(HttpResponse<String> response) {
         if (response.statusCode() / ONE_HUNDRED == SUCCESS_FAMILY) {
             return stringToStream(response.body());
+        } else if (response.statusCode() / ONE_HUNDRED == CLIENT_ERROR_FAMILY) {
+            logger.info("Request for publication channel <{}> returned 404", response.uri());
+            return null;
         }
         throw new RuntimeException("Unexpected response " + response);
     }

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -101,6 +101,7 @@ import no.unit.nva.publication.uriretriever.FakeUriResponse;
 import no.unit.nva.publication.uriretriever.FakeUriRetriever;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
+import nva.commons.logutils.LogUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -191,6 +192,18 @@ class ExpandedResourceTest {
                                             .toList();
 
         assertThat(actualContributorsPreview, is(equalTo(expectedContributors)));
+    }
+
+    @Test
+    void shouldAllowAndLogMissingChannel() {
+        final var logger = LogUtils.getTestingAppenderForRootLogger();
+        var publication = randomPublication(AcademicArticle.class);
+        FakeUriResponse.setupFakeForType(publication, fakeUriRetriever);
+        var channel = ((Journal)publication.getEntityDescription().getReference().getPublicationContext()).getId();
+        fakeUriRetriever.registerResponse(channel, 404, APPLICATION_JSON_LD, "");
+        assertDoesNotThrow(() -> fromPublication(fakeUriRetriever, publication));
+        assertThat(logger.getMessages(),
+                   containsString("Request for publication channel <%s> returned 404".formatted(channel)));
     }
 
     @Test


### PR DESCRIPTION
- We currently fail when a channel does not exist, but we should not — we should log it