### PR TITLE
Np 48474 supporting external clients on file upload

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2542,7 +2542,7 @@ components:
         type:
           type: string
           enum:
-            - InternalCompleteUpload
+            - ExternalCompleteUpload
         uploadId:
           type: string
           description: S3 Identifier upload

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2536,7 +2536,7 @@ components:
         - key
         - parts
     ExternalCompleteUploadRequestBody:
-      description: Request body containing the details of the file to be uploaded for external use
+      description: Request body containing the details of the file and file to be uploaded for external use
       type: object
       properties:
         type:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -933,7 +933,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CompleteUploadRequestBody'
+              oneOf:
+                - $ref: '#/components/schemas/InternalCompleteUploadRequestBody'
+                - $ref: '#/components/schemas/ExternalCompleteUploadRequestBody'
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CompleteUploadFunction.Arn}/invocations
@@ -2499,10 +2501,14 @@ components:
           type: string
           description: Key to reference uploaded resource in S3 (UUID)
           example: f335ab02-35b3-4fda-9204-cd999e166ce0
-    CompleteUploadRequestBody:
-      description: Request body containg the details of the file to be uploaded
+    InternalCompleteUploadRequestBody:
+      description: Request body containing the details of the file to be uploaded for internal use
       type: object
       properties:
+        type:
+          type: string
+          enum:
+            - InternalCompleteUpload
         uploadId:
           type: string
           description: S3 Identifier upload
@@ -2529,6 +2535,57 @@ components:
         - uploadId
         - key
         - parts
+    ExternalCompleteUploadRequestBody:
+      description: Request body containing the details of the file to be uploaded for external use
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - InternalCompleteUpload
+        uploadId:
+          type: string
+          description: S3 Identifier upload
+          example: 543534gfdgdsgerFEDSGF4438rhgdg.FEfefgnijwefew8234234nfsdfweFESEGGL_MFAWRMFiewfnvsdo234950SDFM_FESAFn384234fsdDSAFNEUFAS.g8SDFNWEUFbf--
+        key:
+          type: string
+          description: Identifier (UUID) of the uploaded file, object key in the S3 bucket
+          example: f335ab02-35b3-4fda-9204-cd999e166ce0
+        parts:
+          type: array
+          description: List of part numbers and ETags that identify the individual parts of the upload
+          items:
+            type: object
+            properties:
+              ETag:
+                type: string
+                description: eTag of the uploaded part
+                example: f335ab02-35b3-4fda-9204-cd999e166ce0
+              PartNumber:
+                type: integer
+                description: The index of this part in the upload
+                example: 1
+        fileType:
+          type: string
+          enum:
+            - OpenFile
+            - InternalFile
+        license:
+          type: string
+          format: uri
+        publisherVersion:
+          type: string
+          enum:
+            - PublishedVersion
+            - AcceptedVersion
+        embargoDate:
+          type: string
+          format: date-time
+      required:
+        - uploadId
+        - key
+        - parts
+        - fileType
     CustomerRightsRetentionStrategy:
       required:
         - type

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/CompleteUploadHandler.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/CompleteUploadHandler.java
@@ -4,14 +4,14 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.publication.RequestUtil;
-import no.unit.nva.publication.file.upload.restmodel.CompleteUploadRequestBody;
+import no.unit.nva.publication.file.upload.restmodel.CompleteUploadRequest;
 import no.unit.nva.publication.model.business.UserInstance;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.JacocoGenerated;
 
-public class CompleteUploadHandler extends ApiGatewayHandler<CompleteUploadRequestBody, File> {
+public class CompleteUploadHandler extends ApiGatewayHandler<CompleteUploadRequest, File> {
 
     private final FileService fileService;
 
@@ -21,18 +21,18 @@ public class CompleteUploadHandler extends ApiGatewayHandler<CompleteUploadReque
     }
 
     public CompleteUploadHandler(FileService fileService) {
-        super(CompleteUploadRequestBody.class);
+        super(CompleteUploadRequest.class);
         this.fileService = fileService;
     }
 
     @Override
-    protected void validateRequest(CompleteUploadRequestBody completeUploadRequestBody, RequestInfo requestInfo,
+    protected void validateRequest(CompleteUploadRequest completeUploadRequestBody, RequestInfo requestInfo,
                                    Context context) throws ApiGatewayException {
         completeUploadRequestBody.validate();
     }
 
     @Override
-    protected File processInput(CompleteUploadRequestBody input, RequestInfo requestInfo,
+    protected File processInput(CompleteUploadRequest input, RequestInfo requestInfo,
                                 Context context) throws ApiGatewayException {
 
         var resourceIdentifier = RequestUtil.getIdentifier(requestInfo);
@@ -42,7 +42,7 @@ public class CompleteUploadHandler extends ApiGatewayHandler<CompleteUploadReque
     }
 
     @Override
-    protected Integer getSuccessStatusCode(CompleteUploadRequestBody input, File output) {
+    protected Integer getSuccessStatusCode(CompleteUploadRequest input, File output) {
         return HTTP_OK;
     }
 }

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
@@ -90,12 +90,9 @@ public class FileService {
         var s3ObjectKey = completeMultipartUploadResult.getKey();
         var objectMetadata = getObjectMetadata(s3ObjectKey);
 
-        File file;
-        if (userInstance.isExternalClient() && request instanceof ExternalCompleteUploadRequest externalRequest) {
-            file = constructFileForExternalClient(UUID.fromString(s3ObjectKey), externalRequest, objectMetadata);
-        } else {
-            file = constructUploadedFile(UUID.fromString(s3ObjectKey), objectMetadata, userInstance);
-        }
+        var file = userInstance.isExternalClient() && request instanceof ExternalCompleteUploadRequest externalRequest
+                       ? constructFileForExternalClient(UUID.fromString(s3ObjectKey), externalRequest, objectMetadata)
+                       : constructUploadedFile(UUID.fromString(s3ObjectKey), objectMetadata, userInstance);
         FileEntry.create(file, resource.getIdentifier(), userInstance).persist(resourceService);
         return file;
     }

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequest.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequest.java
@@ -1,0 +1,11 @@
+package no.unit.nva.publication.file.upload.restmodel;
+
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import nva.commons.apigateway.exceptions.BadRequestException;
+
+public interface CompleteUploadRequest {
+
+    CompleteMultipartUploadRequest toCompleteMultipartUploadRequest(String bucketName);
+
+    void validate() throws BadRequestException;
+}

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequest.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequest.java
@@ -1,8 +1,14 @@
 package no.unit.nva.publication.file.upload.restmodel;
 
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import nva.commons.apigateway.exceptions.BadRequestException;
 
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(name = InternalCompleteUploadRequest.TYPE, value = InternalCompleteUploadRequest.class),
+    @JsonSubTypes.Type(name = ExternalCompleteUploadRequest.TYPE, value = ExternalCompleteUploadRequest.class)})
 public interface CompleteUploadRequest {
 
     CompleteMultipartUploadRequest toCompleteMultipartUploadRequest(String bucketName);

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/ExternalCompleteUploadRequest.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/ExternalCompleteUploadRequest.java
@@ -6,21 +6,16 @@ import com.amazonaws.services.s3.model.PartETag;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
-import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
-import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
-import no.unit.nva.model.associatedartifacts.file.UploadDetails;
-import no.unit.nva.model.time.Instant;
 import nva.commons.apigateway.exceptions.BadRequestException;
 
 @JsonTypeName(ExternalCompleteUploadRequest.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record ExternalCompleteUploadRequest(String uploadId, String key, List<CompleteUploadPart> parts,
-                                            String fileType, String name,
-                                            String mimeType, Long size, URI license, PublisherVersion publisherVersion,
-                                            Instant embargoDate, UploadDetails uploadDetails,
-                                            RightsRetentionStrategy rightsRetentionStrategy)
+                                            String fileType, URI license,
+                                            PublisherVersion publisherVersion, Instant embargoDate)
     implements CompleteUploadRequest {
 
     public static final String TYPE = "ExternalCompleteUpload";
@@ -40,10 +35,6 @@ public record ExternalCompleteUploadRequest(String uploadId, String key, List<Co
         } catch (Exception e) {
             throw new BadRequestException("Invalid input");
         }
-    }
-
-    public File toFile() {
-        return null;
     }
 
     private List<PartETag> partETags() {

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/ExternalCompleteUploadRequest.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/ExternalCompleteUploadRequest.java
@@ -1,0 +1,52 @@
+package no.unit.nva.publication.file.upload.restmodel;
+
+import static java.util.Objects.requireNonNull;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.PartETag;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.net.URI;
+import java.util.List;
+import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
+import no.unit.nva.model.associatedartifacts.file.File;
+import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
+import no.unit.nva.model.associatedartifacts.file.UploadDetails;
+import no.unit.nva.model.time.Instant;
+import nva.commons.apigateway.exceptions.BadRequestException;
+
+@JsonTypeName(ExternalCompleteUploadRequest.TYPE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record ExternalCompleteUploadRequest(String uploadId, String key, List<CompleteUploadPart> parts,
+                                            String fileType, String name,
+                                            String mimeType, Long size, URI license, PublisherVersion publisherVersion,
+                                            Instant embargoDate, UploadDetails uploadDetails,
+                                            RightsRetentionStrategy rightsRetentionStrategy)
+    implements CompleteUploadRequest {
+
+    public static final String TYPE = "ExternalCompleteUpload";
+
+    public CompleteMultipartUploadRequest toCompleteMultipartUploadRequest(String bucketName) {
+        return new CompleteMultipartUploadRequest().withBucketName(bucketName)
+                   .withKey(key())
+                   .withUploadId(uploadId())
+                   .withPartETags(partETags());
+    }
+
+    public void validate() throws BadRequestException {
+        try {
+            requireNonNull(this.uploadId());
+            requireNonNull(this.key());
+            requireNonNull(this.parts());
+        } catch (Exception e) {
+            throw new BadRequestException("Invalid input");
+        }
+    }
+
+    public File toFile() {
+        return null;
+    }
+
+    private List<PartETag> partETags() {
+        return parts().stream().filter(CompleteUploadPart::hasValue).map(CompleteUploadPart::toPartETag).toList();
+    }
+}

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/InternalCompleteUploadRequest.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/InternalCompleteUploadRequest.java
@@ -3,18 +3,20 @@ package no.unit.nva.publication.file.upload.restmodel;
 import static java.util.Objects.requireNonNull;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.PartETag;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
 import nva.commons.apigateway.exceptions.BadRequestException;
 
-public record CompleteUploadRequestBody(String uploadId, String key, List<CompleteUploadPart> parts) {
+@JsonTypeName(InternalCompleteUploadRequest.TYPE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record InternalCompleteUploadRequest(String uploadId, String key, List<CompleteUploadPart> parts)
+    implements CompleteUploadRequest {
 
-    public List<PartETag> partETags() {
-        return parts().stream().filter(CompleteUploadPart::hasValue).map(CompleteUploadPart::toPartETag).toList();
-    }
+    public static final String TYPE = "InternalCompleteUpload";
 
     public CompleteMultipartUploadRequest toCompleteMultipartUploadRequest(String bucketName) {
-        return new CompleteMultipartUploadRequest()
-                   .withBucketName(bucketName)
+        return new CompleteMultipartUploadRequest().withBucketName(bucketName)
                    .withKey(key())
                    .withUploadId(uploadId())
                    .withPartETags(partETags());
@@ -28,5 +30,9 @@ public record CompleteUploadRequestBody(String uploadId, String key, List<Comple
         } catch (Exception e) {
             throw new BadRequestException("Invalid input");
         }
+    }
+
+    private List<PartETag> partETags() {
+        return parts().stream().filter(CompleteUploadPart::hasValue).map(CompleteUploadPart::toPartETag).toList();
     }
 }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CompleteUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CompleteUploadHandlerTest.java
@@ -36,7 +36,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.associatedartifacts.file.UploadedFile;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.file.upload.restmodel.CompleteUploadPart;
-import no.unit.nva.publication.file.upload.restmodel.CompleteUploadRequestBody;
+import no.unit.nva.publication.file.upload.restmodel.InternalCompleteUploadRequest;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.ResourcesLocalTest;
@@ -124,7 +124,7 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
     void canCreateRequestWithEmptyElement() throws IOException {
         var stream = inputStreamFromResources(COMPLETE_UPLOAD_REQUEST_WITH_EMPTY_ELEMENT_JSON);
         var completeUploadRequestBody = dtoObjectMapper.readValue(
-            new InputStreamReader(stream), CompleteUploadRequestBody.class);
+            new InputStreamReader(stream), InternalCompleteUploadRequest.class);
 
         var completeMultipartUploadRequest =
             completeUploadRequestBody.toCompleteMultipartUploadRequest(randomString());
@@ -139,7 +139,7 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
     void canCreateRequestWithOnePart() throws IOException {
         var stream = inputStreamFromResources(COMPLETE_UPLOAD_REQUEST_WITH_ONE_PART_JSON);
         var completeUploadRequestBody = dtoObjectMapper.readValue(
-            new InputStreamReader(stream), CompleteUploadRequestBody.class);
+            new InputStreamReader(stream), InternalCompleteUploadRequest.class);
 
         assertThat(completeUploadRequestBody, is(notNullValue()));
         assertThat(completeUploadRequestBody.parts(), is(notNullValue()));
@@ -167,7 +167,7 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
     }
 
     private InputStream request(SortableIdentifier identifier, UserInstance userInstance) throws JsonProcessingException {
-        return new HandlerRequestBuilder<CompleteUploadRequestBody>(dtoObjectMapper)
+        return new HandlerRequestBuilder<InternalCompleteUploadRequest>(dtoObjectMapper)
                    .withBody(completeUploadRequestBody())
                    .withPathParameters(Map.of("publicationIdentifier", identifier.toString()))
                    .withUserName(userInstance.getUsername())
@@ -182,9 +182,9 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
                    .build();
     }
 
-    private CompleteUploadRequestBody completeUploadRequestBody() {
+    private InternalCompleteUploadRequest completeUploadRequestBody() {
         var partEtags = new ArrayList<CompleteUploadPart>();
         partEtags.add(new CompleteUploadPart(1, "eTag1"));
-        return new CompleteUploadRequestBody(SAMPLE_UPLOAD_ID, SAMPLE_KEY, partEtags);
+        return new InternalCompleteUploadRequest(SAMPLE_UPLOAD_ID, SAMPLE_KEY, partEtags);
     }
 }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CompleteUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CompleteUploadHandlerTest.java
@@ -36,6 +36,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.associatedartifacts.file.UploadedFile;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.file.upload.restmodel.CompleteUploadPart;
+import no.unit.nva.publication.file.upload.restmodel.CompleteUploadRequest;
+import no.unit.nva.publication.file.upload.restmodel.ExternalCompleteUploadRequest;
 import no.unit.nva.publication.file.upload.restmodel.InternalCompleteUploadRequest;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -96,8 +98,16 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void completeUploadWithInvalidInputReturnsBadRequest() throws IOException {
-        handler.handleRequest(completeUploadRequestWithoutBody(), outputStream, context);
+    void completeUploadWithInvalidInputReturnsBadRequestWhenInternalClient() throws IOException {
+        handler.handleRequest(completeInternalUploadRequestWithoutBody(), outputStream, context);
+        var response = GatewayResponse.fromOutputStream(outputStream, Problem.class);
+
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_BAD_REQUEST)));
+    }
+
+    @Test
+    void completeUploadWithInvalidInputReturnsBadRequestWhenExternalClient() throws IOException {
+        handler.handleRequest(completeExternalUploadRequestWithoutBody(), outputStream, context);
         var response = GatewayResponse.fromOutputStream(outputStream, Problem.class);
 
         assertThat(response.getStatusCode(), is(equalTo(HTTP_BAD_REQUEST)));
@@ -176,9 +186,15 @@ public class CompleteUploadHandlerTest extends ResourcesLocalTest {
                    .build();
     }
 
-    private InputStream completeUploadRequestWithoutBody() throws JsonProcessingException {
-        return new HandlerRequestBuilder<CompleteMultipartUploadRequest>(dtoObjectMapper)
-                   .withBody(new CompleteMultipartUploadRequest(null, null, null, null))
+    private InputStream completeExternalUploadRequestWithoutBody() throws JsonProcessingException {
+        return new HandlerRequestBuilder<CompleteUploadRequest>(dtoObjectMapper)
+                   .withBody(new ExternalCompleteUploadRequest(null, null, null, null, null, null, null))
+                   .build();
+    }
+
+    private InputStream completeInternalUploadRequestWithoutBody() throws JsonProcessingException {
+        return new HandlerRequestBuilder<CompleteUploadRequest>(dtoObjectMapper)
+                   .withBody(new InternalCompleteUploadRequest(null, null, null))
                    .build();
     }
 

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
@@ -380,6 +380,10 @@ class FileServiceTest extends ResourcesLocalTest {
         var fileEntry = FileEntry.queryObject(UUID.fromString(completeMultipartUploadResult.getKey()),
                                               resource.getIdentifier()).fetch(resourceService).orElseThrow();
 
+
+        assertEquals(request.license(), fileEntry.getFile().getLicense());
+        assertEquals(request.publisherVersion(), fileEntry.getFile().getPublisherVersion());
+        assertEquals(request.embargoDate(), fileEntry.getFile().getEmbargoDate().orElse(null));
         assertInstanceOf(expectedFileClass, fileEntry.getFile());
     }
 

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/FileServiceTest.java
@@ -41,7 +41,7 @@ import no.unit.nva.model.associatedartifacts.file.UserUploadDetails;
 import no.unit.nva.publication.commons.customer.Customer;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.commons.customer.CustomerApiRightsRetention;
-import no.unit.nva.publication.file.upload.restmodel.CompleteUploadRequestBody;
+import no.unit.nva.publication.file.upload.restmodel.InternalCompleteUploadRequest;
 import no.unit.nva.publication.file.upload.restmodel.CreateUploadRequestBody;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.Resource;
@@ -331,7 +331,7 @@ class FileServiceTest extends ResourcesLocalTest {
         var publication = randomPublication();
         var userInstance = UserInstance.fromPublication(publication);
         mockCompleteMultipartUpload();
-        var request = new CompleteUploadRequestBody(randomString(), randomString(), List.of());
+        var request = new InternalCompleteUploadRequest(randomString(), randomString(), List.of());
 
         assertThrows(NotFoundException.class,
                      () -> fileService.completeMultipartUpload(publication.getIdentifier(), request, userInstance));
@@ -343,7 +343,7 @@ class FileServiceTest extends ResourcesLocalTest {
         var userInstance = UserInstance.fromPublication(publication);
         var resource = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
         var completeMultipartUploadResult = mockCompleteMultipartUpload();
-        var request = new CompleteUploadRequestBody(randomString(), randomString(), List.of());
+        var request = new InternalCompleteUploadRequest(randomString(), randomString(), List.of());
 
         mockCustomerResponse(userInstance);
         fileService.completeMultipartUpload(resource.getIdentifier(), request, userInstance);

--- a/publication-file/src/test/resources/CompleteRequestWithEmptyElement.json
+++ b/publication-file/src/test/resources/CompleteRequestWithEmptyElement.json
@@ -1,4 +1,5 @@
 {
+  "type": "InternalCompleteUpload",
   "uploadId": "bCIstagBM6h_JMX5KHo1fvSLOsKUyi9pjj0uMQ0lo8iyveg1KqoSHt8CBemxNad8KrmnVyxGXoitmHFhei8g2lh7zM4WddxKkSHgGTaIaK2IrN2F20R3pciGzHG6sgQHE644r._WZWFUbYi48Bulu9BpPQTQbxfFwuM_55O31hvxShj6AHuyQBdaIXi7ejbZsmRD.t6LuTsINp8zJIY37A--",
   "key": "528d5577-40f9-4366-8f5a-0dc8afac07cd",
   "parts": [

--- a/publication-file/src/test/resources/CompleteRequestWithOnePart.json
+++ b/publication-file/src/test/resources/CompleteRequestWithOnePart.json
@@ -1,4 +1,5 @@
 {
+  "type": "InternalCompleteUpload",
   "uploadId": "vfe9UrztPYnOlaVdR3hWM63EA9iVjBu3dfP8F8O2BDtSecLcKCAvdzn5duXIi9QvxuqDACQfn2K0MH66_Kxbdnb0..7z8wy3Sn5YFH.M2qagC_zvyaW5qIO8mpbxzYLSB0_F_.4kVvXe8qFs0yTF9.tioCgYe8d65lAqVTyRILpRBLYdx4RjYVSZ1rk4SNFp61juOLTW9Yx9w0G.hg.ISw--",
   "key": "f5e86f14-aa7c-4a44-b0c7-3b297cfd6ada",
   "parts": [


### PR DESCRIPTION
Adding support for external client on file upload:

- Differentiating between external and internal request by request body.
- Request body must be of type`InternalCompleteUpload` or `ExternalCompleteUpload`.
- Supporting upload of OpenFile and InternalFile only when external client.

Not sure what RRS and upload details to set when consuming external file, these two fields are not implemented. 