### PR TITLE
Removing jsonld-java

### DIFF
--- a/expansion/build.gradle
+++ b/expansion/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation libs.nva.identifiers
     implementation libs.nva.secrets
     implementation project(":publication-model")
-    implementation libs.jsonld
     implementation libs.guava
     implementation libs.aws.sdk.dynamodb
     implementation libs.bundles.jena

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 apache-bval = { strictly = '3.0.1' }
-apacheCommonsCollections = { require = '4.4' }
-apacheCommonsText = { require = '1.12.0' }
+apacheCommonsCollections = { strictly = '4.4' }
+apacheCommonsText = { strictly = '1.12.0' }
 awsIon = { strictly = '1.11.9' }
 awsLambdaCore = { strictly = '1.2.3' }
 awsLambdaEvents = { strictly = '3.13.0' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,42 +1,42 @@
 [versions]
-nva = { strictly = '1.41.0' }
-nvaDoiPartnerData = { strictly = '0.5.8' }
-jackson = { strictly = '2.17.2' }
-awsSdk = { strictly = '1.12.772' }
-awsSdk2 = { strictly = '2.27.24' }
-log4j = { strictly = '2.24.0' }
-slf4j = { strictly = '2.0.16' }
-zalandoProblem = { strictly = '0.27.1' }
-awsLambdaCore = { strictly = '1.2.3' }
-awsLambdaEvents = { strictly = '3.13.0' }
-httpcore = { strictly = '5.3' }
-dynamoDbLocal = { strictly = '2.0.0' }
-awsIon = { strictly = '1.11.9' }
-commonsValidator = { strictly = '1.9.0' }
+apache-bval = { strictly = '3.0.1' }
 apacheCommonsCollections = { require = '4.4' }
 apacheCommonsText = { require = '1.12.0' }
-hamcrest = { strictly = '3.0' }
-cucumber = { strictly = '7.18.1' }
-junit = { strictly = '5.11.0' }
-mockito = { strictly = '5.13.0' }
-wiremock = { strictly = "3.9.1" }
+awsIon = { strictly = '1.11.9' }
+awsLambdaCore = { strictly = '1.2.3' }
+awsLambdaEvents = { strictly = '3.13.0' }
+awsSdk = { strictly = '1.12.772' }
+awsSdk2 = { strictly = '2.27.24' }
+commonsValidator = { strictly = '1.9.0' }
 configTypesafe = { strictly = '1.4.3' }
-nva-language = { strictly = '1.2.0' }
+cucumber = { strictly = '7.18.1' }
+datafaker = { strictly = '2.3.1' }
+dynamoDbLocal = { strictly = '2.0.0' }
+glassfish-el = { strictly = '4.0.2' }
 guava = { strictly = '33.3.0-jre' }
-javers = { strictly = '7.6.1' }
+hamcrest = { strictly = '3.0' }
 hamcrestSpotify = { strictly = '1.3.2' }
+httpcore = { strictly = '5.3' }
+jackson = { strictly = '2.17.2' }
+jakarta-el-api = { strictly = '6.0.1' }
+jakarta-validation-api = { strictly = '3.1.0' }
+javers = { strictly = '7.6.1' }
 jena = { strictly = '5.2.0'}
 jsonassert = { strictly = '1.5.3'}
-datafaker = { strictly = '2.3.1' }
-tika = { strictly = '2.9.2' }
-resilience4j = { strictly = '2.2.0' }
-vavrVersion = { strictly = '0.10.4' }
-jakarta-validation-api = { strictly = '3.1.0' }
-jakarta-el-api = { strictly = '6.0.1' }
-glassfish-el = { strictly = '4.0.2' }
-apache-bval = { strictly = '3.0.1' }
-swaggerCoreVersion = { strictly = '2.2.22' }
+junit = { strictly = '5.11.0' }
+log4j = { strictly = '2.24.0' }
+mockito = { strictly = '5.13.0' }
+nva = { strictly = '1.41.0' }
+nva-language = { strictly = '1.2.0' }
+nvaDoiPartnerData = { strictly = '0.5.8' }
 reflections = { strictly = '0.10.2' }
+resilience4j = { strictly = '2.2.0' }
+slf4j = { strictly = '2.0.16' }
+swaggerCoreVersion = { strictly = '2.2.22' }
+tika = { strictly = '2.9.2' }
+vavrVersion = { strictly = '0.10.4' }
+wiremock = { strictly = "3.9.1" }
+zalandoProblem = { strictly = '0.27.1' }
 
 [libraries]
 nva-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,13 +5,11 @@ jackson = { strictly = '2.17.2' }
 awsSdk = { strictly = '1.12.772' }
 awsSdk2 = { strictly = '2.27.24' }
 log4j = { strictly = '2.24.0' }
-# slf4j takes "require", not "strictly" as wiremock has multiple versions
-slf4j = { require = '2.0.16' }
+slf4j = { strictly = '2.0.16' }
 zalandoProblem = { strictly = '0.27.1' }
 awsLambdaCore = { strictly = '1.2.3' }
 awsLambdaEvents = { strictly = '3.13.0' }
-# jsonld and awssdk have different versions. update libraries and check again
-httpcore = { require = '5.3' }
+httpcore = { strictly = '5.3' }
 dynamoDbLocal = { strictly = '2.0.0' }
 awsIon = { strictly = '1.11.9' }
 commonsValidator = { strictly = '1.9.0' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ junit = { strictly = '5.11.0' }
 mockito = { strictly = '5.13.0' }
 wiremock = { strictly = "3.9.1" }
 configTypesafe = { strictly = '1.4.3' }
-jsonld = { strictly = '0.13.4' }
 nva-language = { strictly = '1.2.0' }
 guava = { strictly = '33.3.0-jre' }
 javers = { strictly = '7.6.1' }
@@ -40,6 +39,7 @@ glassfish-el = { strictly = '4.0.2' }
 apache-bval = { strictly = '3.0.1' }
 swaggerCoreVersion = { strictly = '2.2.22' }
 reflections = { strictly = '0.10.2' }
+
 [libraries]
 nva-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }
 nva-json = { group = 'com.github.bibsysdev', name = 'json', version.ref = 'nva' }
@@ -92,7 +92,6 @@ aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'awsIon' 
 apache-commons-collections = { group = 'org.apache.commons', name = 'commons-collections4', version.ref = 'apacheCommonsCollections' }
 apache-commons-text = { group = 'org.apache.commons', name = 'commons-text', version.ref = 'apacheCommonsText' }
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commonsValidator' }
-jsonld = { group = 'com.github.jsonld-java', name = 'jsonld-java', version.ref = 'jsonld' }
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 jaxb-runtime = { group = 'org.glassfish.jaxb', name = 'jaxb-runtime', version = '2.3.1' }
 xsd2java-xjc = { group = 'com.sun.xml.bind', name = 'jaxb-xjc', version = '4.0.5' }

--- a/publication-model/build.gradle
+++ b/publication-model/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation( libs.nva.core )
     implementation( libs.nva.json )
     implementation( libs.nva.identifiers )
-    implementation ( libs.jsonld )
     implementation ( libs.commons.validator )
     implementation( libs.jackson.databind )
 

--- a/publication-model/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
@@ -1,7 +1,6 @@
 package no.unit.nva.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.jsonldjava.utils.JsonUtils;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.model.testing.PublicationInstanceBuilder;
 import org.junit.jupiter.api.Assertions;
@@ -39,14 +38,14 @@ public class PublicationJournalArticleTest extends PublicationTest {
     @Test
     void objectMappingOfPublicationClassReturnsSerializedJsonWithJsonLdFrame() throws IOException {
 
-        Publication publication = PublicationGenerator.randomPublication();
+        var publication = PublicationGenerator.randomPublication();
         var title = publication.getEntityDescription().getMainTitle();
 
-        JsonNode publicationWithContext = toPublicationWithContext(publication);
+        var publicationWithContext = toPublicationWithContext(publication);
 
-        Object framedPublication = produceFramedPublication(publicationWithContext);
+        var framedPublication = produceFramedPublication(publicationWithContext).toString();
 
-        Assertions.assertTrue(JsonUtils.toString(framedPublication).contains(title));
+        Assertions.assertTrue(framedPublication.contains(title));
     }
 
     @DisplayName("Test publications can be serialized/deserialized")

--- a/tickets-test/build.gradle
+++ b/tickets-test/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation libs.nva.secrets
     implementation project(":publication-model")
     implementation project(":publication-model-testing")
-    implementation libs.jsonld
     implementation libs.guava
     implementation libs.aws.sdk.dynamodb
     implementation libs.junit.jupiter.params


### PR DESCRIPTION
 - Removes traces of JsonLd-java since we now use titanium
 - Removes a few vulnerabilities (the initial motivation for removing — we had erroneously declared deps)