### PR TITLE
sync tickets when updating publication

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/GeneralSupportRequest.java
@@ -19,6 +19,7 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.storage.Dao;
 import no.unit.nva.publication.model.storage.GeneralSupportRequestDao;
+import no.unit.nva.publication.model.storage.TicketDao;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.JacocoGenerated;
 
@@ -120,7 +121,7 @@ public class GeneralSupportRequest extends TicketEntry {
     }
 
     @Override
-    public Dao toDao() {
+    public TicketDao toDao() {
         return new GeneralSupportRequestDao(this);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -18,6 +18,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Username;
+import no.unit.nva.publication.model.storage.TicketDao;
 import no.unit.nva.publication.service.impl.TicketService;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -275,6 +276,8 @@ public abstract class TicketEntry implements Entity {
     public abstract URI getOwnerAffiliation();
 
     public abstract void setOwnerAffiliation(URI ownerAffiliation);
+
+    public abstract TicketDao toDao();
 
     public final List<Message> fetchMessages(TicketService ticketService) {
         return ticketService.fetchTicketMessages(this);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
@@ -24,6 +24,7 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.model.storage.Dao;
+import no.unit.nva.publication.model.storage.TicketDao;
 import no.unit.nva.publication.model.storage.UnpublishRequestDao;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.JacocoGenerated;
@@ -147,7 +148,7 @@ public class UnpublishRequest extends TicketEntry {
     }
 
     @Override
-    public Dao toDao() {
+    public TicketDao toDao() {
         return new UnpublishRequestDao(this);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/TicketDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/TicketDao.java
@@ -106,6 +106,11 @@ public abstract class TicketDao extends Dao implements JoinWithResource {
                    .withExpressionAttributeNames(condition.getExpressionAttributeNames())
                    .withExpressionAttributeValues(condition.getExpressionAttributeValues());
     }
+
+    public TransactWriteItem toPutTransactionItem(String tableName) {
+        var put = new Put().withItem(this.toDynamoFormat()).withTableName(tableName);
+        return new TransactWriteItem().withPut(put);
+    }
     
     public Optional<TicketDao> fetchByResourceIdentifier(AmazonDynamoDB client) {
         QueryRequest queryRequest = new QueryRequest()

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -52,7 +52,6 @@ import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.Owner;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
-import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.UnpublishRequest;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
@@ -66,7 +65,6 @@ import no.unit.nva.publication.model.storage.IdentifierEntry;
 import no.unit.nva.publication.model.storage.KeyField;
 import no.unit.nva.publication.model.storage.LogEntryDao;
 import no.unit.nva.publication.model.storage.ResourceDao;
-import no.unit.nva.publication.model.storage.TicketDao;
 import no.unit.nva.publication.model.storage.UniqueDoiRequestEntry;
 import no.unit.nva.publication.model.storage.WithPrimaryKey;
 import no.unit.nva.publication.model.utils.CuratingInstitutionsUtil;
@@ -346,19 +344,7 @@ public class ResourceService extends ServiceWithTransactions {
     }
 
     public Stream<TicketEntry> fetchAllTicketsForResource(Resource resource) {
-        var dao = (ResourceDao) resource.toDao();
-        return dao.fetchAllTickets(getClient())
-                   .stream()
-                   .map(TicketDao::getData)
-                   .map(TicketEntry.class::cast)
-                   .filter(ResourceService::isNotRemoved);
-    }
-
-    public Stream<TicketEntry> fetchAllTicketsForPublication(UserInstance userInstance,
-                                                             SortableIdentifier publicationIdentifier)
-        throws ApiGatewayException {
-        var resource = readResourceService.getResource(userInstance, publicationIdentifier);
-        return resource.fetchAllTickets(this).filter(ResourceService::isNotRemoved);
+        return readResourceService.fetchAllTicketsForResource(resource);
     }
 
     public void refresh(SortableIdentifier identifier) {
@@ -450,10 +436,6 @@ public class ResourceService extends ServiceWithTransactions {
         }
 
         toResource.setStatus(status);
-    }
-
-    private static boolean isNotRemoved(TicketEntry ticket) {
-        return !TicketStatus.REMOVED.equals(ticket.getStatus());
     }
 
     private List<Entity> refreshAndMigrate(List<Entity> dataEntries) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -228,9 +228,20 @@ public class UpdateResourceService extends ServiceWithTransactions {
     private List<TransactWriteItem> createUpdateResourceTransactionItems(Resource resource, UserInstance userInstance,
                                                                          Resource persistedResource) {
         var transactionItems = new ArrayList<TransactWriteItem>();
+
+        var ticketsTransactions = refreshTicketsTransactions(resource);
         transactionItems.add(createPutTransaction(resource));
         transactionItems.addAll(updateFilesTransactions(resource, userInstance, persistedResource));
+        transactionItems.addAll(ticketsTransactions);
         return transactionItems;
+    }
+
+    private List<TransactWriteItem> refreshTicketsTransactions(Resource resource) {
+        return readResourceService.fetchAllTicketsForResource(resource)
+                   .map(TicketEntry::refresh)
+                   .map(TicketEntry::toDao)
+                   .map(ticketDao -> ticketDao.toPutTransactionItem(tableName))
+                   .toList();
     }
 
     private void updateCuratingInstitutions(Resource resource, Resource persistedResource) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1662,6 +1663,22 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var updatedFileEntry = fileEntry.fetch(resourceService).orElseThrow();
 
         assertInstanceOf(FileImportedEvent.class, updatedFileEntry.getFileEvent());
+    }
+
+    @Test
+    void updateResourceMethodShouldRefreshTickets() throws ApiGatewayException {
+        var publication = randomPublication().copy().withAssociatedArtifacts(List.of()).build();
+        var userInstance = UserInstance.fromPublication(publication);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+
+        var ticket = createDoiRequest(publication);
+
+        Resource.fromPublication(publication).update(resourceService, userInstance);
+
+        var refreshedTicket = ticket.fetch(ticketService);
+
+        assertNotEquals(ticket.getModifiedDate(), refreshedTicket.getModifiedDate());
+
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/TicketServiceTest.java
@@ -601,16 +601,6 @@ public class TicketServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldReturnAllTicketsForPublicationWhenRequesterIsPublicationOwner() throws ApiGatewayException {
-        var publication = persistPublication(owner, DRAFT);
-        var originalTickets = createAllTypesOfTickets(publication);
-        var fetchedTickets = resourceService.fetchAllTicketsForPublication(owner, publication.getIdentifier())
-                                 .toList();
-
-        assertThat(fetchedTickets, containsInAnyOrder(originalTickets.toArray(TicketEntry[]::new)));
-    }
-
-    @Test
     void shouldReturnEmptyTicketListWhenPublicationHasNoTickets() throws ApiGatewayException {
         var publication = persistPublication(owner, DRAFT);
         var fetchedTickets = Resource.fromPublication(publication)
@@ -626,7 +616,7 @@ public class TicketServiceTest extends ResourcesLocalTest {
                                      .boxed()
                                      .map(ticketType -> createPersistedTicket(publication, PublishingRequestCase.class))
                                      .toList());
-        var ticketsFromDatabase = resourceService.fetchAllTicketsForPublication(owner, publication.getIdentifier())
+        var ticketsFromDatabase = resourceService.fetchAllTicketsForResource(Resource.fromPublication(publication))
                                       .toList();
         assertThat(ticketsFromDatabase, allOf(hasSize(2), everyItem(instanceOf(PublishingRequestCase.class))));
     }


### PR DESCRIPTION
When updating publication, we have to hold tickets in search index in sync with publication in database. Otherwise there can be cases where title/status/contributor from ticket differ from data on publication. 

Achieving that by refreshing all tickets on publication update, so tickets are getting expanded on publication update and populated with "latest" publication data in search-index. 