### PR TITLE
removing not needed method from resource service

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
@@ -4,7 +4,6 @@ import static com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder.S;
 import static java.util.Objects.isNull;
 import static no.unit.nva.publication.model.business.Resource.resourceQueryObject;
 import static no.unit.nva.publication.model.storage.DynamoEntry.parseAttributeValuesMap;
-import static no.unit.nva.publication.service.impl.ResourceService.EMPTY_RESOURCE_IDENTIFIER_ERROR;
 import static no.unit.nva.publication.service.impl.ResourceServiceUtils.conditionValueMapToAttributeValueMap;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_CUSTOMER_RESOURCE_INDEX_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.PRIMARY_KEY_PARTITION_KEY_NAME;
@@ -23,15 +22,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.DoiRequestDao;
 import no.unit.nva.publication.model.storage.ResourceDao;
-import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 
 public class ReadResourceService {
@@ -47,14 +44,6 @@ public class ReadResourceService {
     protected ReadResourceService(AmazonDynamoDB client, String tableName) {
         this.client = client;
         this.tableName = tableName;
-    }
-
-    public Publication getPublication(UserInstance userInstance, SortableIdentifier resourceIdentifier)
-        throws ApiGatewayException {
-        if (isNull(resourceIdentifier)) {
-            throw new BadRequestException(EMPTY_RESOURCE_IDENTIFIER_ERROR);
-        }
-        return getResource(userInstance, resourceIdentifier).toPublication();
     }
 
     public Publication getPublication(Publication publication) throws NotFoundException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -257,11 +257,6 @@ public class ResourceService extends ServiceWithTransactions {
         writeToDynamoInBatches(writeRequests);
     }
 
-    public Publication getPublication(UserInstance userInstance, SortableIdentifier resourceIdentifier)
-        throws ApiGatewayException {
-        return readResourceService.getPublication(userInstance, resourceIdentifier);
-    }
-
     public Publication getPublication(Publication sampleResource) throws NotFoundException {
         return readResourceService.getPublication(sampleResource);
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -286,7 +286,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
     PublishPublicationStatusResponse publishPublication(UserInstance userInstance,
                                                         SortableIdentifier resourceIdentifier)
         throws ApiGatewayException {
-        var publication = readResourceService.getPublication(userInstance, resourceIdentifier);
+        var publication = readResourceService.getResourceByIdentifier(resourceIdentifier).toPublication();
         if (publicationIsPublished(publication)) {
             return publishCompletedStatus();
         } else if (publicationIsAllowedForPublishing(publication)) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/identifiers/HandleIdentifierEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/identifiers/HandleIdentifierEventHandler.java
@@ -21,16 +21,15 @@ import no.unit.nva.events.models.AwsEventBridgeDetail;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
-import no.unit.nva.model.additionalidentifiers.HandleIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.model.additionalidentifiers.AdditionalIdentifier;
+import no.unit.nva.model.additionalidentifiers.HandleIdentifier;
 import no.unit.nva.model.additionalidentifiers.SourceName;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.events.handlers.PublicationEventsConfig;
 import no.unit.nva.publication.model.BackendClientCredentials;
 import no.unit.nva.publication.model.business.Resource;
-import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
 import nva.commons.core.Environment;
@@ -125,8 +124,7 @@ public class HandleIdentifierEventHandler
             var resourceUpdate = parseResourceUpdateInput(eventBlob);
             if (isPublished(resourceUpdate) && isMissingHandle(resourceUpdate)) {
                 logger.info("Creating handle for publication: {}", resourceUpdate.getIdentifier());
-                var userInstance = UserInstance.create(resourceUpdate.getOwner(), resourceUpdate.getCustomerId());
-                var publication = fetchPublication(userInstance, resourceUpdate.getIdentifier());
+                var publication = fetchPublication(resourceUpdate.getIdentifier());
                 var additionalIdentifiers = new HashSet<>(publication.getAdditionalIdentifiers());
                 var handle = createNewHandle(getLandingPage(publication.getIdentifier()));
                 logger.info("Created handle: {}", handle.value());
@@ -168,9 +166,8 @@ public class HandleIdentifierEventHandler
         return new HandleIdentifier(new SourceName("nva", "sikt"), handleService.createHandle(link));
     }
 
-    private Publication fetchPublication(UserInstance userInstance, SortableIdentifier publicationIdentifier) {
-        return attempt(() -> resourceService.getPublication(userInstance, publicationIdentifier))
-                   .orElseThrow();
+    private Publication fetchPublication(SortableIdentifier publicationIdentifier) {
+        return attempt(() -> resourceService.getPublicationByIdentifier(publicationIdentifier)).orElseThrow();
     }
 
     private static Resource parseResourceUpdateInput(String eventBlob) {


### PR DESCRIPTION
Following method is not needed and is in use single place where there is no need to use it:
`
public Publication getPublication(UserInstance userInstance, SortableIdentifier resourceIdentifier)
`
We have multiple fetchByIdentifier() methods to fetch publication
