### PR TITLE
using unspecified license when creating file from scopus from doi response

### DIFF
--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/CrossrefResponse.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/CrossrefResponse.java
@@ -119,6 +119,10 @@ public class CrossrefResponse implements JsonSerializable {
         public boolean hasDelay() {
             return delay != 0;
         }
+
+        public boolean hasUnspecifiedContentVersion() {
+            return ContentVersion.UNSPECIFIED.equals(contentVersion);
+        }
     }
 
     public static class Start implements JsonSerializable {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -38,6 +38,7 @@ import no.scopus.generated.UpwOpenAccessType;
 import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.sikt.nva.scopus.conversion.files.TikaUtils;
 import no.sikt.nva.scopus.utils.ScopusGenerator;
+import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails.Source;
 import no.unit.nva.model.associatedartifacts.file.OpenFile;
@@ -130,6 +131,19 @@ public class ScopusFileConverterTest {
         var files = fileConverter.fetchAssociatedArtifacts(scopusData.getDocument());
 
         assertThat(files, is(emptyIterable()));
+    }
+
+    @Description("Resource primary url is a landing page url for resource and will never be a content file.")
+    @Test
+    void shouldCreateFileWithLicenseFromCrossrefResponseWithLicenseWithContentVersionUnspecifiedWhenNoLicenseForLinkWithLinkVersion()
+        throws IOException, InterruptedException {
+        mockResponses("crossrefResponseWithUnspecifiedLicense.json");
+
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+
+        var expectedLicense = URI.create("https://creativecommons.org/licenses/by/4.0");
+
+        assertThat(file.getLicense(), is(equalTo(expectedLicense)));
     }
 
     @Test

--- a/scopus-import/src/test/resources/crossrefResponseWithUnspecifiedLicense.json
+++ b/scopus-import/src/test/resources/crossrefResponseWithUnspecifiedLicense.json
@@ -1,0 +1,30 @@
+{
+  "message": {
+    "license": [
+      {
+        "start": {
+          "date-parts": [
+            [
+              2022,
+              10,
+              24
+            ]
+          ],
+          "date-time": "2022-10-24T00:00:00Z",
+          "timestamp": 1666569600000
+        },
+        "content-version": "unspecified",
+        "delay-in-days": 10,
+        "URL": "http:\/\/creativecommons.org\/licenses\/by\/4.0"
+      }
+    ],
+    "link": [
+      {
+        "URL": "https://www.nature.com/articles/s41467-023-40306-w",
+        "content-type": "application/pdf",
+        "content-version": "vor",
+        "intended-application": "similarity-checking"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
When receiving Doi response from Crossref with license where `content-version` equals `unspecified`, and there is no license with the same content version as in `content-version` for file `link` -> create file with license provided in license with content-version unspecified.

Example of Crossref response:

```
{
  "message": {
    "license": [
      {
        "start": {
          "date-parts": [
            [
              2022,
              10,
              24
            ]
          ],
          "date-time": "2022-10-24T00:00:00Z",
          "timestamp": 1666569600000
        },
        "content-version": "unspecified",
        "delay-in-days": 10,
        "URL": "http:\/\/creativecommons.org\/licenses\/by\/4.0"
      }
    ],
    "link": [
      {
        "URL": "https://www.nature.com/articles/s41467-023-40306-w",
        "content-type": "application/pdf",
        "content-version": "vor",
        "intended-application": "similarity-checking"
      }
    ]
  }
}
```