### PR TITLE
removing fromPublication method from GSR

### DIFF
--- a/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDataEntryTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/model/ExpandedDataEntryTest.java
@@ -75,6 +75,7 @@ import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.UnpublishRequest;
 import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.UserClientType;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate.Builder;
@@ -498,7 +499,8 @@ class ExpandedDataEntryTest extends ResourcesLocalTest {
                                                                              ResourceExpansionService expansionService,
                                                                              TicketService ticketService)
             throws NotFoundException, JsonProcessingException {
-            var request = (GeneralSupportRequest) GeneralSupportRequest.fromPublication(publication);
+            var userInstance = UserInstance.fromPublication(publication);
+            var request = GeneralSupportRequest.create(Resource.fromPublication(publication), userInstance);
             return ExpandedGeneralSupportRequest.create(request, resourceService, expansionService,
                                                         ticketService);
         }
@@ -566,5 +568,10 @@ class ExpandedDataEntryTest extends ResourcesLocalTest {
             requestCase.setOwner(new User(publication.getResourceOwner().getOwner().getValue()));
             return requestCase;
         }
+    }
+
+    private static UserInstance randomUserInstance() {
+        return new UserInstance(randomString(), randomUri(), randomUri(), randomUri(), randomUri(),
+                                List.of(), UserClientType.INTERNAL);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
@@ -14,11 +14,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
-import java.util.Optional;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.GeneralSupportRequestDao;
@@ -47,18 +44,6 @@ public class GeneralSupportRequest extends TicketEntry {
 
     public GeneralSupportRequest() {
         super();
-    }
-
-    public static TicketEntry fromPublication(Publication publication) {
-        var ticket = new GeneralSupportRequest();
-        ticket.setResourceIdentifier(publication.getIdentifier());
-        ticket.setCustomerId(extractCustomerId(publication));
-        ticket.setCreatedDate(Instant.now());
-        ticket.setModifiedDate(Instant.now());
-        ticket.setStatus(TicketStatus.PENDING);
-        ticket.setIdentifier(SortableIdentifier.next());
-        ticket.setViewedBy(ViewedBy.addAll(UserInstance.fromPublication(publication).getUser()));
-        return ticket;
     }
 
     public static GeneralSupportRequest createQueryObject(URI customerId, SortableIdentifier resourceIdentifier) {
@@ -232,9 +217,5 @@ public class GeneralSupportRequest extends TicketEntry {
                && getStatus() == that.getStatus()
                && Objects.equals(getAssignee(), that.getAssignee())
                && Objects.equals(getOwnerAffiliation(), that.getOwnerAffiliation());
-    }
-
-    private static URI extractCustomerId(Publication publication) {
-        return Optional.of(publication).map(Publication::getPublisher).map(Organization::getId).orElse(null);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -81,7 +81,7 @@ public abstract class TicketEntry implements Entity {
         } else if (PublishingRequestCase.class.equals(ticketType)) {
             return fromPublication(publication);
         } else if (GeneralSupportRequest.class.equals(ticketType)) {
-            return GeneralSupportRequest.fromPublication(publication);
+            return GeneralSupportRequest.create(Resource.fromPublication(publication), UserInstance.fromPublication(publication));
         } else if (UnpublishRequest.class.equals(ticketType)) {
             return UnpublishRequest.fromPublication(publication);
         }
@@ -111,13 +111,6 @@ public abstract class TicketEntry implements Entity {
 
     public static UntypedTicketQueryObject createQueryObject(SortableIdentifier ticketIdentifier) {
         return UntypedTicketQueryObject.create(ticketIdentifier);
-    }
-
-    public static TicketEntry createNewGeneralSupportRequest(Publication publication,
-                                                             Supplier<SortableIdentifier> identifierProvider) {
-        var ticket = GeneralSupportRequest.fromPublication(publication);
-        setServiceControlledFields(ticket, identifierProvider);
-        return ticket;
     }
 
     public static TicketEntry createNewUnpublishRequest(Publication publication,
@@ -371,25 +364,19 @@ public abstract class TicketEntry implements Entity {
         Class<T> ticketType,
         Supplier<SortableIdentifier> identifierProvider) {
 
+        var userInstance = UserInstance.fromPublication(publication);
+        var resource = Resource.fromPublication(publication);
         if (DoiRequest.class.equals(ticketType)) {
-            return createNewDoiRequest(publication, identifierProvider);
+            return DoiRequest.create(resource, userInstance);
         } else if (PublishingRequestCase.class.equals(ticketType)) {
             return createNewPublishingRequestEntry(publication, identifierProvider);
         } else if (GeneralSupportRequest.class.equals(ticketType)) {
-            return createNewGeneralSupportRequest(publication, identifierProvider);
+            return GeneralSupportRequest.create(resource, userInstance);
         } else if (UnpublishRequest.class.equals(ticketType)) {
             return createNewUnpublishRequest(publication, identifierProvider);
         } else {
             throw new UnsupportedOperationException();
         }
-    }
-
-    private static TicketEntry createNewDoiRequest(Publication publication,
-                                                   Supplier<SortableIdentifier> identifierProvider) {
-        var doiRequest = DoiRequest.create(Resource.fromPublication(publication),
-                                           UserInstance.fromPublication(publication));
-        setServiceControlledFields(doiRequest, identifierProvider);
-        return doiRequest;
     }
 
     private static TicketEntry createNewPublishingRequestEntry(Publication publication,

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1238,14 +1238,13 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublishedPublicationWithUnpublishedFilesAndContributor(
             userCristinId,
             resourceService);
-        GeneralSupportRequest.fromPublication(publication)
-            .withOwner(UserInstance.fromPublication(publication).getUsername())
-            .persistNewTicket(ticketService);
-        DoiRequest.create(Resource.fromPublication(publication), UserInstance.fromPublication(publication))
-            .persistNewTicket(ticketService);
+        var resource = Resource.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
+        GeneralSupportRequest.create(resource, userInstance).persistNewTicket(ticketService);
+        DoiRequest.create(resource, userInstance).persistNewTicket(ticketService);
         var publishingRequestTicket =
             PublishingRequestCase.fromPublication(publication)
-                .withOwner(UserInstance.fromPublication(publication).getUsername())
+                .withOwner(userInstance.getUsername())
                 .persistNewTicket(ticketService);
         var completedPublishingRequest = publishingRequestTicket.complete(publication, UserInstance.create(userName,
                                                                                                            randomUri()));
@@ -1255,7 +1254,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                                                         RandomPersonServiceResponse.randomUri(), userCristinId);
         updatePublicationHandler.handleRequest(inputStream, output, context);
         var ticketsAfterUnpublishing =
-            resourceService.fetchAllTicketsForResource(Resource.fromPublication(publication)).toList();
+            resourceService.fetchAllTicketsForResource(resource).toList();
         var updatedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
         assertThat(updatedPublication.getStatus(), is(equalTo(UNPUBLISHED)));
         assertThat(ticketsAfterUnpublishing,


### PR DESCRIPTION
Removing `GeneralSupportRequest.fromPublication(publication)` method. Should always use `create` method.