### PR TITLE
Np 48665 consume scopus entries from queue

### DIFF
--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteImportCandidateEventConsumer.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeleteImportCandidateEventConsumer.java
@@ -30,7 +30,7 @@ public class DeleteImportCandidateEventConsumer
     public static final String EVENTS_BUCKET = new Environment().readEnv("EVENTS_BUCKET");
     public static final String API_HOST = new Environment().readEnv("API_HOST");
     public static final String SEARCH = "search";
-    public static final String IMPORT_CANDIDATES_2 = "import-candidates2";
+    public static final String IMPORT_CANDIDATES = "import-candidates";
     public static final String CONTENT_TYPE = "application/json";
     public static final String COULD_NOT_FETCH_UNIQUE_IMPORT_CANDIDATE_MESSAGE = "Could not fetch unique import "
                                                                                  + "candidate";
@@ -109,7 +109,7 @@ public class DeleteImportCandidateEventConsumer
     private URI constructUri(String scopusIdentifier) {
         return UriWrapper.fromHost(API_HOST)
                    .addChild(SEARCH)
-                   .addChild(IMPORT_CANDIDATES_2)
+                   .addChild(IMPORT_CANDIDATES)
                    .addQueryParameter(SCOPUS_IDENTIFIER, scopusIdentifier)
                    .getUri();
     }

--- a/scopus-import/build.gradle
+++ b/scopus-import/build.gradle
@@ -59,4 +59,5 @@ test {
     environment "CROSSREF_FETCH_DOI_URI", "https://api.crossref.org/v1/works/"
     environment "CUSTOMER_ID", "someValue"
     environment "AWS_REGION", "eu-west-1"
+    environment "XML_BUCKET_NAME", "xmlBucket"
 }

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
@@ -98,7 +98,7 @@ public class ScopusHandler implements RequestHandler<SQSEvent, ImportCandidate> 
     @Override
     public ImportCandidate handleRequest(SQSEvent event, Context context) {
         var message = event.getRecords().getFirst();
-        var s3Uri = UriWrapper.fromUri(message.getAttributes().get(URI_ATTRIBUTE)).getUri();
+        var s3Uri = UriWrapper.fromUri(message.getMessageAttributes().get(URI_ATTRIBUTE).getStringValue()).getUri();
         return attempt(() -> createImportCandidate(s3Uri))
                    .map(this::updateExistingIfNeeded)
                    .flatMap(this::persistOrUpdateInDatabase)

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusHandler.java
@@ -4,13 +4,14 @@ import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import jakarta.xml.bind.JAXB;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
+import java.time.Instant;
 import java.util.Random;
 import no.scopus.generated.DocTp;
 import no.sikt.nva.scopus.conversion.CristinConnection;
@@ -22,7 +23,6 @@ import no.sikt.nva.scopus.conversion.files.TikaUtils;
 import no.sikt.nva.scopus.exception.ExceptionMapper;
 import no.sikt.nva.scopus.update.ScopusUpdater;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.additionalidentifiers.ScopusIdentifier;
 import no.unit.nva.publication.model.business.importcandidate.ImportCandidate;
 import no.unit.nva.publication.s3imports.ImportResult;
@@ -40,22 +40,22 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @SuppressWarnings("PMD.GodClass")
-public class ScopusHandler implements RequestHandler<S3Event, Publication> {
+public class ScopusHandler implements RequestHandler<SQSEvent, ImportCandidate> {
 
     public static final String BACKEND_CLIENT_SECRET_NAME = new Environment().readEnv("BACKEND_CLIENT_SECRET_NAME");
     public static final String BACKEND_CLIENT_AUTH_URL = new Environment().readEnv("BACKEND_CLIENT_AUTH_URL");
-    public static final String YYYY_MM_DD_HH_FORMAT = "yyyy-MM-dd:HH";
     public static final Random RANDOM = new Random(System.currentTimeMillis());
     public static final int MAX_EFFORTS = 10;
-    public static final String S3_URI_TEMPLATE = "s3://%s/%s";
     public static final String PATH_SEPERATOR = "/";
     public static final String SCOPUS_IMPORT_BUCKET = "SCOPUS_IMPORT_BUCKET";
+    public static final String SCOPUS_XML_BUCKET = new Environment().readEnv("XML_BUCKET_NAME");
     public static final String SUCCESS_BUCKET_PATH = "SUCCESS";
-    private static final String ERROR_SAVING_SCOPUS_PUBLICATION = "Error saving imported scopus publication object "
-                                                                  + "key: {} {}";
+    private static final String ERROR_SAVING_IMPORT_CANDIDATE = "Error saving import cadidate "
+                                                                + "key: {} {}";
     private static final int MAX_SLEEP_TIME = 100;
     private static final Logger logger = LoggerFactory.getLogger(ScopusHandler.class);
     private static final String ERROR_BUCKET_PATH = "ERROR";
+    public static final String URI_ATTRIBUTE = "uri";
     private final S3Client s3Client;
     private final PiaConnection piaConnection;
     private final CristinConnection cristinConnection;
@@ -96,12 +96,14 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
     }
 
     @Override
-    public ImportCandidate handleRequest(S3Event event, Context context) {
-        return attempt(() -> createImportCandidate(event))
+    public ImportCandidate handleRequest(SQSEvent event, Context context) {
+        var message = event.getRecords().getFirst();
+        var s3Uri = UriWrapper.fromUri(message.getAttributes().get(URI_ATTRIBUTE)).getUri();
+        return attempt(() -> createImportCandidate(s3Uri))
                    .map(this::updateExistingIfNeeded)
                    .flatMap(this::persistOrUpdateInDatabase)
-                   .map(publication -> storeSuccessReport(publication, event))
-                   .orElseThrow(fail -> handleSavingError(fail, event));
+                   .map(this::storeSuccessReport)
+                   .orElseThrow(fail -> handleSavingError(fail, s3Uri));
     }
 
     @JacocoGenerated
@@ -127,14 +129,14 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
         return scopusUpdater.updateImportCandidate(importCandidate);
     }
 
-    private ImportCandidate storeSuccessReport(ImportCandidate importCandidate, S3Event event) {
+    private ImportCandidate storeSuccessReport(ImportCandidate importCandidate) {
         return attempt(this::getS3DriverForScopusImportBucket).map(
-            s3Driver -> insertSucceededReportFile(importCandidate, event, s3Driver)).orElseThrow();
+            s3Driver -> insertSucceededReportFile(importCandidate, s3Driver)).orElseThrow();
     }
 
-    private ImportCandidate insertSucceededReportFile(ImportCandidate importCandidate, S3Event event, S3Driver s3Driver)
+    private ImportCandidate insertSucceededReportFile(ImportCandidate importCandidate, S3Driver s3Driver)
         throws IOException {
-        s3Driver.insertFile(constructFileUri(event, importCandidate).toS3bucketPath(),
+        s3Driver.insertFile(constructFileUri(importCandidate).toS3bucketPath(),
                             getScopusIdentifier(importCandidate));
         return importCandidate;
     }
@@ -143,11 +145,10 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
         return new S3Driver(s3Client, new Environment().readEnv(SCOPUS_IMPORT_BUCKET));
     }
 
-    private UriWrapper constructFileUri(S3Event s3Event, Publication publication) {
-        var timestamp = timePath(s3Event);
+    private UriWrapper constructFileUri(ImportCandidate importCandidate) {
         return UriWrapper.fromUri(SUCCESS_BUCKET_PATH)
-                   .addChild(timestamp)
-                   .addChild(publication.getIdentifier().toString());
+                   .addChild(Instant.now().toString())
+                   .addChild(importCandidate.getIdentifier().toString());
     }
 
     private String getScopusIdentifier(ImportCandidate importCandidate) {
@@ -160,49 +161,39 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
                    .orElse(null);
     }
 
-    private RuntimeException handleSavingError(Failure<ImportCandidate> fail, S3Event event) {
-        loggError(event, fail);
-        saveReportToS3(fail, event);
+    private RuntimeException handleSavingError(Failure<ImportCandidate> fail, URI s3Uri) {
+        loggError(s3Uri, fail);
+        saveReportToS3(fail, s3Uri);
         return ExceptionMapper.castToCorrectRuntimeException(fail.getException());
     }
 
-    private void loggError(S3Event event, Failure<ImportCandidate> fail) {
-        logger.error(ERROR_SAVING_SCOPUS_PUBLICATION, extractObjectKey(event), fail.getException());
+    private void loggError(URI s3Uri, Failure<ImportCandidate> fail) {
+        logger.error(ERROR_SAVING_IMPORT_CANDIDATE, s3Uri, fail.getException());
     }
 
-    private void saveReportToS3(Failure<ImportCandidate> fail, S3Event event) {
-        attempt(() -> getContentToSave(event)).map(content -> generateReportFromContent(fail, content))
-            .map(report -> insertReport(fail, event, report));
+    private void saveReportToS3(Failure<ImportCandidate> fail, URI s3Uri) {
+        attempt(() -> getContentToSave(s3Uri)).map(content -> generateReportFromContent(fail, content))
+            .map(report -> insertReport(fail, s3Uri, report));
     }
 
-    private URI insertReport(Failure<ImportCandidate> fail, S3Event event, ImportResult<String> report)
+    private URI insertReport(Failure<ImportCandidate> fail, URI s3Uri, ImportResult<String> report)
         throws IOException {
         return getS3DriverForScopusImportBucket().insertFile(
-            constructErrorFileUri(event, fail.getException()).toS3bucketPath(), report.toJsonString());
+            constructErrorFileUri(s3Uri, fail.getException()).toS3bucketPath(), report.toJsonString());
     }
 
-    private String getContentToSave(S3Event event) {
-        return attempt(() -> readFile(event)).orElseThrow();
+    private String getContentToSave(URI s3Uri) {
+        return attempt(() -> readFile(s3Uri)).orElseThrow();
     }
 
-    private UriWrapper constructErrorFileUri(S3Event event, Exception exception) {
-        var fileUri = UriWrapper.fromUri(extractObjectKey(event));
-        var timestamp = timePath(event);
+    private UriWrapper constructErrorFileUri(URI s3Uri, Exception exception) {
         return UriWrapper.fromUri(ERROR_BUCKET_PATH
                                   + PATH_SEPERATOR
-                                  + timestamp
+                                  + Instant.now().toString()
                                   + PATH_SEPERATOR
                                   + exception.getClass().getSimpleName()
                                   + PATH_SEPERATOR
-                                  + fileUri.getLastPathElement());
-    }
-
-    private String timePath(S3Event event) {
-        return event.getRecords().getFirst().getEventTime().toString(YYYY_MM_DD_HH_FORMAT);
-    }
-
-    private String extractObjectKey(S3Event s3Event) {
-        return s3Event.getRecords().getFirst().getS3().getObject().getKey();
+                                  + UriWrapper.fromUri(s3Uri).getLastPathElement());
     }
 
     private Try<ImportCandidate> persistOrUpdateInDatabase(ImportCandidate importCandidate) throws BadRequestException {
@@ -247,8 +238,8 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
         return resourceService.persistImportCandidate(importCandidate);
     }
 
-    private ImportCandidate createImportCandidate(S3Event event) {
-        return attempt(() -> readFile(event)).map(this::parseXmlFile)
+    private ImportCandidate createImportCandidate(URI s3Uri) {
+        return attempt(() -> readFile(s3Uri)).map(this::parseXmlFile)
                    .map(this::generateImportCandidate)
                    .orElseThrow(fail -> logErrorAndThrowException(fail.getException()));
     }
@@ -269,21 +260,8 @@ public class ScopusHandler implements RequestHandler<S3Event, Publication> {
         return scopusConverter.generateImportCandidate();
     }
 
-    private String readFile(S3Event event) {
-        var s3Driver = new S3Driver(s3Client, extractBucketName(event));
-        var fileUri = createS3BucketUri(event);
-        return s3Driver.getFile(UriWrapper.fromUri(fileUri).toS3bucketPath());
-    }
-
-    private String extractBucketName(S3Event event) {
-        return event.getRecords().getFirst().getS3().getBucket().getName();
-    }
-
-    private String extractFilename(S3Event event) {
-        return event.getRecords().getFirst().getS3().getObject().getKey();
-    }
-
-    private URI createS3BucketUri(S3Event s3Event) {
-        return URI.create(String.format(S3_URI_TEMPLATE, extractBucketName(s3Event), extractFilename(s3Event)));
+    private String readFile(URI s3Uri) {
+        var s3Driver = new S3Driver(s3Client, SCOPUS_XML_BUCKET);
+        return s3Driver.getFile(UriWrapper.fromUri(s3Uri).toS3bucketPath());
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -1360,20 +1360,16 @@ Resources:
           PIA_PASSWORD_KEY: !Ref PiaRestUsernamePasswordKey
           PIA_REST_API: !Ref PiaRestHost
           SCOPUS_IMPORT_BUCKET: !Sub "${ScopusImportReportBucketName}-${AWS::AccountId}"
+          XML_BUCKET_NAME: !Ref ScopusXmlBucket
           IMPORT_CANDIDATES_STORAGE_BUCKET: !Ref ImportCandidateStorageBucket
           BACKEND_CLIENT_SECRET_NAME: 'BackendCognitoClientCredentials'
           CROSSREF_FETCH_DOI_URI: 'https://api.crossref.org/v1/works/'
       Events:
-        Scopus:
-          Type: S3
+        SqsEvent:
+          Type: SQS
           Properties:
-            Bucket: !Ref ScopusXmlBucket
-            Events: 's3:ObjectCreated:*'
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: suffix
-                    Value: '.xml'
+            Queue: !GetAtt ScopusImportQueue.Arn
+            BatchSize: 1
 
   ScopusDeletionEventEmitter:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -2369,6 +2369,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt ScopusImportDLQ.Arn
         maxReceiveCount: 5
+      VisibilityTimeout: 900 #Equal to or more than NvaScopusFunction Timeout
   ScopusImportDLQ:
     Type: AWS::SQS::Queue
 

--- a/template.yaml
+++ b/template.yaml
@@ -2372,6 +2372,7 @@ Resources:
         deadLetterTargetArn: !GetAtt ScopusImportDLQ.Arn
         maxReceiveCount: 5
       VisibilityTimeout: 900 #Equal to or more than NvaScopusFunction Timeout
+      MessageRetentionPeriod: 1209600 #14 days
   ScopusImportDLQ:
     Type: AWS::SQS::Queue
 

--- a/template.yaml
+++ b/template.yaml
@@ -1370,6 +1370,8 @@ Resources:
           Properties:
             Queue: !GetAtt ScopusImportQueue.Arn
             BatchSize: 1
+            ScalingConfig:
+              MaximumConcurrency: 5  # Limit the number of concurrent invocations from this SQS queue
 
   ScopusDeletionEventEmitter:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Making ScopusFunction consume SQS event instead of S3Event. 

This improvement makes that we can process xml files received from Scopus when it suits best for us. 

Changes:

- Handler consumes SQS event
- Setting ScopusFunction MaximumConcurrency to 5, so there is max 5 concurrent lambdas processing candidates.
- Setting ScopusFunction BatchSize to 1, so we process 1 candidate per invocation.