### PR TITLE
moving all publication updates based on ticket to event handler

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -1,6 +1,7 @@
 package no.unit.nva.publication.events.handlers.tickets;
 
 import static java.util.Objects.nonNull;
+import static no.unit.nva.publication.model.business.PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.List;
@@ -11,6 +12,7 @@ import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.file.File;
@@ -87,11 +89,19 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
 
     private void handleChanges(PublishingRequestCase publishingRequest) {
         switch (publishingRequest.getStatus()) {
+            case PENDING -> handlePendingPublishingRequest(publishingRequest);
             case COMPLETED -> handleCompletedPublishingRequest(publishingRequest);
             case CLOSED -> handleClosedPublishingRequest(publishingRequest);
             default -> {
                 // Ignore other non-final statuses
             }
+        }
+    }
+
+    private void handlePendingPublishingRequest(PublishingRequestCase publishingRequest) {
+        var publication = fetchPublication(publishingRequest.getResourceIdentifier());
+        if (REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(publishingRequest.getWorkflow())) {
+            publishPublication(publication);
         }
     }
 
@@ -167,8 +177,18 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
     private void handleCompletedPublishingRequest(PublishingRequestCase publishingRequestCase) {
         var publication = fetchPublication(publishingRequestCase.getResourceIdentifier());
         var publishingRequest = fetchPublishingRequest(publishingRequestCase);
-        var updatedPublication = toPublicationWithPublishedFiles(publication, publishingRequest);
         var ticketIdentifier = publishingRequest.getIdentifier();
+
+        if (PublicationStatus.DRAFT.equals(publication.getStatus())) {
+            publishPublication(publication);
+        }
+
+        var updatedPublication =
+            attempt(() -> resourceService.getPublicationByIdentifier(publication.getIdentifier()))
+                .map(p -> toPublicationWithPublishedFiles(p, publishingRequest))
+                .orElseThrow();
+
+
         switch (publishingRequestCase.getWorkflow()) {
             case REGISTRATOR_PUBLISHES_METADATA_ONLY, REGISTRATOR_PUBLISHES_METADATA_AND_FILES -> {
                 publishFiles(updatedPublication);
@@ -176,7 +196,6 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
             }
             case REGISTRATOR_REQUIRES_APPROVAL_FOR_METADATA_AND_FILES -> {
                 publishFiles(updatedPublication);
-                publishPublication(publishingRequestCase);
                 logger.info(PUBLISHING_METADATA_AND_FILES_MESSAGE, publication.getIdentifier(),
                             ticketIdentifier);
             }
@@ -197,12 +216,12 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         return new RuntimeException();
     }
 
-    private void publishPublication(PublishingRequestCase publishingRequestCase) {
-        var userInstance = UserInstance.create(publishingRequestCase.getOwner(), publishingRequestCase.getCustomerId());
+    private void publishPublication(Publication publication) {
+        var userInstance = UserInstance.fromPublication(publication);
         attempt(() -> resourceService.publishPublication(userInstance,
-                                                         publishingRequestCase.getResourceIdentifier())).orElseThrow(
+                                                         publication.getIdentifier())).orElseThrow(
             fail -> throwException(
-                String.format(PUBLISHING_ERROR_MESSAGE, publishingRequestCase.getResourceIdentifier()), fail));
+                String.format(PUBLISHING_ERROR_MESSAGE, publication.getIdentifier()), fail));
     }
 
     private void publishFiles(Publication updatedPublication) {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -431,6 +431,25 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         assertTrue(updatedPublication.getAssociatedArtifacts().stream().allMatch(RejectedFile.class::isInstance));
     }
 
+    @Test
+    void shouldPublishPublicationWhenPendingPublishingRequestAndCustomerAllowsPublishingMetadata() throws ApiGatewayException, IOException {
+        var publication = createPublication();
+        publication.setAssociatedArtifacts(new AssociatedArtifactList(randomPendingInternalFile(), randomPendingOpenFile()));
+        resourceService.updatePublication(publication);
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
+                                                            .withOwner(randomString())
+                                                            .withOwnerAffiliation(randomUri());
+        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
+        var ticket = publishingRequest.persistNewTicket(ticketService);
+        var event = createEvent(null, ticket);
+
+        handler.handleRequest(event, outputStream, CONTEXT);
+
+        var publishedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
+
+        assertTrue(PublicationStatus.PUBLISHED.equals(publishedPublication.getStatus()));
+    }
+
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(
             Publication publication, File file) throws ApiGatewayException {
         var publishingRequest =

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -3,13 +3,10 @@ package no.unit.nva.publication.ticket.create;
 import static no.unit.nva.model.PublicationOperation.DOI_REQUEST_CREATE;
 import static no.unit.nva.model.PublicationOperation.PUBLISHING_REQUEST_CREATE;
 import static no.unit.nva.model.PublicationOperation.SUPPORT_REQUEST_CREATE;
-import static no.unit.nva.publication.model.business.PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_AND_FILES;
-import static no.unit.nva.publication.model.business.PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY;
 import static no.unit.nva.publication.ticket.create.CreateTicketHandler.BACKEND_CLIENT_AUTH_URL;
 import static no.unit.nva.publication.ticket.create.CreateTicketHandler.BACKEND_CLIENT_SECRET_NAME;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import no.unit.nva.commons.json.JsonUtils;
@@ -17,15 +14,12 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.File;
-import no.unit.nva.model.associatedartifacts.file.PendingFile;
-import no.unit.nva.model.associatedartifacts.file.UnpublishedFile;
 import no.unit.nva.publication.external.services.AuthorizedBackendUriRetriever;
 import no.unit.nva.publication.external.services.RawContentRetriever;
 import no.unit.nva.publication.model.business.FileForApproval;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.PublishingWorkflow;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permission.strategy.PublicationPermissionStrategy;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
@@ -142,48 +136,32 @@ public class TicketResolver {
     private PublishingRequestCase createPublishingRequest(PublishingRequestCase publishingRequestCase,
                                                           Publication publication, RequestUtils requestUtils)
         throws ApiGatewayException {
+
         var username = new Username(requestUtils.username());
-        return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(publishingRequestCase.getWorkflow())
-                   ? createPublishingRequestAndPublishMetadateWithFiles(publishingRequestCase, publication, username)
-                   : createPublishingRequestForNonCurator(publishingRequestCase, publication, username);
+
+        return switch (publishingRequestCase.getWorkflow()) {
+            case REGISTRATOR_PUBLISHES_METADATA_AND_FILES ->
+                persistCompletedPublishingRequest(publishingRequestCase, publication, username);
+            case REGISTRATOR_PUBLISHES_METADATA_ONLY ->
+                persistPublishingRequest(publishingRequestCase, publication, username);
+            default -> (PublishingRequestCase) publishingRequestCase.persistNewTicket(ticketService);
+        };
     }
 
-    private PublishingRequestCase createPublishingRequestAndPublishMetadateWithFiles(
+    private PublishingRequestCase persistCompletedPublishingRequest(
         PublishingRequestCase publishingRequestCase, Publication publication, Username curator)
-        throws ApiGatewayException {
-        publishPublicationAndFiles(publication);
-        return createAutoApprovedTicketForCurator(publishingRequestCase, publication, curator);
-    }
-
-    private PublishingRequestCase createPublishingRequestForNonCurator(PublishingRequestCase publishingRequestCase,
-                                                                       Publication publication, Username curator)
-        throws ApiGatewayException {
-        if (REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(publishingRequestCase.getWorkflow())) {
-            publishPublicationAndFiles(publication);
-            return createAutoApprovedTicket(publishingRequestCase, publication, curator);
-        }
-        if (REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(publishingRequestCase.getWorkflow())) {
-            publishMetadata(publication);
-            return createAutoApprovedTicketWhenPublicationContainsMetadataOnly(publishingRequestCase, publication,
-                                                                               curator);
-        } else {
-            return (PublishingRequestCase) publishingRequestCase.persistNewTicket(ticketService);
-        }
-    }
-
-    private PublishingRequestCase createAutoApprovedTicketForCurator(PublishingRequestCase publishingRequestCase,
-                                                                     Publication publication, Username curator)
         throws ApiGatewayException {
         publishingRequestCase.setAssignee(curator);
         return publishingRequestCase.approveFiles().persistAutoComplete(ticketService, publication, curator);
     }
 
-    private PublishingRequestCase createAutoApprovedTicketWhenPublicationContainsMetadataOnly(
-        PublishingRequestCase ticket, Publication publication, Username finalizedBy) throws ApiGatewayException {
+    private PublishingRequestCase persistPublishingRequest(PublishingRequestCase publishingRequestCase,
+                                                           Publication publication, Username username)
+        throws ApiGatewayException {
         if (hasNoFiles(publication)) {
-            return createAutoApprovedTicket(ticket, publication, finalizedBy);
+            return createAutoApprovedTicket(publishingRequestCase, publication, username);
         } else {
-            return (PublishingRequestCase) ticket.persistNewTicket(ticketService);
+            return (PublishingRequestCase) publishingRequestCase.persistNewTicket(ticketService);
         }
     }
 
@@ -203,40 +181,6 @@ public class TicketResolver {
 
     private TicketEntry persistTicket(TicketEntry newTicket) {
         return attempt(() -> newTicket.persistNewTicket(ticketService)).orElseThrow();
-    }
-
-    private void publishPublicationAndFiles(Publication publication) throws ApiGatewayException {
-        var updatedPublication = toPublicationWithPublishedFiles(publication);
-        publishPublication(updatedPublication);
-    }
-
-    private void publishPublication(Publication publication) throws ApiGatewayException {
-        resourceService.updatePublication(publication);
-        resourceService.publishPublication(UserInstance.fromPublication(publication), publication.getIdentifier());
-    }
-
-    private void publishMetadata(Publication publication) throws ApiGatewayException {
-        publishPublication(publication);
-    }
-
-    private Publication toPublicationWithPublishedFiles(Publication publication) {
-        return publication.copy().withAssociatedArtifacts(convertFilesToPublished(publication)).build();
-    }
-
-    private List<AssociatedArtifact> convertFilesToPublished(Publication publication) {
-        return publication.getAssociatedArtifacts().stream().map(this::openFiles).toList();
-    }
-
-    //TODO: Remove unpublishable file and logic related to it after we have migrated files
-    private AssociatedArtifact openFiles(AssociatedArtifact artifact) {
-        if (artifact instanceof PendingFile<?> file) {
-            return file.approve();
-        }
-        if (artifact instanceof UnpublishedFile unpublishedFile) {
-            return unpublishedFile.toPublishedFile();
-        } else {
-            return artifact;
-        }
     }
 
     private BadGatewayException createBadGatewayException() {


### PR DESCRIPTION
Refactoring TicketResolver which is used in CreateTicketHandler to handle ticket and publication updates when ticket is being create by contributor/curator.

- Moving all publishing of metadata and files from `CreateTicketHandler` and `TicketResolver` to `AcceptedPublishingRequestEventHandler`. It makes that ALL changes to publication based on created(pending), completed and closed PublishingRequest handles in EventHandler. It makes it easy to manage changes and create new publishing flow.

Whats new:

_1. Case: When contributor requests publishing of publication with metadata only and customer allows publishing metadata._

- Before: CreateTicketHandler persists Completed PublishingRequest and publishes publication metadata. 
- Now: CreateTicketHandler persists Completed PublishingRequest -> AcceptedPublishingRequestHandler consumes Completed PublishingRequest and publishes metadata. 

_2. Case: When contributor requests publishing of publication with metadata and files and customer allows publishing metadata._

- Before: CreateTicketHandler persists Pending PublishingRequest and publishes metadata only. 
- Now:  CreateTicketHandler persists Pending PublishingRequest -> AcceptedPublishingRequestHandler consumes  Pending PublishingRequest and publishes metadata.

_3. Case: When contributor requests publishing of publication with metadata and files and customer allows publishing metadata._

- Before: CreateTicketHandler persists Completed PublishingRequest and publishes metadata and files. 
- Now:  CreateTicketHandler persists Completed PublishingRequest -> AcceptedPublishingRequestHandler consumes  Completed PublishingRequest and publishes metadata and files.

