### PR TITLE
refreshing ticket when publishing metadata

### DIFF
--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -162,19 +162,6 @@ class ExpandedResourceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnIndexDocumentWithValidContributorAffiliationCountryCode() throws Exception {
-        var publication = randomPublication();
-        FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);
-
-        var indexDocument = fromPublication(fakeUriRetriever, resourceService, publication);
-        var framedResultNode = indexDocument.asJsonNode();
-
-        var actualCountryCode = framedResultNode.at("/entityDescription/contributors/1/affiliations/0/countryCode")
-                                    .textValue();
-        assertThat(actualCountryCode, is(not(nullValue())));
-    }
-
-    @Test
     void shouldReturnIndexDocumentWithContributorsPreviewAndCount() throws Exception {
         var publication = randomPublication(AcademicArticle.class);
 

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -102,7 +102,16 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         var publication = fetchPublication(publishingRequest.getResourceIdentifier());
         if (REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(publishingRequest.getWorkflow())) {
             publishPublication(publication);
+            refreshPublishingRequestAfterPublishingMetadata(publishingRequest);
         }
+    }
+
+    /**
+     * Is needed in order to populate publication status changes in search-index when publication is being published.
+     * @param publishingRequest to refresh
+     */
+    private void refreshPublishingRequestAfterPublishingMetadata(PublishingRequestCase publishingRequest) {
+        publishingRequest.persistUpdate(ticketService);
     }
 
     private void handleClosedPublishingRequest(PublishingRequestCase publishingRequestCase) {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -447,7 +449,32 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
 
         var publishedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
 
-        assertTrue(PublicationStatus.PUBLISHED.equals(publishedPublication.getStatus()));
+        assertEquals(PublicationStatus.PUBLISHED, publishedPublication.getStatus());
+    }
+
+    @Test
+    void shouldRefreshPendingPublishingRequestWhenPublishingMetadataWithoutDoingAnyTicketUpdates()
+        throws ApiGatewayException, IOException {
+        var publication = createPublication();
+        publication.setAssociatedArtifacts(new AssociatedArtifactList(randomPendingInternalFile(), randomPendingOpenFile()));
+        resourceService.updatePublication(publication);
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
+                                                            .withOwner(randomString())
+                                                            .withOwnerAffiliation(randomUri());
+        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
+        var ticket = publishingRequest.persistNewTicket(ticketService);
+        var event = createEvent(null, ticket);
+
+        handler.handleRequest(event, outputStream, CONTEXT);
+
+        var refreshedPublishingRequest = (PublishingRequestCase) publishingRequest.fetch(ticketService);
+
+        assertNotEquals(publishingRequest, refreshedPublishingRequest);
+
+        publishingRequest.setModifiedDate(null);
+        refreshedPublishingRequest.setModifiedDate(null);
+
+        assertEquals(publishingRequest, refreshedPublishingRequest);
     }
 
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(


### PR DESCRIPTION
Refreshing PublishingRequest when publishing publication metadata. This is needed in order to populate publication status changes in search index. Otherwise we end up with published publication and publishing request which says that publication is not published. It happens as the cause of metadata being published after we update ticket, cause ticket includes in that case "outdated" publication summary. 