### PR TITLE
removing null artifact automatically when adding file or link

### DIFF
--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactList.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactList.java
@@ -1,6 +1,8 @@
 package no.unit.nva.model.associatedartifacts;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static java.util.function.Predicate.not;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,14 +15,25 @@ import nva.commons.core.JacocoGenerated;
 
 public class AssociatedArtifactList implements List<AssociatedArtifact> {
 
-    public static final String NULL_OBJECT_MUST_BE_SINGLETON_IN_LIST = "AssociatedArtifactLists containing "
-            + "NullAssociatedArtifact must contain only this element as a singleton";
     private final List<AssociatedArtifact> associatedArtifacts;
     
     @JsonCreator
     public AssociatedArtifactList(List<AssociatedArtifact> artifacts) {
-        throwExceptionIfNullObjectIsNotOnlyElementInList(artifacts);
-        this.associatedArtifacts = nonNull(artifacts) ? artifacts : Collections.emptyList();
+        if (isNull(artifacts)) {
+            this.associatedArtifacts = Collections.emptyList();
+        } else if (containsNotOnlyNullAssociatedArtifacts(artifacts)) {
+            this.associatedArtifacts = artifacts.stream()
+                                           .filter(not(NullAssociatedArtifact.class::isInstance))
+                                           .toList();
+        } else {
+            this.associatedArtifacts = artifacts;
+        }
+    }
+
+    private boolean containsNotOnlyNullAssociatedArtifacts(List<AssociatedArtifact> artifacts) {
+        return nonNull(artifacts)
+               && artifacts.stream().anyMatch(NullAssociatedArtifact.class::isInstance)
+               && !artifacts.stream().allMatch(NullAssociatedArtifact.class::isInstance);
     }
 
     public AssociatedArtifactList(AssociatedArtifact... artifacts) {
@@ -157,16 +170,4 @@ public class AssociatedArtifactList implements List<AssociatedArtifact> {
     public List<AssociatedArtifact> subList(int fromIndex, int toIndex) {
         return associatedArtifacts.subList(fromIndex, toIndex);
     }
-
-
-    private void throwExceptionIfNullObjectIsNotOnlyElementInList(List<AssociatedArtifact> artifacts) {
-        if (nonNull(artifacts) && containsNullObject(artifacts) && artifacts.size() > 1) {
-            throw new InvalidAssociatedArtifactsException(NULL_OBJECT_MUST_BE_SINGLETON_IN_LIST);
-        }
-    }
-
-    private boolean containsNullObject(List<AssociatedArtifact> artifacts) {
-        return artifacts.stream().anyMatch(NullAssociatedArtifact.class::isInstance);
-    }
-
 }

--- a/publication-model/src/test/java/no/unit/nva/PublicationTest.java
+++ b/publication-model/src/test/java/no/unit/nva/PublicationTest.java
@@ -43,8 +43,6 @@ import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
-import no.unit.nva.model.associatedartifacts.InvalidAssociatedArtifactsException;
-import no.unit.nva.model.associatedartifacts.NullAssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
 import no.unit.nva.model.exceptions.InvalidPublicationStatusTransitionException;
@@ -57,7 +55,6 @@ import org.javers.core.diff.Diff;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -205,13 +202,6 @@ public class PublicationTest {
     @Test
     void initializingPublicationShouldNotThrowException() {
         assertDoesNotThrow(Publication::new);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenCreatingAssociatedArtifactsWithNullArtifactsAndOtherArtifacts() {
-        Executable executable = () -> new AssociatedArtifactList(randomAssociatedLink(),
-                                                                 new NullAssociatedArtifact());
-        assertThrows(InvalidAssociatedArtifactsException.class, executable);
     }
 
     @ParameterizedTest(name = "Publication can be published when basic data is OK and associated files is OK")

--- a/publication-model/src/test/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactListTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactListTest.java
@@ -1,0 +1,21 @@
+package no.unit.nva.model.associatedartifacts;
+
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AssociatedArtifactListTest {
+
+    @Test
+    void shouldRemoveNullAssociatedArtifactFromListWhenListContainsNotOnlyNullAssociatedArtifact() {
+        var nullAssociatedArtifact = new NullAssociatedArtifact();
+        var file = randomOpenFile();
+
+        var associatedArtifactList = new AssociatedArtifactList(List.of(file, nullAssociatedArtifact));
+
+        assertFalse(associatedArtifactList.contains(nullAssociatedArtifact));
+        assertTrue(associatedArtifactList.contains(file));
+    }
+}

--- a/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/create/CreatePublicationHandlerTest.java
@@ -331,16 +331,6 @@ class CreatePublicationHandlerTest extends ResourcesLocalTest {
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
     }
 
-    @Test
-    void shouldThrowBadRequestExceptionWhenAssociatedArtifactsIsBad() throws IOException {
-        var event = createPublicationRequestEventWithInvalidAssociatedArtifacts();
-        handler.handleRequest(event, outputStream, context);
-        var response = GatewayResponse.fromOutputStream(outputStream, Problem.class);
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
-        var body = response.getBodyObject(Problem.class);
-        assertThat(body.getDetail(), containsString("AssociatedArtifact"));
-    }
-
     @ParameterizedTest
     @MethodSource("httpClientExceptionsProvider")
     void shouldReturnBadGatewayIfCustomerApiHttpClientThrowsException(Exception exceptionToThrow)


### PR DESCRIPTION
There is a bug in all environments that occurs when a publication contains a NullAssociatedArtifact and an attempt is made to update it with a file. During file upload, the list of associated artifacts is not being mutated. Consequently, if the associatedArtifacts list already contains a NullAssociatedArtifact, fetching the publication from the database fails due to serialization errors with the artifacts.