### PR TITLE
persisting published publication log message with ticket owner

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -103,7 +103,7 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
     private void handlePendingPublishingRequest(PublishingRequestCase publishingRequest) {
         var resource = fetchResource(publishingRequest.getResourceIdentifier());
         if (REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(publishingRequest.getWorkflow())) {
-            publishResource(resource);
+            publishResource(resource, publishingRequest);
             refreshPublishingRequestAfterPublishingMetadata(publishingRequest);
         }
         createDoiRequestIfNeeded(resource.getIdentifier(), UserInstance.fromTicket(publishingRequest));
@@ -130,7 +130,7 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         var resource = fetchResource(publishingRequestCase.getResourceIdentifier());
         var publishingRequest = fetchPublishingRequest(publishingRequestCase);
 
-        publishWhenPublicationStatusDraft(resource);
+        publishWhenPublicationStatusDraft(resource, publishingRequest);
 
         if (!publishingRequest.getApprovedFiles().isEmpty()) {
             publishingRequest.publishApprovedFiles(resourceService);
@@ -141,9 +141,9 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         createDoiRequestIfNeeded(resource.getIdentifier(), UserInstance.fromTicket(publishingRequest));
     }
 
-    private void publishWhenPublicationStatusDraft(Resource resource) {
+    private void publishWhenPublicationStatusDraft(Resource resource, PublishingRequestCase publishingRequest) {
         if (PublicationStatus.DRAFT.equals(resource.getStatus())) {
-            publishResource(resource);
+            publishResource(resource, publishingRequest);
         }
     }
 
@@ -159,8 +159,8 @@ public class AcceptedPublishingRequestEventHandler extends DestinationsEventBrid
         throw new RuntimeException();
     }
 
-    private void publishResource(Resource resource) {
-        var userInstance = UserInstance.fromPublication(resource.toPublication());
+    private void publishResource(Resource resource, PublishingRequestCase publishingRequestCase) {
+        var userInstance = UserInstance.fromTicket(publishingRequestCase);
         logger.info("Publishing resource: {}", resource.getIdentifier());
         try {
             resource.publish(resourceService, userInstance);

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -515,6 +515,26 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         assertEquals(publishingRequest, refreshedPublishingRequest);
     }
 
+    @Test
+    void shouldSetPublishingRequestOwnerAsThePersonWhoPublishedPublicationInResourceEventWhenPublishingPublicationByConsumingTicket()
+        throws ApiGatewayException, IOException {
+        var publication = createPublication();
+        var publishingRequest = PublishingRequestCase
+                                    .create(Resource.fromPublication(publication),
+                                            UserInstance.fromPublication(publication),
+                                            REGISTRATOR_PUBLISHES_METADATA_ONLY);
+        var ticket = publishingRequest.persistNewTicket(ticketService);
+        var event = createEvent(null, ticket);
+
+        handler.handleRequest(event, outputStream, CONTEXT);
+
+        var resource = Resource.resourceQueryObject(publication.getIdentifier())
+                           .fetch(resourceService)
+                           .orElseThrow();
+
+        assertEquals(publishingRequest.getOwner().toString(), resource.getResourceEvent().user().toString());
+    }
+
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(
             Publication publication, File file) throws ApiGatewayException {
         var userInstance = UserInstance.fromPublication(publication);


### PR DESCRIPTION
When consuming publishingRequest ticket and publishing publication, the user who pressed the "publish metadata" button should be set as person on PublicationPublished log message, and that user is a ticket owner :)