### PR TITLE
persisting doi request on pending pub req

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -89,6 +89,7 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
             publishPublication(publication);
             refreshPublishingRequestAfterPublishingMetadata(publishingRequest);
         }
+        createDoiRequestIfNeeded(publication);
     }
 
     /**


### PR DESCRIPTION
Persisting doi request when publishing publication by consuming pending publishing request and customer allows publishing metadata. 