### PR TITLE
update ticket viewed by list when updating ticket status

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -183,6 +183,7 @@ public abstract class TicketEntry implements Entity {
         updated.setFinalizedBy(new Username(userInstance.getUser().toString()));
         updated.setStatus(TicketStatus.COMPLETED);
         updated.validateCompletionRequirements(publication);
+        updated.setViewedBy(ViewedBy.addAll(userInstance.getUser()));
         return updated;
     }
 
@@ -193,6 +194,7 @@ public abstract class TicketEntry implements Entity {
         updated.setModifiedDate(Instant.now());
         updated.setFinalizedBy(new Username(userInstance.getUsername()));
         updated.setFinalizedDate(Instant.now());
+        updated.setViewedBy(ViewedBy.addAll(userInstance.getUser()));
         return updated;
     }
 


### PR DESCRIPTION
Resetting viewedBy list when curator completes or closes ticket, so ticket owner is notified about status change.