### PR TITLE
Np 48175 creating persist log entry event handler

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -1,6 +1,7 @@
 package no.unit.nva.publication.model.business;
 
 import static java.util.Objects.nonNull;
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -128,6 +129,15 @@ public class Resource implements Entity {
         this.resourceEvent = resourceEvent;
     }
 
+    public boolean hasResourceEvent() {
+        return nonNull(getResourceEvent());
+    }
+
+    public void clearResourceEvent(ResourceService resourceService) {
+        this.setResourceEvent(null);
+        resourceService.updateResource(this);
+    }
+
     private static Resource convertToResource(Publication publication) {
         return Resource.builder()
                    .withIdentifier(publication.getIdentifier())
@@ -200,6 +210,10 @@ public class Resource implements Entity {
 
     public List<LogEntry> fetchLogEntries(ResourceService resourceService) {
         return resourceService.getLogEntriesForResource(this);
+    }
+
+    public Resource fetch(ResourceService resourceService) {
+        return attempt(() -> resourceService.getResourceByIdentifier(this.getIdentifier())).orElseThrow();
     }
 
     public URI getDuplicateOf() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
@@ -8,12 +8,63 @@ import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.service.impl.ResourceService;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record LogEntry(SortableIdentifier identifier, SortableIdentifier publicationIdentifier, LogTopic topic,
+public record LogEntry(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, LogTopic topic,
                        Instant timestamp, User performedBy, URI institution) {
 
     public static final String TYPE = "LogEntry";
 
     public void persist(ResourceService resourceService) {
         resourceService.persistLogEntry(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private SortableIdentifier identifier;
+        private SortableIdentifier resourceIdentifier;
+        private LogTopic topic;
+        private Instant timestamp;
+        private User performedBy;
+        private URI institution;
+
+        private Builder() {
+        }
+
+        public Builder withIdentifier(SortableIdentifier identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withResourceIdentifier(SortableIdentifier publicationIdentifier) {
+            this.resourceIdentifier = publicationIdentifier;
+            return this;
+        }
+
+        public Builder withTopic(LogTopic topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Builder withTimestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public Builder withPerformedBy(User performedBy) {
+            this.performedBy = performedBy;
+            return this;
+        }
+
+        public Builder withInstitution(URI institution) {
+            this.institution = institution;
+            return this;
+        }
+
+        public LogEntry build() {
+            return new LogEntry(identifier, resourceIdentifier, topic, timestamp, performedBy, institution);
+        }
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -8,9 +8,9 @@ public enum LogTopic {
     FILE_PUBLISHED("FilePublished"),
     FILE_REJECTED("FileRejected"),
     FILE_UPLOADED("FileUploaded"),
-    PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_CREATED("PublicationCreated"),
     PUBLICATION_DELETED("PublicationDeleted"),
+    PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_UNPUBLISHED("PublicationUnpublished");
 
     private final String value;

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -8,7 +8,7 @@ public enum LogTopic {
     FILE_PUBLISHED("FilePublished"),
     FILE_REJECTED("FileRejected"),
     FILE_UPLOADED("FileUploaded"),
-    METADATA_PUBLISHED("PublicationPublished"),
+    PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_CREATED("PublicationCreated"),
     PUBLICATION_DELETED("PublicationDeleted"),
     PUBLICATION_UNPUBLISHED("PublicationUnpublished");

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -2,12 +2,27 @@ package no.unit.nva.publication.model.business.publicationstate;
 
 import java.net.URI;
 import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
 
 public record CreatedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
 
     public static CreatedResourceEvent create(UserInstance userInstance, Instant date) {
         return new CreatedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    }
+
+    @Override
+    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier) {
+        return LogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(SortableIdentifier.next())
+                   .withTopic(LogTopic.PUBLICATION_CREATED)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(user())
+                   .withInstitution(institution())
+                   .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
@@ -2,12 +2,28 @@ package no.unit.nva.publication.model.business.publicationstate;
 
 import java.net.URI;
 import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
 
 public record DeletedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
 
     public static DeletedResourceEvent create(UserInstance userInstance, Instant date) {
         return new DeletedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    }
+
+
+    @Override
+    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier) {
+        return LogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(SortableIdentifier.next())
+                   .withTopic(LogTopic.PUBLICATION_DELETED)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(user())
+                   .withInstitution(institution())
+                   .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -2,12 +2,27 @@ package no.unit.nva.publication.model.business.publicationstate;
 
 import java.net.URI;
 import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
 
 public record PublishedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
 
     public static PublishedResourceEvent create(UserInstance userInstance, Instant date) {
         return new PublishedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    }
+
+    @Override
+    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier) {
+        return LogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(SortableIdentifier.next())
+                   .withTopic(LogTopic.PUBLICATION_PUBLISHED)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(user())
+                   .withInstitution(institution())
+                   .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.LogEntry;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(PublishedResourceEvent.class),
@@ -19,4 +21,6 @@ public interface ResourceEvent {
      * @return id of the top level cristin organizations
      */
     URI institution();
+
+    LogEntry toLogEntry(SortableIdentifier resourceIdentifier);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
@@ -2,12 +2,27 @@ package no.unit.nva.publication.model.business.publicationstate;
 
 import java.net.URI;
 import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
 
 public record UnpublishedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
 
     public static UnpublishedResourceEvent create(UserInstance userInstance, Instant date) {
         return new UnpublishedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    }
+
+    @Override
+    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier) {
+        return LogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(SortableIdentifier.next())
+                   .withTopic(LogTopic.PUBLICATION_UNPUBLISHED)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(user())
+                   .withInstitution(institution())
+                   .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
@@ -34,7 +34,7 @@ public record LogEntryDao(SortableIdentifier identifier, SortableIdentifier reso
     }
 
     public static LogEntryDao fromLogEntry(LogEntry logEntry) {
-        return new LogEntryDao(logEntry.identifier(), logEntry.publicationIdentifier(), Instant.now(), logEntry.topic(),
+        return new LogEntryDao(logEntry.identifier(), logEntry.resourceIdentifier(), Instant.now(), logEntry.topic(),
                                logEntry.timestamp(), logEntry.performedBy(), logEntry.institution(), logEntry);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
@@ -10,19 +10,15 @@ import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.ItemUtils;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.Resource;
-import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
-import no.unit.nva.publication.model.business.logentry.LogTopic;
 
-public record LogEntryDao(SortableIdentifier identifier, SortableIdentifier resourceIdentifier,
-                          Instant createdDate, LogTopic topic,
-                          Instant timestamp, User performedBy, URI institution, LogEntry data) {
+public record LogEntryDao(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, Instant createdDate,
+                          LogEntry data) {
 
     public static final String TYPE = "LogEntry";
     public static final String KEY_PATTERN = "%s:%s";
@@ -34,18 +30,17 @@ public record LogEntryDao(SortableIdentifier identifier, SortableIdentifier reso
     }
 
     public static LogEntryDao fromLogEntry(LogEntry logEntry) {
-        return new LogEntryDao(logEntry.identifier(), logEntry.resourceIdentifier(), Instant.now(), logEntry.topic(),
-                               logEntry.timestamp(), logEntry.performedBy(), logEntry.institution(), logEntry);
+        return new LogEntryDao(logEntry.identifier(), logEntry.resourceIdentifier(), Instant.now(), logEntry);
+    }
+
+    public static String getLogEntriesByResourceIdentifierPartitionKey(Resource resource) {
+        return KEY_PATTERN.formatted(Resource.TYPE, resource.getIdentifier());
     }
 
     public Map<String, AttributeValue> toDynamoFormat() {
         return attempt(() -> JsonUtils.dynamoObjectMapper.writeValueAsString(this)).map(Item::fromJSON)
                    .map(ItemUtils::toAttributeValues)
                    .orElseThrow();
-    }
-
-    public static String getLogEntriesByResourceIdentifierPartitionKey(Resource resource) {
-        return KEY_PATTERN.formatted(Resource.TYPE, resource.getIdentifier());
     }
 
     @JsonProperty(BY_TYPE_AND_IDENTIFIER_INDEX_PARTITION_KEY_NAME)

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -305,6 +305,10 @@ public class ResourceService extends ServiceWithTransactions {
         return updateResourceService.updatePublicationButDoNotChangeStatus(resourceUpdate);
     }
 
+    public void updateResource(Resource resource) {
+        updateResourceService.updateResource(resource);
+    }
+
     // update this method according to current needs.
     public Entity migrate(Entity dataEntry) {
         return dataEntry;

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -162,6 +162,13 @@ public class UpdateResourceService extends ServiceWithTransactions {
         sendTransactionWriteRequest(request);
     }
 
+    public void updateResource(Resource resource) {
+        resource.setModifiedDate(clockForTimestamps.instant());
+        TransactWriteItem insertionAction = createPutTransaction(resource);
+        TransactWriteItemsRequest request = newTransactWriteItemsRequest(insertionAction);
+        sendTransactionWriteRequest(request);
+    }
+
     public ImportCandidate updateImportCandidate(ImportCandidate importCandidate) throws BadRequestException {
         var existingImportCandidate = fetchImportCandidate(importCandidate);
         if (isNotImported(existingImportCandidate)) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceTest.java
@@ -2,19 +2,23 @@ package no.unit.nva.publication.model.business;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static no.unit.nva.publication.model.business.StorageModelConfig.dynamoDbObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.model.testing.PublicationInstanceBuilder;
+import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
@@ -115,6 +119,14 @@ public class ResourceTest {
         assertThat(resource.getIdentifier(), is(equalTo(sampleIdentifier)));
         assertThat(resource.getPublisher().getId(), is(equalTo(SOME_HOST)));
         assertThat(resource.getOwner(), is(equalTo(SOME_OWNER)));
+    }
+
+    @Test
+    void shouldReturnTrueWhenResourceIsPresent() {
+        var resource = Resource.resourceQueryObject(SortableIdentifier.next());
+        resource.setResourceEvent(new CreatedResourceEvent(Instant.now(), new User(randomString()), randomUri()));
+
+        assertTrue(resource.hasResourceEvent());
     }
 
     private static Stream<Class<?>> publicationInstanceProvider() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/logentry/LogEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/logentry/LogEntryTest.java
@@ -68,8 +68,14 @@ class LogEntryTest extends ResourcesLocalTest {
         assertTrue(logEntries.containsAll(List.of(firstLogEntry, secondLogEntry)));
     }
 
-    private static LogEntry randomLogEntry(SortableIdentifier identifier, LogTopic logTopic) {
-        return new LogEntry(SortableIdentifier.next(), identifier, logTopic, Instant.now(),
-                            new User(randomString()), randomUri());
+    private static LogEntry randomLogEntry(SortableIdentifier resourceIdentifier, LogTopic logTopic) {
+        return LogEntry.builder()
+                   .withIdentifier(SortableIdentifier.next())
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withTopic(logTopic)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(new User(randomString()))
+                   .withInstitution(randomUri())
+                   .build();
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -1,0 +1,35 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.time.Instant;
+import java.util.stream.Stream;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResourceEventTest {
+
+    public static Stream<Arguments> resourceEventProvider() {
+        return Stream.of(Arguments.of(new CreatedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
+                                      LogTopic.PUBLICATION_CREATED),
+                         Arguments.of(new PublishedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
+                                      LogTopic.PUBLICATION_PUBLISHED), Arguments.of(
+                new UnpublishedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
+                LogTopic.PUBLICATION_UNPUBLISHED),
+                         Arguments.of(new DeletedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
+                                      LogTopic.PUBLICATION_DELETED));
+    }
+
+    @ParameterizedTest
+    @MethodSource("resourceEventProvider")
+    void shouldConvertResourceEventToLogEntryWithExpectedTopic(ResourceEvent resourceEvent, LogTopic expectedLogTopic) {
+        var logEntry = resourceEvent.toLogEntry(SortableIdentifier.next());
+
+        assertEquals(expectedLogTopic, logEntry.topic());
+    }
+}

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -35,7 +35,9 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -1225,6 +1227,36 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var resource = resourceService.getResourceByIdentifier(peristedPublication.getIdentifier());
 
         assertNotNull(resource.getResourceEvent());
+    }
+
+    @Test
+    void shouldFetchResource() throws BadRequestException {
+        var publication = randomPublication();
+        var userInstance = UserInstance.fromPublication(publication);
+        var peristedPublication = Resource.fromPublication(publication)
+                                      .persistNew(resourceService, userInstance);
+
+        var resource = Resource.resourceQueryObject(peristedPublication.getIdentifier())
+                           .fetch(resourceService);
+
+        assertEquals(peristedPublication, resource.toPublication());
+    }
+
+    @Test
+    void shouldSetResourceEventToNull() throws BadRequestException {
+        var publication = randomPublication();
+        var userInstance = UserInstance.fromPublication(publication);
+        var peristedPublication = Resource.fromPublication(publication)
+                                      .persistNew(resourceService, userInstance);
+
+        var resource = Resource.resourceQueryObject(peristedPublication.getIdentifier())
+                           .fetch(resourceService);
+
+        assertNotNull(resource.getResourceEvent());
+
+        resource.clearResourceEvent(resourceService);
+
+        assertNull(resource.getResourceEvent());
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
@@ -1,0 +1,38 @@
+package no.unit.nva.publication.events.handlers.log;
+
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.events.models.EventReference;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
+import no.unit.nva.publication.model.business.Entity;
+import no.unit.nva.s3.S3Driver;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class PersistLogEntryEventHandler extends EventHandler<EventReference, Void> {
+
+    private final S3Client s3Client;
+
+    protected PersistLogEntryEventHandler(Class iclass, ObjectMapper objectMapper) {
+        super(iclass, objectMapper);
+    }
+
+    @Override
+    protected Void processInput(EventReference eventReference, AwsEventBridgeEvent<EventReference> awsEventBridgeEvent,
+                                Context context) {
+        eventReference.getUri();
+        return null;
+    }
+
+    private SortableIdentifier readBlobFromS3(EventReference input) {
+        return attempt(() -> new S3Driver(s3Client, EVENTS_BUCKET)).map(s3Driver -> s3Driver.readEvent(input.getUri()))
+                   .map(DataEntryUpdateEvent::fromJson)
+                   .map(DataEntryUpdateEvent::getNewData)
+                   .map(Entity::getIdentifier)
+                   .orElseThrow();
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
@@ -21,9 +21,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class PersistLogEntryEventHandler extends DestinationsEventBridgeEventHandler<EventReference, Void> {
 
-    public static final Logger logger = LoggerFactory.getLogger(PersistLogEntryEventHandler.class);
     public static final String PERSISTING_LOG_ENTRY_MESSAGE = "Persisting log entry for event {} for resource {}";
-
+    public static final Logger logger = LoggerFactory.getLogger(PersistLogEntryEventHandler.class);
     private final S3Client s3Client;
     private final ResourceService resourceService;
 
@@ -42,7 +41,9 @@ public class PersistLogEntryEventHandler extends DestinationsEventBridgeEventHan
     protected Void processInputPayload(EventReference eventReference,
                                        AwsEventBridgeEvent<AwsEventBridgeDetail<EventReference>> awsEventBridgeEvent,
                                        Context context) {
-        return readNewImageResourceIdentifier(eventReference).map(this::handleNewImage).orElse(null);
+        return readNewImageResourceIdentifier(eventReference)
+                   .map(this::handleNewImage)
+                   .orElse(null);
     }
 
     private Void handleNewImage(SortableIdentifier resourceIdentifier) {
@@ -57,7 +58,8 @@ public class PersistLogEntryEventHandler extends DestinationsEventBridgeEventHan
     }
 
     private Optional<SortableIdentifier> readNewImageResourceIdentifier(EventReference eventReference) {
-        return attempt(() -> fetchDynamoDbStreamRecord(eventReference)).map(DataEntryUpdateEvent::fromJson)
+        return attempt(() -> fetchDynamoDbStreamRecord(eventReference))
+                   .map(DataEntryUpdateEvent::fromJson)
                    .map(DataEntryUpdateEvent::getNewData)
                    .map(Entity::getIdentifier)
                    .toOptional();

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
@@ -1,38 +1,81 @@
 package no.unit.nva.publication.events.handlers.log;
 
 import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
+import static no.unit.nva.publication.events.handlers.fanout.DynamodbStreamRecordDaoMapper.toEntity;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import java.util.Map;
+import java.util.Optional;
+import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.Entity;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class PersistLogEntryEventHandler extends EventHandler<EventReference, Void> {
 
     private final S3Client s3Client;
+    private final ResourceService resourceService;
 
-    protected PersistLogEntryEventHandler(Class iclass, ObjectMapper objectMapper) {
-        super(iclass, objectMapper);
+    @JacocoGenerated
+    protected PersistLogEntryEventHandler() {
+        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService());
+    }
+
+    protected PersistLogEntryEventHandler(S3Client s3Client, ResourceService resourceService) {
+        super(EventReference.class);
+        this.s3Client = s3Client;
+        this.resourceService = resourceService;
     }
 
     @Override
     protected Void processInput(EventReference eventReference, AwsEventBridgeEvent<EventReference> awsEventBridgeEvent,
                                 Context context) {
-        eventReference.getUri();
+        return readNewImageResourceIdentifier(eventReference).map(this::handleNewImage).orElse(null);
+    }
+
+    private static DynamodbStreamRecord parseDynamoDbStreamRecord(String value) {
+        return attempt(() -> JsonUtils.dtoObjectMapper.readValue(value, DynamodbStreamRecord.class)).orElseThrow();
+    }
+
+    private Void handleNewImage(SortableIdentifier resourceIdentifier) {
+        var resource = Resource.resourceQueryObject(resourceIdentifier).fetch(resourceService);
+        if (resource.hasResourceEvent()) {
+            resource.getResourceEvent().toLogEntry(resourceIdentifier).persist(resourceService);
+            resource.clearResourceEvent(resourceService);
+        }
         return null;
     }
 
-    private SortableIdentifier readBlobFromS3(EventReference input) {
-        return attempt(() -> new S3Driver(s3Client, EVENTS_BUCKET)).map(s3Driver -> s3Driver.readEvent(input.getUri()))
-                   .map(DataEntryUpdateEvent::fromJson)
+    private Optional<SortableIdentifier> readNewImageResourceIdentifier(EventReference input) {
+        return attempt(() -> fetchDynamoDbStreamRecord(input)).map(
+                PersistLogEntryEventHandler::parseDynamoDbStreamRecord)
+                   .map(this::convertToDataEntryUpdateEvent)
                    .map(DataEntryUpdateEvent::getNewData)
                    .map(Entity::getIdentifier)
-                   .orElseThrow();
+                   .toOptional();
+    }
+
+    private String fetchDynamoDbStreamRecord(EventReference input) {
+        return new S3Driver(s3Client, EVENTS_BUCKET).readEvent(input.getUri());
+    }
+
+    private Entity getEntity(Map<String, AttributeValue> image) {
+        return attempt(() -> toEntity(image)).orElse(failure -> Optional.<Entity>empty()).orElse(null);
+    }
+
+    private DataEntryUpdateEvent convertToDataEntryUpdateEvent(DynamodbStreamRecord dynamoDbRecord) {
+        return new DataEntryUpdateEvent(dynamoDbRecord.getEventName(),
+                                        getEntity(dynamoDbRecord.getDynamodb().getOldImage()),
+                                        getEntity(dynamoDbRecord.getDynamodb().getNewImage()));
     }
 }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
@@ -1,15 +1,12 @@
 package no.unit.nva.publication.events.handlers.log;
 
 import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
-import static no.unit.nva.publication.events.handlers.fanout.DynamodbStreamRecordDaoMapper.toEntity;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
-import java.util.Map;
 import java.util.Optional;
-import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.events.handlers.DestinationsEventBridgeEventHandler;
 import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeDetail;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
@@ -21,13 +18,13 @@ import no.unit.nva.s3.S3Driver;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class PersistLogEntryEventHandler extends EventHandler<EventReference, Void> {
+public class PersistLogEntryEventHandler extends DestinationsEventBridgeEventHandler<EventReference, Void> {
 
     private final S3Client s3Client;
     private final ResourceService resourceService;
 
     @JacocoGenerated
-    protected PersistLogEntryEventHandler() {
+    public PersistLogEntryEventHandler() {
         this(S3Driver.defaultS3Client().build(), ResourceService.defaultService());
     }
 
@@ -38,13 +35,10 @@ public class PersistLogEntryEventHandler extends EventHandler<EventReference, Vo
     }
 
     @Override
-    protected Void processInput(EventReference eventReference, AwsEventBridgeEvent<EventReference> awsEventBridgeEvent,
-                                Context context) {
+    protected Void processInputPayload(EventReference eventReference,
+                                       AwsEventBridgeEvent<AwsEventBridgeDetail<EventReference>> awsEventBridgeEvent,
+                                       Context context) {
         return readNewImageResourceIdentifier(eventReference).map(this::handleNewImage).orElse(null);
-    }
-
-    private static DynamodbStreamRecord parseDynamoDbStreamRecord(String value) {
-        return attempt(() -> JsonUtils.dtoObjectMapper.readValue(value, DynamodbStreamRecord.class)).orElseThrow();
     }
 
     private Void handleNewImage(SortableIdentifier resourceIdentifier) {
@@ -56,26 +50,15 @@ public class PersistLogEntryEventHandler extends EventHandler<EventReference, Vo
         return null;
     }
 
-    private Optional<SortableIdentifier> readNewImageResourceIdentifier(EventReference input) {
-        return attempt(() -> fetchDynamoDbStreamRecord(input)).map(
-                PersistLogEntryEventHandler::parseDynamoDbStreamRecord)
-                   .map(this::convertToDataEntryUpdateEvent)
+    private Optional<SortableIdentifier> readNewImageResourceIdentifier(EventReference eventReference) {
+        return attempt(() -> fetchDynamoDbStreamRecord(eventReference))
+                   .map(DataEntryUpdateEvent::fromJson)
                    .map(DataEntryUpdateEvent::getNewData)
                    .map(Entity::getIdentifier)
                    .toOptional();
     }
 
-    private String fetchDynamoDbStreamRecord(EventReference input) {
-        return new S3Driver(s3Client, EVENTS_BUCKET).readEvent(input.getUri());
-    }
-
-    private Entity getEntity(Map<String, AttributeValue> image) {
-        return attempt(() -> toEntity(image)).orElse(failure -> Optional.<Entity>empty()).orElse(null);
-    }
-
-    private DataEntryUpdateEvent convertToDataEntryUpdateEvent(DynamodbStreamRecord dynamoDbRecord) {
-        return new DataEntryUpdateEvent(dynamoDbRecord.getEventName(),
-                                        getEntity(dynamoDbRecord.getDynamodb().getOldImage()),
-                                        getEntity(dynamoDbRecord.getDynamodb().getNewImage()));
+    private String fetchDynamoDbStreamRecord(EventReference eventReference) {
+        return new S3Driver(s3Client, EVENTS_BUCKET).readEvent(eventReference.getUri());
     }
 }

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandlerTest.java
@@ -1,0 +1,161 @@
+package no.unit.nva.publication.events.handlers.log;
+
+import static java.util.Objects.nonNull;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
+import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
+import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import no.unit.nva.events.models.EventReference;
+import no.unit.nva.model.Publication;
+import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.storage.DynamoEntry;
+import no.unit.nva.publication.model.storage.ResourceDao;
+import no.unit.nva.publication.service.ResourcesLocalTest;
+import no.unit.nva.publication.service.impl.ResourceService;
+import no.unit.nva.s3.S3Driver;
+import no.unit.nva.stubs.FakeS3Client;
+import no.unit.nva.testutils.EventBridgeEventBuilder;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.paths.UnixPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PersistLogEntryEventHandlerTest extends ResourcesLocalTest {
+
+    private PersistLogEntryEventHandler handler;
+    private ResourceService resourceService;
+    private FakeS3Client s3Client;
+    private ByteArrayOutputStream outputStream;
+    private Context context;
+
+    @BeforeEach
+    public void setUp() {
+        super.init();
+        outputStream = new ByteArrayOutputStream();
+        context = null;
+        s3Client = new FakeS3Client();
+        resourceService = getResourceServiceBuilder().build();
+        handler = new PersistLogEntryEventHandler(s3Client, resourceService);
+    }
+
+    @Test
+    void shouldCreateLogEntryWhenConsumedEventHasResourceWithNewImageWhereResourceEventIsPresent()
+        throws BadRequestException, IOException {
+        var publication = createPublication();
+        var event = createEvent(publication);
+
+        handler.handleRequest(event, outputStream, context);
+
+        var logEntries = Resource.fromPublication(publication).fetchLogEntries(resourceService);
+
+        assertFalse(logEntries.isEmpty());
+    }
+
+    @Test
+    void shouldNotCreateLogEntryWhenConsumedEventHasResourceWithNewImageWhereResourceEventIsNull()
+        throws BadRequestException, IOException {
+        var publication = createPublication();
+        Resource.fromPublication(publication).clearResourceEvent(resourceService);
+        var event = createEvent(publication);
+
+        handler.handleRequest(event, outputStream, context);
+
+        var logEntries = Resource.fromPublication(publication).fetchLogEntries(resourceService);
+
+        assertTrue(logEntries.isEmpty());
+    }
+
+    @Test
+    void shouldNotFailWhenWhenConsumedEventIsMissingNewImage()
+        throws IOException {
+        var event = createEvent(null);
+
+        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
+    }
+
+    private Publication createPublication() throws BadRequestException {
+        var publication = randomPublication();
+        return resourceService.createPublication(UserInstance.fromPublication(publication),
+                                                 publication);
+    }
+
+    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
+                                              Map<String, AttributeValue> newImage) {
+        var streamRecord = new StreamRecord();
+        streamRecord.setOldImage(oldImage);
+        streamRecord.setNewImage(newImage);
+        return streamRecord;
+    }
+
+    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
+        var streamRecord = new DynamodbStreamRecord();
+        streamRecord.setEventName(randomElement(OperationType.values()));
+        streamRecord.setEventID(randomString());
+        streamRecord.setAwsRegion(AWS_REGION);
+
+        streamRecord.setDynamodb(payload);
+        streamRecord.setEventSource(randomString());
+        streamRecord.setEventVersion(randomString());
+        return streamRecord;
+    }
+
+    private static DynamoEntry toDynamoEntry(Publication publication) {
+        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
+    }
+
+    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
+        throws JsonProcessingException {
+        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
+                             convertToAttributeValueMap(toDynamoEntry(newImage)));
+    }
+
+    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
+        throws JsonProcessingException {
+        return nonNull(payload) ? toAttributeValueMap(payload) : null;
+    }
+
+    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
+        throws JsonProcessingException {
+        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
+        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
+        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
+    }
+
+    private static JavaType dynamoMapStructureAsJacksonType() {
+        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
+    }
+
+    private InputStream createEvent(Publication publication) throws IOException {
+        var dynamodbStreamRecord = createDynamoRecord(createPayload(null, publication));
+        var blobUri = saveBlobInS3(dynamodbStreamRecord);
+        var eventBody = new EventReference(DataEntryUpdateEvent.RESOURCE_UPDATE_EVENT_TOPIC, blobUri);
+        return EventBridgeEventBuilder.sampleEvent(eventBody);
+    }
+
+    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
+        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
+        return new S3Driver(s3Client, EVENTS_BUCKET)
+                   .insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandlerTest.java
@@ -1,36 +1,22 @@
 package no.unit.nva.publication.events.handlers.log;
 
-import static java.util.Objects.nonNull;
-import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.AWS_REGION;
+import static no.unit.nva.publication.events.bodies.DataEntryUpdateEvent.RESOURCE_UPDATE_EVENT_TOPIC;
 import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
-import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
-import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.storage.DynamoEntry;
-import no.unit.nva.publication.model.storage.ResourceDao;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
@@ -63,7 +49,7 @@ class PersistLogEntryEventHandlerTest extends ResourcesLocalTest {
     void shouldCreateLogEntryWhenConsumedEventHasResourceWithNewImageWhereResourceEventIsPresent()
         throws BadRequestException, IOException {
         var publication = createPublication();
-        var event = createEvent(publication);
+        var event = createEvent(null,publication);
 
         handler.handleRequest(event, outputStream, context);
 
@@ -77,7 +63,7 @@ class PersistLogEntryEventHandlerTest extends ResourcesLocalTest {
         throws BadRequestException, IOException {
         var publication = createPublication();
         Resource.fromPublication(publication).clearResourceEvent(resourceService);
-        var event = createEvent(publication);
+        var event = createEvent(null, publication);
 
         handler.handleRequest(event, outputStream, context);
 
@@ -87,75 +73,24 @@ class PersistLogEntryEventHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldNotFailWhenWhenConsumedEventIsMissingNewImage()
-        throws IOException {
-        var event = createEvent(null);
+    void shouldNotFailWhenWhenConsumedEventIsMissingNewImage() throws IOException {
+        var event = createEvent(randomPublication(), null);
 
         assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, context));
     }
 
     private Publication createPublication() throws BadRequestException {
         var publication = randomPublication();
-        return resourceService.createPublication(UserInstance.fromPublication(publication),
-                                                 publication);
+        return resourceService.createPublication(UserInstance.fromPublication(publication), publication);
     }
 
-    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
-                                              Map<String, AttributeValue> newImage) {
-        var streamRecord = new StreamRecord();
-        streamRecord.setOldImage(oldImage);
-        streamRecord.setNewImage(newImage);
-        return streamRecord;
-    }
-
-    private static DynamodbStreamRecord createDynamoRecord(StreamRecord payload) {
-        var streamRecord = new DynamodbStreamRecord();
-        streamRecord.setEventName(randomElement(OperationType.values()));
-        streamRecord.setEventID(randomString());
-        streamRecord.setAwsRegion(AWS_REGION);
-
-        streamRecord.setDynamodb(payload);
-        streamRecord.setEventSource(randomString());
-        streamRecord.setEventVersion(randomString());
-        return streamRecord;
-    }
-
-    private static DynamoEntry toDynamoEntry(Publication publication) {
-        return nonNull(publication) ? new ResourceDao(Resource.fromPublication(publication)) : null;
-    }
-
-    private static StreamRecord createPayload(Publication oldImage, Publication newImage)
-        throws JsonProcessingException {
-        return createPayload(convertToAttributeValueMap(toDynamoEntry(oldImage)),
-                             convertToAttributeValueMap(toDynamoEntry(newImage)));
-    }
-
-    private static <T> Map<String, AttributeValue> convertToAttributeValueMap(DynamoEntry payload)
-        throws JsonProcessingException {
-        return nonNull(payload) ? toAttributeValueMap(payload) : null;
-    }
-
-    private static Map<String, AttributeValue> toAttributeValueMap(DynamoEntry dynamoEntry)
-        throws JsonProcessingException {
-        Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> dynamoFormat = dynamoEntry.toDynamoFormat();
-        var json = dtoObjectMapper.writeValueAsString(dynamoFormat);
-        return dtoObjectMapper.readValue(json, dynamoMapStructureAsJacksonType());
-    }
-
-    private static JavaType dynamoMapStructureAsJacksonType() {
-        return dtoObjectMapper.getTypeFactory().constructParametricType(Map.class, String.class, AttributeValue.class);
-    }
-
-    private InputStream createEvent(Publication publication) throws IOException {
-        var dynamodbStreamRecord = createDynamoRecord(createPayload(null, publication));
-        var blobUri = saveBlobInS3(dynamodbStreamRecord);
-        var eventBody = new EventReference(DataEntryUpdateEvent.RESOURCE_UPDATE_EVENT_TOPIC, blobUri);
-        return EventBridgeEventBuilder.sampleEvent(eventBody);
-    }
-
-    private URI saveBlobInS3(DynamodbStreamRecord blob) throws IOException {
-        var json = attempt(() -> dtoObjectMapper.writeValueAsString(blob)).orElseThrow();
-        return new S3Driver(s3Client, EVENTS_BUCKET)
-                   .insertFile(UnixPath.of(UUID.randomUUID().toString()), json);
+    private InputStream createEvent(Publication oldImage, Publication newImage) throws IOException {
+        var dataEntryUpdateEvent = new DataEntryUpdateEvent(RESOURCE_UPDATE_EVENT_TOPIC,
+                                                            Resource.fromPublication(oldImage),
+                                                            Resource.fromPublication(newImage));
+        var uri = new S3Driver(s3Client, EVENTS_BUCKET).insertEvent(UnixPath.of(UUID.randomUUID().toString()),
+                                                                    dataEntryUpdateEvent.toJsonString());
+        var eventReference = new EventReference(RESOURCE_UPDATE_EVENT_TOPIC, uri);
+        return EventBridgeEventBuilder.sampleLambdaDestinationsEvent(eventReference);
     }
 }

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -319,11 +319,11 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     @Test
     void shouldThrowRuntimeExceptionAndLogExceptionMessageWhenUpdatingPublicationFails()
             throws ApiGatewayException, IOException {
-        var publication = createUnpublishablePublication();
-        var pendingPublishingRequest = pendingPublishingRequest(publication);
+        var publication = createPublication();
+        var pendingPublishingRequest =
+            (PublishingRequestCase) persistPublishingRequestContainingExistingUnpublishedFiles(publication);
         pendingPublishingRequest.setWorkflow(REGISTRATOR_REQUIRES_APPROVAL_FOR_METADATA_AND_FILES);
-        var approvedPublishingRequest =
-                pendingPublishingRequest
+        var approvedPublishingRequest = pendingPublishingRequest.approveFiles()
                         .complete(publication, USERNAME)
                         .persistNewTicket(ticketService);
         var handlerThrowingException =

--- a/template.yaml
+++ b/template.yaml
@@ -1598,6 +1598,28 @@ Resources:
               ArnEquals:
                 aws:SourceArn: !GetAtt PublicationServiceUpdateRule.Arn
 
+  PersistLogEntryEventHandler:
+    DependsOn: EventsLambdaManagedPolicy
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: publication-event-handlers
+      Handler: no.unit.nva.publication.events.handlers.log.PersistLogEntryEventHandler::handleRequest
+      Timeout: 200
+      Role: !GetAtt LambdaRole.Arn
+      Environment:
+        Variables:
+          EVENTS_BUCKET: !Ref NvaEventsBucketsName
+          TABLE_NAME: !Ref NvaResourcesTable
+      Events:
+        EventBridgeEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: !GetAtt InternalBus.Name
+            Pattern:
+              detail:
+                responsePayload:
+                  topic: PublicationService.Resource.Update
+
   EventBasedBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -1618,7 +1618,7 @@ Resources:
             Pattern:
               detail:
                 responsePayload:
-                  topic: PublicationService.Resource.Update
+                  topic: [ "PublicationService.Resource.Update" ]
 
   EventBasedBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy


### PR DESCRIPTION
Implementing `PersistLogEntryEventHandler`. 
- Handler consumes DataEntryUpdateEvent -> fetches resources when present -> creates log entry when resource event is present -> removes resource event from publication.
