### PR TITLE
handling orphans tickets

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -347,7 +347,8 @@ public class ResourceService extends ServiceWithTransactions {
 
     private File migrateFile(File file, SortableIdentifier resourceIdentifier) {
         var publication = attempt(() -> readResourceService.getResourceByIdentifier(resourceIdentifier))
-                              .map(Resource::toPublication).orElseThrow();
+                              .map(Resource::toPublication)
+                              .orElse(failure -> new Publication());
         return publication.getFile(file.getIdentifier())
             .orElse(file);
     }


### PR DESCRIPTION
Handle orphan tickets when migrating.

Impossible to handle tickets with deleted publications. This lets migration go through, then we have to remove all orphans from database, and do not allow removing publications without removing its tickets.