### PR TITLE
implementing publish publication endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -213,6 +213,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Publication'
+  /{publicationIdentifier}/publish:
+    post:
+      operationId: publishPublication
+      summary: Publish publication by identifier
+      security:
+        - CognitoUserPool: [
+          'https://api.nva.unit.no/scopes/backend',
+          'https://api.nva.unit.no/scopes/frontend',
+          'aws.cognito.signin.user.admin',
+          'https://api.nva.unit.no/scopes/third-party/publication-upsert'
+        ]
+      requestBody:
+        required: false
+        content: {}
+      parameters:
+        - in: path
+          name: publicationIdentifier
+          schema:
+            type: string
+          required: true
+          style: simple
+          explode: false
+          description: UUID identifier of the Publication to publish.
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PublishPublicationFunction.Arn}/invocations
+        responses: { }
+        httpMethod: POST
+        type: AWS_PROXY
+      responses:
+        200:
+          description: OK - Publication is published
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicationResponse'
+        400:
+          description: Bad Request - Publication is not publishable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        401:
+          description: Unauthorized - User is not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        403:
+          description: Forbidden - User has no permissions to publish publication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        404:
+          description: Not found - Publication does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        502:
+          description: Bad Gateway - Error in external service
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /by-owner:
     get:
       operationId: listPublicationsByOwner
@@ -241,7 +307,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Publication'
-
   /{publicationIdentifier}/doi:
     post:
       operationId: reserveDoiForDraftPublication
@@ -770,7 +835,7 @@ paths:
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchPublicationLogFunction.Arn}/invocations
-        responses: {}
+        responses: { }
         httpMethod: POST
         type: AWS_PROXY
       responses:

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -54,7 +54,7 @@ public class Resource implements Entity {
     public static final String TYPE = "Resource";
     public static final URI NOT_IMPORTANT = null;
     public static final List<PublicationStatus> PUBLISHABLE_STATUSES = List.of(DRAFT, PUBLISHED_METADATA,
-                                                                                        UNPUBLISHED, DELETED);
+                                                                                        UNPUBLISHED);
 
     @JsonProperty
     private SortableIdentifier identifier;

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -81,8 +81,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
     private static final List<PublicationStatus> allowedPublicationStatusesForPublishing = List.of(
         DRAFT,
         PUBLISHED_METADATA,
-        UNPUBLISHED,
-        DELETED
+        UNPUBLISHED
     );
     private final RawContentRetriever uriRetriever;
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1141,7 +1141,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = PublicationStatus.class, mode = Mode.EXCLUDE, names = {"NEW", "DRAFT_FOR_DELETION"})
+    @EnumSource(value = PublicationStatus.class, mode = Mode.EXCLUDE, names = {"NEW", "DRAFT_FOR_DELETION", "DELETED"})
     void shouldAllowPublish(PublicationStatus status) throws ApiGatewayException {
         var publication = randomPublication().copy().withStatus(status).build();
         resourceService.insertPreexistingPublication(publication);

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishPublicationHandler.java
@@ -1,0 +1,81 @@
+package no.unit.nva.publication.update;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import com.amazonaws.services.lambda.runtime.Context;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.permission.strategy.PublicationPermissionStrategy;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+import nva.commons.core.JacocoGenerated;
+
+public class PublishPublicationHandler extends ApiGatewayHandler<Void, Void> {
+
+    private final ResourceService resourceService;
+
+    @JacocoGenerated
+    public PublishPublicationHandler() {
+        this(ResourceService.defaultService());
+    }
+
+    public PublishPublicationHandler(ResourceService resourceService) {
+        super(Void.class);
+        this.resourceService = resourceService;
+    }
+
+    @Override
+    protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+        //No input to validate
+    }
+
+    @Override
+    protected Void processInput(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+        var resourceIdentifier = RequestUtil.getIdentifier(requestInfo);
+        var userInstance = UserInstance.fromRequestInfo(requestInfo);
+
+        publishResource(resourceIdentifier, userInstance);
+
+        return null;
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(Void input, Void output) {
+        return HTTP_OK;
+    }
+
+    private static void validatePermissions(Resource resource, UserInstance userInstance) throws ForbiddenException {
+        var permissionStrategy = PublicationPermissionStrategy.create(resource.toPublication(), userInstance);
+        if (!permissionStrategy.allowsAction(PublicationOperation.UPDATE)) {
+            throw new ForbiddenException();
+        }
+    }
+
+    private void publishResource(SortableIdentifier resourceIdentifier, UserInstance userInstance)
+        throws ApiGatewayException {
+        try {
+            var resource = Resource.resourceQueryObject(resourceIdentifier).fetch(resourceService);
+            validatePermissions(resource, userInstance);
+            resource.publish(resourceService, userInstance);
+        } catch (Exception e) {
+            handleException(e);
+        }
+    }
+
+    private void handleException(Exception exception) throws ApiGatewayException {
+        if (exception instanceof IllegalStateException) {
+            throw new BadRequestException(exception.getMessage());
+        } else if (exception instanceof ApiGatewayException apiGatewayException) {
+            throw apiGatewayException;
+        } else {
+            throw new BadGatewayException(exception.getMessage());
+        }
+    }
+}

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
@@ -1,0 +1,175 @@
+package no.unit.nva.publication.update;
+
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static no.unit.nva.model.testing.PublicationGenerator.randomNonDegreePublication;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.publication.PublicationServiceConfig.PUBLICATION_IDENTIFIER_PATH_PARAMETER_NAME;
+import static no.unit.nva.publication.PublicationServiceConfig.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.service.ResourcesLocalTest;
+import no.unit.nva.publication.service.impl.ResourceService;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zalando.problem.Problem;
+
+class PublishPublicationHandlerTest extends ResourcesLocalTest {
+
+    private Context context;
+    private ByteArrayOutputStream output;
+    private ResourceService resourceService;
+    private PublishPublicationHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        super.init();
+        context = new FakeContext();
+        output = new ByteArrayOutputStream();
+        resourceService = getResourceServiceBuilder().build();
+        handler = new PublishPublicationHandler(resourceService);
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenUserIsNotAuthorized() throws IOException {
+        var publicationIdentifier = SortableIdentifier.next();
+        var request = createUnauthorizedRequest(publicationIdentifier);
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_UNAUTHORIZED, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenPublicationDoesNotExist() throws IOException {
+        var publicationIdentifier = SortableIdentifier.next();
+        var request = createRequestWithRandomUser(publicationIdentifier);
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenUserHasNoPermissionsToPublishPublication() throws IOException, BadRequestException {
+        var publication = createPublication();
+        var request = createRequestWithRandomUser(publication.getIdentifier());
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenPublishingNotPublishablePublication()
+        throws IOException, BadRequestException, NotFoundException {
+        var publication = createUnpublishablePublication();
+        var request = createRequest(publication);
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnBadGatewayWhenUnexpectedExceptionOccurs()
+        throws IOException, BadRequestException, NotFoundException {
+        var publication = createPublication();
+        var request = createRequest(publication);
+
+        resourceService = mock(ResourceService.class);
+        when(resourceService.getResourceByIdentifier(publication.getIdentifier())).thenThrow(new RuntimeException());
+        var handler = new PublishPublicationHandler(resourceService);
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_BAD_GATEWAY, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnOkWhenPublishingPublication()
+        throws IOException, BadRequestException {
+        var publication = createPublication();
+        var request = createRequest(publication);
+
+        handler.handleRequest(request, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertEquals(HTTP_OK, response.getStatusCode());
+    }
+
+    private static Map<String, String> publicationIdentifierPathParam(SortableIdentifier publicationIdentifier) {
+        return Map.of(PUBLICATION_IDENTIFIER_PATH_PARAMETER_NAME, publicationIdentifier.toString());
+    }
+
+    private Publication createUnpublishablePublication() throws BadRequestException, NotFoundException {
+        var publication = createPublication();
+        UserInstance userInstance = UserInstance.fromPublication(publication);
+        Resource.fromPublication(publication).publish(resourceService, userInstance);
+        resourceService.unpublishPublication(publication, userInstance);
+        resourceService.deletePublication(publication, userInstance);
+        return publication;
+    }
+
+    private Publication createPublication() throws BadRequestException {
+        Publication publication = randomNonDegreePublication();
+        return Resource.fromPublication(publication)
+                   .persistNew(resourceService, UserInstance.fromPublication(publication));
+    }
+
+    private InputStream createRequestWithRandomUser(SortableIdentifier publicationIdentifier)
+        throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(dtoObjectMapper).withPathParameters(
+                publicationIdentifierPathParam(publicationIdentifier))
+                   .withCurrentCustomer(randomUri())
+                   .withUserName(randomString())
+                   .withPersonCristinId(randomUri())
+                   .withTopLevelCristinOrgId(randomUri())
+                   .build();
+    }
+
+    private InputStream createRequest(Publication publication) throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(dtoObjectMapper).withPathParameters(
+                publicationIdentifierPathParam(publication.getIdentifier()))
+                   .withCurrentCustomer(publication.getPublisher().getId())
+                   .withUserName(publication.getResourceOwner().getOwner().getValue())
+                   .withPersonCristinId(randomUri())
+                   .withTopLevelCristinOrgId(publication.getResourceOwner().getOwnerAffiliation())
+                   .withAccessRights(publication.getPublisher().getId(), AccessRight.MANAGE_RESOURCES_STANDARD)
+                   .build();
+    }
+
+    private InputStream createUnauthorizedRequest(SortableIdentifier publicationIdentifier)
+        throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(dtoObjectMapper).withPathParameters(
+            publicationIdentifierPathParam(publicationIdentifier)).build();
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -737,6 +737,26 @@ Resources:
             Method: put
             RestApiId: !Ref NvaPublicationApi
 
+  PublishPublicationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: publication-rest
+      Handler: no.unit.nva.publication.update.PublishPublicationHandler::handleRequest
+      MemorySize: 8192
+      Environment:
+        Variables:
+          ALLOWED_ORIGIN: !Ref AllowedOrigins
+          TABLE_NAME: !Ref NvaResourcesTable
+      Policies:
+        - !GetAtt DatabaseAccessLambdaManagedPolicy.PolicyArn
+      Events:
+        PutEvent:
+          Type: Api
+          Properties:
+            Path: /{publicationIdentifier}/publish
+            Method: post
+            RestApiId: !Ref NvaPublicationApi
+
   NvaDeletePublicationFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
- Implementing Publish publication endpoint:
` POST: /{publicationIdentifier}/publish - No request body required - PublicationResponse in response body`
- Not allowing to publish publication with status `DELETED`. This is not something we support in GUI. 

Why?

Since we now persist log entries for publication update statuses, there is no need to publish metadata via `CreateTicketHandler + AcceptedPublishingRequestEventHandler` by persisting PublishingRequestCase and approving it in order to be able to populate log. 