### PR TITLE
Np 48547 craft log for publication

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -13,7 +13,8 @@ public enum LogTopic {
     PUBLICATION_DELETED("PublicationDeleted"),
     PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_REPUBLISHED("PublicationRepublished"),
-    PUBLICATION_UNPUBLISHED("PublicationUnpublished");
+    PUBLICATION_UNPUBLISHED("PublicationUnpublished"),
+    PUBLICATION_IMPORTED("PublicationImported");
 
     private final String value;
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
@@ -3,11 +3,13 @@ package no.unit.nva.publication.model.business.logentry;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.service.impl.ResourceService;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, LogTopic topic,
-                                  Instant timestamp, LogUser performedBy) implements LogEntry {
+                                  Instant timestamp, LogUser performedBy, ImportSource importSource)
+    implements LogEntry {
 
     public static final String TYPE = "PublicationLogEntry";
 
@@ -26,6 +28,7 @@ public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentif
         private LogTopic topic;
         private Instant timestamp;
         private LogUser performedBy;
+        private ImportSource importSource;
 
         private Builder() {
         }
@@ -55,9 +58,13 @@ public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentif
             return this;
         }
 
-        public PublicationLogEntry build() {
-            return new PublicationLogEntry(identifier, resourceIdentifier, topic, timestamp, performedBy);
+        public Builder withImportSource(ImportSource importSource) {
+            this.importSource = importSource;
+            return this;
         }
 
+        public PublicationLogEntry build() {
+            return new PublicationLogEntry(identifier, resourceIdentifier, topic, timestamp, performedBy, importSource);
+        }
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -21,7 +21,7 @@ public record CreatedResourceEvent(Instant date, User user, URI institution) imp
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_CREATED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
                    .build();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
@@ -22,7 +22,7 @@ public record DeletedResourceEvent(Instant date, User user, URI institution) imp
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_DELETED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
                    .build();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
@@ -3,16 +3,17 @@ package no.unit.nva.publication.model.business.publicationstate;
 import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.model.business.User;
-import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
-public record ImportedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
+public record ImportedResourceEvent(Instant date, User user, URI institution, ImportSource importSource)
+    implements ResourceEvent {
 
-    public static RepublishedResourceEvent create(UserInstance userInstance, Instant date) {
-        return new RepublishedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    public static ImportedResourceEvent fromImportSource(ImportSource importSource, Instant date) {
+        return new ImportedResourceEvent(date, null, null, importSource);
     }
 
     @Override
@@ -21,8 +22,9 @@ public record ImportedResourceEvent(Instant date, User user, URI institution) im
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_IMPORTED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
+                   .withImportSource(importSource)
                    .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
@@ -1,0 +1,28 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
+
+public record ImportedResourceEvent(Instant date, User user, URI institution) implements ResourceEvent {
+
+    public static RepublishedResourceEvent create(UserInstance userInstance, Instant date) {
+        return new RepublishedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId());
+    }
+
+    @Override
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(SortableIdentifier.next())
+                   .withTopic(LogTopic.PUBLICATION_IMPORTED)
+                   .withTimestamp(Instant.now())
+                   .withPerformedBy(user)
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -21,7 +21,7 @@ public record PublishedResourceEvent(Instant date, User user, URI institution) i
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_PUBLISHED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
                    .build();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
@@ -21,7 +21,7 @@ public record RepublishedResourceEvent(Instant date, User user, URI institution)
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_REPUBLISHED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
                    .build();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
@@ -12,7 +12,8 @@ import no.unit.nva.publication.model.business.logentry.LogUser;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(PublishedResourceEvent.class),
     @JsonSubTypes.Type(UnpublishedResourceEvent.class), @JsonSubTypes.Type(DeletedResourceEvent.class),
-    @JsonSubTypes.Type(RepublishedResourceEvent.class)})
+    @JsonSubTypes.Type(RepublishedResourceEvent.class),
+    @JsonSubTypes.Type(ImportedResourceEvent.class)})
 public interface ResourceEvent {
 
     Instant date();

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
@@ -21,7 +21,7 @@ public record UnpublishedResourceEvent(Instant date, User user, URI institution)
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(SortableIdentifier.next())
                    .withTopic(LogTopic.PUBLICATION_UNPUBLISHED)
-                   .withTimestamp(Instant.now())
+                   .withTimestamp(date)
                    .withPerformedBy(user)
                    .build();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -60,7 +60,6 @@ import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.model.business.importcandidate.ImportStatus;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
-import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -385,17 +385,16 @@ public class ResourceService extends ServiceWithTransactions {
 
     private void persistLogEntriesIfNeeded(Resource resource) {
         var userInstance = UserInstance.fromPublication(resource.toPublication());
-        var publishedDate = Optional.of(resource)
-                                .map(Resource::getPublishedDate)
-                                .or(() -> Optional.ofNullable(resource.getCreatedDate()))
-                                .orElseGet(Instant::now);
         if ("nve@5948.0.0.0".equals(resource.getResourceOwner().getUser().toString())) {
-            resource.setResourceEvent(ImportedResourceEvent.create(userInstance, publishedDate));
-        }
-        if (PUBLISHED.equals(resource.getStatus())) {
+            resource.setResourceEvent(ImportedResourceEvent.fromImportSource(ImportSource.fromBrageArchive("NVE"),
+                                                                   resource.getCreatedDate()));
+        } else if (PUBLISHED.equals(resource.getStatus())) {
+            var publishedDate = Optional.of(resource)
+                                    .map(Resource::getPublishedDate)
+                                    .orElse(resource.getCreatedDate());
             resource.setResourceEvent(PublishedResourceEvent.create(userInstance, publishedDate));
         } else {
-            resource.setResourceEvent(CreatedResourceEvent.create(userInstance, publishedDate));
+            resource.setResourceEvent(CreatedResourceEvent.create(userInstance, resource.getCreatedDate()));
         }
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -384,19 +384,22 @@ public class ResourceService extends ServiceWithTransactions {
         return dataEntry;
     }
 
+    @Deprecated
     private void persistLogEntriesIfNeeded(Resource resource) {
         var userInstance = UserInstance.fromPublication(resource.toPublication());
         var logEntries = resource.fetchLogEntries(this);
-        if ("nve@5948.0.0.0".equals(resource.getResourceOwner().getUser().toString())) {
-            resource.setResourceEvent(ImportedResourceEvent.fromImportSource(ImportSource.fromBrageArchive("NVE"),
-                                                                   resource.getCreatedDate()));
-        } else if (PUBLISHED.equals(resource.getStatus()) && logEntries.stream().noneMatch(entry -> LogTopic.PUBLICATION_PUBLISHED.equals(entry.topic()))) {
-            var publishedDate = Optional.of(resource)
-                                    .map(Resource::getPublishedDate)
-                                    .orElse(resource.getCreatedDate());
-            resource.setResourceEvent(PublishedResourceEvent.create(userInstance, publishedDate));
-        } else if (!PUBLISHED.equals(resource.getStatus()) && logEntries.stream().noneMatch(entry -> LogTopic.PUBLICATION_CREATED.equals(entry.topic()))) {
-            resource.setResourceEvent(CreatedResourceEvent.create(userInstance, resource.getCreatedDate()));
+        if (logEntries.isEmpty()) {
+            if ("nve@5948.0.0.0".equals(resource.getResourceOwner().getUser().toString())) {
+                resource.setResourceEvent(ImportedResourceEvent.fromImportSource(
+                    ImportSource.fromBrageArchive("NVE"), resource.getCreatedDate()));
+            } else if (PUBLISHED.equals(resource.getStatus())) {
+                var publishedDate = Optional.of(resource)
+                                        .map(Resource::getPublishedDate)
+                                        .orElse(resource.getCreatedDate());
+                resource.setResourceEvent(PublishedResourceEvent.create(userInstance, publishedDate));
+            } else if (!PUBLISHED.equals(resource.getStatus())) {
+                resource.setResourceEvent(CreatedResourceEvent.create(userInstance, resource.getCreatedDate()));
+            }
         }
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
@@ -7,8 +7,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Instant;
 import java.util.stream.Stream;
 import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.model.ImportSource;
+import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.DeletedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.UnpublishedResourceEvent;
@@ -22,7 +25,9 @@ public class ResourceEventTest {
         return Stream.of(Arguments.of(new CreatedResourceEvent(Instant.now(), new User(randomString()), randomUri())),
                          Arguments.of(new UnpublishedResourceEvent(Instant.now(), new User(randomString()), randomUri())),
                          Arguments.of(new PublishedResourceEvent(Instant.now(), new User(randomString()), randomUri())),
-                         Arguments.of(new DeletedResourceEvent(Instant.now(), new User(randomString()), randomUri())));
+                         Arguments.of(new DeletedResourceEvent(Instant.now(), new User(randomString()), randomUri())),
+                         Arguments.of(ImportedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
+                                                                             Instant.now())));
     }
 
     @ParameterizedTest

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.Instant;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.ImportSource;
+import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,7 +26,9 @@ class ResourceEventTest {
                          Arguments.of(new DeletedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
                                       LogTopic.PUBLICATION_DELETED),
                          Arguments.of(new RepublishedResourceEvent(Instant.now(), new User(randomString()), randomUri()),
-                                      LogTopic.PUBLICATION_REPUBLISHED));
+                                      LogTopic.PUBLICATION_REPUBLISHED),
+                         Arguments.of(ImportedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
+                                                                             Instant.now()), LogTopic.PUBLICATION_IMPORTED));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Crafting log for publications in production. Creating log messages for created, published and imported publications from Brage. 

Populating following log entries for publication in production:
- PublicationCreated for all publications
- PublicationPublished for published publications
- PublicationImported for imported publications from NVE

After this pr is merged I think we are ready to run migration in test and prod. 