### PR TITLE
creating doi request for publishing resource

### DIFF
--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -277,13 +277,14 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
 
         assertThat(updatedPublication.getStatus(), is(equalTo(PublicationStatus.PUBLISHED)));
         assertThat(ticket.getStatus(), is(equalTo(TicketStatus.PENDING)));
+        assertThat(ticket.getResourceStatus(), is(equalTo(PublicationStatus.PUBLISHED)));
         assertThat(
             ticket.getOwnerAffiliation(),
             is(equalTo(pendingPublishingRequest.getOwnerAffiliation())));
     }
 
     @Test
-    void shouldCreateDoiRequestTicketAndSetTicketEventWithTheUserFromPublishingRequest()
+    void shouldCreateDoiRequestTicketForPublishedResourceAndSetTicketEventWithTheUserFromPublishingRequest()
         throws IOException, ApiGatewayException {
         var publication = createDraftPublicationWithDoi();
         var publishingRequest = pendingPublishingRequest(publication);


### PR DESCRIPTION
When creating DoiRequest in AcceptedPublishingRequestHandler - publication is always published. DoiRequest that is being persisted should also have resourceStatus set to Published. 

Otherwise DoiRequest will not be expanded and indexed because of following condition in ResourceExpansionHandler:

```
    private boolean shouldBeEnriched(Entity entry) {
        if (isNull(entry)) {
            return false;
        }
        var publicationStatus = getPublicationStatus(entry);
        if (publicationStatus.isPresent()) {
            return PUBLICATION_STATUS_TO_BE_ENRICHED.contains(publicationStatus.get());
        } else if (entry instanceof DoiRequest doiRequest) {
            return isDoiRequestReadyForEvaluation(doiRequest);
        } else {
            return true;
        }
    }

    private boolean isDoiRequestReadyForEvaluation(DoiRequest doiRequest) {
        return PUBLISHED.equals(doiRequest.getResourceStatus());
    }
```
