### PR TITLE
not throwing exception when fetching parent ref returns 404

### DIFF
--- a/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedParentPublicationTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedParentPublicationTest.java
@@ -2,15 +2,22 @@ package no.unit.nva.expansion.model;
 
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.publication.testing.http.RandomPersonServiceResponse.randomUri;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.net.URI;
+import java.util.Optional;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.instancetypes.book.BookAnthology;
+import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
+import no.unit.nva.publication.testing.http.FakeHttpResponse;
 import no.unit.nva.publication.uriretriever.FakeUriRetriever;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.paths.UriWrapper;
@@ -35,8 +42,7 @@ class ExpandedParentPublicationTest extends ResourcesLocalTest {
         var publicationId = randomPublicationId();
         var parent = new ExpandedParentPublication(fakeUriRetriever, resourceService);
 
-        assertThrows(RuntimeException.class,
-                     () -> parent.getExpandedParentPublication(publicationId),
+        assertThrows(RuntimeException.class, () -> parent.getExpandedParentPublication(publicationId),
                      "Parent publication not found " + publicationId);
     }
 
@@ -49,6 +55,19 @@ class ExpandedParentPublicationTest extends ResourcesLocalTest {
         assertThrows(RuntimeException.class, () -> parent.getExpandedParentPublication(publicationId));
     }
 
+    @Test
+    void shouldNotThrowExceptionWhenExternalReferenceReturnsResponseWithStatusCode4XX() throws BadRequestException {
+        var publication = persistedParentPublication();
+        var publicationId = toPublicationId(publication.getIdentifier());
+        var mockedUriRetriever = mock(UriRetriever.class);
+        when(mockedUriRetriever.fetchResponse(any(), any())).thenReturn(
+            Optional.of(FakeHttpResponse.create(emptyJsonBody(), 404)));
+
+        assertDoesNotThrow(
+            () -> new ExpandedParentPublication(mockedUriRetriever, resourceService).getExpandedParentPublication(
+                publicationId));
+    }
+
     private static URI randomPublicationId() {
         return UriWrapper.fromUri(randomUri())
                    .addChild(PUBLICATION_PATH)
@@ -58,6 +77,12 @@ class ExpandedParentPublicationTest extends ResourcesLocalTest {
 
     private static URI toPublicationId(SortableIdentifier identifier) {
         return UriWrapper.fromUri(randomUri()).addChild(PUBLICATION_PATH).addChild(identifier.toString()).getUri();
+    }
+
+    private String emptyJsonBody() {
+        return """
+            {}
+            """;
     }
 
     private Publication persistedParentPublication() throws BadRequestException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -282,6 +282,8 @@ public class PublishingRequestCase extends TicketEntry {
         return this;
     }
 
+
+
     public PublishingRequestCase withWorkflow(PublishingWorkflow workflow) {
         this.workflow = workflow;
         return this;


### PR DESCRIPTION
When expanding parent publication, we do not handle 4xx responses. Fixing it.