### PR TITLE
adding new log topic PublicationMerged

### DIFF
--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumerTest.java
@@ -165,6 +165,7 @@ import no.unit.nva.publication.model.SearchResourceApiResponse;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.s3.S3Driver;
@@ -2016,7 +2017,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
         var resource = Resource.resourceQueryObject(publicationRepresentation.publication().getIdentifier())
                            .fetch(resourceService)
                            .orElseThrow();
-        var resourceEvent = (ImportedResourceEvent) resource.getResourceEvent();
+        var resourceEvent = (MergedResourceEvent) resource.getResourceEvent();
 
         assertEquals(Source.BRAGE, resourceEvent.importSource().getSource());
     }
@@ -2061,7 +2062,7 @@ public class BrageEntryEventConsumerTest extends ResourcesLocalTest {
                             .build();
         var s3Event = createNewBrageRecordEvent(generator.getBrageRecord());
         handler.handleRequest(s3Event, CONTEXT);
-        var updatedPublication = resourceService.getPublication(existingPublication);
+        var updatedPublication = resourceService.getPublicationByIdentifier(existingPublication.getIdentifier());
         var expectedCristinIdentifierFromBrage =
             new CristinIdentifier(SourceName.fromBrage(generator.getBrageRecord().getCustomer().getName()),
                                   brageCristinIdentifier);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -259,10 +259,10 @@ public final class FileEntry implements Entity, QueryObject<FileEntry> {
 
     public void reject(ResourceService resourceService, User user) {
         if (file instanceof PendingFile<?,?> pendingFile) {
-            this.file = pendingFile.reject();
             var now = Instant.now();
+            this.setFileEvent(FileRejectedEvent.create(user, now, file.getArtifactType()));
             this.modifiedDate = now;
-            this.setFileEvent(FileRejectedEvent.create(user, now));
+            this.file = pendingFile.reject();
             resourceService.updateFile(this);
         }
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -50,6 +50,7 @@ import no.unit.nva.publication.model.business.importcandidate.ImportStatus;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
 import no.unit.nva.publication.model.business.publicationstate.DeletedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.RepublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
@@ -323,7 +324,7 @@ public class Resource implements Entity {
 
     public void updateResourceFromImport(ResourceService resourceService, ImportSource importSource) {
         var userInstance = UserInstance.fromPublication(this.toPublication());
-        this.setResourceEvent(ImportedResourceEvent.fromImportSource(importSource, userInstance, Instant.now()));
+        this.setResourceEvent(MergedResourceEvent.fromImportSource(importSource, userInstance, Instant.now()));
         resourceService.updateResource(this, userInstance);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -21,7 +21,8 @@ public enum LogTopic {
     PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_REPUBLISHED("PublicationRepublished"),
     PUBLICATION_UNPUBLISHED("PublicationUnpublished"),
-    PUBLICATION_IMPORTED("PublicationImported");
+    PUBLICATION_IMPORTED("PublicationImported"),
+    PUBLICATION_MERGED("PublicationMerged");
 
     private final String value;
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
@@ -8,10 +8,11 @@ import no.unit.nva.publication.model.business.logentry.FileLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
-public record FileRejectedEvent(Instant date, User user, SortableIdentifier identifier) implements FileEvent {
+public record FileRejectedEvent(Instant date, User user, SortableIdentifier identifier, String rejectedFileType)
+    implements FileEvent {
 
-    public static FileRejectedEvent create(User user, Instant timestamp) {
-        return new FileRejectedEvent(timestamp, user, SortableIdentifier.next());
+    public static FileRejectedEvent create(User user, Instant timestamp, String rejectedFileType) {
+        return new FileRejectedEvent(timestamp, user, SortableIdentifier.next(), rejectedFileType);
     }
 
     @Override
@@ -24,7 +25,7 @@ public record FileRejectedEvent(Instant date, User user, SortableIdentifier iden
                    .withTimestamp(date)
                    .withPerformedBy(user)
                    .withFilename(fileEntry.getFile().getName())
-                   .withFileType(fileEntry.getFile().getClass().getSimpleName())
+                   .withFileType(rejectedFileType)
                    .build();
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
@@ -1,0 +1,33 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.ImportSource;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
+
+public record MergedResourceEvent(Instant date, User user, URI institution, ImportSource importSource,
+                                  SortableIdentifier identifier) implements ResourceEvent {
+
+    public static MergedResourceEvent fromImportSource(ImportSource importSource, UserInstance userInstance,
+                                                         Instant date) {
+        return new MergedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId(),
+                                         importSource, SortableIdentifier.next());
+    }
+
+    @Override
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+        return PublicationLogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(identifier)
+                   .withTopic(LogTopic.PUBLICATION_MERGED)
+                   .withTimestamp(date)
+                   .withPerformedBy(user)
+                   .withImportSource(importSource)
+                   .build();
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
@@ -6,15 +6,14 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
-import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(PublishedResourceEvent.class),
     @JsonSubTypes.Type(UnpublishedResourceEvent.class), @JsonSubTypes.Type(DeletedResourceEvent.class),
-    @JsonSubTypes.Type(RepublishedResourceEvent.class),
-    @JsonSubTypes.Type(ImportedResourceEvent.class),
-    @JsonSubTypes.Type(DoiReservedEvent.class)})
+    @JsonSubTypes.Type(RepublishedResourceEvent.class), @JsonSubTypes.Type(ImportedResourceEvent.class),
+    @JsonSubTypes.Type(DoiReservedEvent.class), @JsonSubTypes.Type(MergedResourceEvent.class)})
 public interface ResourceEvent {
 
     Instant date();

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
@@ -14,6 +14,7 @@ import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEv
 import no.unit.nva.publication.model.business.publicationstate.DeletedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.DoiReservedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.UnpublishedResourceEvent;
@@ -36,7 +37,11 @@ public class ResourceEventTest {
                 ImportedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
                                                        UserInstance.create(randomString(), randomUri()),
                                                        Instant.now())), Arguments.of(
-                DoiReservedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now())));
+                DoiReservedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now())),
+                         Arguments.of(
+                             MergedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
+                                                                  UserInstance.create(randomString(), randomUri()),
+                                                                  Instant.now())));
     }
 
     @ParameterizedTest

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/FileEventTest.java
@@ -26,7 +26,8 @@ public class FileEventTest {
         return Stream.of(Arguments.of(new FileUploadedEvent(Instant.now(), randomUser(), SortableIdentifier.next())),
                          Arguments.of(
                              new FileApprovedEvent(Instant.now(), randomUser(), SortableIdentifier.next())),
-                         Arguments.of(new FileRejectedEvent(Instant.now(), randomUser(), SortableIdentifier.next())),
+                         Arguments.of(new FileRejectedEvent(Instant.now(), randomUser(), SortableIdentifier.next(),
+                                                            randomString())),
                          Arguments.of(new FileDeletedEvent(Instant.now(), randomUser(), SortableIdentifier.next())),
                          Arguments.of(new FileImportedEvent(Instant.now(), randomUser(), SortableIdentifier.next(),
                                                             ImportSource.fromSource(Source.SCOPUS))),

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -1,5 +1,16 @@
 package no.unit.nva.publication.model.business.publicationstate;
 
+import static no.unit.nva.publication.model.business.logentry.LogTopic.DOI_ASSIGNED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.DOI_REJECTED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.DOI_REQUESTED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.DOI_RESERVED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_CREATED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_DELETED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_IMPORTED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_MERGED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_PUBLISHED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_REPUBLISHED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_UNPUBLISHED;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,38 +29,34 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ResourceEventTest {
 
     public static Stream<Arguments> resourceEventProvider() {
-        return Stream.of(Arguments.of(
-            new CreatedResourceEvent(Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next()),
-            LogTopic.PUBLICATION_CREATED), Arguments.of(
-            new PublishedResourceEvent(Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next()),
-            LogTopic.PUBLICATION_PUBLISHED), Arguments.of(
-            new UnpublishedResourceEvent(Instant.now(), new User(randomString()), randomUri(),
-                                         SortableIdentifier.next()), LogTopic.PUBLICATION_UNPUBLISHED), Arguments.of(
-            new DeletedResourceEvent(Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next()),
-            LogTopic.PUBLICATION_DELETED), Arguments.of(
-            new RepublishedResourceEvent(Instant.now(), new User(randomString()), randomUri(),
-                                         SortableIdentifier.next()), LogTopic.PUBLICATION_REPUBLISHED), Arguments.of(
-            ImportedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
-                                                   UserInstance.create(randomString(), randomUri()), Instant.now()),
-            LogTopic.PUBLICATION_IMPORTED), Arguments.of(
-            DoiReservedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now()),
-            LogTopic.DOI_RESERVED));
+        return Stream.of(Arguments.of(new CreatedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+                                      PUBLICATION_CREATED), Arguments.of(
+                             new PublishedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+                             PUBLICATION_PUBLISHED),
+                         Arguments.of(
+                             new UnpublishedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+                             PUBLICATION_UNPUBLISHED),
+                         Arguments.of(new DeletedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+                                      PUBLICATION_DELETED), Arguments.of(
+                new RepublishedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+                PUBLICATION_REPUBLISHED), Arguments.of(
+                ImportedResourceEvent.fromImportSource(getImportSource(), randomUserInstance(), Instant.now()),
+                PUBLICATION_IMPORTED),
+                         Arguments.of(DoiReservedEvent.create(randomUserInstance(), Instant.now()), DOI_RESERVED),
+                         Arguments.of(MergedResourceEvent.fromImportSource(getImportSource(), randomUserInstance(),
+                                                                           Instant.now()), PUBLICATION_MERGED));
     }
 
     public static Stream<Arguments> ticketEventProvider() {
-        return Stream.of(
-            Arguments.of(DoiRequestedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now()),
-                         LogTopic.DOI_REQUESTED),
-            Arguments.of(DoiAssignedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now()),
-                         LogTopic.DOI_ASSIGNED),
-            Arguments.of(DoiRejectedEvent.create(UserInstance.create(randomString(), randomUri()), Instant.now()),
-                         LogTopic.DOI_REJECTED));
+        return Stream.of(Arguments.of(DoiRequestedEvent.create(randomUserInstance(), Instant.now()), DOI_REQUESTED),
+                         Arguments.of(DoiAssignedEvent.create(randomUserInstance(), Instant.now()), DOI_ASSIGNED),
+                         Arguments.of(DoiRejectedEvent.create(randomUserInstance(), Instant.now()), DOI_REJECTED));
     }
 
     @ParameterizedTest
     @MethodSource("resourceEventProvider")
     void shouldConvertResourceEventToLogEntryWithExpectedTopic(ResourceEvent resourceEvent, LogTopic expectedLogTopic) {
-        var logEntry = resourceEvent.toLogEntry(SortableIdentifier.next(), null);
+        var logEntry = resourceEvent.toLogEntry(identifier(), null);
 
         assertEquals(expectedLogTopic, logEntry.topic());
     }
@@ -57,8 +64,24 @@ class ResourceEventTest {
     @ParameterizedTest
     @MethodSource("ticketEventProvider")
     void shouldConvertTicketEventToLogEntryWithExpectedTopic(TicketEvent resourceEvent, LogTopic expectedLogTopic) {
-        var logEntry = resourceEvent.toLogEntry(SortableIdentifier.next(), SortableIdentifier.next(), null);
+        var logEntry = resourceEvent.toLogEntry(identifier(), identifier(), null);
 
         assertEquals(expectedLogTopic, logEntry.topic());
+    }
+
+    private static ImportSource getImportSource() {
+        return new ImportSource(Source.BRAGE, "A");
+    }
+
+    private static UserInstance randomUserInstance() {
+        return UserInstance.create(randomString(), randomUri());
+    }
+
+    private static SortableIdentifier identifier() {
+        return SortableIdentifier.next();
+    }
+
+    private static User randomUser() {
+        return new User(randomString());
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -119,7 +119,9 @@ import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.model.business.importcandidate.ImportStatusFactory;
 import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
+import no.unit.nva.publication.model.business.publicationstate.FileEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileHiddenEvent;
+import no.unit.nva.publication.model.business.publicationstate.FileRejectedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileRetractedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
@@ -1424,7 +1426,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldRejectPersistedFile() throws BadRequestException {
+    void shouldRejectPersistedFileAndSetFileEventWithFileTypeThatHasBeenRejected() throws BadRequestException {
         var publication = randomPublication();
         var userInstance = UserInstance.fromPublication(publication);
         var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
@@ -1439,6 +1441,8 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
         var rejectedFileEntry = fileEntry.fetch(resourceService).orElseThrow();
 
+        var fileEvent = (FileRejectedEvent) rejectedFileEntry.getFileEvent();
+        assertEquals(file.getArtifactType(), fileEvent.rejectedFileType());
         assertInstanceOf(RejectedFile.class, rejectedFileEntry.getFile());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -122,6 +122,7 @@ import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileHiddenEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileRetractedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.RepublishedResourceEvent;
 import no.unit.nva.publication.model.storage.ResourceDao;
 import no.unit.nva.publication.service.ResourcesLocalTest;
@@ -1607,7 +1608,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldUpdateResourceFromImportAndSetImportedResourceEventWhenUpdatingExistingPublication()
+    void shouldUpdateResourceFromImportAndSetMergedResourceEventWhenUpdatingExistingPublication()
         throws BadRequestException, NotFoundException {
         var publication = randomPublication();
         var userInstance = UserInstance.fromPublication(publication);
@@ -1617,7 +1618,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         Resource.fromPublication(resource).updateResourceFromImport(resourceService, ImportSource.fromSource(Source.SCOPUS));
         var updatedResource = resourceService.getResourceByIdentifier(resource.getIdentifier());
 
-        var resourceEvent = (ImportedResourceEvent) updatedResource.getResourceEvent();
+        var resourceEvent = (MergedResourceEvent) updatedResource.getResourceEvent();
 
         assertEquals(Source.SCOPUS, resourceEvent.importSource().getSource());
     }


### PR DESCRIPTION
PO wants to differentiate between two import events in log, one when publication is getting imported to NVA and another one where existing publication is being updated by import.

Adding new log topic `PublicationMerged`:


<img width="241" alt="Skjermbilde 2025-02-21 kl  08 44 42" src="https://github.com/user-attachments/assets/29dab924-31be-42dd-881a-a858c4d5c449" />



Additional fix:

When setting file rejected event, setting file type that actually has been rejected. 
