### PR TITLE
crafting log messages for migrated files

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -15,7 +15,10 @@ import java.util.UUID;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.file.File;
+import no.unit.nva.model.associatedartifacts.file.InternalFile;
+import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
+import no.unit.nva.model.associatedartifacts.file.UploadDetails;
 import no.unit.nva.publication.model.business.publicationstate.FileApprovedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileEvent;
@@ -25,6 +28,7 @@ import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.FileDao;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.JacocoGenerated;
+import org.apache.thrift.Option;
 
 @JsonTypeName(FileEntry.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -249,6 +253,30 @@ public final class FileEntry implements Entity {
     public void clearResourceEvent(ResourceService resourceService) {
         this.setFileEvent(null);
         resourceService.updateFile(this);
+    }
+
+    public void migrate(ResourceService resourceService, Resource resource) {
+        var now = Instant.now();
+        this.modifiedDate = now;
+        this.setFileEvent(createFileEventWhenMigratingFile(resource));
+        resourceService.persistFile(this);
+    }
+
+    private FileEvent createFileEventWhenMigratingFile(Resource resource) {
+        if (file instanceof OpenFile || file instanceof InternalFile) {
+            var timeStamp = file.getPublishedDate()
+                           .or(() -> Optional.ofNullable(resource.getPublishedDate()))
+                           .or(() -> Optional.ofNullable(resource.getCreatedDate()))
+                           .orElseGet(Instant::now);
+            return FileApprovedEvent.create(getOwner(), timeStamp);
+        } else {
+            var timeStamp = Optional.ofNullable(file)
+                                .map(File::getUploadDetails)
+                                .map(UploadDetails::uploadedDate)
+                                .or(() -> Optional.ofNullable(resource.getCreatedDate()))
+                                .orElseGet(Instant::now);
+            return FileUploadedEvent.create(getOwner(), timeStamp);
+        }
     }
 
     private void setFileEvent(FileEvent fileEvent) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -400,7 +400,7 @@ public class ResourceService extends ServiceWithTransactions {
             var existingFile = FileEntry.queryObject(file.getIdentifier(), resourceIdentifier)
                                    .fetch(this);
             if (existingFile.isEmpty()) {
-                FileEntry.create(file, resourceIdentifier, userInstance).persist(this);
+                FileEntry.create(file, resourceIdentifier, userInstance).migrate(this, resource);
             }
         } catch (Exception e) {
             logger.error("Failed to persist file entry: {} {}", file.toJsonString(), e);


### PR DESCRIPTION
Use case: When migrating files, we create new database entry. By default we are persisting "file uploaded" log entry when it happens. It is wrong for migrated files, as they will get uploaded date which is "migration" date.

Solution: Crafting FileApproved and FileUploaded log messages when migrating depending on file type and which dates file has, as after a little research it seems that "old" files in production are missing publishedDate.