### PR TITLE
Persisiting log entries on file changes

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -17,6 +17,7 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.publication.model.business.publicationstate.FileApprovedEvent;
+import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileRejectedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileUploadedEvent;
@@ -76,7 +77,7 @@ public final class FileEntry implements Entity {
     public void persist(ResourceService resourceService) {
         var now = Instant.now();
         this.modifiedDate = now;
-        this.setFileEvent(FileUploadedEvent.create(getOwner(), getOwnerAffiliation(), now));
+        this.setFileEvent(FileUploadedEvent.create(getOwner(), now));
         resourceService.persistFile(this);
     }
 
@@ -165,7 +166,14 @@ public final class FileEntry implements Entity {
         return ownerAffiliation;
     }
 
-    public void delete(ResourceService resourceIdentifier) {
+    public void softDelete(ResourceService resourceIdentifier, User user) {
+        var now = Instant.now();
+        this.setFileEvent(FileDeletedEvent.create(user, now));
+        this.modifiedDate = now;
+        resourceIdentifier.updateFile(this);
+    }
+
+    public void hardDelete(ResourceService resourceIdentifier) {
         resourceIdentifier.deleteFile(this);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -295,7 +295,8 @@ public class PublishingRequestCase extends TicketEntry {
         if (resourceService.shouldUseNewFiles()) {
             getApprovedFiles().forEach(file -> FileEntry.queryObject(file.getIdentifier(), getResourceIdentifier())
                                                    .fetch(resourceService)
-                                                   .ifPresent(fileEntry -> fileEntry.approve(resourceService)));
+                                                   .ifPresent(fileEntry -> fileEntry.approve(resourceService,
+                                                                                             new User(getFinalizedBy().getValue()))));
         } else {
             var resource = Resource.resourceQueryObject(getResourceIdentifier()).fetch(resourceService).orElseThrow();
             var resourceWithUpdatedAssociatedArtifacts = toPublicationWithApprovedFiles(resource).toPublication();
@@ -309,7 +310,7 @@ public class PublishingRequestCase extends TicketEntry {
                 .map(PendingFile.class::cast)
                 .forEach(file -> FileEntry.queryObject(file.getIdentifier(), getResourceIdentifier())
                                      .fetch(resourceService)
-                                     .ifPresent(fileEntry -> fileEntry.reject(resourceService)));
+                                     .ifPresent(fileEntry -> fileEntry.reject(resourceService, new User(getFinalizedBy().getValue()))));
         } else {
             var resource = Resource.resourceQueryObject(getResourceIdentifier()).fetch(resourceService).orElseThrow();
             var resourceWithRejectedFiles = resource.copy()

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/FileLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/FileLogEntry.java
@@ -1,0 +1,76 @@
+package no.unit.nva.publication.model.business.logentry;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.service.impl.ResourceService;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record FileLogEntry(SortableIdentifier identifier, SortableIdentifier fileIdentifier,
+                           SortableIdentifier resourceIdentifier, LogTopic topic, String filename, Instant timestamp,
+                           LogUser performedBy) implements LogEntry {
+
+    public static final String TYPE = "FileLogEntry";
+
+    public void persist(ResourceService resourceService) {
+        resourceService.persistLogEntry(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private SortableIdentifier identifier;
+        private SortableIdentifier fileIdentifier;
+        private SortableIdentifier resourceIdentifier;
+        private LogTopic topic;
+        private String filename;
+        private Instant timestamp;
+        private LogUser performedBy;
+
+        private Builder() {
+        }
+
+        public Builder withIdentifier(SortableIdentifier identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withFileIdentifier(SortableIdentifier fileIdentifier) {
+            this.fileIdentifier = fileIdentifier;
+            return this;
+        }
+
+        public Builder withResourceIdentifier(SortableIdentifier resourceIdentifier) {
+            this.resourceIdentifier = resourceIdentifier;
+            return this;
+        }
+
+        public Builder withTopic(LogTopic topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Builder withFilename(String filename) {
+            this.filename = filename;
+            return this;
+        }
+
+        public Builder withTimestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public Builder withPerformedBy(LogUser performedBy) {
+            this.performedBy = performedBy;
+            return this;
+        }
+
+        public FileLogEntry build() {
+            return new FileLogEntry(identifier, fileIdentifier, resourceIdentifier, topic, filename, timestamp,
+                                    performedBy);
+        }
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
@@ -1,61 +1,22 @@
 package no.unit.nva.publication.model.business.logentry;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.publication.service.impl.ResourceService;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record LogEntry(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, LogTopic topic,
-                       Instant timestamp, LogUser performedBy) {
+@JsonSubTypes({@JsonSubTypes.Type(names = {PublicationLogEntry.TYPE, "LogEntry"}, value = PublicationLogEntry.class),
+    @JsonSubTypes.Type(name = FileLogEntry.TYPE, value = FileLogEntry.class)})
+public interface LogEntry {
 
-    public static Builder builder() {
-        return new Builder();
-    }
+    SortableIdentifier identifier();
 
-    public void persist(ResourceService resourceService) {
-        resourceService.persistLogEntry(this);
-    }
+    SortableIdentifier resourceIdentifier();
 
-    public static final class Builder {
+    LogTopic topic();
 
-        private SortableIdentifier identifier;
-        private SortableIdentifier resourceIdentifier;
-        private LogTopic topic;
-        private Instant timestamp;
-        private LogUser performedBy;
+    Instant timestamp();
 
-        private Builder() {
-        }
-
-        public Builder withIdentifier(SortableIdentifier identifier) {
-            this.identifier = identifier;
-            return this;
-        }
-
-        public Builder withResourceIdentifier(SortableIdentifier publicationIdentifier) {
-            this.resourceIdentifier = publicationIdentifier;
-            return this;
-        }
-
-        public Builder withTopic(LogTopic topic) {
-            this.topic = topic;
-            return this;
-        }
-
-        public Builder withTimestamp(Instant timestamp) {
-            this.timestamp = timestamp;
-            return this;
-        }
-
-        public Builder withPerformedBy(LogUser performedBy) {
-            this.performedBy = performedBy;
-            return this;
-        }
-
-        public LogEntry build() {
-            return new LogEntry(identifier, resourceIdentifier, topic, timestamp, performedBy);
-        }
-
-    }
+    LogUser performedBy();
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -8,6 +8,7 @@ public enum LogTopic {
     FILE_APPROVED("FileApproved"),
     FILE_REJECTED("FileRejected"),
     FILE_UPLOADED("FileUploaded"),
+    FILE_DELETED("FileDeleted"),
     PUBLICATION_CREATED("PublicationCreated"),
     PUBLICATION_DELETED("PublicationDeleted"),
     PUBLICATION_PUBLISHED("PublicationPublished"),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum LogTopic {
 
-    FILE_PUBLISHED("FilePublished"),
+    FILE_APPROVED("FileApproved"),
     FILE_REJECTED("FileRejected"),
     FILE_UPLOADED("FileUploaded"),
     PUBLICATION_CREATED("PublicationCreated"),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
@@ -1,0 +1,63 @@
+package no.unit.nva.publication.model.business.logentry;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.service.impl.ResourceService;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, LogTopic topic,
+                                  Instant timestamp, LogUser performedBy) implements LogEntry {
+
+    public static final String TYPE = "PublicationLogEntry";
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void persist(ResourceService resourceService) {
+        resourceService.persistLogEntry(this);
+    }
+
+    public static final class Builder {
+
+        private SortableIdentifier identifier;
+        private SortableIdentifier resourceIdentifier;
+        private LogTopic topic;
+        private Instant timestamp;
+        private LogUser performedBy;
+
+        private Builder() {
+        }
+
+        public Builder withIdentifier(SortableIdentifier identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withResourceIdentifier(SortableIdentifier publicationIdentifier) {
+            this.resourceIdentifier = publicationIdentifier;
+            return this;
+        }
+
+        public Builder withTopic(LogTopic topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Builder withTimestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public Builder withPerformedBy(LogUser performedBy) {
+            this.performedBy = performedBy;
+            return this;
+        }
+
+        public PublicationLogEntry build() {
+            return new PublicationLogEntry(identifier, resourceIdentifier, topic, timestamp, performedBy);
+        }
+
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -16,8 +16,8 @@ public record CreatedResourceEvent(Instant date, User user, URI institution) imp
     }
 
     @Override
-    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
-        return LogEntry.builder()
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_CREATED)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -17,8 +17,8 @@ public record DeletedResourceEvent(Instant date, User user, URI institution) imp
 
 
     @Override
-    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
-        return LogEntry.builder()
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_DELETED)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileApprovedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileApprovedEvent.java
@@ -1,0 +1,30 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+
+public record FileApprovedEvent(Instant date, User user, URI institution) implements FileEvent {
+
+    public static FileApprovedEvent create(User user, Instant timestamp) {
+        return new FileApprovedEvent(timestamp, user, null);
+    }
+
+    @Override
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+        return FileLogEntry.builder()
+                   .withIdentifier(SortableIdentifier.next())
+                   .withFileIdentifier(fileEntry.getIdentifier())
+                   .withResourceIdentifier(fileEntry.getResourceIdentifier())
+                   .withTopic(LogTopic.FILE_APPROVED)
+                   .withTimestamp(date)
+                   .withPerformedBy(user)
+                   .withFilename(fileEntry.getFile().getName())
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileDeletedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileDeletedEvent.java
@@ -8,10 +8,10 @@ import no.unit.nva.publication.model.business.logentry.FileLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
-public record FileApprovedEvent(Instant date, User user) implements FileEvent {
+public record FileDeletedEvent(Instant date, User user) implements FileEvent {
 
-    public static FileApprovedEvent create(User user, Instant timestamp) {
-        return new FileApprovedEvent(timestamp, user);
+    public static FileDeletedEvent create(User user, Instant timestamp) {
+        return new FileDeletedEvent(timestamp, user);
     }
 
     @Override
@@ -20,7 +20,7 @@ public record FileApprovedEvent(Instant date, User user) implements FileEvent {
                    .withIdentifier(SortableIdentifier.next())
                    .withFileIdentifier(fileEntry.getIdentifier())
                    .withResourceIdentifier(fileEntry.getResourceIdentifier())
-                   .withTopic(LogTopic.FILE_APPROVED)
+                   .withTopic(LogTopic.FILE_DELETED)
                    .withTimestamp(date)
                    .withPerformedBy(user)
                    .withFilename(fileEntry.getFile().getName())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
@@ -4,16 +4,15 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.time.Instant;
-import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
-import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
+import no.unit.nva.publication.model.business.logentry.FileLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(PublishedResourceEvent.class),
-    @JsonSubTypes.Type(UnpublishedResourceEvent.class), @JsonSubTypes.Type(DeletedResourceEvent.class),
-    @JsonSubTypes.Type(RepublishedResourceEvent.class)})
-public interface ResourceEvent {
+@JsonSubTypes({@JsonSubTypes.Type(FileUploadedEvent.class), @JsonSubTypes.Type(FileApprovedEvent.class),
+    @JsonSubTypes.Type(FileRejectedEvent.class)})
+public interface FileEvent {
 
     Instant date();
 
@@ -24,5 +23,5 @@ public interface ResourceEvent {
      */
     URI institution();
 
-    PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user);
+    FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
@@ -2,7 +2,6 @@ package no.unit.nva.publication.model.business.publicationstate;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
@@ -11,17 +10,13 @@ import no.unit.nva.publication.model.business.logentry.LogUser;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(FileUploadedEvent.class), @JsonSubTypes.Type(FileApprovedEvent.class),
-    @JsonSubTypes.Type(FileRejectedEvent.class)})
+    @JsonSubTypes.Type(FileRejectedEvent.class), @JsonSubTypes.Type(FileDeletedEvent.class)})
 public interface FileEvent {
 
     Instant date();
 
     User user();
 
-    /**
-     * @return id of the top level cristin organizations
-     */
-    URI institution();
 
     FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
@@ -1,0 +1,30 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+
+public record FileRejectedEvent(Instant date, User user, URI institution) implements FileEvent {
+
+    public static FileRejectedEvent create(User user, Instant timestamp) {
+        return new FileRejectedEvent(timestamp, user, null);
+    }
+
+    @Override
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+        return FileLogEntry.builder()
+                   .withIdentifier(SortableIdentifier.next())
+                   .withFileIdentifier(fileEntry.getIdentifier())
+                   .withResourceIdentifier(fileEntry.getResourceIdentifier())
+                   .withTopic(LogTopic.FILE_REJECTED)
+                   .withTimestamp(date)
+                   .withPerformedBy(user)
+                   .withFilename(fileEntry.getFile().getName())
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.model.business.publicationstate;
 
-import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
@@ -9,10 +8,10 @@ import no.unit.nva.publication.model.business.logentry.FileLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
-public record FileRejectedEvent(Instant date, User user, URI institution) implements FileEvent {
+public record FileRejectedEvent(Instant date, User user) implements FileEvent {
 
     public static FileRejectedEvent create(User user, Instant timestamp) {
-        return new FileRejectedEvent(timestamp, user, null);
+        return new FileRejectedEvent(timestamp, user);
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.model.business.publicationstate;
 
-import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
@@ -9,10 +8,10 @@ import no.unit.nva.publication.model.business.logentry.FileLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
-public record FileUploadedEvent(Instant date, User user, URI institution) implements FileEvent {
+public record FileUploadedEvent(Instant date, User user) implements FileEvent {
 
-    public static FileUploadedEvent create(User user, URI institution, Instant timestamp) {
-        return new FileUploadedEvent(timestamp, user, institution);
+    public static FileUploadedEvent create(User user, Instant timestamp) {
+        return new FileUploadedEvent(timestamp, user);
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -1,0 +1,30 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+
+public record FileUploadedEvent(Instant date, User user, URI institution) implements FileEvent {
+
+    public static FileUploadedEvent create(User user, URI institution, Instant timestamp) {
+        return new FileUploadedEvent(timestamp, user, institution);
+    }
+
+    @Override
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+        return FileLogEntry.builder()
+                   .withIdentifier(SortableIdentifier.next())
+                   .withFileIdentifier(fileEntry.getIdentifier())
+                   .withResourceIdentifier(fileEntry.getResourceIdentifier())
+                   .withTopic(LogTopic.FILE_UPLOADED)
+                   .withTimestamp(date)
+                   .withPerformedBy(user)
+                   .withFilename(fileEntry.getFile().getName())
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -16,8 +16,8 @@ public record PublishedResourceEvent(Instant date, User user, URI institution) i
     }
 
     @Override
-    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
-        return LogEntry.builder()
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_PUBLISHED)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -16,8 +16,8 @@ public record RepublishedResourceEvent(Instant date, User user, URI institution)
     }
 
     @Override
-    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
-        return LogEntry.builder()
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_REPUBLISHED)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
-import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -16,8 +16,8 @@ public record UnpublishedResourceEvent(Instant date, User user, URI institution)
     }
 
     @Override
-    public LogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
-        return LogEntry.builder()
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_UNPUBLISHED)

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/FileEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/FileEntryTest.java
@@ -4,6 +4,7 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomHiddenFile;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.util.List;
 import no.unit.nva.identifiers.SortableIdentifier;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,16 @@ class FileEntryTest {
         var fileEntry = FileEntry.create(file, resourceIdentifier, userInstance);
 
         assertEquals(file, fileEntry.getFile());
+    }
+
+    @Test
+    void shouldReturnFalseWhenFileEventIsNull() {
+        var file = randomOpenFile();
+        var userInstance = randomUserInstance();
+        var resourceIdentifier = SortableIdentifier.next();
+        var fileEntry = FileEntry.create(file, resourceIdentifier, userInstance);
+
+        assertFalse(fileEntry.hasFileEvent());
     }
 
     private static UserInstance randomUserInstance() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
@@ -1,0 +1,46 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.Instant;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FileEventTest {
+
+    public static Stream<Arguments> stateProvider() {
+        return Stream.of(Arguments.of(new FileUploadedEvent(Instant.now(), randomUser(), randomUri())),
+                         Arguments.of(
+                             new FileApprovedEvent(Instant.now(), randomUser(), randomUri())),
+                         Arguments.of(new FileRejectedEvent(Instant.now(), randomUser(), randomUri())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("stateProvider")
+    void shouldDoRoundTripWithoutLossOfData(FileEvent state) throws JsonProcessingException {
+        var json = JsonUtils.dtoObjectMapper.writeValueAsString(state);
+        var roundTrippedState = JsonUtils.dtoObjectMapper.readValue(json, FileEvent.class);
+        var fileEntry = FileEntry.create(randomOpenFile(), SortableIdentifier.next(),
+                                        UserInstance.create(randomUser(), randomUri()));
+
+        assertEquals(state, roundTrippedState);
+        assertDoesNotThrow(() -> roundTrippedState.toLogEntry(fileEntry,
+                                                              LogUser.fromResourceEvent(randomUser(), randomUri())));
+    }
+
+    private static User randomUser() {
+        return new User(randomString());
+    }
+}

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
@@ -21,10 +21,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class FileEventTest {
 
     public static Stream<Arguments> stateProvider() {
-        return Stream.of(Arguments.of(new FileUploadedEvent(Instant.now(), randomUser(), randomUri())),
+        return Stream.of(Arguments.of(new FileUploadedEvent(Instant.now(), randomUser())),
                          Arguments.of(
-                             new FileApprovedEvent(Instant.now(), randomUser(), randomUri())),
-                         Arguments.of(new FileRejectedEvent(Instant.now(), randomUser(), randomUri())));
+                             new FileApprovedEvent(Instant.now(), randomUser())),
+                         Arguments.of(new FileRejectedEvent(Instant.now(), randomUser())),
+                         Arguments.of(new FileDeletedEvent(Instant.now(), randomUser())));
     }
 
     @ParameterizedTest

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
@@ -1,6 +1,5 @@
 package no.unit.nva.publication.events.bodies;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,6 +16,7 @@ import no.unit.nva.publication.model.business.Message;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UnpublishRequest;
+import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import nva.commons.core.JacocoGenerated;
 
 public class DataEntryUpdateEvent implements JsonSerializable {
@@ -74,11 +74,6 @@ public class DataEntryUpdateEvent implements JsonSerializable {
     public Entity getNewData() {
         return newData;
     }
-
-    @JsonIgnore
-    public boolean isDeleteEvent() {
-        return nonNull(oldData) && isNull(newData);
-    }
     
     @Override
     @JacocoGenerated
@@ -117,7 +112,7 @@ public class DataEntryUpdateEvent implements JsonSerializable {
             case Message message -> MESSAGE_UPDATE_EVENT_TOPIC;
             case GeneralSupportRequest generalSupportRequest -> GENERAL_SUPPORT_REQUEST_UPDATE_EVENT_TOPIC;
             case UnpublishRequest unpublishRequest -> UNPUBLISH_REQUEST_UPDATE_EVENT_TOPIC;
-            case FileEntry fileEntry -> this.isDeleteEvent()
+            case FileEntry fileEntry -> fileEntry.getFileEvent() instanceof FileDeletedEvent
                                             ? FILE_ENTRY_DELETE_EVENT_TOPIC
                                             : FILE_ENTRY_UPDATE_EVENT_TOPIC;
             default -> throw new IllegalArgumentException("Unknown entry type: " + type);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
@@ -112,7 +112,7 @@ public class DataEntryUpdateEvent implements JsonSerializable {
             case Message message -> MESSAGE_UPDATE_EVENT_TOPIC;
             case GeneralSupportRequest generalSupportRequest -> GENERAL_SUPPORT_REQUEST_UPDATE_EVENT_TOPIC;
             case UnpublishRequest unpublishRequest -> UNPUBLISH_REQUEST_UPDATE_EVENT_TOPIC;
-            case FileEntry fileEntry -> fileEntry.getFileEvent() instanceof FileDeletedEvent
+            case FileEntry fileEntry -> nonNull(fileEntry.getFileEvent()) && fileEntry.getFileEvent() instanceof FileDeletedEvent
                                             ? FILE_ENTRY_DELETE_EVENT_TOPIC
                                             : FILE_ENTRY_UPDATE_EVENT_TOPIC;
             default -> throw new IllegalArgumentException("Unknown entry type: " + type);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandler.java
@@ -8,7 +8,6 @@ import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.FileEntry;
-import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
 import nva.commons.core.Environment;
@@ -21,8 +20,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class DeleteFileFromS3EventHandler extends DestinationsEventBridgeEventHandler<EventReference, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(DeleteFileFromS3EventHandler.class);
-    private static final String FILE_DELETED_MESSAGE =
-        "File with key {} has been deleted from S3 bucket for publication {}";
+    private static final String FILE_DELETED_MESSAGE = "File with key {} has been deleted from S3 bucket for " +
+                                                       "publication {}";
     private static final String PERSISTED_STORAGE_BUCKET_NAME = new Environment().readEnv(
         "NVA_PERSISTED_STORAGE_BUCKET_NAME");
     private final S3Client s3Client;
@@ -45,13 +44,11 @@ public class DeleteFileFromS3EventHandler extends DestinationsEventBridgeEventHa
                                        Context context) {
 
         var fileEntry = (FileEntry) getEvent(eventReference).getNewData();
-        if (fileEntry.getFileEvent() instanceof FileDeletedEvent) {
-            var key = fileEntry.getIdentifier().toString();
-            deleteFile(key);
-            FileEntry.queryObject(fileEntry.getFile().getIdentifier(), fileEntry.getResourceIdentifier())
-                         .hardDelete(resourceService);
-            logger.info(FILE_DELETED_MESSAGE, key, fileEntry.getResourceIdentifier());
-        }
+        var key = fileEntry.getIdentifier().toString();
+        deleteFile(key);
+        FileEntry.queryObject(fileEntry.getFile().getIdentifier(), fileEntry.getResourceIdentifier())
+            .hardDelete(resourceService);
+        logger.info(FILE_DELETED_MESSAGE, key, fileEntry.getResourceIdentifier());
 
         return null;
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandler.java
@@ -8,6 +8,8 @@ import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
+import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -24,15 +26,17 @@ public class DeleteFileFromS3EventHandler extends DestinationsEventBridgeEventHa
     private static final String PERSISTED_STORAGE_BUCKET_NAME = new Environment().readEnv(
         "NVA_PERSISTED_STORAGE_BUCKET_NAME");
     private final S3Client s3Client;
+    private final ResourceService resourceService;
 
     @JacocoGenerated
     public DeleteFileFromS3EventHandler() {
-        this(S3Driver.defaultS3Client().build());
+        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService());
     }
 
-    protected DeleteFileFromS3EventHandler(S3Client s3Client) {
+    protected DeleteFileFromS3EventHandler(S3Client s3Client, ResourceService resourceService) {
         super(EventReference.class);
         this.s3Client = s3Client;
+        this.resourceService = resourceService;
     }
 
     @Override
@@ -40,11 +44,12 @@ public class DeleteFileFromS3EventHandler extends DestinationsEventBridgeEventHa
                                        AwsEventBridgeEvent<AwsEventBridgeDetail<EventReference>> awsEventBridgeEvent,
                                        Context context) {
 
-        var event = getEvent(eventReference);
-        if (event.isDeleteEvent()) {
-            var fileEntry = (FileEntry) event.getOldData();
+        var fileEntry = (FileEntry) getEvent(eventReference).getNewData();
+        if (fileEntry.getFileEvent() instanceof FileDeletedEvent) {
             var key = fileEntry.getIdentifier().toString();
             deleteFile(key);
+            FileEntry.queryObject(fileEntry.getFile().getIdentifier(), fileEntry.getResourceIdentifier())
+                         .hardDelete(resourceService);
             logger.info(FILE_DELETED_MESSAGE, key, fileEntry.getResourceIdentifier());
         }
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/delete/DeleteFileFromS3EventHandlerTest.java
@@ -1,12 +1,13 @@
 package no.unit.nva.publication.events.handlers.delete;
 
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
-import static no.unit.nva.publication.events.bodies.DataEntryUpdateEvent.FILE_ENTRY_DELETE_EVENT_TOPIC;
+import static no.unit.nva.publication.events.bodies.DataEntryUpdateEvent.FILE_ENTRY_UPDATE_EVENT_TOPIC;
 import static no.unit.nva.publication.events.handlers.PublicationEventsConfig.EVENTS_BUCKET;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,7 +17,10 @@ import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.service.ResourcesLocalTest;
+import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.FakeS3Client;
@@ -27,34 +31,40 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
-class DeleteFileFromS3EventHandlerTest {
+class DeleteFileFromS3EventHandlerTest extends ResourcesLocalTest {
 
     private static final Context CONTEXT = new FakeContext();
     private DeleteFileFromS3EventHandler handler;
     private FakeS3Client s3Client;
+    private ResourceService resourceService;
     private ByteArrayOutputStream output;
 
     @BeforeEach
     public void setUp() {
+        super.init();
         output = new ByteArrayOutputStream();
         s3Client = new FakeS3Client();
-        handler = new DeleteFileFromS3EventHandler(s3Client);
+        resourceService = getResourceServiceBuilder().build();
+        handler = new DeleteFileFromS3EventHandler(s3Client, resourceService);
     }
 
     @Test
-    void shouldDeleteFileFromS3WhenFileEntryHasBeenDeleted() throws IOException {
+    void shouldDeleteFileFromS3AndDatabaseWhenFileEntryHasBeenDeleted() throws IOException {
         var fileEntry = FileEntry.create(randomOpenFile(), SortableIdentifier.next(),
                                          UserInstance.create(randomString(), randomUri()));
+        fileEntry.persist(resourceService);
+        fileEntry.softDelete(resourceService, new User(randomString()));
 
         var persistedStorageS3Driver = new S3Driver(s3Client,
                                                     new Environment().readEnv("NVA_PERSISTED_STORAGE_BUCKET_NAME"));
         persistedStorageS3Driver.insertEvent(UnixPath.of(fileEntry.getIdentifier().toString()), randomString());
         insertFile(fileEntry, persistedStorageS3Driver);
-        var event = createEvent(fileEntry, null);
+        var event = createEvent(fileEntry, fileEntry);
         handler.handleRequest(event, output, CONTEXT);
 
         assertThrows(NoSuchKeyException.class,
                      () -> persistedStorageS3Driver.getFile(UnixPath.of(fileEntry.getIdentifier().toString())));
+        assertTrue(fileEntry.fetch(resourceService).isEmpty());
     }
 
     @Test
@@ -79,10 +89,10 @@ class DeleteFileFromS3EventHandlerTest {
     }
 
     private InputStream createEvent(FileEntry oldImage, FileEntry newImage) throws IOException {
-        var dataEntryUpdateEvent = new DataEntryUpdateEvent(FILE_ENTRY_DELETE_EVENT_TOPIC, oldImage, newImage);
+        var dataEntryUpdateEvent = new DataEntryUpdateEvent(FILE_ENTRY_UPDATE_EVENT_TOPIC, oldImage, newImage);
         var uri = new S3Driver(s3Client, EVENTS_BUCKET).insertEvent(UnixPath.of(UUID.randomUUID().toString()),
                                                                     dataEntryUpdateEvent.toJsonString());
-        var eventReference = new EventReference(FILE_ENTRY_DELETE_EVENT_TOPIC, uri);
+        var eventReference = new EventReference(FILE_ENTRY_UPDATE_EVENT_TOPIC, uri);
         return EventBridgeEventBuilder.sampleLambdaDestinationsEvent(eventReference);
     }
 }

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
@@ -20,6 +20,7 @@ import no.unit.nva.model.associatedartifacts.CustomerRightsRetentionStrategy;
 import no.unit.nva.model.associatedartifacts.RightsRetentionStrategyConfiguration;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
+import no.unit.nva.model.associatedartifacts.file.UploadedFile;
 import no.unit.nva.model.associatedartifacts.file.UserUploadDetails;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.publication.commons.customer.Customer;
@@ -74,7 +75,7 @@ public class FileService {
         return amazonS3.initiateMultipartUpload(request);
     }
 
-    public PendingOpenFile completeMultipartUpload(SortableIdentifier resourceIdentifier,
+    public UploadedFile completeMultipartUpload(SortableIdentifier resourceIdentifier,
                                                    CompleteUploadRequestBody completeUploadRequestBody,
                                                    UserInstance userInstance) throws NotFoundException {
 
@@ -133,11 +134,10 @@ public class FileService {
         return amazonS3.getObjectMetadata(new GetObjectMetadataRequest(BUCKET_NAME, key));
     }
 
-    private PendingOpenFile constructUploadedFile(UUID identifier, ObjectMetadata metadata, UserInstance userInstance) {
-        return new PendingOpenFile(identifier, toFileName(metadata.getContentDisposition()), metadata.getContentType(),
-                                   metadata.getContentLength(), null, null, null,
-                                   getRrs(userInstance.getCustomerId()),
-                                   null, createUploadDetails(userInstance));
+    private UploadedFile constructUploadedFile(UUID identifier, ObjectMetadata metadata, UserInstance userInstance) {
+        return new UploadedFile(identifier, toFileName(metadata.getContentDisposition()), metadata.getContentType(),
+                                metadata.getContentLength(), getRrs(userInstance.getCustomerId()),
+                                createUploadDetails(userInstance));
     }
 
     private CustomerRightsRetentionStrategy getRrs(URI customerId) {

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
@@ -101,7 +101,7 @@ public class FileService {
 
             FileEntry.queryObject(fileIdentifier, resourceIdentifier)
                 .fetch(resourceService)
-                .ifPresent(resourceService::deleteFile);
+                .ifPresent(fileEntry -> fileEntry.softDelete(resourceService, userInstance.getUser()));
         }
     }
 

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/DeleteFileHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/DeleteFileHandlerTest.java
@@ -186,7 +186,7 @@ class DeleteFileHandlerTest extends ResourcesLocalTest {
             Resource.fromPublication(publication));
         when(resourceService.fetchFile(any())).thenReturn(
             Optional.of(FileEntry.create(randomOpenFile(), publication.getIdentifier(), userInstance)));
-        doThrow(new RuntimeException()).when(resourceService).deleteFile(any());
+        doThrow(new RuntimeException()).when(resourceService).updateFile(any());
         return new DeleteFileHandler(
             new FileService(mock(AmazonS3.class), mock(CustomerApiClient.class), resourceService));
     }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
@@ -363,9 +363,9 @@ class FileServiceTest extends ResourcesLocalTest {
 
     private static File constructExpectedFile(CompleteMultipartUploadResult completeMultipartUploadResult,
                                                       UserInstance userInstance, FileEntry fileEntry) {
-        return new PendingOpenFile(UUID.fromString(completeMultipartUploadResult.getKey()), FILE_NAME, CONTENT_TYPE,
-                                (long) CONTENT_LENGTH, null, null, null,
-                                   CustomerRightsRetentionStrategy.create(RIGHTS_RETENTION_STRATEGY), null,
+        return new UploadedFile(UUID.fromString(completeMultipartUploadResult.getKey()), FILE_NAME, CONTENT_TYPE,
+                                (long) CONTENT_LENGTH,
+                                CustomerRightsRetentionStrategy.create(RIGHTS_RETENTION_STRATEGY),
                                    new UserUploadDetails(new Username(userInstance.getUsername()),
                                                                              fileEntry.getFile()
                                                                                  .getUploadDetails()

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
-import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Collection;
 import java.util.List;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(PublicationLogResponse.TYPE)

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Collection;
 import java.util.List;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
-import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(PublicationLogResponse.TYPE)

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -2,7 +2,6 @@ package no.unit.nva.publication.log.service;
 
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
-import java.util.UUID;
 import no.unit.nva.clients.GetCustomerResponse;
 import no.unit.nva.clients.GetUserResponse;
 import no.unit.nva.clients.IdentityServiceClient;
@@ -34,19 +33,17 @@ public class LogEntryService {
     public void persistLogEntry(Entity entity) {
         switch (entity) {
             case Resource resource -> persistLogEntry(resource.getIdentifier());
-            case FileEntry fileEntry -> persistLogEntry(fileEntry.getFile().getIdentifier(),
-                                                        fileEntry.getResourceIdentifier());
+            case FileEntry fileEntry -> persistLogEntry(fileEntry);
             case null, default -> {
                 // Ignore
             }
         }
     }
 
-    private void persistLogEntry(UUID fileIdentifier, SortableIdentifier resourceIdentifier) {
-        FileEntry.queryObject(fileIdentifier, resourceIdentifier)
-            .fetch(resourceService)
-            .filter(FileEntry::hasFileEvent)
-            .ifPresent(this::persistFileLogEntry);
+    private void persistLogEntry(FileEntry fileEntry) {
+        if (fileEntry.hasFileEvent()) {
+            persistFileLogEntry(fileEntry);
+        }
     }
 
     private void persistLogEntry(SortableIdentifier identifier) {

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -351,7 +351,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         }
 
         public File buildUploadedFile() {
-            return new UploadedFile(identifier, name, mimeType, size, uploadDetails);
+            return new UploadedFile(identifier, name, mimeType, size, rightsRetentionStrategy, uploadDetails);
         }
 
         public File build(Class<? extends File> clazz) {

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadedFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadedFile.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.UUID;
+import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(UploadedFile.TYPE)
@@ -18,8 +19,9 @@ public class UploadedFile extends File {
                         @JsonProperty(NAME_FIELD) String name,
                         @JsonProperty(MIME_TYPE_FIELD) String mimeType,
                         @JsonProperty(SIZE_FIELD) Long size,
+                        @JsonProperty(RIGHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
                         @JsonProperty(UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails) {
-        super(identifier, name, mimeType, size, null, null, null, null, null, null, uploadDetails);
+        super(identifier, name, mimeType, size, null, null, null, rightsRetentionStrategy, null, null, uploadDetails);
     }
 
     @Override

--- a/publication-model/src/test/java/no/unit/nva/model/file/FileProvider.java
+++ b/publication-model/src/test/java/no/unit/nva/model/file/FileProvider.java
@@ -66,7 +66,7 @@ public class FileProvider implements ArgumentsProvider {
 
     private static File randomUploadedFile() {
         return new UploadedFile(UUID.randomUUID(), randomString(), randomString(), randomInteger().longValue(),
-                                randomInserted());
+                                null, randomInserted());
     }
 
     private static File randomOpenFile() {

--- a/template.yaml
+++ b/template.yaml
@@ -2132,6 +2132,7 @@ Resources:
         - !GetAtt EventsLambdaManagedPolicy.PolicyArn
         - !GetAtt S3AccessManagedPolicy.PolicyArn
         - !GetAtt S3DeleteAccessManagedPolicy.PolicyArn
+        - !GetAtt DatabaseAccessLambdaManagedPolicy.PolicyArn
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule

--- a/template.yaml
+++ b/template.yaml
@@ -1814,7 +1814,7 @@ Resources:
             Pattern:
               detail:
                 responsePayload:
-                  topic: [ "PublicationService.Resource.Update", "PublicationService.FileEntry.Update" ]
+                  topic: [ "PublicationService.Resource.Update", "PublicationService.FileEntry.Update", "PublicationService.FileEntry.Delete" ]
 
   EventBasedBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy
@@ -2126,6 +2126,7 @@ Resources:
         Variables:
           EVENTS_BUCKET: !Ref NvaEventsBucketsName
           EVENT_BUS_NAME: !GetAtt InternalBus.Name
+          TABLE_NAME: !Ref NvaResourcesTable
           NVA_PERSISTED_STORAGE_BUCKET_NAME: !Ref ResourceStorageBucketName
       Policies:
         - !GetAtt EventsLambdaManagedPolicy.PolicyArn

--- a/template.yaml
+++ b/template.yaml
@@ -1814,7 +1814,7 @@ Resources:
             Pattern:
               detail:
                 responsePayload:
-                  topic: [ "PublicationService.Resource.Update" ]
+                  topic: [ "PublicationService.Resource.Update", "PublicationService.FileEntry.Update" ]
 
   EventBasedBatchScanHandlerTest:
     DependsOn: EventsLambdaManagedPolicy


### PR DESCRIPTION
Persisting Log entries for file for following events:

- File uploaded
- File approved
- File rejected

Using the same pattern as on for resource, we persist FileEvent on file updates which is consumed by PersistLogEntryEventHandler.


Next step will be to create log event on relevant file type update + when file is being deleted. But there is some cases we need to discuss before implementing. 