### PR TITLE
moving rejecting of files to accepted pub req handler

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -16,6 +16,7 @@ import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.InternalFile;
 import no.unit.nva.model.associatedartifacts.file.OpenFile;
+import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.model.associatedartifacts.file.PendingInternalFile;
 import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
 import no.unit.nva.model.associatedartifacts.file.PublishedFile;
@@ -27,7 +28,6 @@ import no.unit.nva.publication.external.services.UriRetriever;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.Entity;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
@@ -79,14 +79,44 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
                                        Context context) {
         var eventBlob = s3Driver.readEvent(input.getUri());
         var ticketUpdate = parseInput(eventBlob);
-        if (isCompleted(ticketUpdate) && hasEffectiveChanges(eventBlob)) {
-            publishPublicationAndFiles(ticketUpdate);
+        if (hasEffectiveChanges(eventBlob)) {
+            handleChanges(ticketUpdate);
         }
         return null;
     }
 
-    private static boolean isCompleted(PublishingRequestCase latestUpdate) {
-        return TicketStatus.COMPLETED.equals(latestUpdate.getStatus());
+    private void handleChanges(PublishingRequestCase publishingRequest) {
+        switch (publishingRequest.getStatus()) {
+            case COMPLETED -> handleCompletedPublishingRequest(publishingRequest);
+            case CLOSED -> handleClosedPublishingRequest(publishingRequest);
+            default -> {
+                // Ignore other non-final statuses
+            }
+        }
+    }
+
+    private void handleClosedPublishingRequest(PublishingRequestCase publishingRequestCase) {
+        var publication = fetchPublication(publishingRequestCase.getResourceIdentifier());
+        var updatedPublication = publication.copy()
+                                     .withAssociatedArtifacts(rejectFiles(publication))
+                                     .build();
+        resourceService.updatePublication(updatedPublication);
+    }
+
+    private List<AssociatedArtifact> rejectFiles(Publication publication) {
+        var associatedArtifacts = publication.getAssociatedArtifacts();
+        return associatedArtifacts.stream()
+                   .map(this::rejectFile)
+                   .toList();
+    }
+
+    //TODO: Remove unpublishable file and logic related to it after we have migrated files
+    private AssociatedArtifact rejectFile(AssociatedArtifact associatedArtifact) {
+        return switch (associatedArtifact) {
+            case UnpublishedFile unpublishedFile -> unpublishedFile.toUnpublishableFile();
+            case PendingFile<?> pendingFile -> pendingFile.reject();
+            default -> associatedArtifact;
+        };
     }
 
     private static boolean hasDoi(Publication publication) {
@@ -134,7 +164,7 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         return !noEffectiveChanges(DataEntryUpdateEvent.fromJson(eventBlob));
     }
 
-    private void publishPublicationAndFiles(PublishingRequestCase publishingRequestCase) {
+    private void handleCompletedPublishingRequest(PublishingRequestCase publishingRequestCase) {
         var publication = fetchPublication(publishingRequestCase.getResourceIdentifier());
         var publishingRequest = fetchPublishingRequest(publishingRequestCase);
         var updatedPublication = toPublicationWithPublishedFiles(publication, publishingRequest);


### PR DESCRIPTION
Simplifying logic in backend and moving rejection of file to AcceptedPublishingRequestHandler.
Before: When updating PublishingRequest to status CLOSED in UpdateTicketHandler -> update ticket status to Completed + update files to rejected.
Now: updating ticket status to completed only in UpdateTicketHandler + Handling Closed PubReq in AcceptedPublishingRequestEventHandler and rejecting files there. 

I think it simplifies updates on publication.