### PR TITLE
removing from publication method from pub req

### DIFF
--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BragePatchEventConsumerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/BragePatchEventConsumerTest.java
@@ -69,7 +69,7 @@ class BragePatchEventConsumerTest extends ResourcesLocalTest {
         mockSearchApiResponse(existingParentPublication, 1);
         handler.handleRequest(event, CONTEXT);
 
-        var updatedChild = resourceService.getPublication(partOfReport.getPublication());
+        var updatedChild = resourceService.getPublicationByIdentifier(partOfReport.getPublication().getIdentifier());
         var partOfValue = getPartOfValue(updatedChild);
 
         assertEquals(SortableIdentifier.fromUri(partOfValue), existingParentPublication.getIdentifier());
@@ -85,7 +85,7 @@ class BragePatchEventConsumerTest extends ResourcesLocalTest {
         mockSearchApiResponse(existingParentPublication, 1);
         handler.handleRequest(event, CONTEXT);
 
-        var notUpdatedChild = resourceService.getPublication(partOfReport.getPublication());
+        var notUpdatedChild = resourceService.getPublicationByIdentifier(partOfReport.getPublication().getIdentifier());
 
         assertNull(getPartOfValue(notUpdatedChild));
     }
@@ -99,7 +99,7 @@ class BragePatchEventConsumerTest extends ResourcesLocalTest {
         mockSearchApiResponse(existingParentPublication, 2);
         handler.handleRequest(event, CONTEXT);
 
-        var notUpdatedChild = resourceService.getPublication(partOfReport.getPublication());
+        var notUpdatedChild = resourceService.getPublicationByIdentifier(partOfReport.getPublication().getIdentifier());
 
         assertNull(getPartOfValue(notUpdatedChild));
     }

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -772,7 +772,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
     private TicketEntry createCompletedTicketAndPublishFiles(Publication publication) throws ApiGatewayException {
         var ticket = (PublishingRequestCase) TicketTestUtils.createCompletedTicket(
             publication, PublishingRequestCase.class, ticketService);
-        ticket.withFilesForApproval(TicketTestUtils.getFilesForApproval(publication)).publishApprovedFile()
+        ticket.withFilesForApproval(TicketTestUtils.getFilesForApproval(publication)).approveFiles()
             .publishApprovedFiles(resourceService);
         return ticket;
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -71,30 +71,12 @@ public class PublishingRequestCase extends TicketEntry {
         super();
     }
 
-    public static PublishingRequestCase fromPublication(Publication publication) {
-        var userInstance = UserInstance.fromPublication(publication);
-        var openingCaseObject = new PublishingRequestCase();
-        openingCaseObject.setCustomerId(userInstance.getCustomerId());
-        openingCaseObject.setStatus(TicketStatus.PENDING);
-        openingCaseObject.setViewedBy(ViewedBy.addAll(userInstance.getUser()));
-        openingCaseObject.setResourceIdentifier(publication.getIdentifier());
-        return openingCaseObject;
-    }
-
     public static PublishingRequestCase create(Resource resource, UserInstance userInstance,
                                                PublishingWorkflow workflow) {
         var publishingRequestCase = createPublishingRequest(resource, userInstance, workflow);
-        return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(workflow)
-                   ? completePublishingRequestAndApproveFiles(resource, userInstance, publishingRequestCase)
+        return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(workflow) ? completePublishingRequestAndApproveFiles(
+            resource, userInstance, publishingRequestCase)
                    : handleMetadataOnlyWorkflow(resource, userInstance, workflow, publishingRequestCase);
-    }
-
-    private static PublishingRequestCase handleMetadataOnlyWorkflow(Resource resource, UserInstance userInstance,
-                                                                  PublishingWorkflow workflow,
-                                                                  PublishingRequestCase publishingRequestCase) {
-        return canPublishMetadataAndNoFilesToApprove(workflow, publishingRequestCase)
-                   ? publishingRequestCase.complete(resource.toPublication(), userInstance)
-                   : publishingRequestCase;
     }
 
     public static PublishingRequestCase createWithFilesForApproval(Resource resource, UserInstance userInstance,
@@ -290,7 +272,7 @@ public class PublishingRequestCase extends TicketEntry {
         return this;
     }
 
-    public PublishingRequestCase publishApprovedFile() {
+    public PublishingRequestCase approveFiles() {
         this.approvedFiles = getFilesForApproval().stream().map(this::toApprovedFile).collect(Collectors.toSet());
         this.filesForApproval = Set.of();
         return this;
@@ -351,6 +333,13 @@ public class PublishingRequestCase extends TicketEntry {
         return getApprovedFiles().stream().map(File::getIdentifier).toList().contains(file.getIdentifier());
     }
 
+    private static PublishingRequestCase handleMetadataOnlyWorkflow(Resource resource, UserInstance userInstance,
+                                                                    PublishingWorkflow workflow,
+                                                                    PublishingRequestCase publishingRequestCase) {
+        return canPublishMetadataAndNoFilesToApprove(workflow, publishingRequestCase) ? publishingRequestCase.complete(
+            resource.toPublication(), userInstance) : publishingRequestCase;
+    }
+
     private static boolean canPublishMetadataAndNoFilesToApprove(PublishingWorkflow workflow,
                                                                  PublishingRequestCase publishingRequestCase) {
         return REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(workflow) &&
@@ -361,7 +350,7 @@ public class PublishingRequestCase extends TicketEntry {
                                                                                   UserInstance userInstance,
                                                                                   PublishingRequestCase publishingRequestCase) {
         publishingRequestCase.setAssignee(new Username(userInstance.getUsername()));
-        publishingRequestCase.publishApprovedFile();
+        publishingRequestCase.approveFiles();
         return publishingRequestCase.complete(resource.toPublication(), userInstance);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -288,12 +288,6 @@ public class ResourceService extends ServiceWithTransactions {
         writeToDynamoInBatches(writeRequests);
     }
 
-    // TODO: Remove all usages of this method in tests and use getPublicationByIdentifier instead
-    @Deprecated(forRemoval = true)
-    public Publication getPublication(Publication publication) throws NotFoundException {
-        return getResourceByIdentifier(publication.getIdentifier()).toPublication();
-    }
-
     public Resource getResourceByIdentifier(SortableIdentifier identifier) throws NotFoundException {
         return readResourceService.getResourceByIdentifier(identifier)
                    .orElseThrow(() -> new NotFoundException(

--- a/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/TestingUtils.java
@@ -11,6 +11,7 @@ import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UnpublishRequest;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -51,8 +52,7 @@ public final class TestingUtils extends TestDataSource {
     }
     
     public static GeneralSupportRequest createGeneralSupportRequest(Publication publication) {
-        return (GeneralSupportRequest) TicketEntry.requestNewTicket(publication, GeneralSupportRequest.class)
-                                           .withOwner(UserInstance.fromPublication(publication).getUsername());
+        return GeneralSupportRequest.create(Resource.fromPublication(publication), UserInstance.fromPublication(publication));
     }
 
     public static UnpublishRequest createUnpublishRequest(Publication publication) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestCaseTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestCaseTest.java
@@ -28,7 +28,7 @@ class PublishingRequestCaseTest {
     void shouldReturnTrueWhenApprovedFilesListContainsFileIdentifier() {
         var file = OpenFile.builder().withIdentifier(UUID.randomUUID()).buildOpenFile();
         var publishingRequestCase = createSample(randomElement(TicketStatus.values())).withFilesForApproval(
-            Set.of(file)).publishApprovedFile();
+            Set.of(file)).approveFiles();
 
         assertTrue(publishingRequestCase.fileIsApproved(file));
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/PublishingRequestTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +29,9 @@ class PublishingRequestTest {
     @Test
     void shouldReturnPublishingRequestWithAdequateInfoForCreatingEntryWhenSuppliedWithUserAndPublicationInfo() {
         var publication = randomPublication();
+        var resource = Resource.fromPublication(publication);
         var userInstance = UserInstance.fromPublication(publication);
-        var objectForCreatingNewEntry = PublishingRequestCase.fromPublication(publication)
+        var objectForCreatingNewEntry = PublishingRequestCase.create(resource, userInstance, PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY)
                                             .withOwner(userInstance.getUsername());
         assertThat(objectForCreatingNewEntry.getResourceIdentifier(), is(equalTo(publication.getIdentifier())));
         assertThat(objectForCreatingNewEntry.getOwner(), is(equalTo(userInstance.getUser())));

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
@@ -42,7 +42,7 @@ class TicketEntryTest {
     @Test
     void shouldThrowExceptionForUnrecognizedTicketType() {
         var publication = TicketTestUtils.createNonPersistedPublication(PublicationStatus.DRAFT);
-        assertThrows(RuntimeException.class, () -> TicketEntry.requestNewTicket(publication, DoiRequest.class));
+        assertThrows(RuntimeException.class, () -> TicketEntry.requestNewTicket(publication, TicketEntry.class));
     }
 
     @Test
@@ -94,7 +94,7 @@ class TicketEntryTest {
             publication, PublishingRequestCase.class, SortableIdentifier::next);
         ticket.withFilesForApproval(Set.of(randomPendingOpenFile()))
             .withWorkflow(PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY)
-            .publishApprovedFile();
+            .approveFiles();
 
         assertThat(ticket.getApprovedFiles().size(), is(equalTo(1)));
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/PublishingRequestDaoTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/PublishingRequestDaoTest.java
@@ -91,7 +91,9 @@ class PublishingRequestDaoTest extends ResourcesLocalTest {
         var query = PublishingRequestDao.queryPublishingRequestByResource(publication.getPublisher().getId(),
                                                                           publication.getIdentifier());
 
-        var publishingRequest = PublishingRequestCase.fromPublication(publication)
+        var publishingRequest = PublishingRequestCase.create(Resource.fromPublication(publication),
+                                                             UserInstance.fromPublication(publication),
+                                                             PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY)
                                     .withOwner(randomString());
         var persistedRequest = publishingRequest.persistNewTicket(ticketService);
         var queryResult = client.query(query);

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/storage/UniquePublishingRequestEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/storage/UniquePublishingRequestEntryTest.java
@@ -1,10 +1,15 @@
 package no.unit.nva.publication.model.storage;
 
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
+import no.unit.nva.publication.model.business.PublishingWorkflow;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
 import org.junit.jupiter.api.Test;
 
 class UniquePublishingRequestEntryTest {
@@ -12,7 +17,9 @@ class UniquePublishingRequestEntryTest {
     @Test
     void shouldContainPrimaryKeyThatEnsuresThatOnlyOnePublishingRequestExistsPerPublication() {
         var publication = randomPublication();
-        var publishingRequest = PublishingRequestCase.fromPublication(publication);
+        var resource = Resource.fromPublication(publication);
+        var userInstance = UserInstance.create(randomString(), randomUri());
+        var publishingRequest = PublishingRequestCase.create(resource, userInstance, PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY);
         var firstUniquenessEntry = UniquePublishingRequestEntry.create(publishingRequest);
         var secondUniquenessEntry = UniquePublishingRequestEntry.create(publishingRequest);
         assertThat(firstUniquenessEntry.primaryKey(), is(equalTo(secondUniquenessEntry.primaryKey())));

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -706,7 +706,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         Executable fetchResourceAction = () -> resourceService.getPublicationByIdentifier(publication.getIdentifier());
         assertDoesNotThrow(fetchResourceAction);
 
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
         Executable deleteAction = () -> resourceService.deleteDraftPublication(userInstance,
                                                                                publication.getIdentifier());
         assertThrows(TransactionFailedException.class, deleteAction);
@@ -716,8 +716,8 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
     @Test
     void deleteDraftPublicationThrowsExceptionWhenResourceIsPublished() throws ApiGatewayException {
-        Publication publication = createPersistedPublicationWithoutDoi();
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var publication = createPersistedPublicationWithoutDoi();
+        var userInstance = UserInstance.fromPublication(publication);
         Resource.fromPublication(publication).publish(resourceService, userInstance);
         assertThatIdentifierEntryHasBeenCreated();
 
@@ -733,10 +733,10 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
     @Test
     void deleteDraftPublicationDeletesDoiRequestWhenPublicationHasDoiRequest() throws ApiGatewayException {
-        Publication publication = createPersistedPublicationWithoutDoi();
+        var publication = createPersistedPublicationWithoutDoi();
         createDoiRequest(publication);
 
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
         resourceService.deleteDraftPublication(userInstance, publication.getIdentifier());
 
         assertThatAllEntriesHaveBeenDeleted();

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1459,22 +1459,24 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
         var publication = randomPublication().copy().withAssociatedArtifacts(new ArrayList<>()).build();
         var userInstance = UserInstance.fromPublication(publication);
-        var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
 
         var file = randomPendingInternalFile();
-        FileEntry.create(file, persistedPublication.getIdentifier(), userInstance).persist(resourceService);
+        FileEntry.create(file, publication.getIdentifier(), userInstance).persist(resourceService);
 
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(persistedPublication)
-                                                            .withFilesForApproval(Set.of(file))
-                                                            .withOwner(randomString())
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase
+                                                            .createWithFilesForApproval(Resource.fromPublication(publication),
+                                                                                        userInstance,
+                                                                                        PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY,
+                                                                                        Set.of(file))
                                                             .persistNewTicket(ticketService);
 
-        publishingRequest.publishApprovedFile().persistUpdate(ticketService);
+        publishingRequest.approveFiles().persistUpdate(ticketService);
         publishingRequest.setFinalizedBy(new Username(randomString()));
         publishingRequest.publishApprovedFiles(resourceService);
 
         assertInstanceOf(InternalFile.class,
-                         FileEntry.queryObject(file.getIdentifier(), persistedPublication.getIdentifier())
+                         FileEntry.queryObject(file.getIdentifier(), publication.getIdentifier())
                              .fetch(resourceService)
                              .orElseThrow()
                              .getFile());
@@ -1485,18 +1487,17 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var file = randomPendingInternalFile();
         var publication = randomPublication().copy().withAssociatedArtifacts(List.of(file)).build();
         var userInstance = UserInstance.fromPublication(publication);
-        var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
 
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(persistedPublication)
-                                                            .withFilesForApproval(Set.of(file))
-                                                            .withOwner(randomString())
-                                                            .persistNewTicket(ticketService);
-        publishingRequest.publishApprovedFile().close(randomUserInstance()).persistUpdate(ticketService);
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.createWithFilesForApproval(
+            Resource.fromPublication(publication), userInstance, PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY, Set.of(file))
+                                    .persistNewTicket(ticketService);
+        publishingRequest.approveFiles().close(randomUserInstance()).persistUpdate(ticketService);
         publishingRequest = (PublishingRequestCase) publishingRequest.fetch(ticketService);
 
         publishingRequest.publishApprovedFiles(resourceService);
 
-        var associatedArtifact = Resource.fromPublication(persistedPublication)
+        var associatedArtifact = Resource.fromPublication(publication)
                                      .fetch(resourceService).orElseThrow().getAssociatedArtifacts().getFirst();
         assertInstanceOf(InternalFile.class, associatedArtifact);
     }
@@ -1508,21 +1509,23 @@ class ResourceServiceTest extends ResourcesLocalTest {
 
         var publication = randomPublication().copy().withAssociatedArtifacts(new ArrayList<>()).build();
         var userInstance = UserInstance.fromPublication(publication);
-        var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
 
         var file = randomPendingInternalFile();
-        FileEntry.create(file, persistedPublication.getIdentifier(), userInstance).persist(resourceService);
+        FileEntry.create(file, publication.getIdentifier(), userInstance).persist(resourceService);
 
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(persistedPublication)
-                                                            .withFilesForApproval(Set.of(file))
-                                                            .withOwner(randomString())
+        var publishingRequest =
+            (PublishingRequestCase) PublishingRequestCase.createWithFilesForApproval(Resource.fromPublication(publication),
+                                                                 UserInstance.create(randomString(), randomUri()),
+                                                                 PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY,
+                                                                 Set.of(file))
                                                             .persistNewTicket(ticketService);
 
         publishingRequest.setFinalizedBy(new Username(randomString()));
         publishingRequest.rejectRejectedFiles(resourceService);
 
         assertInstanceOf(RejectedFile.class,
-                         FileEntry.queryObject(file.getIdentifier(), persistedPublication.getIdentifier())
+                         FileEntry.queryObject(file.getIdentifier(), publication.getIdentifier())
                              .fetch(resourceService)
                              .orElseThrow()
                              .getFile());
@@ -1533,17 +1536,18 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var file = randomPendingInternalFile();
         var publication = randomPublication().copy().withAssociatedArtifacts(List.of(file)).build();
         var userInstance = UserInstance.fromPublication(publication);
-        var persistedPublication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
 
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(persistedPublication)
-                                                            .withFilesForApproval(Set.of(file))
-                                                            .withOwner(randomString())
-                                                            .persistNewTicket(ticketService);
+        var publishingRequest = (PublishingRequestCase) PublishingRequestCase
+                                    .createWithFilesForApproval(Resource.fromPublication(publication),
+                                                                userInstance,
+                                                                PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY,
+                                                                Set.of(file)).persistNewTicket(ticketService);
         publishingRequest.close(randomUserInstance()).persistUpdate(ticketService);
         publishingRequest = (PublishingRequestCase) publishingRequest.fetch(ticketService);
         publishingRequest.rejectRejectedFiles(resourceService);
 
-        var associatedArtifact = Resource.fromPublication(persistedPublication)
+        var associatedArtifact = Resource.fromPublication(publication)
                                      .fetch(resourceService).orElseThrow().getAssociatedArtifacts().getFirst();
 
         assertInstanceOf(RejectedFile.class, associatedArtifact);

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
@@ -279,7 +279,7 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
     }
 
     private Publication createPublication(Publication publication) throws ApiGatewayException {
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
         return Resource.fromPublication(publication).persistNew(resourceService, userInstance);
     }
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/RecoveryBatchScanHandlerTest.java
@@ -69,7 +69,7 @@ class RecoveryBatchScanHandlerTest extends ResourcesLocalTest {
         putMessageOnRecoveryQueue(publication.getIdentifier(), "Resource");
         recoveryBatchScanHandler.handleRequest(createEvent(null), outputStream, CONTEXT);
 
-        var refreshedPublication = resourceService.getPublication(publication);
+        var refreshedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
         var resourceVersionAfterRefresh = Resource.fromPublication(refreshedPublication).toDao().getVersion();
 
         assertThat(resourceVersionAfterRefresh, is(not(equalTo(resourceVersion))));

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -435,7 +435,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     @Test
     void shouldProceedTicketOwnedByOtherInstitutionThanPublication() throws ApiGatewayException, IOException {
         var publication = createPublication();
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
         var publishingRequest = PublishingRequestCase.create(Resource.fromPublication(publication),
                                                              userInstance,
                                                                  REGISTRATOR_PUBLISHES_METADATA_ONLY)

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -38,7 +38,6 @@ import no.unit.nva.events.models.EventReference;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
-import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.file.File;
@@ -193,7 +192,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         pendingPublishingRequest.setWorkflow(publishingWorkflow);
         var approvedPublishingRequest =
                 pendingPublishingRequest
-                        .publishApprovedFile()
+                        .approveFiles()
                         .complete(publication, USER_INSTANCE)
                         .persistNewTicket(ticketService);
         var event = createEvent(pendingPublishingRequest, approvedPublishingRequest);
@@ -378,7 +377,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var pendingPublishingRequest =
             (PublishingRequestCase) persistPublishingRequestContainingExistingUnpublishedFiles(publication);
         pendingPublishingRequest.setWorkflow(REGISTRATOR_REQUIRES_APPROVAL_FOR_METADATA_AND_FILES);
-        var approvedPublishingRequest = pendingPublishingRequest.publishApprovedFile()
+        var approvedPublishingRequest = pendingPublishingRequest.approveFiles()
                         .complete(publication, USER_INSTANCE)
                         .persistNewTicket(ticketService);
         var handlerThrowingException =
@@ -436,13 +435,13 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
     @Test
     void shouldProceedTicketOwnedByOtherInstitutionThanPublication() throws ApiGatewayException, IOException {
         var publication = createPublication();
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
-                    .withOwner(randomString())
-                    .withOwnerAffiliation(randomUri());
-        publishingRequest.setStatus(TicketStatus.COMPLETED);
-        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
-        var ticket = publishingRequest.persistNewTicket(ticketService);
-        var event = createEvent(null, ticket);
+        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var publishingRequest = PublishingRequestCase.create(Resource.fromPublication(publication),
+                                                             userInstance,
+                                                                 REGISTRATOR_PUBLISHES_METADATA_ONLY)
+                                    .complete(publication, userInstance)
+                                    .persistNewTicket(ticketService);
+        var event = createEvent(null, publishingRequest);
 
         assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, CONTEXT));
     }
@@ -453,12 +452,13 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var internalFileToReject = randomPendingInternalFile();
         var openFileToReject = randomPendingOpenFile();
         publication.setAssociatedArtifacts(new AssociatedArtifactList(internalFileToReject, openFileToReject));
-        var persistedPublication = Resource.fromPublication(publication)
+        publication = Resource.fromPublication(publication)
                    .persistNew(resourceService, UserInstance.fromPublication(publication));
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(persistedPublication)
-                                                            .withFilesForApproval(Set.of(internalFileToReject, openFileToReject))
-                                                            .withOwner(randomString())
-                                                            .withOwnerAffiliation(randomUri());
+        var publishingRequest = PublishingRequestCase
+                                    .createWithFilesForApproval(Resource.fromPublication(publication),
+                                                                UserInstance.fromPublication(publication),
+                                                                REGISTRATOR_PUBLISHES_METADATA_ONLY,
+                                                                Set.of(internalFileToReject, openFileToReject));
         var ticket = publishingRequest.persistNewTicket(ticketService);
         ticket.close(UserInstance.create(randomString(), randomUri())).persistUpdate(ticketService);
 
@@ -467,7 +467,7 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
 
         handler.handleRequest(event, outputStream, CONTEXT);
 
-        var updatedPublication = resourceService.getPublicationByIdentifier(persistedPublication.getIdentifier());
+        var updatedPublication = resourceService.getPublicationByIdentifier(publication.getIdentifier());
 
         assertTrue(updatedPublication.getAssociatedArtifacts().stream().allMatch(RejectedFile.class::isInstance));
     }
@@ -477,10 +477,9 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var publication = createPublication();
         publication.setAssociatedArtifacts(new AssociatedArtifactList(randomPendingInternalFile(), randomPendingOpenFile()));
         resourceService.updatePublication(publication);
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
-                                                            .withOwner(randomString())
-                                                            .withOwnerAffiliation(randomUri());
-        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
+        var publishingRequest = PublishingRequestCase.create(Resource.fromPublication(publication),
+                                                             UserInstance.fromPublication(publication),
+                                                             REGISTRATOR_PUBLISHES_METADATA_ONLY);
         var ticket = publishingRequest.persistNewTicket(ticketService);
         var event = createEvent(null, ticket);
 
@@ -497,10 +496,10 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var publication = createPublication();
         publication.setAssociatedArtifacts(new AssociatedArtifactList(randomPendingInternalFile(), randomPendingOpenFile()));
         resourceService.updatePublication(publication);
-        var publishingRequest = (PublishingRequestCase) PublishingRequestCase.fromPublication(publication)
-                                                            .withOwner(randomString())
-                                                            .withOwnerAffiliation(randomUri());
-        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
+        var publishingRequest = PublishingRequestCase
+                                    .create(Resource.fromPublication(publication),
+                                            UserInstance.fromPublication(publication),
+                                            REGISTRATOR_PUBLISHES_METADATA_ONLY);
         var ticket = publishingRequest.persistNewTicket(ticketService);
         var event = createEvent(null, ticket);
 
@@ -518,17 +517,13 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
 
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(
             Publication publication, File file) throws ApiGatewayException {
-        var publishingRequest =
-                (PublishingRequestCase)
-                        PublishingRequestCase.fromPublication(publication)
-                                .withOwner(UserInstance.fromPublication(publication).getUsername())
-                                .withOwnerAffiliation(
-                                        publication.getResourceOwner().getOwnerAffiliation());
-        publishingRequest.setStatus(TicketStatus.COMPLETED);
-        publishingRequest.setApprovedFiles(Set.of(file));
-        publishingRequest.setWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY);
-        publishingRequest.setFinalizedBy(new Username(randomString()));
-        return (PublishingRequestCase) publishingRequest.persistNewTicket(ticketService);
+        var userInstance = UserInstance.fromPublication(publication);
+        return (PublishingRequestCase) PublishingRequestCase.createWithFilesForApproval(Resource.fromPublication(publication),
+                                                             userInstance,
+                                                             REGISTRATOR_PUBLISHES_METADATA_ONLY,
+                                                             Set.of(file))
+                .approveFiles().complete(publication, userInstance)
+                                           .persistNewTicket(ticketService);
     }
 
     private Publication createPublicationWithFiles(File file, File fileInPublishingRequest)

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
@@ -118,7 +118,7 @@ public final class PublishingRequestResolver {
         throws ApiGatewayException {
         return customerAllowsPublishingMetadataAndFiles()
                    ? publishingRequest
-                         .publishApprovedFile()
+                         .approveFiles()
                          .persistAutoComplete(ticketService, newImage, userInstance)
                    : publishingRequest.persistNewTicket(ticketService);
     }
@@ -182,7 +182,7 @@ public final class PublishingRequestResolver {
         if (customerAllowsPublishingMetadataAndFiles()) {
             publishingRequest
                 .withFilesForApproval(files)
-                .publishApprovedFile()
+                .approveFiles()
                 .complete(newImage, userInstance)
                 .persistUpdate(ticketService);
         } else {

--- a/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/fetch/FetchPublicationHandlerTest.java
@@ -633,9 +633,9 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
     }
 
     private Publication createPublication() throws ApiGatewayException {
-        Publication publication = PublicationGenerator.randomPublication();
-        UserInstance userInstance = UserInstance.fromPublication(publication);
-        SortableIdentifier publicationIdentifier =
+        var publication = PublicationGenerator.randomPublication();
+        var userInstance = UserInstance.fromPublication(publication);
+        var publicationIdentifier =
             Resource.fromPublication(publication).persistNew(publicationService, userInstance).getIdentifier();
         return publicationService.getResourceByIdentifier(publicationIdentifier).toPublication();
     }
@@ -652,9 +652,9 @@ class FetchPublicationHandlerTest extends ResourcesLocalTest {
     }
 
     private Publication createPublication(Class<? extends PublicationInstance<?>> instance) throws ApiGatewayException {
-        Publication publication = PublicationGenerator.randomPublication(instance);
-        UserInstance userInstance = UserInstance.fromPublication(publication);
-        SortableIdentifier publicationIdentifier = Resource.fromPublication(publication)
+        var publication = PublicationGenerator.randomPublication(instance);
+        var userInstance = UserInstance.fromPublication(publication);
+        var publicationIdentifier = Resource.fromPublication(publication)
                                                        .persistNew(publicationService, userInstance)
                                                        .getIdentifier();
         return publicationService.getPublicationByIdentifier(publicationIdentifier);

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
@@ -135,7 +135,7 @@ class PublishPublicationHandlerTest extends ResourcesLocalTest {
 
     private Publication createUnpublishablePublication() throws BadRequestException, NotFoundException {
         var publication = createPublication();
-        UserInstance userInstance = UserInstance.fromPublication(publication);
+        var userInstance = UserInstance.fromPublication(publication);
         var resource = Resource.fromPublication(publication);
         resource.publish(resourceService, userInstance);
         resourceService.unpublishPublication(publication, userInstance);

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandler.java
@@ -11,8 +11,8 @@ import no.unit.nva.publication.ticket.TicketHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadGatewayException;
+import nva.commons.apigateway.exceptions.ForbiddenException;
 import nva.commons.apigateway.exceptions.NotFoundException;
-import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 
@@ -55,7 +55,7 @@ public class DeleteTicketHandler extends TicketHandler<Void, Void> {
         if (failure.getException() instanceof NotFoundException) {
             return new NotFoundException(TICKET_NOT_FOUND_MESSAGE);
         }
-        if (failure.getException() instanceof UnauthorizedException) {
+        if (failure.getException() instanceof ForbiddenException) {
             return (ApiGatewayException) failure.getException();
         }
         return new BadGatewayException(UNEXPECTED_ERROR_MESSAGE);

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import no.unit.nva.doi.DataCiteDoiClient;
 import no.unit.nva.doi.DoiClient;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.publication.model.business.DoiRequest;
@@ -202,7 +201,7 @@ public class UpdateTicketHandler extends TicketHandler<UpdateTicketRequest, Void
 
         if (COMPLETED.equals(ticketRequest.getStatus())) {
             validateFilesForApproval(ticket);
-            ticket.publishApprovedFile().persistUpdate(ticketService);
+            ticket.approveFiles().persistUpdate(ticketService);
         }
     }
 

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoParser.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketDtoParser.java
@@ -52,6 +52,7 @@ public final class TicketDtoParser {
         ticket.setAssignee(publishingRequestDto.getAssignee());
         ticket.setOwner(publishingRequestDto.getOwner());
         ticket.setOwnerAffiliation(publishingRequestDto.getOwnerAffiliation());
+        ticket.setFilesForApproval(publishingRequestDto.getFilesForApproval());
         return ticket;
     }
 

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/TicketTestLocal.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/TicketTestLocal.java
@@ -91,7 +91,7 @@ public abstract class TicketTestLocal extends ResourcesLocalTest {
         var userInstance = UserInstance.fromPublication(publication);
         var storedResult = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
         action.accept(storedResult);
-        return resourceService.getPublication(storedResult);
+        return resourceService.getPublicationByIdentifier(storedResult.getIdentifier());
     }
 
     private Publication createAndPersistPublicationWithDoiAndThenActOnIt(Consumer<Publication> action)
@@ -102,6 +102,6 @@ public abstract class TicketTestLocal extends ResourcesLocalTest {
         var userInstance = UserInstance.fromPublication(publication);
         var storedResult = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
         action.accept(storedResult);
-        return resourceService.getPublication(storedResult);
+        return resourceService.getPublicationByIdentifier(storedResult.getIdentifier());
     }
 }

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/delete/DeleteTicketHandlerTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static software.amazon.awssdk.http.HttpStatusCode.FORBIDDEN;
 import static software.amazon.awssdk.http.HttpStatusCode.NOT_FOUND;
-import static software.amazon.awssdk.http.HttpStatusCode.UNAUTHORIZED;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -68,14 +68,14 @@ class DeleteTicketHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnUnauthorizedWhenAttemptingToDeleteTicketUserDoesNotOwn() throws IOException, ApiGatewayException {
+    void shouldReturnForbiddenWhenAttemptingToDeleteTicketUserDoesNotOwn() throws IOException, ApiGatewayException {
         var publication = createPublication();
         var ticket = createTicket(publication);
         var request = deleteRequest(publication.getIdentifier(), ticket.getIdentifier());
 
         handler.handleRequest(request, output, CONTEXT);
 
-        assertThat(GatewayResponse.fromOutputStream(output, Void.class).getStatusCode(), is(equalTo(UNAUTHORIZED)));
+        assertThat(GatewayResponse.fromOutputStream(output, Void.class).getStatusCode(), is(equalTo(FORBIDDEN)));
     }
 
     @Test

--- a/tickets/src/test/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandlerTest.java
+++ b/tickets/src/test/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandlerTest.java
@@ -168,11 +168,8 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         var publication = TicketTestUtils.createPersistedPublication(PublicationStatus.PUBLISHED, resourceService);
         var userInstance = UserInstance.fromPublication(publication);
         var resource = Resource.fromPublication(publication);
-        var username = userInstance.getUsername();
-
-        var ownerAffiliation = publication.getResourceOwner().getOwnerAffiliation();
         DoiRequest.create(Resource.fromPublication(publication), userInstance).persistNewTicket(ticketService);
-        PublishingRequestCase.fromPublication(publication).withOwner(username).withOwnerAffiliation(ownerAffiliation).persistNewTicket(ticketService);
+        PublishingRequestCase.create(resource, userInstance, PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY).persistNewTicket(ticketService);
         GeneralSupportRequest.create(resource, userInstance).persistNewTicket(ticketService);
 
         var request = curatorWithAccessRightRequestTicketsForPublication(publication, accessRight);
@@ -210,13 +207,11 @@ class ListTicketsForPublicationHandlerTest extends TicketTestLocal {
         throws ApiGatewayException, IOException {
         var publication = TicketTestUtils.createPersistedPublication(PublicationStatus.PUBLISHED, resourceService);
         var userInstance = UserInstance.fromPublication(publication);
-        var username = userInstance.getUsername();
 
         var ownerAffiliation = publication.getResourceOwner().getOwnerAffiliation();
         var resource = Resource.fromPublication(publication);
         DoiRequest.create(resource, userInstance).persistNewTicket(ticketService);
-        PublishingRequestCase.fromPublication(publication).withOwnerAffiliation(
-            ownerAffiliation).withOwner(username).persistNewTicket(ticketService);
+        PublishingRequestCase.create(resource, userInstance, PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY).persistNewTicket(ticketService);
         GeneralSupportRequest.create(resource, userInstance).persistNewTicket(ticketService);
 
         var request = userRequestsTickets(publication, randomUri(), ownerAffiliation, accessRight);


### PR DESCRIPTION
- Removing `PublishingRequestCase.fromPublication()` method.
- Removing usages of deprecated method `resourceServices.getPublication()`