### PR TITLE
creating skeleton handler and openapi spec for fetch log endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -752,6 +752,50 @@ paths:
         responses: { }
         httpMethod: POST
         type: AWS_PROXY
+  /{publicationIdentifier}/log:
+    get:
+      operationId: fetchPublicationLog
+      summary: Fetch Publication log by identifier
+      parameters:
+        - in: path
+          name: publicationIdentifier
+          schema:
+            type: string
+          required: true
+          style: simple
+          explode: false
+          description: UUID identifier of the Publication to fetch Log for.
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchPublicationLogFunction.Arn}/invocations
+        responses: {}
+        httpMethod: POST
+        type: AWS_PROXY
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TicketCollection"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
 
   /context:
     get:
@@ -1335,6 +1379,14 @@ components:
           type: string
           format: uri
           description: Shortened alias of the id, will return a redirect to the id.
+    PublicationLogResponse:
+      description: PublicationLog response
+      type: array
+      items:
+        $ref: "#/components/schemas/PublicationLogEntry"
+    PublicationLogEntry:
+      description: PublicationLogEntry
+      type: object
 #region content from "documentation/schema.yaml"
     AcademicArticle:
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -765,6 +765,8 @@ paths:
           style: simple
           explode: false
           description: UUID identifier of the Publication to fetch Log for.
+      security:
+        - CognitoUserPool: [ 'https://api.nva.unit.no/scopes/backend', 'https://api.nva.unit.no/scopes/frontend','aws.cognito.signin.user.admin' ]
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchPublicationLogFunction.Arn}/invocations

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -779,7 +779,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TicketCollection"
+                $ref: "#/components/schemas/PublicationLogResponse"
         401:
           description: Unauthorized
           content:
@@ -1382,10 +1382,15 @@ components:
           format: uri
           description: Shortened alias of the id, will return a redirect to the id.
     PublicationLogResponse:
-      description: PublicationLog response
-      type: array
-      items:
-        $ref: "#/components/schemas/PublicationLogEntry"
+      type: object
+      properties:
+        type:
+          type: string
+          example: "PublicationLog"
+        logEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicationLogEntry'
     PublicationLogEntry:
       description: PublicationLogEntry
       type: object

--- a/publication-log/build.gradle
+++ b/publication-log/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+
+    implementation libs.nva.apigateway
+    implementation libs.nva.core
+    implementation libs.nva.json
+    implementation libs.nva.identifiers
+
+    implementation libs.jackson.core
+    implementation libs.jackson.databind
+
+    testImplementation libs.bundles.testing
+}
+
+test {
+    environment "ALLOWED_ORIGIN", "*"
+}

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandler.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandler.java
@@ -1,0 +1,29 @@
+package no.unit.nva.publication.log.rest;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import com.amazonaws.services.lambda.runtime.Context;
+import java.util.List;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.RequestInfo;
+
+public class FetchPublicationLogHandler extends ApiGatewayHandler<Void, PublicationLogResponse> {
+
+    public FetchPublicationLogHandler() {
+        super(Void.class);
+    }
+
+    @Override
+    protected void validateRequest(Void input, RequestInfo requestInfo, Context context) {
+        //NO OP
+    }
+
+    @Override
+    protected PublicationLogResponse processInput(Void input, RequestInfo requestInfo, Context context) {
+        return new PublicationLogResponse(List.of());
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(Void input, PublicationLogResponse publicationLogResponse) {
+        return HTTP_OK;
+    }
+}

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
@@ -1,0 +1,13 @@
+package no.unit.nva.publication.log.rest;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.List;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonTypeName(PublicationLogResponse.TYPE)
+public record PublicationLogResponse(List<?> logEntries) {
+
+    public static final String TYPE = "PublicationLog";
+}

--- a/publication-log/src/test/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandlerTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandlerTest.java
@@ -1,0 +1,50 @@
+package no.unit.nva.publication.log.rest;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.GatewayResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FetchPublicationLogHandlerTest {
+
+    private final Context context = new FakeContext();
+    private ByteArrayOutputStream output;
+    private FetchPublicationLogHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        output = new ByteArrayOutputStream();
+        handler = new FetchPublicationLogHandler();
+    }
+
+    @Test
+    void shouldReturnEmptyPublicationLog() throws IOException {
+        var publicationIdentifier = SortableIdentifier.next();
+
+        handler.handleRequest(createRequest(publicationIdentifier), output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PublicationLogResponse.class);
+
+        assertEquals(HTTP_OK, response.getStatusCode());
+        assertTrue(response.getBodyObject(PublicationLogResponse.class).logEntries().isEmpty());
+    }
+
+    private InputStream createRequest(SortableIdentifier identifier) throws JsonProcessingException {
+        var dtoObjectMapper = JsonUtils.dtoObjectMapper;
+        return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
+                   .withPathParameters(Map.of("publicationIdentifier", identifier.toString()))
+                   .build();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,5 @@ include 'brage-import'
 include 'scopus-generate'
 include 'scopus-import'
 include 'tickets-test'
+include 'publication-log'
 

--- a/template.yaml
+++ b/template.yaml
@@ -1076,7 +1076,7 @@ Resources:
   FetchPublicationLogFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: publication-rest
+      CodeUri: publication-log
       Handler: no.unit.nva.publication.log.rest.FetchPublicationLogHandler::handleRequest
       Environment:
         Variables:

--- a/template.yaml
+++ b/template.yaml
@@ -1073,6 +1073,24 @@ Resources:
             Method: get
             RestApiId: !Ref NvaPublicationApi
 
+  FetchPublicationLogFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: publication-rest
+      Handler: no.unit.nva.publication.log.rest.FetchPublicationLogHandler::handleRequest
+      Environment:
+        Variables:
+          ALLOWED_ORIGIN: !Ref AllowedOrigins
+      Role: !GetAtt LambdaRole.Arn
+      Events:
+        GetEvent:
+          Type: Api
+          Properties:
+            Path: /{publicationIdentifier}/log
+            Method: get
+            RestApiId: !Ref NvaPublicationApi
+
+
   #==========================Event Lambda functions====================================================
 
   BrageMigrationEventConsumer:


### PR DESCRIPTION
- Adding new module in publication-api called publication-log with GroupId `no.unit.nva.publication.log`.
- Adding FetchPublicationLogHandler which return response object with empty list. 
- Adding function to template .
- Adding basic endpoint spec to openapi scheme. 