### PR TITLE
extracting publication date from additional field - scopus import

### DIFF
--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -186,6 +186,25 @@ Artistic:
     properties:
       type:
         type: string
+ArtisticDegreePhd:
+  required:
+  - type
+  type: object
+  allOf:
+  - $ref: "#/components/schemas/PublicationInstancePages"
+  - type: object
+    properties:
+      pages:
+        $ref: "#/components/schemas/MonographPages"
+      submittedDate:
+        $ref: "#/components/schemas/PublicationDate"
+      related:
+        uniqueItems: true
+        type: array
+        items:
+          $ref: "#/components/schemas/RelatedDocument"
+      type:
+        type: string
 ArtisticDesign:
   required:
   - type
@@ -1044,8 +1063,6 @@ File:
       license:
         type: string
         format: uri
-      administrativeAgreement:
-        type: boolean
       publisherVersion:
         type: string
         enum:
@@ -1063,8 +1080,6 @@ File:
         format: date-time
       uploadDetails:
         $ref: "#/components/schemas/UploadDetails"
-      visibleForNonOwner:
-        type: boolean
       type:
         type: string
 FunderRightsRetentionStrategy:
@@ -1082,8 +1097,6 @@ Funding:
   - type
   type: object
   properties:
-    identifier:
-      type: string
     labels:
       type: object
       additionalProperties:
@@ -1099,6 +1112,8 @@ Funding:
     activeTo:
       type: string
       format: date-time
+    identifier:
+      type: string
     type:
       type: string
 GeographicalContent:
@@ -1434,9 +1449,6 @@ LiteraryArtsAudioVisualSubtype:
       - ShortFilm
       - Podcast
       - LiteraryArtsAudioVisualOther
-    description:
-      type: string
-      writeOnly: true
 LiteraryArtsManifestation:
   required:
   - type
@@ -1487,9 +1499,6 @@ LiteraryArtsPerformanceSubtype:
       - Reading
       - Play
       - LiteraryArtsPerformanceOther
-    description:
-      type: string
-      writeOnly: true
 LiteraryArtsSubtype:
   type: object
   properties:

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -33,8 +33,6 @@ import no.scopus.generated.HeadTp;
 import no.scopus.generated.InfTp;
 import no.scopus.generated.MetaTp;
 import no.scopus.generated.OpenAccessType;
-import no.scopus.generated.OrigItemTp;
-import no.scopus.generated.ProcessInfo;
 import no.scopus.generated.SupTp;
 import no.scopus.generated.TitletextTp;
 import no.scopus.generated.YesnoAtt;
@@ -201,9 +199,9 @@ public class ScopusConverter {
     private PublicationDate getPublicationDateFromDateSort() {
         var dateSort = getDateSortTp();
         return new PublicationDate.Builder()
-                   .withDay(dateSort.map(DateSortTp::getDay).orElse(null))
-                   .withMonth(dateSort.map(DateSortTp::getMonth).orElse(null))
-                   .withYear(dateSort.map(DateSortTp::getYear).orElse(null))
+                   .withDay(dateSort.getDay())
+                   .withMonth(dateSort.getMonth())
+                   .withYear(dateSort.getYear())
                    .build();
     }
 
@@ -232,10 +230,8 @@ public class ScopusConverter {
      if not there are several rules to determine what's the second-best date is. See "SciVerse SCOPUS CUSTOM DATA
      DOCUMENTATION" for details.
      */
-    private Optional<DateSortTp> getDateSortTp() {
-        return Optional.ofNullable(docTp.getItem().getItem())
-                   .map(OrigItemTp::getProcessInfo)
-                   .map(ProcessInfo::getDateSort);
+    private DateSortTp getDateSortTp() {
+        return docTp.getItem().getItem().getProcessInfo().getDateSort();
     }
 
     private String extractMainAbstract() {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import no.scopus.generated.AbstractTp;
 import no.scopus.generated.AuthorGroupTp;
 import no.scopus.generated.AuthorKeywordTp;
@@ -61,7 +60,6 @@ import no.unit.nva.publication.model.business.importcandidate.ImportStatusFactor
 import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
 import nva.commons.core.paths.UriWrapper;
-import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("PMD.GodClass")
 public class ScopusConverter {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -12,6 +12,7 @@ import static nva.commons.core.attempt.Try.attempt;
 import jakarta.xml.bind.JAXBElement;
 import java.net.URI;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -210,25 +211,20 @@ public class ScopusConverter {
         return Optional.of(docTp.getMeta())
                    .map(MetaTp::getOpenAccess)
                    .map(OpenAccessType::getOaAccessEffectiveDate)
-                   .map(this::toPublicationDate)
-                   .filter(this::isCompletePublicationDate);
-    }
-
-    private boolean isCompletePublicationDate(PublicationDate date) {
-        return nonNull(date.getYear()) && nonNull(date.getMonth()) && nonNull(date.getDay());
+                   .map(this::toPublicationDate);
     }
 
     private PublicationDate toPublicationDate(String value) {
-        var dateParts = value.split("-");
-        var year = attempt(() -> dateParts[0]).toOptional();
-        var month = attempt(() -> dateParts[1]).toOptional();
-        var day = attempt(() -> dateParts[2]).toOptional();
-        return new PublicationDate.Builder()
-                   .withYear(year.orElse(null))
-                   .withMonth(month.orElse(null))
-                   .withDay(day.orElse(null))
-                   .build();
+        var localDate = attempt(() -> LocalDate.parse(value)).toOptional();
+        return localDate.map(ScopusConverter::toPublicationDate).orElse(null);
+    }
 
+    private static PublicationDate toPublicationDate(LocalDate date) {
+        return new PublicationDate.Builder()
+                   .withYear(String.valueOf(date.getYear()))
+                   .withMonth(String.valueOf(date.getMonthValue()))
+                   .withDay(String.valueOf(date.getDayOfMonth()))
+                   .build();
     }
 
     /*

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusConverterTest.java
@@ -3,12 +3,16 @@ package no.sikt.nva.scopus.conversion;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import no.scopus.generated.OpenAccessType;
 import no.sikt.nva.scopus.ScopusConverter;
 import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.sikt.nva.scopus.utils.ScopusGenerator;
+import no.unit.nva.model.PublicationDate;
+import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import org.junit.jupiter.api.Test;
 
 public class ScopusConverterTest {
@@ -17,13 +21,7 @@ public class ScopusConverterTest {
     void shouldReturnImportCandidateWithoutTitleWhenTitleListFromScopusXmlISEmpty() {
         var generator = new ScopusGenerator();
         generator.getDocument().getItem().getItem().getBibrecord().getHead().getCitationTitle().getTitletext().clear();
-        var customerConnection = mock(NvaCustomerConnection.class);
-        var converter = new ScopusConverter(generator.getDocument(), mock(PiaConnection.class),
-                                            mock(CristinConnection.class), mock(PublicationChannelConnection.class),
-                                            customerConnection,
-                                            mock(ScopusFileConverter.class));
-        when(customerConnection.atLeastOneNvaCustomerPresent(any())).thenReturn(true);
-        var candidate = converter.generateImportCandidate();
+        var candidate = generateImportCandidate(generator);
 
         assertThat(candidate.getEntityDescription().getMainTitle(), is(nullValue()));
     }
@@ -32,6 +30,52 @@ public class ScopusConverterTest {
     void shouldReturnImportCandidateWithoutTitleWhenTitleFromXmlIsNull() {
         var generator = new ScopusGenerator();
         setNullTitle(generator);
+        var candidate = generateImportCandidate(generator);
+
+        assertThat(candidate.getEntityDescription().getMainTitle(), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnImportCandidateWithPublicationDateFromOaAccessEffectiveDateWhenDateIsPresent() {
+        var generator = new ScopusGenerator();
+        generator.getDocument().getMeta().setOpenAccess(new OpenAccessType());
+        generator.getDocument().getMeta().getOpenAccess().setOaAccessEffectiveDate("2024-10-16");
+
+        var candidate = generateImportCandidate(generator);
+
+        var expectedPublicationDate = new PublicationDate.Builder().withYear("2024").withMonth("10").withDay("16").build();
+
+        assertEquals(expectedPublicationDate, candidate.getEntityDescription().getPublicationDate());
+    }
+
+    @Test
+    void shouldReturnImportCandidateWithPublicationDateFromDateSortWhenOaAccessEffectiveDateIsMissingDateParts() {
+        var generator = new ScopusGenerator();
+        generator.getDocument().getMeta().setOpenAccess(new OpenAccessType());
+        generator.getDocument().getMeta().getOpenAccess().setOaAccessEffectiveDate("2024");
+
+        var candidate = generateImportCandidate(generator);
+
+        var dateSort = generator.getDocument().getItem().getItem().getProcessInfo().getDateSort();
+        var expectedPublicationDate =
+            new PublicationDate.Builder().withYear(dateSort.getYear()).withMonth(dateSort.getMonth()).withDay(dateSort.getDay()).build();
+
+        assertEquals(expectedPublicationDate, candidate.getEntityDescription().getPublicationDate());
+    }
+
+    @Test
+    void shouldReturnImportCandidateFromDateSortWhenOaAccessEffectiveDateIsNotPresent() {
+        var generator = new ScopusGenerator();
+
+        var candidate = generateImportCandidate(generator);
+        var dateSort = generator.getDocument().getItem().getItem().getProcessInfo().getDateSort();
+        var expectedPublicationDate =
+            new PublicationDate.Builder().withYear(dateSort.getYear()).withMonth(dateSort.getMonth()).withDay(dateSort.getDay()).build();
+
+        assertEquals(expectedPublicationDate, candidate.getEntityDescription().getPublicationDate());
+    }
+
+    private static ImportCandidate generateImportCandidate(ScopusGenerator generator) {
         var customerConnection = mock(NvaCustomerConnection.class);
         var converter = new ScopusConverter(generator.getDocument(), mock(PiaConnection.class),
                                             mock(CristinConnection.class), mock(PublicationChannelConnection.class),
@@ -39,8 +83,7 @@ public class ScopusConverterTest {
                                             mock(ScopusFileConverter.class));
         when(customerConnection.atLeastOneNvaCustomerPresent(any())).thenReturn(true);
         var candidate = converter.generateImportCandidate();
-
-        assertThat(candidate.getEntityDescription().getMainTitle(), is(nullValue()));
+        return candidate;
     }
 
     private static void setNullTitle(ScopusGenerator generator) {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusConverterTest.java
@@ -49,7 +49,7 @@ public class ScopusConverterTest {
     }
 
     @Test
-    void shouldReturnImportCandidateWithPublicationDateFromDateSortWhenOaAccessEffectiveDateIsMissingDateParts() {
+    void shouldReturnImportCandidateWithPublicationDateFromDateSortWhenOaAccessEffectiveDateIsNotISODate() {
         var generator = new ScopusGenerator();
         generator.getDocument().getMeta().setOpenAccess(new OpenAccessType());
         generator.getDocument().getMeta().getOpenAccess().setOaAccessEffectiveDate("2024");


### PR DESCRIPTION
We got comments from testers that current publication date for Scopus imported publication is sometimes wrong. 
From now on we are prioritizing following date if it is present:

`
<xocs:oa-access-effective-date>2024-10-16</xocs:oa-access-effective-date>
`

And if not we use current mapping:

`
<ait:date-sort day="01" month="01" year="2024"/>
`


