### PR TITLE
fixing copy method in ticket

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
@@ -211,6 +211,7 @@ public class DoiRequest extends TicketEntry {
                    .withViewedBy(this.getViewedBy())
                    .withAssignee(getAssignee())
                    .withOwnerAffiliation(getOwnerAffiliation())
+                   .withResponsibilityArea(getResponsibilityArea())
                    .withFinalizedBy(getFinalizedBy())
                    .withFinalizedDate(getFinalizedDate())
                    .build();
@@ -339,6 +340,11 @@ public class DoiRequest extends TicketEntry {
 
         public Builder withOwnerAffiliation(URI ownerAffiliation) {
             doiRequest.setOwnerAffiliation(ownerAffiliation);
+            return this;
+        }
+
+        public Builder withResponsibilityArea(URI responsibilityArea) {
+            doiRequest.setResponsibilityArea(responsibilityArea);
             return this;
         }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
@@ -155,6 +155,7 @@ public class GeneralSupportRequest extends TicketEntry {
         copy.setOwnerAffiliation(this.getOwnerAffiliation());
         copy.setFinalizedBy(this.getFinalizedBy());
         copy.setFinalizedDate(this.getFinalizedDate());
+        copy.setResponsibilityArea(this.getResponsibilityArea());
         return copy;
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -145,6 +145,7 @@ public class PublishingRequestCase extends TicketEntry {
         copy.filesForApproval = this.getFilesForApproval().isEmpty() ? Set.of() : this.getFilesForApproval();
         copy.setFinalizedBy(this.getFinalizedBy());
         copy.setFinalizedDate(this.getFinalizedDate());
+        copy.setResponsibilityArea(this.getResponsibilityArea());
         return copy;
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
@@ -180,6 +180,7 @@ public class UnpublishRequest extends TicketEntry {
                    .withViewedBy(this.getViewedBy())
                    .withAssignee(getAssignee())
                    .withOwnerAffiliation(getOwnerAffiliation())
+                   .withResponsibilityArea(getResponsibilityArea())
                    .withFinalizedBy(getFinalizedBy())
                    .withFinalizedDate(getFinalizedDate())
                    .build();
@@ -315,6 +316,11 @@ public class UnpublishRequest extends TicketEntry {
 
         public UnpublishRequest.Builder withOwnerAffiliation(URI ownerAffiliation) {
             unpublishRequest.setOwnerAffiliation(ownerAffiliation);
+            return this;
+        }
+
+        public UnpublishRequest.Builder withResponsibilityArea(URI responsibilityArea) {
+            unpublishRequest.setResponsibilityArea(responsibilityArea);
             return this;
         }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/TicketEntryTest.java
@@ -15,7 +15,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.model.business.publicationstate.DoiRequestedEvent;
 import no.unit.nva.publication.ticket.test.TicketTestUtils;
@@ -166,13 +165,42 @@ class TicketEntryTest {
         assertFalse(publishingRequestCase.getApprovedFiles().isEmpty());
     }
 
+    @Test
+    void shouldCopyPublishingRequestWithoutLossOfInformation() {
+        var resource = Resource.fromPublication(randomPublication());
+        var userInstance = randomUserInstance();
+        var publishingRequestCase = PublishingRequestCase.create(resource, userInstance,
+                                                                 PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_AND_FILES);
+
+        var copy = publishingRequestCase.copy();
+
+        assertEquals(publishingRequestCase, copy);
+    }
+
+    @Test
+    void shouldCopyDoiRequestWithoutLossOfInformation() {
+        var resource = Resource.fromPublication(randomPublication());
+        var userInstance = randomUserInstance();
+        var doiRequest = DoiRequest.create(resource, userInstance);
+
+        var copy = doiRequest.copy();
+
+        assertEquals(doiRequest, copy);
+    }
+
+    @Test
+    void shouldCopyGeneralSupportWithoutLossOfInformation() {
+        var resource = Resource.fromPublication(randomPublication());
+        var userInstance = randomUserInstance();
+        var generalSupportRequest = GeneralSupportRequest.create(resource, userInstance);
+
+        var copy = generalSupportRequest.copy();
+
+        assertEquals(generalSupportRequest, copy);
+    }
+
     private static UserInstance randomUserInstance() {
         return new UserInstance(randomString(), randomUri(), randomUri(), randomUri(),
                                 randomUri(), List.of(), UserClientType.INTERNAL);
-    }
-
-    private static UserInstance getExpectedUserInstance(Publication publication) {
-        return UserInstance.create(
-            publication.getResourceOwner().getOwner().getValue(), publication.getPublisher().getId());
     }
 }


### PR DESCRIPTION
Copy method in tickets did not include new field responsibilityArea. Copy method is used when updating ticket. 
This makes that organization in expanded ticket is being overridden by following method when ticket is being updated (for example assigned to someone):

```
        var organizationId = nonNull(ticketEntry.getResponsibilityArea())
                                      ? ticketEntry.getResponsibilityArea()
                                      : resourceService.getResourceByIdentifier(ticketEntry.getResourceIdentifier())
                                          .getResourceOwner().getOwnerAffiliation();
```

This pull request should fix it.