### PR TITLE
adding log messages when fetching publication channel

### DIFF
--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationChannelConnection.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationChannelConnection.java
@@ -1,17 +1,21 @@
 package no.sikt.nva.scopus.conversion;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static no.sikt.nva.scopus.conversion.PublicationChannel.PUBLISHER;
 import static no.sikt.nva.scopus.conversion.PublicationChannel.SERIAL_PUBLICATION;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
+import java.net.http.HttpResponse;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import no.sikt.nva.scopus.conversion.model.PublicationChannelResponse;
-import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PublicationChannelConnection {
 
@@ -20,6 +24,7 @@ public class PublicationChannelConnection {
     public static final String YEAR = "year";
     public static final String CONTENT_TYPE = "application/json";
     public static final int SINGLE_ITEM = 1;
+    public static final Logger logger = LoggerFactory.getLogger(PublicationChannelConnection.class);
     private static final String API_HOST = new Environment().readEnv("API_HOST");
     private final AuthorizedBackendUriRetriever uriRetriever;
 
@@ -53,14 +58,23 @@ public class PublicationChannelConnection {
     }
 
     private Optional<URI> fetchPublicationChannelId(Stream<URI> uriStream) {
-        return uriStream.map(uri -> uriRetriever.getRawContent(uri, CONTENT_TYPE))
+        return uriStream.map(uri -> uriRetriever.fetchResponse(uri, CONTENT_TYPE))
                    .filter(Optional::isPresent)
                    .map(Optional::get)
+                   .map(this::handleResponse)
                    .map(PublicationChannelConnection::toPublicationChannelResponse)
                    .filter(Objects::nonNull)
                    .filter(PublicationChannelConnection::containsSingleResult)
                    .map(PublicationChannelConnection::getId)
                    .findFirst();
+    }
+
+    private String handleResponse(HttpResponse<String> response) {
+        if (HTTP_OK != response.statusCode()) {
+            logger.error("Publication channels API responded with {} when searching for {}", response.statusCode(),
+                         response.request().uri());
+        }
+        return response.body();
     }
 
     private URI constructSearchUri(PublicationChannel publicationChannel, String searchTerm, Integer year) {

--- a/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/PublicationChannelConnectionTest.java
+++ b/scopus-import/src/test/java/no/sikt/nva/scopus/conversion/PublicationChannelConnectionTest.java
@@ -1,0 +1,64 @@
+package no.sikt.nva.scopus.conversion;
+
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.net.http.HttpRequest;
+import java.util.List;
+import java.util.Optional;
+import no.sikt.nva.scopus.conversion.model.PublicationChannelResponse;
+import no.sikt.nva.scopus.conversion.model.PublicationChannelResponse.PublicationChannelHit;
+import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.publication.testing.http.FakeHttpResponse;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PublicationChannelConnectionTest {
+
+    private PublicationChannelConnection publicationChannelConnection;
+    private AuthorizedBackendUriRetriever uriRetriever;
+
+    @BeforeEach
+    void setup() {
+        uriRetriever = mock(AuthorizedBackendUriRetriever.class);
+        publicationChannelConnection = new PublicationChannelConnection(uriRetriever);
+    }
+
+    @Test
+    void shouldDoSingleApiCallWhenSearchingForChannelAndReceivingResponseWithSingleHitOnFirstApiCall() {
+        when(uriRetriever.fetchResponse(any(), any())).thenReturn(
+            Optional.of(FakeHttpResponse.create(responseWithSingleHit(), HTTP_OK)));
+
+        publicationChannelConnection.fetchSerialPublication(randomString(), randomString(), randomString(),
+                                                            randomInteger());
+
+        verify(uriRetriever, times(1)).fetchResponse(any(), any());
+    }
+
+    @Test
+    void shouldLogWhenChannelRegisterApiIsFailing() {
+        var request = HttpRequest.newBuilder().GET().uri(randomUri()).build();
+        var response = FakeHttpResponse.create(randomString(), HTTP_BAD_GATEWAY);
+        when(uriRetriever.fetchResponse(any(), any())).thenReturn(
+            Optional.of(FakeHttpResponse.create(request, response)));
+
+        var appender = LogUtils.getTestingAppender(PublicationChannelConnection.class);
+        publicationChannelConnection.fetchSerialPublication(randomString(), randomString(), randomString(),
+                                                            randomInteger());
+
+        assertTrue(appender.getMessages().contains("Publication channels API responded with 502"));
+    }
+
+    private static String responseWithSingleHit() {
+        return new PublicationChannelResponse(1, List.of(new PublicationChannelHit(randomUri()))).toJsonString();
+    }
+}


### PR DESCRIPTION
We should find out why all channels from Scopus are not being fetched from channel register. First step is to find out if channel register is failing or we receive multiple results when searching for channel by channel name/issn/isbn. 

Wednesday will show what we are struggling with :)
