### PR TITLE
locking editor access to publication based on supervisor from his institution

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permission/strategy/restrict/NonDegreePermissionStrategy.java
@@ -1,16 +1,22 @@
 package no.unit.nva.publication.permission.strategy.restrict;
 
+import static no.unit.nva.model.role.Role.SUPERVISOR;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Optional;
+import no.unit.nva.model.Contributor;
+import no.unit.nva.model.CuratingInstitution;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.model.role.RoleType;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.ResourceService;
 
 public class NonDegreePermissionStrategy extends DenyPermissionStrategy {
 
-    public NonDegreePermissionStrategy(Publication publication,
-                                       UserInstance userInstance,
+    public NonDegreePermissionStrategy(Publication publication, UserInstance userInstance,
                                        ResourceService resourceService) {
         super(publication, userInstance, resourceService);
     }
@@ -31,9 +37,42 @@ public class NonDegreePermissionStrategy extends DenyPermissionStrategy {
             if (userDoesNotBelongToPublication()) {
                 return true; // deny
             }
+            return isNotCuratorForRegistratorInstitution() && userIsCuratingSupervisorsOnly(); // deny
         }
 
         return false; // allow
+    }
+
+    private boolean userIsCuratingSupervisorsOnly() {
+        return getCuratingInstitutions().map(CuratingInstitution::contributorCristinIds)
+                   .stream()
+                   .flatMap(Collection::stream)
+                   .map(this::getContributor)
+                   .filter(Optional::isPresent)
+                   .map(Optional::get)
+                   .map(Contributor::getRole)
+                   .map(RoleType::getType)
+                   .allMatch(SUPERVISOR::equals);
+    }
+
+    private boolean isNotCuratorForRegistratorInstitution() {
+        return !userInstance.getTopLevelOrgCristinId().equals(publication.getResourceOwner().getOwnerAffiliation());
+    }
+
+    private Optional<CuratingInstitution> getCuratingInstitutions() {
+        return Optional.ofNullable(publication.getCuratingInstitutions())
+                   .stream()
+                   .flatMap(Collection::stream)
+                   .filter(org -> org.id().equals(userInstance.getTopLevelOrgCristinId()))
+                   .findFirst();
+    }
+
+    private Optional<Contributor> getContributor(URI contributorId) {
+        return publication.getEntityDescription()
+                   .getContributors()
+                   .stream()
+                   .filter(contributor -> contributor.getIdentity().getId().equals(contributorId))
+                   .findFirst();
     }
 
     private boolean userDoesNotBelongToPublication() {


### PR DESCRIPTION
Curator at contributor that is supervisor should not be able to edit the publication. If curator is from the same institution as publication owner, he/she should still be able to update that publication. 