### PR TITLE
build: Add Spotless as dependency to prepare for reformatting

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.10'
     implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.10'
     implementation group: 'io.freefair.lombok', name: 'io.freefair.lombok.gradle.plugin', version: '8.10'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.2'
 }

--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'jacoco-report-aggregation'
+    id 'com.diffplug.spotless'
 }
 
 
@@ -95,3 +96,27 @@ jacocoTestCoverageVerification {
         }
     }
 }
+
+spotless {
+    java {
+        toggleOffOn() // Ignores sections between `spotless:off` / `spotless:on`
+        googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
+    }
+
+    format 'misc', {
+        target '.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle'
+        leadingTabsToSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    enforceCheck false // Temporarily disable checking during build until the project is reformatted
+}
+
+// Commented out for now, uncomment when the project is reformatted and ready to enforce the formatting rules
+//tasks.named('build').configure {
+//    dependsOn('spotlessApply')
+//}
+//
+//tasks.named('test').configure {
+//    dependsOn('spotlessApply')
+//}


### PR DESCRIPTION
This adds Spotless to the project, without running the formatting task. The intention is to reformat the project later in a separate PR for easier review.