### PR TITLE
NP-48436 Spike of input validation and sanitization of entity description

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ mockito = { strictly = '5.14.2' }
 nva = { strictly = '1.41.3' }
 nva-language = { strictly = '1.2.0' }
 nvaDoiPartnerData = { strictly = '0.5.8' }
+owaspJavaHtmlSanitizer = { strictly = '20240325.1' }
 reflections = { strictly = '0.10.2' }
 resilience4j = { strictly = '2.2.0' }
 slf4j = { strictly = '2.0.16' }
@@ -132,6 +133,7 @@ swagger-annotations = { group = 'io.swagger.core.v3', name = 'swagger-annotation
 mockito-junit-jupiter = {group= 'org.mockito', name= 'mockito-junit-jupiter', version= '5.3.1'}
 open-csv = { group = 'com.opencsv', name = 'opencsv', version = '5.9' } # open-csv is used by cristin-import, can be deleted when cristin-import is deleted
 reflections = { group = 'org.reflections', name = 'reflections', version.ref = 'reflections' }
+owaspJavaHtmlSanitizer = { group = 'com.googlecode.owasp-java-html-sanitizer', name = 'owasp-java-html-sanitizer', version.ref = 'owaspJavaHtmlSanitizer' }
 [bundles]
 validation = ['jakarta-validation-api', 'jakarta-el-api', 'glassfish-el', 'apache-bval']
 testing = ['junit-jupiter-params', 'junit-jupiter-api', 'junit-vintage-engine', 'guava',

--- a/publication-model/build.gradle
+++ b/publication-model/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation ( libs.commons.validator )
     implementation( libs.jackson.databind )
     implementation libs.bundles.logging
+    implementation libs.bundles.validation
 
     testImplementation( libs.reflections )
     testImplementation( libs.jena.core )

--- a/publication-model/src/main/java/no/unit/nva/model/EntityDescription.java
+++ b/publication-model/src/main/java/no/unit/nva/model/EntityDescription.java
@@ -3,6 +3,7 @@ package no.unit.nva.model;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.net.URI;
 import java.util.Collections;
 import java.util.Comparator;
@@ -10,22 +11,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
+
+import jakarta.validation.constraints.Size;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class EntityDescription implements WithCopy<EntityDescription.Builder> {
 
+    public static final int MAX_SIZE_MAIN_TITLE = 256;
+    public static final int MIN_SIZE_MAIN_TITLE = 1;
+    public static final int MAX_SIZE_ABSTRACT = 4096;
+    public static final int MIN_SIZE_ABSTRACT = 1;
+
+    @Size(min = MIN_SIZE_MAIN_TITLE, max = MAX_SIZE_MAIN_TITLE)
     private String mainTitle;
-    private Map<String, String> alternativeTitles;
+    private Map<String, @Size(min = MIN_SIZE_MAIN_TITLE, max = MAX_SIZE_MAIN_TITLE) String> alternativeTitles;
     private URI language;
 
     @JsonAlias("date")
     private PublicationDate publicationDate;
     private List<Contributor> contributors;
+    @Size(min = MIN_SIZE_ABSTRACT, max = MAX_SIZE_ABSTRACT)
     @JsonSetter("abstract")
     private String mainLanguageAbstract;
 
-    private Map<String, String> alternativeAbstracts;
+    private Map<String, @Size(min = MIN_SIZE_ABSTRACT, max = MAX_SIZE_ABSTRACT) String> alternativeAbstracts;
     private String npiSubjectHeading;
     private List<String> tags;
     private String description;
@@ -107,8 +117,8 @@ public class EntityDescription implements WithCopy<EntityDescription.Builder> {
 
     private List<Contributor> extractContributors(List<Contributor> contributors) {
         var contributorList = contributors.stream()
-              .sorted(Comparator.comparing(Contributor::getSequence, Comparator.nullsLast(Comparator.naturalOrder())))
-                                  .toList();
+                .sorted(Comparator.comparing(Contributor::getSequence, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
 
         return updatedContributorSequence(contributorList);
     }

--- a/publication-rest/build.gradle
+++ b/publication-rest/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 
     implementation libs.apache.commons.text
 
+    implementation libs.owaspJavaHtmlSanitizer
+
     testImplementation project(":publication-testing")
     testImplementation project(":tickets-test")
     testImplementation libs.bundles.testing

--- a/publication-rest/src/main/java/no/unit/nva/publication/create/CreatePublicationRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/create/CreatePublicationRequest.java
@@ -1,17 +1,16 @@
 package no.unit.nva.publication.create;
 
 import static java.util.Objects.nonNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
+
 import no.unit.nva.WithContext;
 import no.unit.nva.WithMetadata;
 import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
@@ -23,10 +22,13 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResearchProject;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.funding.Funding;
+import no.unit.nva.publication.sanitizer.EntityDescriptionSanitizer;
+import no.unit.nva.publication.sanitizer.HtmlSanitizer;
 import nva.commons.core.JacocoGenerated;
 
 public class CreatePublicationRequest implements WithMetadata, WithContext {
 
+    @Valid
     private EntityDescription entityDescription;
     private AssociatedArtifactList associatedArtifacts;
     @JsonProperty("@context")
@@ -93,7 +95,7 @@ public class CreatePublicationRequest implements WithMetadata, WithContext {
     @JacocoGenerated
     @Override
     public void setEntityDescription(EntityDescription entityDescription) {
-        this.entityDescription = entityDescription;
+        this.entityDescription = EntityDescriptionSanitizer.sanitize(entityDescription);
     }
 
     @JacocoGenerated
@@ -206,15 +208,15 @@ public class CreatePublicationRequest implements WithMetadata, WithContext {
     @Override
     public int hashCode() {
         return Objects.hash(getEntityDescription(),
-                            getAssociatedArtifacts(),
-                            getContext(),
-                            getProjects(),
-                            getSubjects(),
-                            getAdditionalIdentifiers(),
-                            getPublicationNotes(),
-                            getDuplicateOf(),
-                            getStatus(),
-                            getImportDetails());
+                getAssociatedArtifacts(),
+                getContext(),
+                getProjects(),
+                getSubjects(),
+                getAdditionalIdentifiers(),
+                getPublicationNotes(),
+                getDuplicateOf(),
+                getStatus(),
+                getImportDetails());
     }
 
     @JacocoGenerated
@@ -227,14 +229,14 @@ public class CreatePublicationRequest implements WithMetadata, WithContext {
             return false;
         }
         return Objects.equals(getEntityDescription(), that.getEntityDescription())
-               && Objects.equals(getAssociatedArtifacts(), that.getAssociatedArtifacts())
-               && Objects.equals(getContext(), that.getContext())
-               && Objects.equals(getProjects(), that.getProjects())
-               && Objects.equals(getSubjects(), that.getSubjects())
-               && Objects.equals(getDuplicateOf(), that.getDuplicateOf())
-               && Objects.equals(getAdditionalIdentifiers(), that.getAdditionalIdentifiers())
-               && Objects.equals(getPublicationNotes(), that.getPublicationNotes())
-               && Objects.equals(getStatus(), that.getStatus())
-               && Objects.equals(getImportDetails(), that.getImportDetails());
+                && Objects.equals(getAssociatedArtifacts(), that.getAssociatedArtifacts())
+                && Objects.equals(getContext(), that.getContext())
+                && Objects.equals(getProjects(), that.getProjects())
+                && Objects.equals(getSubjects(), that.getSubjects())
+                && Objects.equals(getDuplicateOf(), that.getDuplicateOf())
+                && Objects.equals(getAdditionalIdentifiers(), that.getAdditionalIdentifiers())
+                && Objects.equals(getPublicationNotes(), that.getPublicationNotes())
+                && Objects.equals(getStatus(), that.getStatus())
+                && Objects.equals(getImportDetails(), that.getImportDetails());
     }
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizer.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizer.java
@@ -1,0 +1,48 @@
+package no.unit.nva.publication.sanitizer;
+import no.unit.nva.model.EntityDescription;
+import java.util.HashMap;
+import static java.util.Objects.nonNull;
+
+public class EntityDescriptionSanitizer {
+
+    public static EntityDescription sanitize(EntityDescription entityDescription) {
+        sanitizeMainTitle(entityDescription);
+        sanitizeAlternativeTitles(entityDescription);
+        sanitizeAbstract(entityDescription);
+        sanitizeAlternativeAbstracts(entityDescription);
+
+        return entityDescription;
+    }
+
+    private static void sanitizeAlternativeAbstracts(EntityDescription entityDescription) {
+        if (nonNull(entityDescription.getAlternativeAbstracts()) && !entityDescription.getAlternativeAbstracts().isEmpty()) {
+            var myMap = new HashMap<String, String>();
+            entityDescription.getAlternativeAbstracts().forEach((key, value) -> {
+                myMap.put(key, HtmlSanitizer.sanitize(value));
+            });
+            entityDescription.setAlternativeAbstracts(myMap);
+        }
+    }
+
+    private static void sanitizeAbstract(EntityDescription entityDescription) {
+        if (nonNull(entityDescription.getAbstract())) {
+            entityDescription.setAbstract(HtmlSanitizer.sanitize(entityDescription.getAbstract()));
+        }
+    }
+
+    private static void sanitizeAlternativeTitles(EntityDescription entityDescription) {
+        if (nonNull(entityDescription.getAlternativeTitles()) && !entityDescription.getAlternativeTitles().isEmpty()) {
+            var myMap = new HashMap<String, String>();
+            entityDescription.getAlternativeTitles().forEach((key, value) -> {
+                myMap.put(key, HtmlSanitizer.sanitize(value));
+            });
+            entityDescription.setAlternativeTitles(myMap);
+        }
+    }
+
+    private static void sanitizeMainTitle(EntityDescription entityDescription) {
+        if (nonNull(entityDescription.getMainTitle())) {
+            entityDescription.setMainTitle(HtmlSanitizer.sanitize(entityDescription.getMainTitle()));
+        }
+    }
+}

--- a/publication-rest/src/main/java/no/unit/nva/publication/sanitizer/HtmlSanitizer.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/sanitizer/HtmlSanitizer.java
@@ -1,0 +1,21 @@
+package no.unit.nva.publication.sanitizer;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+public class HtmlSanitizer {
+
+    private static final PolicyFactory POLICY_FACTORY = new HtmlPolicyBuilder()
+            .allowElements("a", "i", "p", "br", "b", "strong", "em")
+            .allowAttributes("href", "target").onElements("a")
+            .allowUrlProtocols("https", "http")
+            .requireRelNofollowOnLinks() // Adds rel=nofollow to all links
+            .toFactory();
+
+    private HtmlSanitizer() {
+    }
+
+    public static String sanitize(String input) {
+        return POLICY_FACTORY.sanitize(input);
+    }
+}

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationRequest.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationRequest.java
@@ -3,9 +3,9 @@ package no.unit.nva.publication.update;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
+
+import java.util.*;
+
 import no.unit.nva.WithContext;
 import no.unit.nva.WithIdentifier;
 import no.unit.nva.WithMetadata;
@@ -16,12 +16,11 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.ResearchProject;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.funding.Funding;
+import no.unit.nva.publication.sanitizer.EntityDescriptionSanitizer;
 import nva.commons.apigateway.exceptions.ForbiddenException;
 import nva.commons.core.JacocoGenerated;
 
 import java.net.URI;
-import java.util.List;
-import java.util.Objects;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -87,7 +86,7 @@ public class UpdatePublicationRequest
     @JacocoGenerated
     @Override
     public void setEntityDescription(EntityDescription entityDescription) {
-        this.entityDescription = entityDescription;
+        this.entityDescription = EntityDescriptionSanitizer.sanitize(entityDescription);
     }
 
     @Override

--- a/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,6 +42,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +54,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+
 import no.unit.nva.api.PublicationResponse;
 import no.unit.nva.api.PublicationResponseElevatedUser;
 import no.unit.nva.clients.GetExternalClientResponse;
@@ -104,10 +107,11 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     public static final Javers JAVERS = JaversBuilder.javers().build();
     public static final String ASSOCIATED_ARTIFACTS_FIELD = "associatedArtifacts";
     private static final String CUSTOMER_API_NOT_RESPONDING_OR_NOT_RESPONDING_AS_EXPECTED
-        = "Customer API not responding or not responding as expected!";
+            = "Customer API not responding or not responding as expected!";
     private static final String EXTERNAL_ISSUER = ENVIRONMENT.readEnv("EXTERNAL_USER_POOL_URI");
     private static final String EXTERNAL_CLIENT_ID = "external-client-id";
     private static final Integer HTTP_STATUS_UNPROCESSABLE_CONTENT = 422;
+    private static final String EMPTY_STRING = "";
     private final Context context = new FakeContext();
     private String testUserName;
     private CreatePublicationHandler handler;
@@ -141,7 +145,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
         var baseUrl = URI.create(wireMockRuntimeInfo.getHttpsBaseUrl());
         lenient().when(environmentMock.readEnv("BACKEND_CLIENT_AUTH_URL"))
-            .thenReturn(baseUrl.toString());
+                .thenReturn(baseUrl.toString());
 
         resourceService = getResourceServiceBuilder().build();
 
@@ -152,22 +156,22 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
         var httpClient = WiremockHttpClient.create();
 
         handler = new CreatePublicationHandler(resourceService,
-                                               environmentMock,
-                                               identityServiceClient,
-                                               secretsManagerClient,
-                                               httpClient);
+                environmentMock,
+                identityServiceClient,
+                secretsManagerClient,
+                httpClient);
         outputStream = new ByteArrayOutputStream();
         samplePublication = randomPublication();
         testUserName = samplePublication.getResourceOwner().getOwner().getValue();
         topLevelCristinOrgId = randomUri();
         customerId = UriWrapper.fromUri(wireMockRuntimeInfo.getHttpsBaseUrl())
-                         .addChild("customer", UUID.randomUUID().toString())
-                         .getUri();
+                .addChild("customer", UUID.randomUUID().toString())
+                .getUri();
 
         getExternalClientResponse = new GetExternalClientResponse(EXTERNAL_CLIENT_ID,
-                                                                  "someone@123",
-                                                                  customerId,
-                                                                  randomUri());
+                "someone@123",
+                customerId,
+                randomUri());
         lenient().when(identityServiceClient.getExternalClient(any())).thenReturn(getExternalClientResponse);
 
         stubSuccessfulTokenResponse();
@@ -181,7 +185,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
     @Test
     void requestToHandlerReturnsMinRequiredFieldsWhenRequestBodyIsEmpty()
-        throws Exception {
+            throws Exception {
         var inputStream = createPublicationRequest(null);
         handler.handleRequest(inputStream, outputStream, context);
 
@@ -217,10 +221,10 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @ParameterizedTest(name = "requestToHandlerWithStatusFromAnExternalClientShouldPersistDocumentWithSameStatus with"
-                              + " status: \"{0}\"")
+            + " status: \"{0}\"")
     @ValueSource(strings = {"DRAFT", "PUBLISHED"})
     void shouldPersistProvidedStatusWhenMachineUserPersistsPublicationWithAnyStatus(String statusString)
-        throws Exception {
+            throws Exception {
         var status = PublicationStatus.valueOf(statusString);
         var request = createEmptyPublicationRequest();
         request.setStatus(status);
@@ -236,7 +240,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
     @Test
     void shouldReturnBadRequestWhenAnExternalClientTriesToCreatePublishedDocumentWithoutTitleAndDoiRef()
-        throws Exception {
+            throws Exception {
         var request = createEmptyPublicationRequest();
         request.setStatus(PublicationStatus.PUBLISHED);
         var inputStream = requestFromExternalClient(request);
@@ -269,7 +273,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
     @Test
     void shouldSaveAllSuppliedInformationOfPublicationRequestExceptForInternalInformationDecidedByService()
-        throws Exception {
+            throws Exception {
         var publicationWithoutFiles = samplePublication.copy().withAssociatedArtifacts(List.of()).build();
         var request = CreatePublicationRequest.fromPublication(publicationWithoutFiles);
         var inputStream = createPublicationRequest(request);
@@ -280,8 +284,8 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
         var actualPublicationResponse = actual.getBodyObject(PublicationResponseElevatedUser.class);
 
         var expectedPublicationResponse =
-            constructResponseSettingFieldsThatAreNotCopiedByTheRequest(publicationWithoutFiles,
-                                                                       actualPublicationResponse);
+                constructResponseSettingFieldsThatAreNotCopiedByTheRequest(publicationWithoutFiles,
+                        actualPublicationResponse);
 
         var diff = JAVERS.compare(expectedPublicationResponse, actualPublicationResponse);
         assertThat(actualPublicationResponse.getIdentifier(), is(equalTo(expectedPublicationResponse.getIdentifier())));
@@ -300,10 +304,10 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     @ParameterizedTest(name = "should return forbidden when creating instance type {0} without being a thesis curator")
     @MethodSource("protectedDegreeInstanceTypeClassesProvider")
     void shouldReturnForbiddenCreatingProtectedDegreePublicationWithoutBeingThesisCurator(
-        final Class<?> protectedDegreeInstanceClass) throws IOException {
+            final Class<?> protectedDegreeInstanceClass) throws IOException {
         var thesisPublication = samplePublication.copy()
-                                    .withEntityDescription(publishableEntityDescription(protectedDegreeInstanceClass))
-                                    .build();
+                .withEntityDescription(publishableEntityDescription(protectedDegreeInstanceClass))
+                .build();
         var event = requestWithoutAccessRights(CreatePublicationRequest.fromPublication(thesisPublication));
         handler.handleRequest(event, outputStream, context);
         var response = GatewayResponse.fromOutputStream(outputStream, Problem.class);
@@ -313,11 +317,11 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     @ParameterizedTest(name = "should allow creating protected degree instance type {0} when done by external client")
     @MethodSource("protectedDegreeInstanceTypeClassesProvider")
     void shouldPersistDegreePublicationWhenUserIsExternalClient(Class<?> protectedDegreeInstanceClass)
-        throws IOException {
+            throws IOException {
         var thesisPublication = samplePublication.copy()
-                                    .withAssociatedArtifacts(List.of())
-                                    .withEntityDescription(publishableEntityDescription(protectedDegreeInstanceClass))
-                                    .build();
+                .withAssociatedArtifacts(List.of())
+                .withEntityDescription(publishableEntityDescription(protectedDegreeInstanceClass))
+                .build();
         var event = requestFromExternalClient(CreatePublicationRequest.fromPublication(thesisPublication));
         handler.handleRequest(event, outputStream, context);
         var response = GatewayResponse.fromOutputStream(outputStream, Problem.class);
@@ -345,17 +349,17 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     @ParameterizedTest
     @MethodSource("httpClientExceptionsProvider")
     void shouldReturnBadGatewayIfCustomerApiHttpClientThrowsException(Exception exceptionToThrow)
-        throws IOException, InterruptedException {
+            throws IOException, InterruptedException {
 
         var httpClient = mock(HttpClient.class);
 
         doThrow(exceptionToThrow).when(httpClient).send(any(), any());
 
         handler = new CreatePublicationHandler(resourceService,
-                                               environmentMock,
-                                               identityServiceClient,
-                                               secretsManagerClient,
-                                               httpClient);
+                environmentMock,
+                identityServiceClient,
+                secretsManagerClient,
+                httpClient);
 
         var event = prepareRequestWithFileForTypeWhereNotAllowed();
 
@@ -420,22 +424,22 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
     @Test
     void shouldReturnBadRequestIfProvidedWithOneOrMoreFilesHasNullRightsRetentionSetButCustomerHasAOverridableConfig()
-        throws IOException {
+            throws IOException {
 
         WireMock.reset();
         stubSuccessfulTokenResponse();
         stubCustomerResponseAcceptingFilesForAllTypesAndOverridableRrs(customerId);
 
         var file = new PendingOpenFile(UUID.randomUUID(),
-                                       RandomDataGenerator.randomString(),
-                                       RandomDataGenerator.randomString(),
-                                       RandomDataGenerator.randomInteger().longValue(),
-                                       RandomDataGenerator.randomUri(),
-                                       PublisherVersion.ACCEPTED_VERSION,
-                                       (Instant) null,
-                                       RightsRetentionStrategyGenerator.randomRightsRetentionStrategy(),
-                                       RandomDataGenerator.randomString(),
-                                       new UserUploadDetails(null, null));
+                RandomDataGenerator.randomString(),
+                RandomDataGenerator.randomString(),
+                RandomDataGenerator.randomInteger().longValue(),
+                RandomDataGenerator.randomUri(),
+                PublisherVersion.ACCEPTED_VERSION,
+                (Instant) null,
+                RightsRetentionStrategyGenerator.randomRightsRetentionStrategy(),
+                RandomDataGenerator.randomString(),
+                new UserUploadDetails(null, null));
         // Waiting for datamodel changes as
         // Generator sets publisherAuth to true
 
@@ -563,31 +567,43 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
     }
 
+    @Test
+    void shouldSanitizeEntityDescription() {
+        var request = createEmptyPublicationRequest();
+        request.setEntityDescription(
+                new EntityDescription.Builder()
+                        .withMainTitle("<script>alert('Oh no!');</script>")
+                        .build()
+        );
+
+        assertThat(request.getEntityDescription().getMainTitle(), is(EMPTY_STRING));
+    }
+
     private static String bodyWithNoReference() {
         return """
-            {
-                "entityDescription": {
-                    "type": "EntityDescription"
+                {
+                    "entityDescription": {
+                        "type": "EntityDescription"
+                    }
                 }
-            }
-            """;
+                """;
     }
 
     private static String bodyWithEmptyReference() {
         return """
-            {
-                "entityDescription": {
-                    "type": "EntityDescription",
-                    "reference": {
-                        "type": "Reference"
+                {
+                    "entityDescription": {
+                        "type": "EntityDescription",
+                        "reference": {
+                            "type": "Reference"
+                        }
                     }
                 }
-            }
-            """;
+                """;
     }
 
     private static void updateCreatePublicationRequestWithInvalidAssociatedArtifact(
-        ObjectNode publicationRequestJsonObject) throws JsonProcessingException {
+            ObjectNode publicationRequestJsonObject) throws JsonProcessingException {
         var associatedArtifacts = (ArrayNode) publicationRequestJsonObject.get(ASSOCIATED_ARTIFACTS_FIELD);
         associatedArtifacts.add(createNullAssociatedArtifact());
     }
@@ -610,7 +626,7 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
 
     private ObjectNode createCreatePublicationRequestAsJsonObject() throws JsonProcessingException {
         var publicationRequest =
-            dtoObjectMapper.writeValueAsString(CreatePublicationRequest.fromPublication(samplePublication));
+                dtoObjectMapper.writeValueAsString(CreatePublicationRequest.fromPublication(samplePublication));
         return (ObjectNode) dtoObjectMapper.readTree(publicationRequest);
     }
 
@@ -619,43 +635,43 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     private PublicationResponse constructResponseSettingFieldsThatAreNotCopiedByTheRequest(
-        Publication samplePublication, PublicationResponse actualPublicationResponse) {
+            Publication samplePublication, PublicationResponse actualPublicationResponse) {
         var expectedPublication = setAllFieldsThatAreNotCopiedFromTheCreateRequest(samplePublication,
-                                                                                   actualPublicationResponse);
+                actualPublicationResponse);
         return PublicationResponseElevatedUser.fromPublication(expectedPublication);
     }
 
     private Publication setAllFieldsThatAreNotCopiedFromTheCreateRequest(
-        Publication samplePublication, PublicationResponse actualPublicationResponse) {
+            Publication samplePublication, PublicationResponse actualPublicationResponse) {
         return attempt(() -> removeAllFieldsThatAreNotCopiedFromTheCreateRequest(samplePublication))
-                   .map(publication ->
-                            setAllFieldsThatAreAutomaticallySetByResourceService(publication,
-                                                                                 actualPublicationResponse))
-                   .orElseThrow();
+                .map(publication ->
+                        setAllFieldsThatAreAutomaticallySetByResourceService(publication,
+                                actualPublicationResponse))
+                .orElseThrow();
     }
 
     private Publication setAllFieldsThatAreAutomaticallySetByResourceService(
-        Publication samplePublication,
-        PublicationResponse actualPublicationResponse) {
+            Publication samplePublication,
+            PublicationResponse actualPublicationResponse) {
         return samplePublication.copy()
-                   .withIdentifier(actualPublicationResponse.getIdentifier())
-                   .withCreatedDate(actualPublicationResponse.getCreatedDate())
-                   .withModifiedDate(actualPublicationResponse.getModifiedDate())
-                   .withIndexedDate(actualPublicationResponse.getIndexedDate())
-                   .withStatus(PublicationStatus.DRAFT)
-                   .withResourceOwner(actualPublicationResponse.getResourceOwner())
-                   .build();
+                .withIdentifier(actualPublicationResponse.getIdentifier())
+                .withCreatedDate(actualPublicationResponse.getCreatedDate())
+                .withModifiedDate(actualPublicationResponse.getModifiedDate())
+                .withIndexedDate(actualPublicationResponse.getIndexedDate())
+                .withStatus(PublicationStatus.DRAFT)
+                .withResourceOwner(actualPublicationResponse.getResourceOwner())
+                .build();
     }
 
     private Publication removeAllFieldsThatAreNotCopiedFromTheCreateRequest(Publication samplePublication) {
         return samplePublication.copy()
-                   .withDoi(null)
-                   .withHandle(null)
-                   .withLink(null)
-                   .withPublishedDate(null)
-                   .withPublisher(new Organization.Builder().withId(customerId).build())
-                   .withResourceOwner(null)
-                   .build();
+                .withDoi(null)
+                .withHandle(null)
+                .withLink(null)
+                .withPublishedDate(null)
+                .withPublisher(new Organization.Builder().withId(customerId).build())
+                .withResourceOwner(null)
+                .build();
     }
 
     private void assertExistenceOfMinimumRequiredFields(PublicationResponse publicationResponse) {
@@ -670,79 +686,79 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
     private InputStream createPublicationRequest(CreatePublicationRequest request) throws JsonProcessingException {
 
         return new HandlerRequestBuilder<CreatePublicationRequest>(dtoObjectMapper)
-                   .withUserName(testUserName)
-                   .withCurrentCustomer(customerId)
-                   .withTopLevelCristinOrgId(topLevelCristinOrgId)
-                   .withBody(request)
-                   .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE)
-                   .build();
+                .withUserName(testUserName)
+                .withCurrentCustomer(customerId)
+                .withTopLevelCristinOrgId(topLevelCristinOrgId)
+                .withBody(request)
+                .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE)
+                .build();
     }
 
     private InputStream requestWithoutAccessRights(CreatePublicationRequest request) throws JsonProcessingException {
 
         return new HandlerRequestBuilder<CreatePublicationRequest>(dtoObjectMapper)
-                   .withUserName(testUserName)
-                   .withCurrentCustomer(customerId)
-                   .withTopLevelCristinOrgId(topLevelCristinOrgId)
-                   .withBody(request)
-                   .build();
+                .withUserName(testUserName)
+                .withCurrentCustomer(customerId)
+                .withTopLevelCristinOrgId(topLevelCristinOrgId)
+                .withBody(request)
+                .build();
     }
 
     private InputStream createPublicationRequestFromString(String request) throws JsonProcessingException {
 
         return new HandlerRequestBuilder<String>(dtoObjectMapper)
-                   .withUserName(testUserName)
-                   .withCurrentCustomer(customerId)
-                   .withTopLevelCristinOrgId(topLevelCristinOrgId)
-                   .withBody(request)
-                   .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE)
-                   .build();
+                .withUserName(testUserName)
+                .withCurrentCustomer(customerId)
+                .withTopLevelCristinOrgId(topLevelCristinOrgId)
+                .withBody(request)
+                .withAccessRights(customerId, MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE)
+                .build();
     }
 
     private InputStream requestFromExternalClient(CreatePublicationRequest request) throws JsonProcessingException {
         return new HandlerRequestBuilder<CreatePublicationRequest>(dtoObjectMapper)
-                   .withBody(request)
-                   .withAuthorizerClaim(ISS_CLAIM, EXTERNAL_ISSUER)
-                   .withAuthorizerClaim(CLIENT_ID_CLAIM, EXTERNAL_CLIENT_ID)
-                   .build();
+                .withBody(request)
+                .withAuthorizerClaim(ISS_CLAIM, EXTERNAL_ISSUER)
+                .withAuthorizerClaim(CLIENT_ID_CLAIM, EXTERNAL_CLIENT_ID)
+                .build();
     }
 
     private InputStream requestFromExternalClientWithoutClientId(CreatePublicationRequest request)
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         return new HandlerRequestBuilder<CreatePublicationRequest>(dtoObjectMapper)
-                   .withBody(request)
-                   .withAuthorizerClaim(ISS_CLAIM, EXTERNAL_ISSUER)
-                   .build();
+                .withBody(request)
+                .withAuthorizerClaim(ISS_CLAIM, EXTERNAL_ISSUER)
+                .build();
     }
 
     private InputStream requestWithoutUsername(CreatePublicationRequest request) throws JsonProcessingException {
 
         return new HandlerRequestBuilder<CreatePublicationRequest>(dtoObjectMapper)
-                   .withCurrentCustomer(customerId)
-                   .withBody(request)
-                   .build();
+                .withCurrentCustomer(customerId)
+                .withBody(request)
+                .build();
     }
 
     private EntityDescription randomPublishableEntityDescription() {
         return new EntityDescription.Builder()
-                   .withMainTitle(randomString())
-                   .withReference(
-                       new Reference.Builder()
-                           .withDoi(RandomDataGenerator.randomDoi())
-                           .withPublicationInstance(PublicationInstanceBuilder.randomPublicationInstance())
-                           .build())
-                   .build();
+                .withMainTitle(randomString())
+                .withReference(
+                        new Reference.Builder()
+                                .withDoi(RandomDataGenerator.randomDoi())
+                                .withPublicationInstance(PublicationInstanceBuilder.randomPublicationInstance())
+                                .build())
+                .build();
     }
 
     private EntityDescription publishableEntityDescription(final Class<?> instanceClass) {
         return new EntityDescription.Builder()
-                   .withMainTitle(randomString())
-                   .withReference(
-                       new Reference.Builder()
-                           .withDoi(RandomDataGenerator.randomDoi())
-                           .withPublicationInstance(
-                               PublicationInstanceBuilder.randomPublicationInstance(instanceClass))
-                           .build())
-                   .build();
+                .withMainTitle(randomString())
+                .withReference(
+                        new Reference.Builder()
+                                .withDoi(RandomDataGenerator.randomDoi())
+                                .withPublicationInstance(
+                                        PublicationInstanceBuilder.randomPublicationInstance(instanceClass))
+                                .build())
+                .build();
     }
 }

--- a/publication-rest/src/test/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizerTest.java
@@ -1,0 +1,101 @@
+package no.unit.nva.publication.sanitizer;
+
+import no.unit.nva.model.EntityDescription;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static no.unit.nva.publication.service.impl.ServiceWithTransactions.EMPTY_STRING;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class EntityDescriptionSanitizerTest {
+
+    @ParameterizedTest
+    @MethodSource("validInputProvider")
+    void shouldAllowValidInputInMainTitle(String validInput) {
+        var randomString = randomString();
+        var entityDescription = new EntityDescription.Builder()
+                        .withMainTitle(validInput)
+                        .withAlternativeTitles(Map.of(randomString, validInput))
+                        .withAbstract(validInput)
+                        .withAlternativeAbstracts(Map.of(randomString, validInput))
+                        .build();
+
+        var sanitized = EntityDescriptionSanitizer.sanitize(entityDescription);
+
+        assertThat(sanitized.getMainTitle(), equalTo(validInput));
+        assertThat(sanitized.getAlternativeTitles().get(randomString), equalTo(validInput));
+        assertThat(sanitized.getAbstract(), equalTo(validInput));
+        assertThat(sanitized.getAlternativeAbstracts().get(randomString), equalTo(validInput));
+    }
+
+    @ParameterizedTest
+    @MethodSource("dangerousInputProvider")
+    void shouldSanitizeInputInMainTitle(String dangerousInput, String expectedSanitizedInput) {
+        var randomString = randomString();
+        var entityDescription = new EntityDescription.Builder()
+                .withMainTitle(dangerousInput)
+                .withAlternativeTitles(Map.of(randomString, dangerousInput))
+                .withAbstract(dangerousInput)
+                .withAlternativeAbstracts(Map.of(randomString, dangerousInput))
+                .build();
+
+        var sanitized = EntityDescriptionSanitizer.sanitize(entityDescription);
+
+        assertThat(sanitized.getMainTitle(), equalTo(expectedSanitizedInput));
+        assertThat(sanitized.getAlternativeTitles().get(randomString), equalTo(expectedSanitizedInput));
+        assertThat(sanitized.getAbstract(), equalTo(expectedSanitizedInput));
+        assertThat(sanitized.getAlternativeAbstracts().get(randomString), equalTo(expectedSanitizedInput));
+    }
+
+    private static Stream<Arguments> validInputProvider() {
+        return Stream.of(
+                argumentSet("Plain text", "Plain text"),
+                argumentSet("Paragraph tag", "<p>Paragraph</p>"),
+                argumentSet("Italic tag", "<i>Italic</i>"),
+                argumentSet("Em tag", "<em>Em</em>"),
+                argumentSet("Bold tag", "<b>Bold</b>"),
+                argumentSet("Strong tag", "<strong>Strong</strong>"),
+                argumentSet("Link tag with rel=nofollow", "<a href=\"https://www.nva.sikt.no\" rel=\"nofollow\">Sikt</a>"),
+                argumentSet("Link tag with target and rel=nofollow noopener noreferrer", "<a href=\"https://www.nva.sikt.no\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">Sikt</a>"),
+                argumentSet("Special characters", "Special characters $€§!#%/|(){}[]-*?^¨_.:,;"),
+                argumentSet("Backslash", "\\"),
+                argumentSet("Newlines", "\r \n \r\n"),
+                argumentSet("Æøå", "ÆØÅ æøå"),
+                argumentSet("Encoded inequality", "3 &gt; 2 and 2 &lt; 3"),
+                argumentSet("Line break", "<br />")
+        );
+    }
+
+    private static Stream<Arguments> dangerousInputProvider() {
+        return Stream.of(
+                argumentSet("Script tag", "<script>alert('Oh no!');</script>", EMPTY_STRING),
+                argumentSet("Backtick", "`", "&#96;"),
+                argumentSet("Quotation mark", "\"", "&#34;"),
+                argumentSet("Apostrophe", "'", "&#39;"),
+                argumentSet("Ampersand", "&", "&amp;"),
+                argumentSet("Img tag", "<img src=x />", EMPTY_STRING),
+                argumentSet("U tag", "<u>Underline</u>", "Underline"),
+                argumentSet("Sup tag", "<sub>Sub</sub>", "Sub"),
+                argumentSet("Sub tag", "<sup>Sup</sup>", "Sup"),
+                argumentSet("Link tag with onclick", "<a href=\"https://www.nva.sikt.com\" onclick=\"alert('Oh no!')\">Sikt</a>", "<a href=\"https://www.nva.sikt.com\" rel=\"nofollow\">Sikt</a>"),
+                argumentSet("Link tag without href", "<a>Sikt</a>", "Sikt"),
+                argumentSet("Link tag without rel=nofollow", "<a href=\"https://www.nva.sikt.com\">Sikt</a>", "<a href=\"https://www.nva.sikt.com\" rel=\"nofollow\">Sikt</a>"),
+                argumentSet("Link tag with rel=noopener noreferrer but without target", "<a href=\"https://www.nva.sikt.com\" rel=\"noopener noreferrer\">Sikt</a>", "<a href=\"https://www.nva.sikt.com\" rel=\"nofollow\">Sikt</a>"),
+                argumentSet("Link tag with target and without rel=", "<a href=\"https://www.nva.sikt.com\" target=\"_blank\">Sikt</a>", "<a href=\"https://www.nva.sikt.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">Sikt</a>"),
+                argumentSet("Link tag with mailto protocol", "<a href=\"mailto:someone@sikt.no\">Mailto</a>", "Mailto"),
+                argumentSet("Equals", "=", "&#61;"),
+                argumentSet("Plus", "+", "&#43;"),
+                argumentSet("At", "@", "&#64;"),
+                argumentSet("Unordered list tag", "<ul><li>List item</li></ul>", "List item"),
+                argumentSet("Ordered List tag", "<ol><li>List item</li></ol>", "List item"),
+                argumentSet("MathML", "<math><mfrac><mrow><mn>1</mn><mo>x</mo><mn>3</mn></mrow></mfrac></math>", "1x3")
+        );
+    }
+}

--- a/publication-rest/src/test/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/sanitizer/EntityDescriptionSanitizerTest.java
@@ -18,7 +18,7 @@ class EntityDescriptionSanitizerTest {
 
     @ParameterizedTest
     @MethodSource("validInputProvider")
-    void shouldAllowValidInputInMainTitle(String validInput) {
+    void shouldAllowValidInputInEntityDescription(String validInput) {
         var randomString = randomString();
         var entityDescription = new EntityDescription.Builder()
                         .withMainTitle(validInput)
@@ -37,7 +37,7 @@ class EntityDescriptionSanitizerTest {
 
     @ParameterizedTest
     @MethodSource("dangerousInputProvider")
-    void shouldSanitizeInputInMainTitle(String dangerousInput, String expectedSanitizedInput) {
+    void shouldSanitizeInputInEntityDescription(String dangerousInput, String expectedSanitizedInput) {
         var randomString = randomString();
         var entityDescription = new EntityDescription.Builder()
                 .withMainTitle(dangerousInput)


### PR DESCRIPTION
Using OWASP JavaHtmlSanitizer to sanitize mainTitle, alternativeTitles, abstract, and alternativeAbstracts when requests go through CreatePublicationRequest and UpdatePublicationRequest.

The same fields are also validated to be at least one character long and maximum 256 or 4096 characters long.