### PR TITLE
adding responsibility area to use under expansion

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -96,8 +96,8 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public ExpandedOrganization getOrganization(Entity dataEntry) throws NotFoundException {
         if (dataEntry instanceof TicketEntry ticketEntry) {
 
-            var organizationId = Objects.nonNull(ticketEntry.getOwnerAffiliation())
-                                      ? ticketEntry.getOwnerAffiliation()
+            var organizationId = Objects.nonNull(ticketEntry.getResponsibilityArea())
+                                      ? ticketEntry.getResponsibilityArea()
                                       : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                           .getResourceOwner().getOwnerAffiliation();
 

--- a/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/ResourceExpansionServiceImpl.java
@@ -1,11 +1,11 @@
 package no.unit.nva.expansion;
 
+import static java.util.Objects.nonNull;
 import static no.unit.nva.expansion.ExpansionConfig.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
-import java.util.Objects;
 import java.util.Optional;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.expansion.model.ExpandedDataEntry;
@@ -96,7 +96,7 @@ public class ResourceExpansionServiceImpl implements ResourceExpansionService {
     public ExpandedOrganization getOrganization(Entity dataEntry) throws NotFoundException {
         if (dataEntry instanceof TicketEntry ticketEntry) {
 
-            var organizationId = Objects.nonNull(ticketEntry.getResponsibilityArea())
+            var organizationId = nonNull(ticketEntry.getResponsibilityArea())
                                       ? ticketEntry.getResponsibilityArea()
                                       : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                           .getResourceOwner().getOwnerAffiliation();

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -119,6 +119,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
     private static final String FINALIZED_BY = "finalizedBy";
     public static final String APPROVED_FILES = "approvedFiles";
     public static final String FILES_FOR_APPROVAL = "filesForApproval";
+    public static final String RESPONSIBILITY_AREA = "responsibilityArea";
 
     private ResourceExpansionService expansionService;
     private ResourceService resourceService;
@@ -142,15 +143,15 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldReturnExpandedTicketContainingTheOrganizationOfTheOwnersAffiliationAsIs(
+    void shouldReturnExpandedTicketContainingTheOrganizationOfTheOwnersResponsibilityAreAsIs(
         Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
-        ticket.setOwnerAffiliation(randomUri());
+        ticket.setResponsibilityArea(PublicationGenerator.randomUri());
         FakeUriResponse.setupFakeForType(ticket, fakeUriRetriever);
         var expandedTicket = (ExpandedTicket) expansionService.expandEntry(ticket, false);
-        assertThat(expandedTicket.getOrganization().id(), is(equalTo(ticket.getOwnerAffiliation())));
+        assertThat(expandedTicket.getOrganization().id(), is(equalTo(ticket.getResponsibilityArea())));
     }
 
     @ParameterizedTest
@@ -162,6 +163,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
+        ticket.setResponsibilityArea(PublicationGenerator.randomUri());
         ticket.setFinalizedBy(new Username(randomString()));
         FakeUriResponse.setupFakeForType(ticket, fakeUriRetriever);
 
@@ -188,7 +190,8 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         assertThat(ticket,
                    doesNotHaveEmptyValuesIgnoringFields(Set.of(WORKFLOW, ASSIGNEE, FINALIZED_BY,
                                                                FINALIZED_DATE, OWNERAFFILIATION, APPROVED_FILES,
-                                                               FILES_FOR_APPROVAL)));
+                                                               FILES_FOR_APPROVAL,
+                                                               RESPONSIBILITY_AREA)));
         var expectedPublicationId = constructExpectedPublicationId(publication);
         assertThat(expandedTicket.getPublication().getPublicationId(), is(equalTo(expectedPublicationId)));
     }
@@ -360,10 +363,10 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);
 
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
-        ticket.setOwnerAffiliation(randomUri());
+        ticket.setResponsibilityArea(PublicationGenerator.randomUri());
         FakeUriResponse.setupFakeForType(ticket, fakeUriRetriever);
 
-        var expectedOrgId = ticket.getOwnerAffiliation();
+        var expectedOrgId = ticket.getResponsibilityArea();
         var actualAffiliation  = expansionService.getOrganization(ticket).id();
         assertThat(actualAffiliation, is(equalTo(expectedOrgId)));
     }

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -143,7 +143,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
 
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
-    void shouldReturnExpandedTicketContainingTheOrganizationOfTheOwnersResponsibilityAreAsIs(
+    void shouldReturnExpandedTicketContainingTheOrganizationOfTheOwnersResponsibilityAreaAsIs(
         Class<? extends TicketEntry> ticketType, PublicationStatus status) throws Exception {
         var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
         FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -60,6 +60,8 @@ public abstract class TicketEntry implements Entity {
     private Username finalizedBy;
     @JsonProperty(FINALIZED_DATE)
     private Instant finalizedDate;
+    @JsonProperty("responsibilityArea")
+    private URI responsibilityArea;
 
     protected TicketEntry() {
         viewedBy = ViewedBy.empty();
@@ -236,6 +238,19 @@ public abstract class TicketEntry implements Entity {
     public TicketEntry withOwner(String username) {
         this.owner = new User(username);
         return this;
+    }
+
+    public URI getResponsibilityArea() {
+        return responsibilityArea;
+    }
+
+    public TicketEntry withOwnerResponsibilityArea(URI responsibilityArea) {
+        this.setResponsibilityArea(responsibilityArea);
+        return this;
+    }
+
+    public void setResponsibilityArea(URI responsibilityArea) {
+        this.responsibilityArea = responsibilityArea;
     }
 
     private void validateTicketOwner(UserInstance userInstance) throws UnauthorizedException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
@@ -26,6 +26,7 @@ public record RequestUtils(List<AccessRight> accessRights,
                            URI topLevelCristinOrgId,
                            String username,
                            URI personCristinId,
+                           URI personAffiliation,
                            Map<String, String> pathParameters) {
 
     public static final String PUBLICATION_IDENTIFIER = "publicationIdentifier";
@@ -39,6 +40,7 @@ public record RequestUtils(List<AccessRight> accessRights,
                                 requestInfo.getTopLevelOrgCristinId().orElse(null),
                                 requestInfo.getUserName(),
                                 requestInfo.getPersonCristinId(),
+                                attempt(requestInfo::getPersonAffiliation).toOptional().orElse(null),
                                 requestInfo.getPathParameters());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/DaoTest.java
@@ -93,7 +93,10 @@ class DaoTest extends ResourcesLocalTest {
     public static final String RESOURCE_REVISION = "resource.entityDescription.reference.publicationContext.revision";
     public static final String RESOURCE_FILES = ".resource.files";
     private static final String DATA_FILES = ".data.files";
-    public static final Set<String> IGNORED_FIELDS = Set.of(DATA_OWNER_AFFILIATION, DATA_ASSIGNEE,
+    private static final String DATA_RESPONSIBILITY_AREA = "data.responsibilityArea";
+    public static final Set<String> IGNORED_FIELDS = Set.of(DATA_OWNER_AFFILIATION,
+                                                            DATA_RESPONSIBILITY_AREA,
+                                                            DATA_ASSIGNEE,
                                                             DATA_FINALIZED_BY,
                                                             DATA_FINALIZED_DATE, DATA_IMPORT_STATUS,
                                                             RESOURCE_IMPORT_STATUS, RESOURCE_REVISION,

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -178,6 +178,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     private static final String ASSIGNEE = "assignee";
     private static final String FINALIZED_BY = "finalizedBy";
     private static final String OWNER_AFFILIATION = "ownerAffiliation";
+    private static final String RESPONSIBILITY_AREA = "responsibilityArea";
     private ResourceService resourceService;
 
     private TicketService ticketService;
@@ -733,10 +734,12 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
         assertThat(updatedDoiRequest, doesNotHaveEmptyValuesIgnoringFields(Set.of(OWNER_AFFILIATION, ASSIGNEE,
                                                                                   FINALIZED_BY,
-                                                                                  FINALIZED_DATE)));
+                                                                                  FINALIZED_DATE,
+                                                                                  RESPONSIBILITY_AREA)));
         assertThat(expectedDoiRequest, doesNotHaveEmptyValuesIgnoringFields(Set.of(OWNER_AFFILIATION, ASSIGNEE,
                                                                                    FINALIZED_BY,
-                                                                                   FINALIZED_DATE)));
+                                                                                   FINALIZED_DATE,
+                                                                                   RESPONSIBILITY_AREA)));
         Diff diff = JAVERS.compare(updatedDoiRequest, expectedDoiRequest);
         assertThat(diff.prettyPrint(), updatedDoiRequest, is(equalTo(expectedDoiRequest)));
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -118,6 +118,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
     private static final String DOI = "doi";
     public static final String APPROVED_FILES = "approvedFiles";
     public static final String FILES_FOR_APPROVAL = "filesForApproval";
+    private static final String RESPONSIBILITY_AREA = "responsibilityArea";
     private ResourceService resourceService;
     private TicketService ticketService;
     private UserInstance owner;
@@ -153,7 +154,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
         assertThat(persistedTicket, is(equalTo(ticket)));
         assertThat(persistedTicket,
                    doesNotHaveEmptyValuesIgnoringFields(Set.of(ONWER_AFFILIATION, DOI, ASSIGNEE, FINALIZED_BY,
-                                                               FINALIZED_DATE)));
+                                                               FINALIZED_DATE, RESPONSIBILITY_AREA)));
     }
 
     @ParameterizedTest(name = "Publication status: {0}")
@@ -184,7 +185,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
         assertThat(persistedTicket, is(equalTo(ticket)));
         assertThat(persistedTicket,
                    doesNotHaveEmptyValuesIgnoringFields(Set.of(ONWER_AFFILIATION, ASSIGNEE, FINALIZED_BY,
-                                                               FINALIZED_DATE, APPROVED_FILES, FILES_FOR_APPROVAL)));
+                                                               FINALIZED_DATE, APPROVED_FILES, FILES_FOR_APPROVAL, RESPONSIBILITY_AREA)));
     }
 
     @Test
@@ -197,7 +198,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
         assertThat(persistedTicket, is(equalTo(ticket)));
         assertThat(persistedTicket,
                    doesNotHaveEmptyValuesIgnoringFields(Set.of(ONWER_AFFILIATION, ASSIGNEE, FINALIZED_BY,
-                                                               FINALIZED_DATE)));
+                                                               FINALIZED_DATE, RESPONSIBILITY_AREA)));
     }
 
     @Test
@@ -960,7 +961,8 @@ public class TicketServiceTest extends ResourcesLocalTest {
         var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createNewTicket(publication, PublishingRequestCase.class,
                                                                                               SortableIdentifier::next)
                                                             .withOwner(UserInstance.fromPublication(publication).getUsername())
-                                                            .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation());
+                                                            .withOwnerAffiliation(publication.getResourceOwner().getOwnerAffiliation())
+                                                            .withOwnerResponsibilityArea(randomUri());
         publishingRequest.withFilesForApproval(TicketTestUtils.getFilesForApproval(publication));
         return publishingRequest.persistNewTicket(ticketService);
     }

--- a/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriResponse.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriResponse.java
@@ -82,9 +82,9 @@ public final class FakeUriResponse {
     }
 
     public static void setupFakeForType(TicketEntry ticket, FakeUriRetriever fakeUriRetriever) {
-        var ownerAffiliation = ticket.getOwnerAffiliation();
-        fakeUriRetriever.registerResponse(ownerAffiliation, SC_OK, APPLICATION_JSON_LD,
-                                          createCristinOrganizationResponse(ownerAffiliation));
+        var responsibilityArea = ticket.getResponsibilityArea();
+        fakeUriRetriever.registerResponse(responsibilityArea, SC_OK, APPLICATION_JSON_LD,
+                                          createCristinOrganizationResponse(responsibilityArea));
         fakeUriRetriever.registerResponse(ticket.getCustomerId(), SC_OK, APPLICATION_JSON_LD,
                                           createCristinOrganizationResponse(ticket.getCustomerId()));
         setUpPersonResponse(fakeUriRetriever, ticket.getOwner());

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -70,6 +70,7 @@ public class TicketResolver {
 
         var ticket = TicketEntry.requestNewTicket(publication, ticketDto.ticketType())
                          .withOwnerAffiliation(requestUtils.topLevelCristinOrgId())
+                         .withOwnerResponsibilityArea(requestUtils.personAffiliation())
                          .withOwner(requestUtils.username());
         if (ticket instanceof PublishingRequestCase publishingRequest) {
             var customerId = requestUtils.customerId();


### PR DESCRIPTION
This solves problem with tickets organization / search by affiliation, so organization is being set as:

```
 "organization": {
                "id": "https://api.sandbox.nva.aws.unit.no/cristin/organization/20754.2.0.0",
                "identifier": "20754.2.0.0",
                "partOf": [
                    {
                        "id": "https://api.sandbox.nva.aws.unit.no/cristin/organization/20754.0.0.0",
                        "identifier": "20754.0.0.0"
                    }
                ]
            }
```

Not sure if **responsibilityArea** is a good name, but it is the affiliation of user, but this field is already taken by **personAffiliation** field.