### PR TITLE
file imported log message in brage import

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -290,12 +290,17 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         var oldFiles = Resource.fromPublication(existinPublication).getFiles().stream().map(File::getIdentifier).toList();
         updatedFiles.stream()
             .filter(not(file -> oldFiles.contains(file.getIdentifier())))
-            .map(file -> FileEntry.importFileEntry(file, resource.getIdentifier(),
-                                                 UserInstance.fromPublication(representation.publication()), importSource))
-            .forEach(resourceService::persistFile);
+            .forEach(file -> importFile(representation, file, resource, importSource));
         resource.updateResourceFromImport(resourceService, importSource);
         var newImage = resource.fetch(resourceService).orElseThrow().toPublication();
         return new BrageMergingReport(existinPublication, newImage);
+    }
+
+    private void importFile(PublicationRepresentation representation, File file, Resource resource,
+                          ImportSource importSource) {
+        var userInstance = UserInstance.fromPublication(representation.publication());
+        FileEntry.create(file, resource.getIdentifier(), userInstance)
+            .importNew(resourceService, userInstance, importSource);
     }
 
     private Publication updatedPublication(PublicationRepresentation publicationRepresentation,

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/BrageEntryEventConsumer.java
@@ -290,8 +290,9 @@ public class BrageEntryEventConsumer implements RequestHandler<S3Event, Publicat
         var oldFiles = Resource.fromPublication(existinPublication).getFiles().stream().map(File::getIdentifier).toList();
         updatedFiles.stream()
             .filter(not(file -> oldFiles.contains(file.getIdentifier())))
-            .forEach(file -> FileEntry.importFileEntry(file, resource.getIdentifier(), UserInstance.fromPublication(representation.publication()), importSource)
-                                 .persist(resourceService));
+            .map(file -> FileEntry.importFileEntry(file, resource.getIdentifier(),
+                                                 UserInstance.fromPublication(representation.publication()), importSource))
+            .forEach(resourceService::persistFile);
         resource.updateResourceFromImport(resourceService, importSource);
         var newImage = resource.fetch(resourceService).orElseThrow().toPublication();
         return new BrageMergingReport(existinPublication, newImage);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -92,8 +92,8 @@ public final class FileEntry implements Entity, QueryObject<FileEntry> {
         return (FileEntry) fileDao.getData();
     }
 
-    public static FileEntry importFileEntry(File file, SortableIdentifier identifier, UserInstance userInstance,
-                                            ImportSource importSource) {
+    public static FileEntry createFromImportSource(File file, SortableIdentifier identifier,
+                                                   UserInstance userInstance, ImportSource importSource) {
         var fileEntry = create(file, identifier, userInstance);
         fileEntry.setFileEvent(FileImportedEvent.create(userInstance.getUser(), Instant.now(), importSource));
         return fileEntry;
@@ -235,6 +235,13 @@ public final class FileEntry implements Entity, QueryObject<FileEntry> {
             this.modifiedDate = Instant.now();
         }
         return this;
+    }
+
+    public void importNew(ResourceService resourceService,UserInstance userInstance, ImportSource importSource) {
+        var now = Instant.now();
+        this.modifiedDate = now;
+        this.setFileEvent(FileImportedEvent.create(userInstance.getUser(), Instant.now(), importSource));
+        resourceService.persistFile(this);
     }
 
     private boolean shouldHideFile(File file) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -223,7 +223,7 @@ public class ResourceService extends ServiceWithTransactions {
 
         var userInstance = UserInstance.fromPublication(resource.toPublication());
         var fileTransactionWriteItems = resource.getFiles().stream()
-                                            .map(file -> FileEntry.importFileEntry(file, resource.getIdentifier(), userInstance, importSource))
+                                            .map(file -> FileEntry.createFromImportSource(file, resource.getIdentifier(), userInstance, importSource))
                                             .map(FileEntry::toDao)
                                             .map(dao -> dao.toPutNewTransactionItem(tableName))
                                             .toList();

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -120,6 +120,7 @@ import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.model.business.importcandidate.ImportStatusFactory;
 import no.unit.nva.publication.model.business.publicationstate.FileDeletedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileHiddenEvent;
+import no.unit.nva.publication.model.business.publicationstate.FileImportedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileRejectedEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileRetractedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
@@ -1646,6 +1647,21 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var updatedResource = Resource.fromPublication(persistedPublication).update(resourceService, userInstance);
 
         assertEquals(doi, updatedResource.getDoi());
+    }
+
+    @Test
+    void shouldSetFileImportedEventWhenFileIsBeingImported() throws BadRequestException {
+        var publication = randomPublication().copy().withAssociatedArtifacts(List.of()).build();
+        var userInstance = UserInstance.fromPublication(publication);
+        var resource = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+
+        var openFile = randomOpenFile();
+        var fileEntry = FileEntry.create(openFile, resource.getIdentifier(), userInstance);
+        fileEntry.importNew(resourceService, userInstance, ImportSource.fromBrageArchive("ntnu"));
+
+        var updatedFileEntry = fileEntry.fetch(resourceService).orElseThrow();
+
+        assertInstanceOf(FileImportedEvent.class, updatedFileEntry.getFileEvent());
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {


### PR DESCRIPTION
When updating publication with new file from Brage, log event should be FileImported. Now there is persisted FileUploaded event because `FileEntry.persist()` overrides value that is being set in `FileEntry.importFileEntry()` method.