### PR TITLE
Np 47916 ticket owner should be user from request

### DIFF
--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -45,8 +45,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.commons.json.JsonUtils;
-import no.unit.nva.expansion.model.ExpandedDoiRequest;
-import no.unit.nva.expansion.model.ExpandedGeneralSupportRequest;
 import no.unit.nva.expansion.model.ExpandedMessage;
 import no.unit.nva.expansion.model.ExpandedOrganization;
 import no.unit.nva.expansion.model.ExpandedPerson;
@@ -292,6 +290,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var owner = UserInstance.fromPublication(publication);
 
         var ticketToBeExpanded = TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class)
+                                     .withOwner(UserInstance.fromPublication(publication).getUsername())
                                      .persistNewTicket(ticketService);
 
         var message = messageService.createMessage(ticketToBeExpanded, owner, randomString());
@@ -309,6 +308,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var owner = UserInstance.fromPublication(publication);
 
         var ticketToBeExpanded = TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class)
+                                     .withOwner(randomString())
                                      .persistNewTicket(ticketService);
 
         var messageThatWillLeadToTicketExpansion = messageService.createMessage(ticketToBeExpanded, owner,
@@ -743,6 +743,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         throws ApiGatewayException {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication, PublishingRequestCase.class,
                                                                                               SortableIdentifier::next)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername())
                                                             .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.withFilesForApproval(convertUnpublishedFilesToFilesForApproval(publication));
         return publishingRequest.persistNewTicket(ticketService);
@@ -897,11 +898,13 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         throws ApiGatewayException {
 
         var differentTicketSameType = TicketEntry.requestNewTicket(publication, ticketType)
+                                          .withOwner(UserInstance.fromPublication(publication).getUsername())
                                           .persistNewTicket(ticketService);
         var firstUnexpectedMessage = ExpandedMessage.createEntry(
             messageService.createMessage(differentTicketSameType, owner, randomString()), expansionService);
         var differentTicketType = someOtherTicketTypeBesidesDoiRequest(ticketType);
         var differentTicketDifferentType = TicketEntry.requestNewTicket(publication, differentTicketType)
+                                               .withOwner(UserInstance.fromPublication(publication).getUsername())
                                                .persistNewTicket(ticketService);
         var secondUnexpectedMessage = ExpandedMessage.createEntry(
             messageService.createMessage(differentTicketDifferentType, owner, randomString()), expansionService);
@@ -932,34 +935,6 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
                    .persistNew(resourceService, UserInstance.fromPublication(publication));
     }
 
-    private DoiRequest toTicketEntry(ExpandedDoiRequest expandedDoiRequest) {
-        DoiRequest doiRequest = new DoiRequest();
-        doiRequest.setCreatedDate(expandedDoiRequest.getCreatedDate());
-        doiRequest.setIdentifier(expandedDoiRequest.identifyExpandedEntry());
-        doiRequest.setCustomerId(expandedDoiRequest.getCustomerId());
-        doiRequest.setModifiedDate(expandedDoiRequest.getModifiedDate());
-        doiRequest.setOwner(expandedDoiRequest.getOwner().username());
-        doiRequest.setResourceIdentifier(expandedDoiRequest.getPublication().getIdentifier());
-        doiRequest.setResourceStatus(expandedDoiRequest.getPublication().getStatus());
-        doiRequest.setStatus(getTicketStatus(expandedDoiRequest.getStatus()));
-        doiRequest.setAssignee(extractUsername(expandedDoiRequest.getAssignee()));
-        doiRequest.setOwnerAffiliation(expandedDoiRequest.getOrganization().id());
-        return doiRequest;
-    }
-
-    private GeneralSupportRequest toTicketEntry(ExpandedGeneralSupportRequest expandedGeneralSupportRequest) {
-        var ticketEntry = new GeneralSupportRequest();
-        ticketEntry.setModifiedDate(expandedGeneralSupportRequest.getModifiedDate());
-        ticketEntry.setCreatedDate(expandedGeneralSupportRequest.getCreatedDate());
-        ticketEntry.setCustomerId(expandedGeneralSupportRequest.getCustomerId());
-        ticketEntry.setIdentifier(extractIdentifier(expandedGeneralSupportRequest.getId()));
-        ticketEntry.setResourceIdentifier(expandedGeneralSupportRequest.getPublication().getIdentifier());
-        ticketEntry.setStatus(getTicketStatus(expandedGeneralSupportRequest.getStatus()));
-        ticketEntry.setOwner(expandedGeneralSupportRequest.getOwner().username());
-        ticketEntry.setAssignee(extractUsername(expandedGeneralSupportRequest.getAssignee()));
-        return ticketEntry;
-    }
-
     private TicketEntry toTicketEntry(ExpandedPublishingRequest expandedPublishingRequest) {
         var publishingRequest = new PublishingRequestCase();
         publishingRequest.setResourceIdentifier(expandedPublishingRequest.getPublication().getIdentifier());
@@ -975,31 +950,6 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         publishingRequest.setFilesForApproval(extractFilesForApproval(expandedPublishingRequest));
         publishingRequest.setOwnerAffiliation(expandedPublishingRequest.getOrganization().id());
         return publishingRequest;
-    }
-
-    private UnpublishRequest toTicketEntry(ExpandedUnpublishRequest expandedUnpublishRequest) {
-        var ticketEntry = new UnpublishRequest();
-        ticketEntry.setModifiedDate(expandedUnpublishRequest.getModifiedDate());
-        ticketEntry.setCreatedDate(expandedUnpublishRequest.getCreatedDate());
-        ticketEntry.setCustomerId(expandedUnpublishRequest.getCustomerId());
-        ticketEntry.setIdentifier(expandedUnpublishRequest.identifyExpandedEntry());
-        ticketEntry.setResourceIdentifier(expandedUnpublishRequest.getPublication().getIdentifier());
-        ticketEntry.setStatus(getTicketStatus(expandedUnpublishRequest.getStatus()));
-        ticketEntry.setOwner(expandedUnpublishRequest.getOwner().username());
-        ticketEntry.setAssignee(extractUsername(expandedUnpublishRequest.getAssignee()));
-        ticketEntry.setOwnerAffiliation(expandedUnpublishRequest.getOrganization().id());
-        return ticketEntry;
-    }
-
-    private TicketEntry toTicketEntry(ExpandedTicket expandedTicket) {
-        return switch (expandedTicket) {
-            case ExpandedDoiRequest expandedDoiRequest -> toTicketEntry(expandedDoiRequest);
-            case ExpandedPublishingRequest expandedPublishingRequest -> toTicketEntry(expandedPublishingRequest);
-            case ExpandedGeneralSupportRequest expandedGeneralSupportRequest ->
-                toTicketEntry(expandedGeneralSupportRequest);
-            case ExpandedUnpublishRequest expandedUnpublishRequest -> toTicketEntry(expandedUnpublishRequest);
-            case null, default -> null;
-        };
     }
 
     private Set<FileForApproval> extractFilesForApproval(ExpandedPublishingRequest expandedPublishingRequest) {

--- a/messages/src/test/java/no/unit/nva/publication/messages/delete/DeleteMessageHandlerTest.java
+++ b/messages/src/test/java/no/unit/nva/publication/messages/delete/DeleteMessageHandlerTest.java
@@ -103,6 +103,7 @@ class DeleteMessageHandlerTest extends ResourcesLocalTest {
         var publication = Resource.fromPublication(randomPublication)
                               .persistNew(resourceService, UserInstance.fromPublication(randomPublication));
         return TicketEntry.createNewTicket(publication, ticketType, SortableIdentifier::next)
+                   .withOwner(randomString())
                    .persistNewTicket(ticketService);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
@@ -7,7 +7,6 @@ import static no.unit.nva.publication.model.business.TicketEntry.Constants.CREAT
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.CUSTOMER_ID_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.IDENTIFIER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_AFFILIATION_FIELD;
-import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.STATUS_FIELD;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -60,8 +59,6 @@ public class DoiRequest extends TicketEntry {
     private Instant createdDate;
     @JsonProperty(CUSTOMER_ID_FIELD)
     private URI customerId;
-    @JsonProperty(OWNER_FIELD)
-    private User owner;
     @JsonProperty(ASSIGNEE_FIELD)
     private Username assignee;
     @JsonProperty(OWNER_AFFILIATION_FIELD)
@@ -149,15 +146,6 @@ public class DoiRequest extends TicketEntry {
     @Override
     public void setModifiedDate(Instant modifiedDate) {
         this.modifiedDate = modifiedDate;
-    }
-
-    @Override
-    public User getOwner() {
-        return owner;
-    }
-
-    public void setOwner(User owner) {
-        this.owner = owner;
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
@@ -6,7 +6,6 @@ import static no.unit.nva.publication.model.business.TicketEntry.Constants.CUSTO
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.IDENTIFIER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.MODIFIED_DATE_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_AFFILIATION_FIELD;
-import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.STATUS_FIELD;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,8 +36,6 @@ public class GeneralSupportRequest extends TicketEntry {
     private Instant createdDate;
     @JsonProperty(MODIFIED_DATE_FIELD)
     private Instant modifiedDate;
-    @JsonProperty(OWNER_FIELD)
-    private User owner;
     @JsonProperty(CUSTOMER_ID_FIELD)
     private URI customerId;
     @JsonProperty(STATUS_FIELD)
@@ -55,13 +52,12 @@ public class GeneralSupportRequest extends TicketEntry {
     public static TicketEntry fromPublication(Publication publication) {
         var ticket = new GeneralSupportRequest();
         ticket.setResourceIdentifier(publication.getIdentifier());
-        ticket.setOwner(extractOwner(publication));
         ticket.setCustomerId(extractCustomerId(publication));
         ticket.setCreatedDate(Instant.now());
         ticket.setModifiedDate(Instant.now());
         ticket.setStatus(TicketStatus.PENDING);
         ticket.setIdentifier(SortableIdentifier.next());
-        ticket.setViewedBy(ViewedBy.addAll(ticket.getOwner()));
+        ticket.setViewedBy(ViewedBy.addAll(UserInstance.fromPublication(publication).getUser()));
         return ticket;
     }
 
@@ -112,15 +108,6 @@ public class GeneralSupportRequest extends TicketEntry {
     @Override
     public void setModifiedDate(Instant modifiedDate) {
         this.modifiedDate = modifiedDate;
-    }
-
-    @Override
-    public User getOwner() {
-        return this.owner;
-    }
-
-    public void setOwner(User owner) {
-        this.owner = owner;
     }
 
     @Override
@@ -234,12 +221,5 @@ public class GeneralSupportRequest extends TicketEntry {
 
     private static URI extractCustomerId(Publication publication) {
         return Optional.of(publication).map(Publication::getPublisher).map(Organization::getId).orElse(null);
-    }
-
-    private static User extractOwner(Publication publication) {
-        return Optional.of(publication).map(Publication::getResourceOwner)
-                   .map(ResourceOwner::getOwner)
-                   .map(owner -> new User(owner.getValue()))
-                   .orElse(null);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -7,7 +7,6 @@ import static no.unit.nva.publication.model.business.TicketEntry.Constants.CUSTO
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.IDENTIFIER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.MODIFIED_DATE_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_AFFILIATION_FIELD;
-import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.STATUS_FIELD;
 import static no.unit.nva.publication.model.business.TicketEntry.Constants.WORKFLOW;
 import static nva.commons.core.attempt.Try.attempt;
@@ -57,16 +56,12 @@ public class PublishingRequestCase extends TicketEntry {
     private TicketStatus status;
     @JsonProperty(CUSTOMER_ID_FIELD)
     private URI customerId;
-    @JsonProperty(OWNER_FIELD)
-    private User owner;
     @JsonProperty(MODIFIED_DATE_FIELD)
     private Instant modifiedDate;
     @JsonProperty(CREATED_DATE_FIELD)
     private Instant createdDate;
-
     @JsonProperty(WORKFLOW)
     private PublishingWorkflow workflow;
-
     @JsonProperty(ASSIGNEE_FIELD)
     private Username assignee;
     @JsonProperty(OWNER_AFFILIATION_FIELD)
@@ -83,10 +78,9 @@ public class PublishingRequestCase extends TicketEntry {
     public static PublishingRequestCase fromPublication(Publication publication) {
         var userInstance = UserInstance.fromPublication(publication);
         var openingCaseObject = new PublishingRequestCase();
-        openingCaseObject.setOwner(userInstance.getUser());
         openingCaseObject.setCustomerId(userInstance.getCustomerId());
         openingCaseObject.setStatus(TicketStatus.PENDING);
-        openingCaseObject.setViewedBy(ViewedBy.addAll(openingCaseObject.getOwner()));
+        openingCaseObject.setViewedBy(ViewedBy.addAll(userInstance.getUser()));
         openingCaseObject.setResourceIdentifier(publication.getIdentifier());
         return openingCaseObject;
     }
@@ -259,11 +253,6 @@ public class PublishingRequestCase extends TicketEntry {
     }
 
     @Override
-    public User getOwner() {
-        return owner;
-    }
-
-    @Override
     public URI getCustomerId() {
         return customerId;
     }
@@ -280,10 +269,6 @@ public class PublishingRequestCase extends TicketEntry {
     @Override
     public String getStatusString() {
         return status.toString();
-    }
-
-    public void setOwner(User owner) {
-        this.owner = owner;
     }
 
     public PublishingRequestCase withFilesForApproval(Set<FileForApproval> filesForApproval) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -4,6 +4,7 @@ import static java.util.Objects.nonNull;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED_METADATA;
 import static no.unit.nva.publication.model.business.PublishingRequestCase.fromPublication;
+import static no.unit.nva.publication.model.business.TicketEntry.Constants.OWNER_FIELD;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -49,6 +50,8 @@ public abstract class TicketEntry implements Entity {
     public static final String UNAUTHENTICATED_TO_REMOVE_TICKET_MESSAGE =
         "Ticket owner only can remove ticket!";
 
+    @JsonProperty(OWNER_FIELD)
+    private User owner;
     @JsonProperty(VIEWED_BY_FIELD)
     private ViewedBy viewedBy;
     @JsonProperty(RESOURCE_IDENTIFIER)
@@ -165,6 +168,15 @@ public abstract class TicketEntry implements Entity {
         this.viewedBy = new ViewedBy(viewedBy);
     }
 
+    @Override
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
     public void persistUpdate(TicketService ticketService) {
         ticketService.updateTicket(this);
     }
@@ -219,6 +231,11 @@ public abstract class TicketEntry implements Entity {
 
     public boolean isPending() {
         return TicketStatus.PENDING.equals(getStatus());
+    }
+
+    public TicketEntry withOwner(String username) {
+        this.owner = new User(username);
+        return this;
     }
 
     private void validateTicketOwner(UserInstance userInstance) throws UnauthorizedException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
@@ -238,8 +238,7 @@ public class TicketService extends ServiceWithTransactions {
     }
 
     private Publication fetchPublicationToEnsureItExists(TicketEntry ticketEntry) throws ForbiddenException {
-        var userInstance = UserInstance.create(ticketEntry.getOwner(), ticketEntry.getCustomerId());
-        return attempt(() -> resourceService.getPublication(userInstance, ticketEntry.getResourceIdentifier()))
+        return attempt(() -> resourceService.getPublicationByIdentifier(ticketEntry.getResourceIdentifier()))
                    .orElseThrow(fail -> new ForbiddenException());
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/TicketService.java
@@ -10,7 +10,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
@@ -27,7 +26,6 @@ import no.unit.nva.publication.model.storage.TicketDao;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.ConflictException;
-import nva.commons.apigateway.exceptions.ForbiddenException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.FunctionWithException;
@@ -127,7 +125,7 @@ public class TicketService extends ServiceWithTransactions {
         return dao.fetchTicketMessages(getClient())
                    .map(MessageDao::getData)
                    .map(Message.class::cast)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     public TicketEntry refreshTicket(TicketEntry ticket) {
@@ -237,9 +235,9 @@ public class TicketService extends ServiceWithTransactions {
                                                ticketEntry.getClass()).orElseThrow();
     }
 
-    private Publication fetchPublicationToEnsureItExists(TicketEntry ticketEntry) throws ForbiddenException {
+    private Publication fetchPublicationToEnsureItExists(TicketEntry ticketEntry) {
         return attempt(() -> resourceService.getPublicationByIdentifier(ticketEntry.getResourceIdentifier()))
-                   .orElseThrow(fail -> new ForbiddenException());
+                   .orElseThrow();
     }
 
     private <T extends TicketEntry> T createTicketForPublication(Publication publication,

--- a/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
@@ -51,10 +51,12 @@ public final class TestingUtils extends TestDataSource {
     }
     
     public static GeneralSupportRequest createGeneralSupportRequest(Publication publication) {
-        return (GeneralSupportRequest) TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class);
+        return (GeneralSupportRequest) TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class)
+                                           .withOwner(UserInstance.fromPublication(publication).getUsername());
     }
 
     public static UnpublishRequest createUnpublishRequest(Publication publication) {
-        return (UnpublishRequest) TicketEntry.requestNewTicket(publication, UnpublishRequest.class);
+        return (UnpublishRequest) TicketEntry.requestNewTicket(publication, UnpublishRequest.class)
+                                      .withOwner(UserInstance.fromPublication(publication).getUsername());
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/MessageTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/MessageTest.java
@@ -46,7 +46,8 @@ class MessageTest extends TestDataSource {
     @Test
     void shouldReturnCopyWithoutLossOfInformation() throws ConflictException {
         Publication publication = randomPublicationEligibleForDoiRequest();
-        var ticket = TicketEntry.createNewTicket(publication, randomTicketType(), SortableIdentifier::next);
+        var ticket = TicketEntry.createNewTicket(publication, randomTicketType(), SortableIdentifier::next)
+                         .withOwner(UserInstance.fromPublication(publication).getUsername());
         var message = Message.create(ticket, UserInstance.fromTicket(ticket), randomString());
         var copy = message.copy();
         assertThat(message, doesNotHaveEmptyValues());

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestTest.java
@@ -28,8 +28,9 @@ class PublishingRequestTest {
     @Test
     void shouldReturnPublishingRequestWithAdequateInfoForCreatingEntryWhenSuppliedWithUserAndPublicationInfo() {
         var publication = randomPublication();
-        var objectForCreatingNewEntry = PublishingRequestCase.fromPublication(publication);
         var userInstance = UserInstance.fromPublication(publication);
+        var objectForCreatingNewEntry = PublishingRequestCase.fromPublication(publication)
+                                            .withOwner(userInstance.getUsername());
         assertThat(objectForCreatingNewEntry.getResourceIdentifier(), is(equalTo(publication.getIdentifier())));
         assertThat(objectForCreatingNewEntry.getOwner(), is(equalTo(userInstance.getUser())));
         assertThat(objectForCreatingNewEntry.getCustomerId(), is(equalTo(userInstance.getCustomerId())));

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
@@ -25,7 +25,8 @@ class TicketEntryTest {
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldRequestNewTicket(Class<? extends TicketEntry> ticketType, PublicationStatus status) {
         var publication = TicketTestUtils.createNonPersistedPublication(status);
-        var ticket = TicketEntry.requestNewTicket(publication, ticketType);
+        var ticket = TicketEntry.requestNewTicket(publication, ticketType)
+                         .withOwner(UserInstance.fromPublication(publication).getUsername());
         var actualUserInstance = UserInstance.fromTicket(ticket);
         var expectedUserInstance = getExpectedUserInstance(publication);
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.model.business;
 
-import static no.unit.nva.testutils.RandomDataGenerator.randomAccessRight;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,13 +10,13 @@ import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.testing.PublicationGenerator;
+import no.unit.nva.publication.ticket.test.TicketTestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import no.unit.nva.publication.ticket.test.TicketTestUtils;
 
 class UserInstanceTest {
     
@@ -42,7 +41,8 @@ class UserInstanceTest {
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldReturnUserInstanceFromMessage(Class<? extends TicketEntry> ticketType, PublicationStatus status) {
         var publication = TicketTestUtils.createNonPersistedPublication(status);
-        var ticket = TicketEntry.requestNewTicket(publication, ticketType);
+        var ticket = TicketEntry.requestNewTicket(publication, ticketType)
+                         .withOwner(UserInstance.fromPublication(publication).getUsername());
         var message = Message.create(ticket, UserInstance.fromTicket(ticket), randomString());
         var userInstance = UserInstance.fromMessage(message);
         assertThat(userInstance.getUsername(), is(equalTo(publication.getResourceOwner().getOwner().getValue())));

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoTest.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
@@ -53,6 +52,7 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResearchProject;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
 import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
@@ -338,7 +338,8 @@ class DaoTest extends ResourcesLocalTest {
     }
     
     private static TicketEntry createTicket(Class<? extends TicketEntry> entityType) throws ConflictException {
-        return TicketEntry.createNewTicket(draftPublicationWithoutDoi(), entityType, SortableIdentifier::next);
+        return TicketEntry.createNewTicket(draftPublicationWithoutDoi(), entityType, SortableIdentifier::next)
+                   .withOwner(randomString());
     }
     
     private static Stream<Dao> instanceProvider() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoUtils.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoUtils.java
@@ -13,16 +13,15 @@ import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
 import no.unit.nva.publication.TestDataSource;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.Message;
@@ -58,7 +57,7 @@ public final class DaoUtils extends TestDataSource {
 
     public static DoiRequestDao doiRequestDao() {
         var publication = randomPublicationEligibleForDoiRequest();
-        var doiRequest = DoiRequest.fromPublication(publication);
+        var doiRequest = (DoiRequest) DoiRequest.fromPublication(publication).withOwner(randomString());
         return new DoiRequestDao(doiRequest);
     }
 
@@ -71,7 +70,7 @@ public final class DaoUtils extends TestDataSource {
     @SuppressWarnings("unchecked")
     public static Class<? extends TicketEntry> randomTicketType() {
         return (Class<? extends TicketEntry>)
-                   randomElement(TypeProvider.listSubTypes(TicketEntry.class).collect(Collectors.toList()));
+                   randomElement(TypeProvider.listSubTypes(TicketEntry.class).toList());
     }
 
     static PutItemRequest toPutItemRequest(Dao resource) {
@@ -87,7 +86,7 @@ public final class DaoUtils extends TestDataSource {
     }
 
     private static PublishingRequestDao sampleApprovePublishingRequestDao() {
-        var publishingRequest = randomPublishingRequest();
+        var publishingRequest = randomPublishingRequest().withOwner(randomString());
         return (PublishingRequestDao) publishingRequest.toDao();
     }
 
@@ -101,6 +100,7 @@ public final class DaoUtils extends TestDataSource {
 
     private static TicketEntry randomTicket(Publication publication) {
         return attempt(() -> TicketEntry.createNewTicket(publication, randomTicketType(), SortableIdentifier::next))
+                   .map(ticketEntry -> ticketEntry.withOwner(randomString()))
                    .orElseThrow();
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/MessageDaoTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/MessageDaoTest.java
@@ -1,6 +1,14 @@
 package no.unit.nva.publication.model.storage;
 
+import static no.unit.nva.publication.model.storage.DynamoEntry.parseAttributeValuesMap;
+import static no.unit.nva.publication.storage.model.DatabaseConstants.RESOURCES_TABLE_NAME;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import java.net.URI;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Organization.Builder;
 import no.unit.nva.model.PublicationStatus;
@@ -19,17 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.net.URI;
-import java.time.Clock;
-
-import static no.unit.nva.publication.model.storage.DynamoEntry.parseAttributeValuesMap;
-import static no.unit.nva.publication.storage.model.DatabaseConstants.RESOURCES_TABLE_NAME;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 class MessageDaoTest extends ResourcesLocalTest {
     

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/PublishingRequestDaoTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/PublishingRequestDaoTest.java
@@ -93,7 +93,8 @@ class PublishingRequestDaoTest extends ResourcesLocalTest {
         var query = PublishingRequestDao.queryPublishingRequestByResource(publication.getPublisher().getId(),
                                                                           publication.getIdentifier());
 
-        var publishingRequest = PublishingRequestCase.fromPublication(publication);
+        var publishingRequest = PublishingRequestCase.fromPublication(publication)
+                                    .withOwner(randomString());
         var persistedRequest = publishingRequest.persistNewTicket(ticketService);
         var queryResult = client.query(query);
         var retrievedByPublicationIdentifier = queryResult.getItems().stream()

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/WithPrimaryKeyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/WithPrimaryKeyTest.java
@@ -11,7 +11,6 @@ import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Organization;
@@ -32,7 +31,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class WithPrimaryKeyTest extends ResourcesLocalTest {
-    
+
+    @Override
     @BeforeEach
     public void init() {
         super.init();
@@ -43,9 +43,9 @@ class WithPrimaryKeyTest extends ResourcesLocalTest {
     @MethodSource("createUnpersistedEntities")
     void primaryKeyPartitionKeyConditionReturnsQueryConditionForListingAllEntriesOfSpecificTypeForASingleUser(
         List<Entity> entities) {
-        var daos = entities.stream().map(Entity::toDao).collect(Collectors.toList());
+        var daos = entities.stream().map(Entity::toDao).toList();
         daos.forEach(this::insertToDb);
-        WithPrimaryKey queryObject = daos.get(0);
+        WithPrimaryKey queryObject = daos.getFirst();
         
         var result = performQuery(queryObject);
         var expectedItems = daos.toArray(Object[]::new);
@@ -60,7 +60,7 @@ class WithPrimaryKeyTest extends ResourcesLocalTest {
     }
     
     private static List<Message> sampleMessages() {
-        return sampleTickets().stream().flatMap(WithPrimaryKeyTest::randomMessages).collect(Collectors.toList());
+        return sampleTickets().stream().flatMap(WithPrimaryKeyTest::randomMessages).toList();
     }
     
     private static Stream<Message> randomMessages(TicketEntry ticket) {
@@ -80,7 +80,7 @@ class WithPrimaryKeyTest extends ResourcesLocalTest {
                    .map(publication -> publication.withPublisher(commonPublisher))
                    .map(Publication.Builder::build)
                    .map(Resource::fromPublication)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private static Username randomUsername() {
@@ -111,7 +111,8 @@ class WithPrimaryKeyTest extends ResourcesLocalTest {
                    .map(attempt(ticketType -> TicketEntry.createNewTicket(resource.toPublication(), ticketType,
                        SortableIdentifier::next)))
                    .map(Try::orElseThrow)
-                   .collect(Collectors.toList());
+                   .map(ticketEntry -> ticketEntry.withOwner(UserInstance.fromPublication(resource.toPublication()).getUsername()))
+                   .toList();
     }
 
     private List<? extends WithPrimaryKey> performQuery(WithPrimaryKey queryObject) {
@@ -124,7 +125,7 @@ class WithPrimaryKeyTest extends ResourcesLocalTest {
                    .getItems()
                    .stream()
                    .map(item -> DynamoEntry.parseAttributeValuesMap(item, Dao.class))
-                   .collect(Collectors.toList());
+                   .toList();
     }
     
     private QueryRequest createQuery(WithPrimaryKey queryObject) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -450,8 +450,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     @Test
     void getResourcesByCristinIdentifierReturnsAllResourcesWithCristinIdentifier() {
         String cristinIdentifier = randomString();
-        Set<Publication> publicationsWithCristinIdentifier =
-            createSamplePublicationsOfSingleCristinIdentifier(cristinIdentifier);
+        createSamplePublicationsOfSingleCristinIdentifier(cristinIdentifier);
         List<Publication> actualPublication = resourceService.getPublicationsByCristinIdentifier(cristinIdentifier);
         HashSet<Publication> actualResourcesSet = new HashSet<>(actualPublication);
         assertTrue(actualPublication.containsAll(actualResourcesSet));
@@ -856,7 +855,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var identifiersFromSecondScan = secondListingResult.getDatabaseEntries()
                                             .stream()
                                             .map(Entity::getIdentifier)
-                                            .collect(Collectors.toList());
+                                            .toList();
 
         var expectedIdentifiers = new ArrayList<>(
             List.of(publication.getIdentifier(), ticket.getIdentifier(), sampleMessage.getIdentifier()));
@@ -1071,7 +1070,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var resources = userResources.stream()
                             .map(Resource::fromPublication)
                             .map(Entity.class::cast)
-                            .collect(Collectors.toList());
+                            .toList();
 
         var testAppender = LogUtils.getTestingAppenderForRootLogger();
 
@@ -1126,15 +1125,14 @@ class ResourceServiceTest extends ResourcesLocalTest {
     @Test
     void shouldSetAllPendingTicketsToNotApplicableWhenUnpublishingPublication() throws ApiGatewayException {
         var publication = createPublishedResource();
-        var pendingGeneralSupportTicket =
-            GeneralSupportRequest.fromPublication(publication).persistNewTicket(ticketService);
-        var pendingDoiRequestTicket = DoiRequest.fromPublication(publication).persistNewTicket(ticketService);
+        var username = UserInstance.fromPublication(publication).getUsername();
+        GeneralSupportRequest.fromPublication(publication).withOwner(username).persistNewTicket(ticketService);
+        DoiRequest.fromPublication(publication).withOwner(username).persistNewTicket(ticketService);
         var closedGeneralSupportTicket =
-            GeneralSupportRequest.fromPublication(publication)
-                .persistNewTicket(ticketService)
+            GeneralSupportRequest.fromPublication(publication).withOwner(username).persistNewTicket(ticketService)
                 .close(new Username(randomString()));
         ticketService.updateTicket(closedGeneralSupportTicket);
-        var publishingRequestTicket = PublishingRequestCase.fromPublication(publication);
+        var publishingRequestTicket = PublishingRequestCase.fromPublication(publication).withOwner(username);
         publishingRequestTicket.setStatus(TicketStatus.COMPLETED);
         publishingRequestTicket.persistNewTicket(ticketService);
         resourceService.unpublishPublication(publication);
@@ -1294,7 +1292,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var contributions = IntStream
                                 .rangeClosed(1, amount)
                                 .mapToObj(i -> randomContributor())
-                                .collect(Collectors.toList());
+                                .toList();
         publication.getEntityDescription().setContributors(contributions);
         return Resource.fromPublication(publication)
                    .persistNew(resourceService, UserInstance.fromPublication(publication));
@@ -1306,7 +1304,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var contributions = IntStream
                                 .rangeClosed(1, amount)
                                 .mapToObj(i -> randomContributor(List.of()))
-                                .collect(Collectors.toList());
+                                .toList();
         publication.getEntityDescription().setContributors(contributions);
         return Resource.fromPublication(publication)
                    .persistNew(resourceService, UserInstance.fromPublication(publication));

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -400,6 +400,19 @@ public class TicketServiceTest extends ResourcesLocalTest {
         assertThrows(NotFoundException.class, () -> ticketService.completeTicket(nonExisingTicket, USERNAME));
     }
 
+    @ParameterizedTest(name = "ticket type:{0}")
+    @MethodSource("ticketTypeProvider")
+    void shouldNotUpdateAssigneeWhenCompletingTicketForAnotherAssignee(
+        Class<? extends TicketEntry> ticketType) throws ApiGatewayException {
+        var publication = persistPublication(owner, PUBLISHED);
+        var ticket = createPersistedTicket(publication, ticketType);
+        ticket.setAssignee(randomUsername());
+        ticket.persistUpdate(ticketService);
+        var completedTicket = ticketService.completeTicket(ticket, USERNAME);
+
+        assertThat(completedTicket.getAssignee(), is(not(equalTo(USERNAME))));
+    }
+
     //TODO: remove this test when ticket service is in place
     @Test
     void shouldCompleteTicketByResourceIdentifierWhenTicketIsUniqueForAPublication() throws ApiGatewayException {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
@@ -72,6 +72,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
     private S3Client s3Client;
     private Environment environment;
 
+    @Override
     @BeforeEach
     public void init() {
         super.init();
@@ -108,6 +109,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
         var initialResource = resourceService.getResourceByIdentifier(createdPublication.getIdentifier());
         var originalDao = new ResourceDao(initialResource).fetchByIdentifier(client, RESOURCES_TABLE_NAME);
         var originalTicket = TicketEntry.requestNewTicket(createdPublication, PublishingRequestCase.class)
+                                 .withOwner(UserInstance.fromPublication(createdPublication).getUsername())
                                  .persistNewTicket(ticketService);
         var originalTicketDao = fetchTicketDao(originalTicket.getIdentifier());
 
@@ -132,6 +134,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
         var initialResource = resourceService.getResourceByIdentifier(createdPublication.getIdentifier());
         var originalDao = new ResourceDao(initialResource).fetchByIdentifier(client, RESOURCES_TABLE_NAME);
         var originalTicket = TicketEntry.requestNewTicket(createdPublication, PublishingRequestCase.class)
+                                 .withOwner(UserInstance.fromPublication(createdPublication).getUsername())
                                  .persistNewTicket(ticketService);
         var originalTicketDao = fetchTicketDao(originalTicket.getIdentifier());
 
@@ -155,6 +158,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
         var initialResource = resourceService.getResourceByIdentifier(createdPublication.getIdentifier());
         var originalDao = new ResourceDao(initialResource).fetchByIdentifier(client, RESOURCES_TABLE_NAME);
         var originalTicket = TicketEntry.requestNewTicket(createdPublication, PublishingRequestCase.class)
+                                 .withOwner(UserInstance.fromPublication(createdPublication).getUsername())
                                  .persistNewTicket(ticketService);
         var originalTicketDao = fetchTicketDao(originalTicket.getIdentifier());
 
@@ -200,7 +204,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
                                     .build();
         handler.handleRequest(eventToInputStream(secondScanRequest), output, context);
 
-        ArgumentCaptor<Map<String, AttributeValue>> startingPointsCapturer = ArgumentCaptor.forClass(Map.class);
+        var startingPointsCapturer = ArgumentCaptor.forClass(Map.class);
         verify(resourceService, atLeastOnce()).scanResources(anyInt(), startingPointsCapturer.capture(), any());
         var scanStartingPointSentToTheService = startingPointsCapturer.getValue();
 
@@ -279,7 +283,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
 
     private ScanDatabaseRequest consumeLatestEmittedEvent() {
         var allRequests = eventBridgeClient.getRequestEntries();
-        var latest = allRequests.remove(allRequests.size() - 1);
+        var latest = allRequests.removeLast();
         return attempt(() -> ScanDatabaseRequest.fromJson(latest.detail())).orElseThrow();
     }
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
@@ -48,6 +48,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
     private FakeSqsClient queueClient;
     private RecoveryBatchScanHandler recoveryBatchScanHandler;
 
+    @Override
     @BeforeEach
     public void init() {
         super.init();
@@ -80,6 +81,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
         var publication = persistedPublication();
         var ticket =
             GeneralSupportRequest.requestNewTicket(publication, GeneralSupportRequest.class)
+                .withOwner(UserInstance.fromPublication(publication).getUsername())
                 .persistNewTicket(ticketService);
         var ticketVersion = ticket.toDao().getVersion();
         putMessageOnRecoveryQueue(ticket.getIdentifier(), "Ticket");
@@ -97,6 +99,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
         var publication = persistedPublication();
         var ticket =
             GeneralSupportRequest.requestNewTicket(publication, GeneralSupportRequest.class)
+                .withOwner(UserInstance.fromPublication(publication).getUsername())
                 .persistNewTicket(ticketService);
         var message = messageService.createMessage(ticket, UserInstance.fromTicket(ticket), randomString());
         var messageVersion = message.toDao().getVersion();

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandlerTest.java
@@ -24,8 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpClient.Redirect;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -109,10 +107,6 @@ class ExpandDataEntriesHandlerTest extends ResourcesLocalTest {
         this.expandResourceHandler = new ExpandDataEntriesHandler(sqsClient, s3Client,
                                                                   resourceExpansionService);
         this.s3Driver = new S3Driver(s3Client, "ignoredForFakeS3Client");
-    }
-
-    void some() {
-        HttpClient.newBuilder().followRedirects(Redirect.ALWAYS)
     }
 
     @ParameterizedTest

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandlerTest.java
@@ -24,6 +24,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -85,6 +87,7 @@ class ExpandDataEntriesHandlerTest extends ResourcesLocalTest {
     private TicketService ticketService;
     private MessageService messageService;
 
+    @Override
     @BeforeEach
     public void init() {
         super.init();
@@ -106,6 +109,10 @@ class ExpandDataEntriesHandlerTest extends ResourcesLocalTest {
         this.expandResourceHandler = new ExpandDataEntriesHandler(sqsClient, s3Client,
                                                                   resourceExpansionService);
         this.s3Driver = new S3Driver(s3Client, "ignoredForFakeS3Client");
+    }
+
+    void some() {
+        HttpClient.newBuilder().followRedirects(Redirect.ALWAYS)
     }
 
     @ParameterizedTest
@@ -239,6 +246,7 @@ class ExpandDataEntriesHandlerTest extends ResourcesLocalTest {
         var persistedPublication =
             resourceService.createPublication(UserInstance.fromPublication(publication), publication);
         var ticket = TicketEntry.requestNewTicket(persistedPublication, GeneralSupportRequest.class)
+                         .withOwner(UserInstance.fromPublication(publication).getUsername())
                          .persistNewTicket(ticketService);
         var message = messageService.createMessage(ticket, UserInstance.fromTicket(ticket), randomString());
         var request = emulateEventEmittedByDataEntryUpdateHandler(null, message);

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/persistence/ExpandedDataEntriesPersistenceHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/persistence/ExpandedDataEntriesPersistenceHandlerTest.java
@@ -110,6 +110,7 @@ class ExpandedDataEntriesPersistenceHandlerTest extends ResourcesLocalTest {
                                                                     mockPersonRetriever, uriRetriever);
     }
 
+    @Override
     @BeforeEach
     public void init() {
         var eventsBucket = new FakeS3Client();
@@ -292,7 +293,9 @@ class ExpandedDataEntriesPersistenceHandlerTest extends ResourcesLocalTest {
     private ExpandedDataEntry randomGeneralSupportRequest() throws ApiGatewayException, JsonProcessingException {
         var publication = createPublicationWithoutDoi();
         var openingCaseObject =
-            TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class).persistNewTicket(ticketService);
+            TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class)
+                .withOwner(UserInstance.fromPublication(publication).getUsername())
+                .persistNewTicket(ticketService);
         return resourceExpansionService.expandEntry(openingCaseObject);
     }
 
@@ -306,7 +309,8 @@ class ExpandedDataEntriesPersistenceHandlerTest extends ResourcesLocalTest {
     private ExpandedPublishingRequest randomPublishingRequest() throws ApiGatewayException, JsonProcessingException {
         var publication = createPublicationWithoutDoi();
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase
-                                                            .fromPublication(publication);
+                                                            .fromPublication(publication)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername());
         publishingRequest.setWorkflow(PublishingWorkflow.REGISTRATOR_REQUIRES_APPROVAL_FOR_METADATA_AND_FILES);
         publishingRequest.persistNewTicket(ticketService);
         return (ExpandedPublishingRequest) resourceExpansionService.expandEntry(publishingRequest);
@@ -315,8 +319,8 @@ class ExpandedDataEntriesPersistenceHandlerTest extends ResourcesLocalTest {
     private ExpandedPublishingRequest publishingRequestWithoutWorkflow()
         throws ApiGatewayException, JsonProcessingException {
         var publication = createPublicationWithoutDoi();
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase
-                                                            .fromPublication(publication);
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername());
         publishingRequest.setWorkflow(null);
         publishingRequest.persistNewTicket(ticketService);
         return (ExpandedPublishingRequest) resourceExpansionService.expandEntry(publishingRequest);
@@ -336,7 +340,9 @@ class ExpandedDataEntriesPersistenceHandlerTest extends ResourcesLocalTest {
 
     private ExpandedDoiRequest randomDoiRequest() throws ApiGatewayException, JsonProcessingException {
         var publication = createPublicationWithoutDoi();
-        var doiRequest = DoiRequest.fromPublication(publication).persistNewTicket(ticketService);
+        var doiRequest = DoiRequest.fromPublication(publication)
+                             .withOwner(UserInstance.fromPublication(publication).getUsername())
+                             .persistNewTicket(ticketService);
         return (ExpandedDoiRequest) resourceExpansionService.expandEntry(doiRequest);
     }
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -59,7 +59,6 @@ import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.paths.UnixPath;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -284,6 +283,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(Publication publication,
                                                                                      File file) throws ApiGatewayException {
         var publishingRequest =  (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
+                                                             .withOwner(UserInstance.fromPublication(publication).getUsername())
                                      .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.setStatus(TicketStatus.COMPLETED);
         publishingRequest.setApprovedFiles(Set.of(file.getIdentifier()));
@@ -362,7 +362,8 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     }
     
     private PublishingRequestCase pendingPublishingRequest(Publication publication) {
-        return PublishingRequestCase.fromPublication(publication);
+        return (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
+                   .withOwner(UserInstance.fromPublication(publication).getUsername());
     }
 
     private AcceptedPublishingRequestEventHandler handlerWithResourceServiceThrowingExceptionWhenUpdatingPublication()
@@ -388,6 +389,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         throws ApiGatewayException {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication, PublishingRequestCase.class,
                                                                                               SortableIdentifier::next)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername())
                                                             .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.withFilesForApproval(convertUnpublishedFilesToFilesForApproval(publication));
         return publishingRequest.persistNewTicket(ticketService);

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
@@ -139,12 +139,13 @@ public final class PublishingRequestResolver {
     }
 
     private void persistPendingPublishingRequest(Publication oldImage, Publication newImage) {
-        attempt(() -> TicketEntry.requestNewTicket(newImage, PublishingRequestCase.class)).map(
-                PublishingRequestCase.class::cast)
+        attempt(() -> TicketEntry.requestNewTicket(newImage, PublishingRequestCase.class))
+            .map(PublishingRequestCase.class::cast)
             .map(publishingRequest -> publishingRequest.withOwnerAffiliation(userInstance.getTopLevelOrgCristinId()))
             .map(publishingRequest -> publishingRequest.withWorkflow(lookUp(customer.getPublicationWorkflow())))
             .map(publishingRequest -> publishingRequest.withFilesForApproval(getFilesForApproval(oldImage, newImage)))
-            .map(publishingRequest -> persistPublishingRequest(newImage, publishingRequest));
+            .map(publishingRequest -> publishingRequest.withOwner(userInstance.getUsername()))
+            .map(publishingRequest -> persistPublishingRequest(newImage, (PublishingRequestCase) publishingRequest));
     }
 
     private boolean isPublishable(File file) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishUtil.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/RepublishUtil.java
@@ -5,6 +5,7 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
+import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permission.strategy.PublicationPermissionStrategy;
 import no.unit.nva.publication.service.impl.ResourceService;
@@ -41,10 +42,10 @@ public class RepublishUtil {
 
     private void persistCompletedPublishingRequest(Publication publication, UserInstance userInstance)
         throws ApiGatewayException {
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase
-                                                            .createNewTicket(publication,
-                                                                             PublishingRequestCase.class,
-                                                                             SortableIdentifier::next);
+        var publishingRequest = (PublishingRequestCase) TicketEntry
+                                                            .createNewTicket(publication, PublishingRequestCase.class,
+                                                                             SortableIdentifier::next)
+                                                            .withOwner(userInstance.getUsername());
         publishingRequest.persistAutoComplete(ticketService, publication, new Username(userInstance.getUsername()));
     }
 

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/PublishingRequestResolverTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/PublishingRequestResolverTest.java
@@ -77,6 +77,7 @@ class PublishingRequestResolverTest extends ResourcesLocalTest {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication,
                                                                                               PublishingRequestCase.class,
                                                                                               SortableIdentifier::next)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername())
                                                             .withOwnerAffiliation(
                                                                 publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.withFilesForApproval(convertUnpublishedFilesToFilesForApproval(publication));

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -422,14 +422,14 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         var publishedPublication = TicketTestUtils.createPersistedPublication(customerId,
                                                                               PUBLISHED,
                                                                               resourceService);
-        var completedTicket = persistCompletedPublishingRequest(publishedPublication);
+        persistCompletedPublishingRequest(publishedPublication);
         var publicationUpdate = addAnotherUnpublishedFile(publishedPublication);
 
         var inputStream = ownerUpdatesOwnPublication(publicationUpdate.getIdentifier(), publicationUpdate);
         stubCustomerResponseAcceptingFilesForAllTypesAndNotAllowingAutoPublishingFiles(customerId);
         updatePublicationHandler.handleRequest(inputStream, output, context);
         var gatewayResponse = GatewayResponse.fromOutputStream(output, PublicationResponse.class);
-        final var tickets = ticketService.fetchTicketsForUser(UserInstance.fromTicket(completedTicket)).toList();
+        final var tickets = resourceService.fetchAllTicketsForResource(Resource.fromPublication(publishedPublication)).toList();
         assertEquals(SC_OK, gatewayResponse.getStatusCode());
         assertThat(gatewayResponse.getHeaders(), hasKey(CONTENT_TYPE));
         assertThat(gatewayResponse.getHeaders(), hasKey(ACCESS_CONTROL_ALLOW_ORIGIN));
@@ -978,6 +978,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                                                                                                   PUBLISHED,
                                                                                                   resourceService);
         var existingTicket = TicketEntry.requestNewTicket(persistedPublication, PublishingRequestCase.class)
+                                 .withOwner(publication.getResourceOwner().getOwner().getValue())
                                  .withOwnerAffiliation(persistedPublication.getResourceOwner().getOwnerAffiliation())
                                  .persistNewTicket(ticketService);
         var updatedPublication = persistedPublication.copy().withAssociatedArtifacts(List.of()).build();
@@ -1004,6 +1005,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         var event = contributorUpdatesPublicationAndHasRightsToUpdate(publicationUpdate, cristinId,
                                                                       username);
         var pendingTicket = PublishingRequestCase.fromPublication(publication)
+                                .withOwner(publication.getResourceOwner().getOwner().getValue())
                                 .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation())
                                 .persistNewTicket(ticketService);
         updatePublicationHandler.handleRequest(event, output, context);
@@ -1013,7 +1015,6 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         assertThat(completedTicket.getFinalizedBy(), is(equalTo(new Username(username))));
         assertThat(completedTicket.getFinalizedBy(), is(not(equalTo(publication.getResourceOwner().getOwner()))));
     }
-
 
     @Test
     void publishingCuratorWithAccessRightManageResourceFilesShouldBeAbleToOverrideRrs()
@@ -1204,10 +1205,12 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublishedPublicationWithUnpublishedFilesAndContributor(
             userCristinId,
             resourceService);
-        GeneralSupportRequest.fromPublication(publication).persistNewTicket(ticketService);
-        DoiRequest.fromPublication(publication).persistNewTicket(ticketService);
+        GeneralSupportRequest.fromPublication(publication).withOwner(UserInstance.fromPublication(publication).getUsername()).persistNewTicket(ticketService);
+        DoiRequest.fromPublication(publication).withOwner(UserInstance.fromPublication(publication).getUsername()).persistNewTicket(ticketService);
         var publishingRequestTicket =
-            PublishingRequestCase.fromPublication(publication).persistNewTicket(ticketService);
+            PublishingRequestCase.fromPublication(publication)
+                .withOwner(UserInstance.fromPublication(publication).getUsername())
+                .persistNewTicket(ticketService);
         var completedPublishingRequest = publishingRequestTicket.complete(publication, new Username(userName));
         ticketService.updateTicket(completedPublishingRequest);
 
@@ -1238,9 +1241,10 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublicationWithPublishedFiles(customerId, PUBLISHED,
                                                                                        resourceService);
-        GeneralSupportRequest.fromPublication(publication).persistNewTicket(ticketService);
-        DoiRequest.fromPublication(publication).persistNewTicket(ticketService);
+        GeneralSupportRequest.fromPublication(publication).withOwner(publication.getResourceOwner().getOwner().getValue()).persistNewTicket(ticketService);
+        DoiRequest.fromPublication(publication).withOwner(publication.getResourceOwner().getOwner().getValue()).persistNewTicket(ticketService);
         PublishingRequestCase.fromPublication(publication)
+            .withOwner(publication.getResourceOwner().getOwner().getValue())
             .persistNewTicket(ticketService)
             .complete(publication, new Username(randomString()))
             .persistUpdate(ticketService);
@@ -1993,7 +1997,8 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         throws ApiGatewayException {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication, PublishingRequestCase.class,
                                                       SortableIdentifier::next)
-                   .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
+                                                            .withOwner(publication.getResourceOwner().getOwner().getValue())
+                                                            .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.withFilesForApproval(convertUnpublishedFilesToFilesForApproval(publication));
         return publishingRequest.persistNewTicket(ticketService);
     }
@@ -2266,6 +2271,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
 
     private TicketEntry createPendingPublishingRequest(Publication publishedPublication) throws ApiGatewayException {
         return PublishingRequestCase.createNewTicket(publishedPublication, PublishingRequestCase.class, SortableIdentifier::next)
+                   .withOwner(publication.getResourceOwner().getOwner().getValue())
                    .withOwnerAffiliation(publishedPublication.getResourceOwner().getOwnerAffiliation())
                    .persistNewTicket(ticketService);
     }
@@ -2273,6 +2279,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
     private TicketEntry persistCompletedPublishingRequest(Publication publishedPublication) throws ApiGatewayException {
         var ticket = PublishingRequestCase.createNewTicket(publishedPublication, PublishingRequestCase.class, SortableIdentifier::next)
                          .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation())
+                         .withOwner(publication.getResourceOwner().getOwner().getValue())
                          .persistNewTicket(ticketService);
         return ticketService.updateTicketStatus(ticket, TicketStatus.COMPLETED, new Username(randomString()));
     }

--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -285,6 +285,7 @@ public final class TicketTestUtils {
         throws ApiGatewayException {
         return TicketEntry.requestNewTicket(publication, ticketType)
                    .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation())
+                   .withOwner(UserInstance.fromPublication(publication).getUsername())
                    .persistNewTicket(ticketService);
     }
 
@@ -307,7 +308,8 @@ public final class TicketTestUtils {
 
     public static TicketEntry createNonPersistedTicket(Publication publication, Class<? extends TicketEntry> ticketType)
         throws ConflictException {
-        return TicketEntry.createNewTicket(publication, ticketType, SortableIdentifier::next);
+        return TicketEntry.createNewTicket(publication, ticketType, SortableIdentifier::next)
+                   .withOwner(UserInstance.fromPublication(publication).getUsername());
     }
 
     private static void setAffiliation(Corporation affiliation) {

--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -301,6 +301,7 @@ public final class TicketTestUtils {
                                                     TicketService ticketService)
         throws ApiGatewayException {
         var completedTicket = TicketEntry.createNewTicket(publication, ticketType, SortableIdentifier::next)
+                                  .withOwner(UserInstance.fromPublication(publication).getUsername())
                                   .persistNewTicket(ticketService).complete(publication, new Username("Username"));
         completedTicket.persistUpdate(ticketService);
         return completedTicket;

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -74,7 +74,8 @@ public class TicketResolver {
         validateUserPermissions(permissionStrategy, ticketDto, requestUtils);
 
         var ticket = TicketEntry.requestNewTicket(publication, ticketDto.ticketType())
-                         .withOwnerAffiliation(requestUtils.topLevelCristinOrgId());
+                         .withOwnerAffiliation(requestUtils.topLevelCristinOrgId())
+                         .withOwner(requestUtils.username());
         if (ticket instanceof PublishingRequestCase publishingRequest) {
             var customerId = requestUtils.customerId();
             publishingRequest.withWorkflow(getCustomerPublishingWorkflowResponse(customerId).convertToPublishingWorkflow())

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandlerTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Clock;
 import java.util.Map;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
@@ -120,6 +119,7 @@ class DeleteTicketHandlerTest extends ResourcesLocalTest {
 
     private TicketEntry createTicket(Publication publication) throws ApiGatewayException {
         return TicketEntry.createNewTicket(publication, PublishingRequestCase.class, SortableIdentifier::next)
+                   .withOwner(UserInstance.fromPublication(publication).getUsername())
                    .persistNewTicket(ticketService);
     }
 

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/read/GetTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/read/GetTicketHandlerTest.java
@@ -238,17 +238,15 @@ class GetTicketHandlerTest extends TicketTestLocal {
         throws NotFoundException {
         return createHttpRequest(ticket)
                    .withCurrentCustomer(customerId)
-                   .withNvaUsername(randomString())
+                   .withUserName(randomString())
                    .withAccessRights(customerId, accessRight);
     }
 
     private TicketEntry createPersistedTicket(Class<? extends TicketEntry> ticketType, Publication publication)
         throws ApiGatewayException {
-        return TicketEntry.requestNewTicket(publication, ticketType).persistNewTicket(ticketService);
-    }
-
-    private User randomOwner() {
-        return new User(randomString());
+        return TicketEntry.requestNewTicket(publication, ticketType)
+                   .withOwner(UserInstance.fromPublication(publication).getUsername())
+                   .persistNewTicket(ticketService);
     }
 
     private HandlerRequestBuilder<TicketDto> createHttpRequest(TicketEntry ticket)

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandlerTest.java
@@ -165,11 +165,12 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         Class<? extends TicketEntry> ticketType, AccessRight[] accessRight)
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PublicationStatus.PUBLISHED, resourceService);
+        var username = UserInstance.fromPublication(publication).getUsername();
 
         var ownerAffiliation = publication.getResourceOwner().getOwnerAffiliation();
-        DoiRequest.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
-        PublishingRequestCase.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
-        GeneralSupportRequest.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
+        DoiRequest.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).withOwner(username).persistNewTicket(ticketService);
+        PublishingRequestCase.fromPublication(publication).withOwner(username).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
+        GeneralSupportRequest.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).withOwner(username).persistNewTicket(ticketService);
 
         var request = curatorWithAccessRightRequestTicketsForPublication(publication, accessRight);
         handler.handleRequest(request, output, CONTEXT);
@@ -205,13 +206,14 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         Class<? extends TicketEntry> ticketType, AccessRight[] accessRight)
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PublicationStatus.PUBLISHED, resourceService);
+        var username = UserInstance.fromPublication(publication).getUsername();
 
         var ownerAffiliation = publication.getResourceOwner().getOwnerAffiliation();
         DoiRequest.fromPublication(publication).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
         PublishingRequestCase.fromPublication(publication).withOwnerAffiliation(
-            ownerAffiliation).persistNewTicket(ticketService);
+            ownerAffiliation).withOwner(username).persistNewTicket(ticketService);
         GeneralSupportRequest.fromPublication(publication).withOwnerAffiliation(
-            ownerAffiliation).persistNewTicket(ticketService);
+            ownerAffiliation).withOwner(username).persistNewTicket(ticketService);
 
         var request = userRequestsTickets(publication, randomUri(), ownerAffiliation, accessRight);
         handler.handleRequest(request, output, CONTEXT);
@@ -266,9 +268,13 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         var contributor = randomContributorWithId(contributorId);
         publication.getEntityDescription().setContributors(List.of(contributor));
         resourceService.updatePublication(publication);
-        DoiRequest.fromPublication(publication).withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
-        PublishingRequestCase.fromPublication(publication).withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
-        GeneralSupportRequest.fromPublication(publication).withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
+        var username = UserInstance.fromPublication(publication).getUsername();
+        DoiRequest.fromPublication(publication).withOwner(username)
+            .withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
+        PublishingRequestCase.fromPublication(publication).withOwner(username)
+            .withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
+        GeneralSupportRequest.fromPublication(publication).withOwner(username)
+            .withOwnerAffiliation(randomUri()).persistNewTicket(ticketService);
 
         var request = userRequestsTickets(publication, contributorId, randomUri());
         handler.handleRequest(request, output, CONTEXT);
@@ -289,6 +295,7 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         resourceService.updatePublication(publication);
         GeneralSupportRequest.fromPublication(publication)
             .withOwnerAffiliation(randomUri())
+            .withOwner(UserInstance.fromPublication(publication).getUsername())
             .persistNewTicket(ticketService)
             .complete(publication, new Username(randomString())).persistUpdate(ticketService);
 

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/update/UpdateTicketHandlerTest.java
@@ -777,6 +777,7 @@ public class UpdateTicketHandlerTest extends TicketTestLocal {
         throws ApiGatewayException {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication, PublishingRequestCase.class,
                                                                                               SortableIdentifier::next)
+                                                            .withOwner(UserInstance.fromPublication(publication).getUsername())
                                                             .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
         publishingRequest.withFilesForApproval(convertUnpublishedFilesToFilesForApproval(publication));
         return publishingRequest.persistNewTicket(ticketService);


### PR DESCRIPTION
Injecting ticket owner to user from requestInfo on ticket creation. 

I think we have to refactor ticket creation logic, cause ticket creation based on publication data is not longer the case and ticket has to be created from RequestInfo data. 