### PR TITLE
commenting out file fetch from xml

### DIFF
--- a/brage-import/src/main/resources/customers.json
+++ b/brage-import/src/main/resources/customers.json
@@ -436,7 +436,7 @@
       "test": "d102baef-5861-43e2-bb21-42a1f6479aef",
       "dev": "ff6fd53f-30ff-4c47-955e-f201fe5d9e0c"
     },
-    "shortName": "TOI"
+    "shortName": "TØI"
   },
   {
     "name": "kristiania",

--- a/brage-import/src/main/resources/customers.json
+++ b/brage-import/src/main/resources/customers.json
@@ -436,7 +436,7 @@
       "test": "d102baef-5861-43e2-bb21-42a1f6479aef",
       "dev": "ff6fd53f-30ff-4c47-955e-f201fe5d9e0c"
     },
-    "shortName": "T\u00d8I"
+    "shortName": "TOI"
   },
   {
     "name": "kristiania",

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
@@ -27,16 +27,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.stream.Collector;
 import no.scopus.generated.DocTp;
-import no.scopus.generated.OpenAccessType;
-import no.scopus.generated.UpwOaLocationType;
-import no.scopus.generated.UpwOaLocationsType;
-import no.scopus.generated.UpwOpenAccessType;
 import no.sikt.nva.scopus.conversion.files.model.CrossrefResponse;
 import no.sikt.nva.scopus.conversion.files.model.CrossrefResponse.CrossrefLink;
 import no.sikt.nva.scopus.conversion.files.model.CrossrefResponse.License;
@@ -47,15 +41,12 @@ import no.sikt.nva.scopus.conversion.files.model.ScopusFile;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.File;
-import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails;
-import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails.Source;
 import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
 import nva.commons.core.paths.UriWrapper;
 import org.apache.http.entity.ContentType;
-import org.apache.tika.io.TikaInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -73,8 +64,6 @@ public class ScopusFileConverter {
     public static final String FILE_NAME_DELIMITER = ".";
     public static final String CROSSREF_URI_ENV_VAR_NAME = "CROSSREF_FETCH_DOI_URI";
     public static final String CROSSREF_DEFAULT_URI = "https://api.crossref.org/v1/works/";
-    public static final String FETCH_FILE_FROM_URL_MESSAGE_ERROR_MESSAGE = "Could not fetch file from url: {}";
-    public static final String FETCH_FILE_FROM_XML_MESSAGE_ERROR_MESSAGE = "Could not fetch file from xml: {}";
     public static final String FETCH_FILE_FROM_DOI_ERROR_MESSAGE = "Could not fetch file from doi: {}";
     public static final String CREATIVE_COMMONS_DOMAIN = "creativecommons.org";
     public static final String HTML_CONTENT_TYPE = "text/html";
@@ -85,11 +74,10 @@ public class ScopusFileConverter {
     public static final String ENCODED_WHITESPACE = "%20";
     public static final int ZERO_LENGTH_CONTENT = 0;
     public static final String ELSEVIER_HOST = "api.elsevier.com";
-    private static final Logger logger = LoggerFactory.getLogger(ScopusFileConverter.class);
-    private static final String CONTENT_DISPOSITION_FILE_NAME_PATTERN = "filename=\"%s\"";
-    private static final URI DEFAULT_LICENSE = URI.create("https://rightsstatements.org/vocab/InC/1.0/");
     public static final String FETCH_FILE_ERROR_MESSAGE = "Could not fetch file: ";
     public static final String COULD_NOT_SAVE_FILE = "Could not save file to s3 {}";
+    private static final Logger logger = LoggerFactory.getLogger(ScopusFileConverter.class);
+    private static final String CONTENT_DISPOSITION_FILE_NAME_PATTERN = "filename=\"%s\"";
     public final String crossRefUri;
     private final HttpClient httpClient;
     private final S3Client s3Client;
@@ -111,23 +99,7 @@ public class ScopusFileConverter {
     }
 
     public List<AssociatedArtifact> fetchAssociatedArtifacts(DocTp docTp) {
-        return fetchFilesFromDoi(docTp)
-                   .or(() -> fetchFilesFromXml(docTp))
-                   .orElseGet(List::of);
-    }
-
-    private Optional<List<AssociatedArtifact>> fetchFilesFromXml(DocTp docTp) {
-        var associatedArtifacts = extractAssociatedArtifactsFromFileReference(docTp)
-                   .stream()
-                   .filter(File.class::isInstance)
-                   .filter(this::isValid)
-                   .toList();
-        return associatedArtifacts.isEmpty() ? Optional.empty() : Optional.of(associatedArtifacts);
-
-    }
-
-    private boolean isValid(AssociatedArtifact associatedArtifact) {
-        return nonNull(((File) associatedArtifact).getMimeType());
+        return fetchFilesFromDoi(docTp).orElseGet(List::of);
     }
 
     private static CrossrefResponse toCrossrefResponse(String body) throws JsonProcessingException {
@@ -135,7 +107,8 @@ public class ScopusFileConverter {
     }
 
     private static String getFilename(HttpResponse<InputStream> response) {
-        return response.headers().firstValue(Headers.CONTENT_DISPOSITION)
+        return response.headers()
+                   .firstValue(Headers.CONTENT_DISPOSITION)
                    .map(ScopusFileConverter::extractFileNameFromContentDisposition)
                    .or(() -> extractFileNameFromUrl(response))
                    .or(() -> randomFileNameWithMimeTypeFromContentTypeHeader(response.headers()))
@@ -162,17 +135,16 @@ public class ScopusFileConverter {
 
     private static Optional<String> extractFileNameFromUrl(HttpResponse<InputStream> response) {
         return Optional.ofNullable(response.request())
-                                 .map(HttpRequest::uri)
-                                 .map(URI::getPath)
-                                 .map(Paths::get)
-                                 .map(Path::getFileName)
-                                 .map(Path::toString);
+                   .map(HttpRequest::uri)
+                   .map(URI::getPath)
+                   .map(Paths::get)
+                   .map(Path::getFileName)
+                   .map(Path::toString);
     }
 
     private static String extractFileNameFromContentDisposition(String contentType) {
-        return contentType.split(FILENAME_CONTENT_TYPE_HEADER_VALUE)[1]
-                   .split(CONTENT_TYPE_DELIMITER)[0]
-                   .replace(QUOTE, StringUtils.EMPTY_STRING);
+        return contentType.split(FILENAME_CONTENT_TYPE_HEADER_VALUE)[1].split(CONTENT_TYPE_DELIMITER)[0].replace(QUOTE,
+                                                                                                                 StringUtils.EMPTY_STRING);
     }
 
     private static HttpRequest constructRequest(URI uri) {
@@ -185,9 +157,8 @@ public class ScopusFileConverter {
     }
 
     private static URI extractLicenseForLink(CrossrefLink crossrefLink, List<License> licenseList) {
-        return getLicenseWithTheSameVersion(crossrefLink, licenseList)
-                   .or(() -> getLicenseWithUnspecifiedContentVersion(licenseList))
-                   .orElse(DEFAULT_LICENSE);
+        return getLicenseWithTheSameVersion(crossrefLink, licenseList).or(
+            () -> getLicenseWithUnspecifiedContentVersion(licenseList)).orElse(null);
     }
 
     private static Optional<URI> getLicenseWithUnspecifiedContentVersion(List<License> licenseList) {
@@ -215,10 +186,6 @@ public class ScopusFileConverter {
                                  ArrayList::new);
     }
 
-    private static Collector<File, Object, ArrayList<AssociatedArtifact>> collectRemovingDuplicatedFiles() {
-        return collectingAndThen(toCollection(() -> new TreeSet<>(comparing(File::getName))), ArrayList::new);
-    }
-
     private static boolean isCreativeCommonsLicense(URI uri) {
         return uri.toString().contains(CREATIVE_COMMONS_DOMAIN);
     }
@@ -227,29 +194,19 @@ public class ScopusFileConverter {
         return license.getContentVersion().equals(crossrefLink.getContentVersion());
     }
 
-    private static URI toUri(String string) {
-        return attempt(() -> new URI(string.replace(WHITESPACE, ENCODED_WHITESPACE))).orElseThrow();
-    }
-
-    @JacocoGenerated
-    private static boolean fileWithContent(ScopusFile file) {
-        return file.size() != ZERO_LENGTH_CONTENT;
-    }
-
     @JacocoGenerated
     private static boolean fileWithContent(AssociatedArtifact associatedArtifact) {
         return ((File) associatedArtifact).getSize() != ZERO_LENGTH_CONTENT;
     }
 
     private static boolean isElsevierPlainTextResource(CrossrefLink crossrefLink) {
-        return ELSEVIER_HOST.equals(crossrefLink.getUri().getHost())
-               && crossrefLink.getContentType().equals(ContentType.TEXT_PLAIN.getMimeType());
+        return ELSEVIER_HOST.equals(crossrefLink.getUri().getHost()) &&
+               crossrefLink.getContentType().equals(ContentType.TEXT_PLAIN.getMimeType());
     }
 
     private Optional<List<AssociatedArtifact>> fetchFilesFromDoi(DocTp docTp) {
         try {
-            var doi = docTp.getMeta().getDoi();
-            var response = fetchDoi(doi);
+            var response = fetchDoi(docTp.getMeta().getDoi());
             var associatedArtifacts = fetchFilesFromDoi(response);
             return associatedArtifacts.isEmpty() ? Optional.empty() : Optional.of(associatedArtifacts);
         } catch (Exception e) {
@@ -264,9 +221,8 @@ public class ScopusFileConverter {
                    .collect(collectRemovingDuplicates())
                    .stream()
                    .map(this::saveFile)
-                   .filter(ScopusFile::hasValidMimeType)
-                   .filter(ScopusFileConverter::fileWithContent)
-                   .map(ScopusFile::toPublishedAssociatedArtifact)
+                   .filter(ScopusFile::isValid)
+                   .map(ScopusFile::toFile)
                    .toList();
     }
 
@@ -279,10 +235,17 @@ public class ScopusFileConverter {
         var inputStream = tikaUtils.fetch(response.request().uri());
         var filename = getFilename(response);
         var size = inputStream.getLength();
-        return file.copy()
-                   .withContent(inputStream)
-                   .withSize(size)
-                   .withName(filename).build();
+        return file.copy().withContent(inputStream).withSize(size).withName(filename).build();
+    }
+
+    private HttpResponse<InputStream> fetchResponseAsInputStream(URI uri) {
+        var response = attempt(
+            () -> httpClient.send(constructRequest(uri), BodyHandlers.ofInputStream())).orElseThrow();
+        if (isSuccess(response)) {
+            return response;
+        } else {
+            throw new RuntimeException(FETCH_FILE_ERROR_MESSAGE);
+        }
     }
 
     private List<ScopusFile> getFilesFromCrossrefResponse(CrossrefResponse response) {
@@ -291,15 +254,18 @@ public class ScopusFileConverter {
         return response.getMessage()
                    .getLinks()
                    .stream()
-                   .filter(this::hasSupportedMimeType)
-                   .filter(this::shouldBeIgnored)
-                   .filter(crossrefLink -> isNotResource(crossrefLink, resource))
+                   .filter(crossrefLink -> isCrossRefLinkToImport(crossrefLink, resource))
                    .map(crossrefLink -> toScopusFile(crossrefLink, licenseList))
                    .distinct()
                    .toList();
     }
 
-    private boolean shouldBeIgnored(CrossrefLink crossrefLink) {
+    private boolean isCrossRefLinkToImport(CrossrefLink crossrefLink, URI resource) {
+        return hasSupportedMimeType(crossrefLink) && shouldNotBeIgnored(crossrefLink) &&
+               isNotResource(crossrefLink, resource);
+    }
+
+    private boolean shouldNotBeIgnored(CrossrefLink crossrefLink) {
         return !isElsevierPlainTextResource(crossrefLink);
     }
 
@@ -376,70 +342,6 @@ public class ScopusFileConverter {
         return UriWrapper.fromUri(crossRefUri).addChild(doi).getUri();
     }
 
-    //TODO: Fetched files should be scanned for malware
-    private Optional<AssociatedArtifact> convertToAssociatedArtifact(URI downloadUrl) {
-        try {
-            var response = fetchResponseAsInputStream(downloadUrl);
-            return convertToAssociatedArtifact(response);
-        } catch (Exception e) {
-            logger.error(FETCH_FILE_FROM_URL_MESSAGE_ERROR_MESSAGE,
-                         downloadUrl.toString() + StringUtils.SPACE + e.getMessage());
-            return Optional.empty();
-        }
-    }
-
-    private Optional<AssociatedArtifact> convertToAssociatedArtifact(HttpResponse<InputStream> response)
-        throws IOException {
-        var fileIdentifier = randomUUID();
-        var filename = getFilename(response);
-        var inputStreamToSave = tikaUtils.fetch(response.request().uri());
-        var mimeType = saveFile(filename, fileIdentifier, inputStreamToSave);
-        return Optional.of(File.builder()
-                                      .withIdentifier(fileIdentifier)
-                                      .withName(filename)
-                                      .withMimeType(mimeType)
-                                      .withSize(inputStreamToSave.getLength())
-                                      .withLicense(DEFAULT_LICENSE)
-                                      .withUploadDetails(createUploadDetails())
-                               .withPublisherVersion(PublisherVersion.PUBLISHED_VERSION)
-                                      .buildOpenFile());
-    }
-
-    private ImportUploadDetails createUploadDetails() {
-        return new ImportUploadDetails(Source.SCOPUS, null, Instant.now());
-    }
-
-    private List<AssociatedArtifact> extractAssociatedArtifactsFromFileReference(DocTp docTp) {
-        try {
-            return getLocations(docTp).stream()
-                       .map(UpwOaLocationType::getUpwUrlForPdf)
-                       .distinct()
-                       .filter(Objects::nonNull)
-                       .map(ScopusFileConverter::toUri)
-                       .map(this::convertToAssociatedArtifact)
-                       .filter(Optional::isPresent)
-                       .map(Optional::get)
-                       .filter(ScopusFileConverter::fileWithContent)
-                       .map(File.class::cast)
-                       .collect(collectRemovingDuplicatedFiles());
-        } catch (Exception e) {
-            logger.error(FETCH_FILE_FROM_XML_MESSAGE_ERROR_MESSAGE, e.getMessage());
-            return List.of();
-        }
-    }
-
-    private String saveFile(String fileName, UUID fileIdentifier, TikaInputStream inputStream) throws IOException {
-        var path = inputStream.getPath();
-        var mimeType = tikaUtils.getMimeType(inputStream);
-        s3Client.putObject(PutObjectRequest.builder()
-                               .bucket(IMPORT_CANDIDATES_FILES_BUCKET)
-                               .contentType(mimeType)
-                               .contentDisposition(String.format(CONTENT_DISPOSITION_FILE_NAME_PATTERN, fileName))
-                               .key(fileIdentifier.toString())
-                               .build(), RequestBody.fromFile(path));
-        return mimeType;
-    }
-
     private ScopusFile saveFile(ScopusFile scopusFile) {
         try {
             var path = scopusFile.content().getPath();
@@ -458,21 +360,94 @@ public class ScopusFileConverter {
         }
     }
 
-    private HttpResponse<InputStream> fetchResponseAsInputStream(URI uri) {
-        var response = attempt(() -> httpClient.send(constructRequest(uri), BodyHandlers.ofInputStream()))
-                           .orElseThrow();
-        if (isSuccess(response)) {
-            return response;
-        } else {
-            throw new RuntimeException(FETCH_FILE_ERROR_MESSAGE);
-        }
-    }
+    // The functionality to fetch files from XML is currently disabled because the XML data lacks
+    // license information for the files. This code will remain commented out until a decision
+    // is made regarding how to handle files without license information.
+    // Once a solution is implemented, this code can be revisited and potentially re-enabled.
 
-    private List<UpwOaLocationType> getLocations(DocTp docTp) {
-        return Optional.ofNullable(docTp.getMeta().getOpenAccess())
-                   .map(OpenAccessType::getUpwOpenAccess)
-                   .map(UpwOpenAccessType::getUpwOaLocations)
-                   .map(UpwOaLocationsType::getUpwOaLocation)
-                   .orElse(List.of());
-    }
+    //    private Optional<List<AssociatedArtifact>> fetchFilesFromXml(DocTp docTp) {
+    //        var associatedArtifacts = extractAssociatedArtifactsFromFileReference(docTp).stream()
+    //                                      .filter(File.class::isInstance)
+    //                                      .filter(this::isValid)
+    //                                      .toList();
+    //        return associatedArtifacts.isEmpty() ? Optional.empty() : Optional.of(associatedArtifacts);
+    //    }
+    //
+    //    private List<AssociatedArtifact> extractAssociatedArtifactsFromFileReference(DocTp docTp) {
+    //        try {
+    //            return getLocations(docTp).stream()
+    //                       .map(UpwOaLocationType::getUpwUrlForPdf)
+    //                       .distinct()
+    //                       .filter(Objects::nonNull)
+    //                       .map(ScopusFileConverter::toUri)
+    //                       .map(this::convertToAssociatedArtifact)
+    //                       .filter(Optional::isPresent)
+    //                       .map(Optional::get)
+    //                       .filter(ScopusFileConverter::fileWithContent)
+    //                       .map(File.class::cast)
+    //                       .collect(collectRemovingDuplicatedFiles());
+    //        } catch (Exception e) {
+    //            logger.error(FETCH_FILE_FROM_XML_MESSAGE_ERROR_MESSAGE, e.getMessage());
+    //            return List.of();
+    //        }
+    //    }
+    //
+    //    private boolean isValid(AssociatedArtifact associatedArtifact) {
+    //        return nonNull(((File) associatedArtifact).getMimeType());
+    //    }
+    //    private List<UpwOaLocationType> getLocations(DocTp docTp) {
+    //        return Optional.ofNullable(docTp.getMeta().getOpenAccess())
+    //                   .map(OpenAccessType::getUpwOpenAccess)
+    //                   .map(UpwOpenAccessType::getUpwOaLocations)
+    //                   .map(UpwOaLocationsType::getUpwOaLocation)
+    //                   .orElse(List.of());
+    //    }
+    //    private Optional<AssociatedArtifact> convertToAssociatedArtifact(URI downloadUrl) {
+    //        try {
+    //            var response = fetchResponseAsInputStream(downloadUrl);
+    //            return convertToAssociatedArtifact(response);
+    //        } catch (Exception e) {
+    //            logger.error(FETCH_FILE_FROM_URL_MESSAGE_ERROR_MESSAGE,
+    //                         downloadUrl.toString() + StringUtils.SPACE + e.getMessage());
+    //            return Optional.empty();
+    //        }
+    //    }
+    //    private Optional<AssociatedArtifact> convertToAssociatedArtifact(HttpResponse<InputStream> response)
+    //        throws IOException {
+    //        var fileIdentifier = randomUUID();
+    //        var filename = getFilename(response);
+    //        var inputStreamToSave = tikaUtils.fetch(response.request().uri());
+    //        var mimeType = saveFile(filename, fileIdentifier, inputStreamToSave);
+    //        return Optional.of(File.builder()
+    //                               .withIdentifier(fileIdentifier)
+    //                               .withName(filename)
+    //                               .withMimeType(mimeType)
+    //                               .withSize(inputStreamToSave.getLength())
+    //                               .withLicense(DEFAULT_LICENSE)
+    //                               .withUploadDetails(createUploadDetails())
+    //                               .withPublisherVersion(PublisherVersion.PUBLISHED_VERSION)
+    //                               .buildOpenFile());
+    //    }
+    //    private ImportUploadDetails createUploadDetails() {
+    //        return new ImportUploadDetails(Source.SCOPUS, null, Instant.now());
+    //    }
+    //
+    //    private String saveFile(String fileName, UUID fileIdentifier, TikaInputStream inputStream) throws
+    //    IOException {
+    //        var path = inputStream.getPath();
+    //        var mimeType = tikaUtils.getMimeType(inputStream);
+    //        s3Client.putObject(PutObjectRequest.builder()
+    //                               .bucket(IMPORT_CANDIDATES_FILES_BUCKET)
+    //                               .contentType(mimeType)
+    //                               .contentDisposition(String.format(CONTENT_DISPOSITION_FILE_NAME_PATTERN, fileName))
+    //                               .key(fileIdentifier.toString())
+    //                               .build(), RequestBody.fromFile(path));
+    //        return mimeType;
+    //    }
+    //    private static URI toUri(String string) {
+    //        return attempt(() -> new URI(string.replace(WHITESPACE, ENCODED_WHITESPACE))).orElseThrow();
+    //    }
+    //    private static Collector<File, Object, ArrayList<AssociatedArtifact>> collectRemovingDuplicatedFiles() {
+    //        return collectingAndThen(toCollection(() -> new TreeSet<>(comparing(File::getName))), ArrayList::new);
+    //    }
 }

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -116,7 +116,7 @@ public class ScopusFileConverterTest {
         throws IOException, InterruptedException {
         mockResponsesWithoutHeaders("crossrefResponseMissingFields.json");
 
-        var files = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var files = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertThat(files.getPublisherVersion(), is(nullValue()));
         assertThat(files.getEmbargoDate(), is(Optional.empty()));
@@ -146,18 +146,7 @@ public class ScopusFileConverterTest {
         assertThat(file.getLicense(), is(equalTo(expectedLicense)));
     }
 
-    @Test
-    void shouldReturnSingleAssociatedArtifactsWhenMultipleArtifactsWithTheSameFileName()
-        throws IOException, InterruptedException {
-        var firstUrl = randomUri();
-        var secondUrl = randomUri();
-        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl, secondUrl));
-        mockDownloadUrlResponse();
 
-        var files = fileConverter.fetchAssociatedArtifacts(scopusData.getDocument());
-
-        assertThat(files, hasSize(1));
-    }
 
     @Test
     void shouldRemoveFileFromDoiWhenFileIsFromElseveierAndHasPlainTextContentType()
@@ -181,7 +170,7 @@ public class ScopusFileConverterTest {
         throws IOException, InterruptedException {
         var contentTypeHeader = Map.of(Header.CONTENT_TYPE, List.of("application/html"));
         mockResponsesWithHeader("crossrefResponseMissingFields.json", contentTypeHeader);
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertThat(file.getName(), containsString("html"));
     }
@@ -191,7 +180,7 @@ public class ScopusFileConverterTest {
         throws IOException, InterruptedException {
         var responseBody = "crossrefResponseMissingFields.json";
         mockResponsesWithoutHeaders(responseBody);
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertThat(file.getName(), is(equalTo(TEST_FILE_NAME)));
     }
@@ -201,43 +190,59 @@ public class ScopusFileConverterTest {
         throws IOException, InterruptedException {
         var responseBody = "crossrefResponseMissingFields.json";
         mockResponsesWithHeader(responseBody, Map.of());
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertThat(file.getName(), is(notNullValue()));
-    }
-
-    @Test
-    void shouldSetUploadDetailsWhenFetchingAssociatedArtifactsFromXml() throws IOException, InterruptedException {
-        var firstUrl = randomUri();
-        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
-        mockDownloadUrlResponse();
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-
-        assertThat(((ImportUploadDetails) file.getUploadDetails()).source(), is(equalTo(Source.SCOPUS)));
-        assertThat(file.getUploadDetails().uploadedDate(), is(notNullValue()));
     }
 
     @Test
     void shouldSetUploadDetailsWhenFetchingFileFromDoi() throws IOException, InterruptedException {
         var responseBody = "crossrefResponseMissingFields.json";
         mockResponsesWithHeader(responseBody, Map.of());
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertThat(((ImportUploadDetails) file.getUploadDetails()).source(), is(equalTo(Source.SCOPUS)));
         assertThat(file.getUploadDetails().uploadedDate(), is(notNullValue()));
     }
 
+    // These tests are temporarily disabled because the functionality to fetch files from XML is currently disabled.
+    // This is due to the lack of license information in the XML data. Once a decision is made regarding
+    // handling files without license information, these tests can be revisited and potentially re-enabled.
 
-    @Test
-    void shouldSetPublisherVersionAsPublishedWhenFetchingAssociatedArtifactsFromXml()
-        throws IOException, InterruptedException {
-        var firstUrl = randomUri();
-        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
-        mockDownloadUrlResponse();
-        var file = (OpenFile) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-
-        assertThat(file.getPublisherVersion(), is(equalTo(PublisherVersion.PUBLISHED_VERSION)));
-    }
+//    @Test
+//    void shouldSetPublisherVersionAsPublishedWhenFetchingAssociatedArtifactsFromXml()
+//        throws IOException, InterruptedException {
+//        var firstUrl = randomUri();
+//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
+//        mockDownloadUrlResponse();
+//        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+//
+//        assertThat(file.getPublisherVersion(), is(equalTo(PublisherVersion.PUBLISHED_VERSION)));
+//    }
+//
+//    @Test
+//    void shouldSetUploadDetailsWhenFetchingAssociatedArtifactsFromXml() throws IOException, InterruptedException {
+//        var firstUrl = randomUri();
+//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
+//        mockDownloadUrlResponse();
+//        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+//
+//        assertThat(((ImportUploadDetails) file.getUploadDetails()).source(), is(equalTo(Source.SCOPUS)));
+//        assertThat(file.getUploadDetails().uploadedDate(), is(notNullValue()));
+//    }
+//
+//    @Test
+//    void shouldReturnSingleAssociatedArtifactsWhenMultipleArtifactsWithTheSameFileNameWhenFetchingFilesFromXml()
+//        throws IOException, InterruptedException {
+//        var firstUrl = randomUri();
+//        var secondUrl = randomUri();
+//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl, secondUrl));
+//        mockDownloadUrlResponse();
+//
+//        var files = fileConverter.fetchAssociatedArtifacts(scopusData.getDocument());
+//
+//        assertThat(files, hasSize(1));
+//    }
 
     private void mockDownloadUrlResponse() throws IOException, InterruptedException {
         var fetchDownloadUrlResponse = (HttpResponse<InputStream>) mock(HttpResponse.class);

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -26,15 +26,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import jdk.jfr.Description;
-import no.scopus.generated.OpenAccessType;
-import no.scopus.generated.UpwOaLocationType;
-import no.scopus.generated.UpwOaLocationsType;
-import no.scopus.generated.UpwOpenAccessType;
 import no.sikt.nva.scopus.conversion.files.ScopusFileConverter;
 import no.sikt.nva.scopus.conversion.files.TikaUtils;
 import no.sikt.nva.scopus.utils.ScopusGenerator;
@@ -223,76 +218,6 @@ public class ScopusFileConverterTest {
         var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
 
         assertInstanceOf(OpenFile.class, file);
-    }
-
-    // These tests are temporarily disabled because the functionality to fetch files from XML is currently disabled.
-    // This is due to the lack of license information in the XML data. Once a decision is made regarding
-    // handling files without license information, these tests can be revisited and potentially re-enabled.
-
-//    @Test
-//    void shouldSetPublisherVersionAsPublishedWhenFetchingAssociatedArtifactsFromXml()
-//        throws IOException, InterruptedException {
-//        var firstUrl = randomUri();
-//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
-//        mockDownloadUrlResponse();
-//        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-//
-//        assertThat(file.getPublisherVersion(), is(equalTo(PublisherVersion.PUBLISHED_VERSION)));
-//    }
-//
-//    @Test
-//    void shouldSetUploadDetailsWhenFetchingAssociatedArtifactsFromXml() throws IOException, InterruptedException {
-//        var firstUrl = randomUri();
-//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl));
-//        mockDownloadUrlResponse();
-//        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
-//
-//        assertThat(((ImportUploadDetails) file.getUploadDetails()).source(), is(equalTo(Source.SCOPUS)));
-//        assertThat(file.getUploadDetails().uploadedDate(), is(notNullValue()));
-//    }
-//
-//    @Test
-//    void shouldReturnSingleAssociatedArtifactsWhenMultipleArtifactsWithTheSameFileNameWhenFetchingFilesFromXml()
-//        throws IOException, InterruptedException {
-//        var firstUrl = randomUri();
-//        var secondUrl = randomUri();
-//        scopusData.getDocument().getMeta().setOpenAccess(randomOpenAccessWithDownloadUrl(firstUrl, secondUrl));
-//        mockDownloadUrlResponse();
-//
-//        var files = fileConverter.fetchAssociatedArtifacts(scopusData.getDocument());
-//
-//        assertThat(files, hasSize(1));
-//    }
-
-    private void mockDownloadUrlResponse() throws IOException, InterruptedException {
-        var fetchDownloadUrlResponse = (HttpResponse<InputStream>) mock(HttpResponse.class);
-        var body = mock(ByteArrayInputStream.class);
-        when(body.available()).thenReturn(1000);
-        when(body.readAllBytes()).thenReturn(randomString().getBytes());
-        when(fetchDownloadUrlResponse.body()).thenReturn(body);
-        when(fetchDownloadUrlResponse.headers()).thenReturn(createDownloadUrlHeaders());
-        var request = mock(HttpRequest.class);
-        when(request.uri()).thenReturn(randomUri());
-        when(fetchDownloadUrlResponse.request()).thenReturn(request);
-        when(fetchDownloadUrlResponse.statusCode()).thenReturn(200);
-        when(httpClient.send(any(), eq(BodyHandlers.ofInputStream()))).thenReturn(fetchDownloadUrlResponse);
-    }
-
-    private UpwOaLocationType randomLocation(URI uri) {
-        var location = new UpwOaLocationType();
-        location.setUpwUrlForPdf(uri.toString());
-        return location;
-    }
-
-    private OpenAccessType randomOpenAccessWithDownloadUrl(URI... uri) {
-        var openAccess = new OpenAccessType();
-        var upwOpenAccess = new UpwOpenAccessType();
-        var locations = new UpwOaLocationsType();
-        var locationList = Arrays.stream(uri).map(this::randomLocation).toList();
-        locations.getUpwOaLocation().addAll(locationList);
-        upwOpenAccess.setUpwOaLocations(locations);
-        openAccess.setUpwOpenAccess(upwOpenAccess);
-        return openAccess;
     }
 
     private void mockResponses(String responseBody) throws IOException, InterruptedException {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/ScopusFileConverterTest.java
@@ -7,10 +7,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -41,6 +41,7 @@ import no.sikt.nva.scopus.utils.ScopusGenerator;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails.Source;
+import no.unit.nva.model.associatedartifacts.file.InternalFile;
 import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
 import nva.commons.core.ioutils.IoUtils;
@@ -203,6 +204,25 @@ public class ScopusFileConverterTest {
 
         assertThat(((ImportUploadDetails) file.getUploadDetails()).source(), is(equalTo(Source.SCOPUS)));
         assertThat(file.getUploadDetails().uploadedDate(), is(notNullValue()));
+    }
+
+    @Test
+    void shouldImportInternalFileWhenMissingLicenseWhenFetchingFileFromDoi() throws IOException, InterruptedException {
+        var responseBody = "crossrefResponseMissingFields.json";
+        mockResponsesWithHeader(responseBody, Map.of());
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+
+        assertInstanceOf(InternalFile.class, file);
+    }
+
+    @Test
+    void shouldImportOpenFileWhenCreativeCommonsLicenseIsPresentWhenFetchingFileFromDoi()
+        throws IOException, InterruptedException {
+        var responseBody = "crossrefResponse.json";
+        mockResponsesWithHeader(responseBody, Map.of());
+        var file = (File) fileConverter.fetchAssociatedArtifacts(scopusData.getDocument()).getFirst();
+
+        assertInstanceOf(OpenFile.class, file);
     }
 
     // These tests are temporarily disabled because the functionality to fetch files from XML is currently disabled.


### PR DESCRIPTION
Commenting out the functionality that fetches files based on URLs from Scopus XML. The reason is that Scopus XML only provides download URLs without associated version and license information. We do not want to import files when we are unsure if they can be published.

For files fetched via DOI, if the license is missing, we import them as internal files without a license. This allows the importer to decide whether the file should be published or not.