### PR TITLE
Np 48090 not allowing curator to approva invalid file

### DIFF
--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -596,7 +596,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var json = expandedResource.asJsonNode();
         json.remove("@context");
         JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("http")));
-        JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("@")));
+//        JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("@")));
     }
 
 

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -596,7 +596,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var json = expandedResource.asJsonNode();
         json.remove("@context");
         JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("http")));
-//        JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("@")));
+        JsonPropertyScraper.getAllProperties(json).forEach(item -> assertFalse(item.contains("@")));
     }
 
 

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingFile.java
@@ -5,4 +5,6 @@ public interface PendingFile<A extends File, R extends File> {
     R reject();
 
     A approve();
+
+    boolean isNotApprovable();
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingFile.java
@@ -1,10 +1,13 @@
 package no.unit.nva.model.associatedartifacts.file;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public interface PendingFile<A extends File, R extends File> {
 
     R reject();
 
     A approve();
 
+    @JsonIgnore
     boolean isNotApprovable();
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
@@ -1,7 +1,6 @@
 package no.unit.nva.model.associatedartifacts.file;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
@@ -1,5 +1,7 @@
 package no.unit.nva.model.associatedartifacts.file;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -84,5 +86,10 @@ public class PendingInternalFile extends File implements PendingFile<InternalFil
         return new InternalFile(getIdentifier(), getName(), getMimeType(), getSize(), getLicense(),
                                 getPublisherVersion(), getEmbargoDate().orElse(null), getRightsRetentionStrategy(),
                                 getLegalNote(), Instant.now(), getUploadDetails());
+    }
+
+    @Override
+    public boolean isNotApprovable() {
+        return isNull(getLicense()) || isNull(getPublisherVersion());
     }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingOpenFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingOpenFile.java
@@ -1,5 +1,6 @@
 package no.unit.nva.model.associatedartifacts.file;
 
+import static java.util.Objects.isNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -71,6 +72,11 @@ public class PendingOpenFile extends File implements PendingFile<OpenFile, Rejec
     public OpenFile approve() {
         return new OpenFile(getIdentifier(), getName(), getMimeType(), getSize(), getLicense(), getPublisherVersion(), getEmbargoDate().orElse(null),
                                 getRightsRetentionStrategy(), getLegalNote(), Instant.now(), getUploadDetails());
+    }
+
+    @Override
+    public boolean isNotApprovable() {
+        return isNull(getLicense()) || isNull(getPublisherVersion());
     }
 
     @Override

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.update;
 
-import static java.util.Objects.nonNull;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED_METADATA;
 import static no.unit.nva.publication.model.business.PublishingWorkflow.lookUp;
@@ -158,12 +157,8 @@ public final class PublishingRequestResolver {
                                         newImage, (PublishingRequestCase) publishingRequest));
     }
 
-    private boolean isPublishable(File file) {
-        return nonNull(file.getLicense());
-    }
-
     private boolean containsNewPublishableFiles(Publication oldImage, Publication newImage) {
-        return getNewUnpublishedFiles(oldImage, newImage).stream().anyMatch(this::isPublishable);
+        return !getNewUnpublishedFiles(oldImage, newImage).isEmpty();
     }
 
     private void updateFilesForApproval(
@@ -184,7 +179,7 @@ public final class PublishingRequestResolver {
     }
 
     private Set<File> getFilesForApproval(Publication oldImage, Publication newImage) {
-        return getNewUnpublishedFiles(oldImage, newImage).stream().collect(Collectors.toSet());
+        return new HashSet<>(getNewUnpublishedFiles(oldImage, newImage));
     }
 
     private void updatePublishingRequest(

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -13,7 +13,6 @@ import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
-import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.publication.external.services.AuthorizedBackendUriRetriever;
 import no.unit.nva.publication.external.services.RawContentRetriever;

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
@@ -60,7 +60,8 @@ public class UpdateTicketHandler extends TicketHandler<UpdateTicketRequest, Void
         "User {} is not authorized to manage ticket {} for publication {}";
     private static final String TICKET_ASSIGNEE_UPDATE_MESSAGE =
         "User {} updates assignee to {} for publication {}";
-    public static final String UPDATE_FORBIDDEN_MESSAGE = "Updating ticket {} for publication {} is forbidden for user {}";
+    public static final String UPDATE_FORBIDDEN_MESSAGE =
+        "Updating ticket {} for publication {} is forbidden for user {}";
     public static final String FILES_MISSING_MANDATORY_FIELDS_MESSAGE = "Files missing mandatory fields: %s";
     private final TicketService ticketService;
     private final ResourceService resourceService;
@@ -207,18 +208,19 @@ public class UpdateTicketHandler extends TicketHandler<UpdateTicketRequest, Void
 
     private void validateFilesForApproval(PublishingRequestCase ticket) throws ConflictException {
         if (filesForApprovalAreNotApprovable(ticket)) {
-            var fileNamesMissingMandatoryFields = getFileNamesMissingMandatoryFields(ticket);
+            var fileIdsMissingMandatoryFields = getFileIdsMissingMandatoryFields(ticket);
             throw new ConflictException(FILES_MISSING_MANDATORY_FIELDS_MESSAGE
-                                            .formatted(fileNamesMissingMandatoryFields));
+                                            .formatted(fileIdsMissingMandatoryFields));
         }
     }
 
-    private static String getFileNamesMissingMandatoryFields(PublishingRequestCase ticket) {
+    private static String getFileIdsMissingMandatoryFields(PublishingRequestCase ticket) {
         return ticket.getFilesForApproval().stream()
                    .map(PendingFile.class::cast)
                    .filter(PendingFile::isNotApprovable)
                    .map(File.class::cast)
-                   .map(File::getName)
+                   .map(File::getIdentifier)
+                   .map(String::valueOf)
                    .collect(Collectors.joining(","));
     }
 


### PR DESCRIPTION
- Allowing to update publication with file that does not contain mandatory fields to be published
- Throwing exception when attempting to complete publishing request with filesForApproval missing mandatory fields.