### PR TITLE
setting topLevelOrgCristinId to resourceOwner ownerAffiliation

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -92,7 +92,10 @@ public class UserInstance implements JsonSerializable {
     }
 
     public static UserInstance fromPublication(Publication publication) {
-        return UserInstance.create(publication.getResourceOwner(), publication.getPublisher().getId());
+        return new UserInstance(publication.getResourceOwner().getOwner().getValue(),
+                                publication.getPublisher().getId(),
+                                publication.getResourceOwner().getOwnerAffiliation(),
+                                null, List.of(), UserClientType.INTERNAL);
     }
 
     public static UserInstance fromMessage(Message message) {


### PR DESCRIPTION
When creating `UserInstance` from `Publication`
Then set `UserInstance.topLevelOrgCristinId` -> `Publication.resourceOwner.ownerAffiliation`

Because when creating Publication, we set
`Publication.resourceOwner.ownerAffiliation` -> `UserInstance.topLevelOrgCristinId`
Here:
```

    public Publication createPublication(UserInstance userInstance, Publication inputData) throws BadRequestException {
        Instant currentTime = clockForTimestamps.instant();
        Resource newResource = Resource.fromPublication(inputData);
        newResource.setIdentifier(identifierSupplier.get());
        newResource.setResourceOwner(createResourceOwner(userInstance));
        newResource.setPublisher(createOrganization(userInstance));
        newResource.setCreatedDate(currentTime);
        newResource.setModifiedDate(currentTime);
        newResource.setResourceEvent(CreatedResourceEvent.create(userInstance, currentTime));
        setStatusOnNewPublication(userInstance, inputData, newResource);
        return insertResource(newResource).toPublication();
    }

    private Owner createResourceOwner(UserInstance userInstance) {
        return new Owner(userInstance.getUsername(), userInstance.getTopLevelOrgCristinId());
    }
```


I need it in order to set `Organization` in `LogEntry` when importing publication, as I use `UserInstance` from imported `Publication`, otherwise `Organization` in `LogEntry` will always be null for imported publications. 