### PR TITLE
removing hardcoded values when mapping seriesnumber

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
@@ -34,15 +34,13 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
     }
 
     protected String constructSeriesNumber() {
-        String volume = extractBookOrReportMetadata()
+        var volume = extractBookOrReportMetadata()
                             .map(CristinBookOrReportMetadata::getVolume)
                             .filter(StringUtils::isNotBlank)
-                            .map(volumeNumber -> String.format("Volume:%s", volumeNumber))
                             .orElse(EMPTY_STRING);
-        String issue = extractBookOrReportMetadata()
+        var issue = extractBookOrReportMetadata()
                            .map(CristinBookOrReportMetadata::getIssue)
                            .filter(StringUtils::isNotBlank)
-                           .map(issueNumber -> String.format("Issue:%s", issueNumber))
                            .orElse(null);
 
         return Stream.of(volume, issue).filter(Objects::nonNull)

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilderTest.java
@@ -15,8 +15,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class NvaBookLikeBuilderTest {
 
-    public static final String ONLY_VOLUME_EXPECTED = "^Volume:[^;]*$";
-    public static final String ONLY_ISSUE_EXPECTED = "^Issue:[^;]*$";
+    public static final String ONLY_VOLUME_EXPECTED = "^[^;]*$";
+    public static final String ONLY_ISSUE_EXPECTED = "^[^;]*$";
 
     @ParameterizedTest(name = "nvaBookLikeBuilder returns Series that does contain blank String represetations"
                               + "when issue is blank")

--- a/cristin-import/src/test/resources/features/BookRules.feature
+++ b/cristin-import/src/test/resources/features/BookRules.feature
@@ -154,7 +154,7 @@ Feature: Book conversion rules
     And the Series mentions a volume "Vol 1"
     And the Series mentions an issue "Issue 2"
     When the Cristin Result is converted to an NVA Resource
-    Then  the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "2434-561X", online issn "2434-561X" and seriesNumber "Volume:Vol 1;Issue:Issue 2"
+    Then  the NVA Resource contains an Unconfirmed Series with title "SomeSeries", issn "2434-561X", online issn "2434-561X" and seriesNumber "Vol 1;Issue 2"
 
     Examples:
       | secondaryCategory |


### PR DESCRIPTION
When mapping volume and issue for Book from Cristin, we place these values in the field for seriesNumber, and hardcode what this values as, like:
Volume:`{value}`;Issue:`{value}`

Remove hardcoding of these values and simply separating them by semicolon when multiple values are present.