### PR TITLE
removing get publication method

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -266,6 +266,8 @@ public class ResourceService extends ServiceWithTransactions {
         writeToDynamoInBatches(writeRequests);
     }
 
+    // TODO: Remove all usages of this method in tests and use getPublicationByIdentifier instead
+    @Deprecated(forRemoval = true)
     public Publication getPublication(Publication sampleResource) throws NotFoundException {
         return readResourceService.getPublication(sampleResource);
     }

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -204,7 +204,7 @@ public class UpdatePublicationHandler
         deleteFiles(existingPublication);
         resourceService.deletePublication(existingPublication, userInstance);
 
-        return resourceService.getPublication(existingPublication);
+        return resourceService.getPublicationByIdentifier(existingPublication.getIdentifier());
     }
 
     private void deleteFiles(Publication publication) {
@@ -230,7 +230,7 @@ public class UpdatePublicationHandler
                                                             existingPublication,
                                                             userInstance);
         resourceService.unpublishPublication(updatedPublication, userInstance);
-        updatedPublication = resourceService.getPublication(updatedPublication);
+        updatedPublication = resourceService.getPublicationByIdentifier(updatedPublication.getIdentifier());
         updateNvaDoi(updatedPublication);
         return updatedPublication;
     }


### PR DESCRIPTION
Removing use of method `resourceService.getPublication()` in production code. 

Now will all methods that are fetching publication use `resourceService.getResourceByIdentifier()` method which fetches files from database (depending on environment variable).

The plan is to remove use of this method from tests and remove it from resource service, cause underlying logic of this method is the same as in `resourceService.getPublicationByIdentifier()`. (fetching by primary key)