### PR TITLE
removing customer config validation for external client on upload

### DIFF
--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/CreateUploadHandler.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/CreateUploadHandler.java
@@ -7,6 +7,7 @@ import no.unit.nva.publication.RequestUtil;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.file.upload.restmodel.CreateUploadRequestBody;
 import no.unit.nva.publication.file.upload.restmodel.CreateUploadResponseBody;
+import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -42,10 +43,10 @@ public class CreateUploadHandler extends ApiGatewayHandler<CreateUploadRequestBo
     @Override
     protected CreateUploadResponseBody processInput(CreateUploadRequestBody input, RequestInfo requestInfo,
                                                     Context context) throws ApiGatewayException {
-        var customerId = requestInfo.getCurrentCustomer();
+        var userInstance = UserInstance.fromRequestInfo(requestInfo);
         var resourceIdentifier = RequestUtil.getIdentifier(requestInfo);
 
-        var createUploadResponseBody =  fileService.initiateMultipartUpload(resourceIdentifier, customerId, input);
+        var createUploadResponseBody =  fileService.initiateMultipartUpload(resourceIdentifier, userInstance, input);
 
         return CreateUploadResponseBody.fromInitiateMultipartUploadResult(createUploadResponseBody);
     }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
@@ -233,6 +233,8 @@ public class CreateUploadHandlerTest {
                    .withPathParameters(Map.of("publicationIdentifier", identifier.toString()))
                    .withBody(uploadRequestBody)
                    .withCurrentCustomer(randomUri())
+                   .withUserName(randomString())
+                   .withClientId(randomString())
                    .build();
     }
 


### PR DESCRIPTION
Not validating allowed publication types for file upload when external client uploads file. 