### PR TITLE
commenting out event consumed by log entry handler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1611,15 +1611,15 @@ Resources:
         Variables:
           EVENTS_BUCKET: !Ref NvaEventsBucketsName
           TABLE_NAME: !Ref NvaResourcesTable
-      Events:
-        EventBridgeEvent:
-          Type: EventBridgeRule
-          Properties:
-            EventBusName: !GetAtt InternalBus.Name
-            Pattern:
-              detail:
-                responsePayload:
-                  topic: [ "PublicationService.Resource.Update" ]
+#      Events:
+#        EventBridgeEvent:
+#          Type: EventBridgeRule
+#          Properties:
+#            EventBusName: !GetAtt InternalBus.Name
+#            Pattern:
+#              detail:
+#                responsePayload:
+#                  topic: [ "PublicationService.Resource.Update" ]
 
   EventBasedBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy


### PR DESCRIPTION
Comment out so I can deploy it to test and prod without need for migration of log entries after we decide log model.