### PR TITLE
adding alias to complete upload request list parts

### DIFF
--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadPart.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadPart.java
@@ -2,9 +2,10 @@ package no.unit.nva.publication.file.upload.restmodel;
 
 import static java.util.Objects.requireNonNull;
 import com.amazonaws.services.s3.model.PartETag;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record CompleteUploadPart(@JsonProperty("PartNumber") Integer partNumber, @JsonProperty("ETag") String etag) {
+public record CompleteUploadPart(@JsonAlias("PartNumber") Integer partNumber, @JsonAlias("ETag") String etag) {
 
     public static PartETag toPartETag(CompleteUploadPart completeUploadPart) {
         return new PartETag(completeUploadPart.partNumber(), completeUploadPart.etag());

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequestTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequestTest.java
@@ -35,4 +35,31 @@ class CompleteUploadRequestTest {
 
         assertEquals(expected, externalCompleteUploadRequest);
     }
+
+    @Test
+    void shouldSerializeAndDeserializeExternalCompleteUploadRequest2() throws JsonProcessingException {
+        var json = """
+            {
+                "type": "ExternalCompleteUpload",
+                "uploadId": "abcde123",
+                "key": "8d1dc28f-fec2-452f-9d58-da3d1ff03e87",
+                "parts": [
+                    {
+                        "PartNumber": "1",
+                        "size": "174907",
+                        "ETag": "34401a771b3e1dbb0d759cedb2fbf02f"
+                    }
+                ],
+                "fileType": "OpenFile"
+            }
+            """;
+
+        var externalCompleteUploadRequest = JsonUtils.dtoObjectMapper.readValue(json,
+                                                                                ExternalCompleteUploadRequest.class);
+
+        var expected = new ExternalCompleteUploadRequest("abcde123", "8d1dc28f-fec2-452f-9d58-da3d1ff03e87", List.of(
+            new CompleteUploadPart(1, "34401a771b3e1dbb0d759cedb2fbf02f")), OpenFile.TYPE, null, null, null);
+
+        assertEquals(expected, externalCompleteUploadRequest);
+    }
 }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequestTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/restmodel/CompleteUploadRequestTest.java
@@ -1,0 +1,38 @@
+package no.unit.nva.publication.file.upload.restmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.model.associatedartifacts.file.OpenFile;
+import org.junit.jupiter.api.Test;
+
+class CompleteUploadRequestTest {
+
+    @Test
+    void shouldSerializeAndDeserializeExternalCompleteUploadRequest() throws JsonProcessingException {
+        var json = """
+            {
+                "type": "ExternalCompleteUpload",
+                "uploadId": "abcde123",
+                "key": "8d1dc28f-fec2-452f-9d58-da3d1ff03e87",
+                "parts": [
+                    {
+                        "partNumber": "1",
+                        "size": "174907",
+                        "etag": "34401a771b3e1dbb0d759cedb2fbf02f"
+                    }
+                ],
+                "fileType": "OpenFile"
+            }
+            """;
+
+        var externalCompleteUploadRequest = JsonUtils.dtoObjectMapper.readValue(json,
+                                                                                ExternalCompleteUploadRequest.class);
+
+        var expected = new ExternalCompleteUploadRequest("abcde123", "8d1dc28f-fec2-452f-9d58-da3d1ff03e87", List.of(
+            new CompleteUploadPart(1, "34401a771b3e1dbb0d759cedb2fbf02f")), OpenFile.TYPE, null, null, null);
+
+        assertEquals(expected, externalCompleteUploadRequest);
+    }
+}


### PR DESCRIPTION
Adding json aliases for `ETag` and `PartNumber` to `CompleteUploadRequestBody`.
Armaz does not use third party library and sends forward values from `/prepare` call, and these values should match, i.e. we have to support both `ETag`, `etag` and `PartNumber` and `partNumber`.