### PR TITLE
new model for log

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jsonassert = { strictly = '1.5.3'}
 junit = { strictly = '5.12.0' }
 log4j = { strictly = '2.24.3' }
 mockito = { strictly = '5.15.2' }
-nva = { strictly = '1.41.8' }
+nva = { strictly = '1.41.9' }
 nva-language = { strictly = '1.2.0' }
 nvaDoiPartnerData = { strictly = '0.5.8' }
 reflections = { strictly = '0.10.2' }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/FileLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/FileLogEntry.java
@@ -10,7 +10,7 @@ import no.unit.nva.publication.service.impl.ResourceService;
 public record FileLogEntry(SortableIdentifier identifier, SortableIdentifier fileIdentifier,
                            SortableIdentifier resourceIdentifier, LogTopic topic, String filename,
                            String fileType, Instant timestamp,
-                           LogUser performedBy, ImportSource importSource) implements LogEntry {
+                           LogAgent performedBy, ImportSource importSource) implements LogEntry {
 
     public static final String TYPE = "FileLogEntry";
 
@@ -31,7 +31,7 @@ public record FileLogEntry(SortableIdentifier identifier, SortableIdentifier fil
         private String filename;
         private String fileType;
         private Instant timestamp;
-        private LogUser performedBy;
+        private LogAgent performedBy;
         private ImportSource importSource;
 
         private Builder() {
@@ -67,7 +67,7 @@ public record FileLogEntry(SortableIdentifier identifier, SortableIdentifier fil
             return this;
         }
 
-        public Builder withPerformedBy(LogUser performedBy) {
+        public Builder withPerformedBy(LogAgent performedBy) {
             this.performedBy = performedBy;
             return this;
         }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogAgent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogAgent.java
@@ -1,0 +1,12 @@
+package no.unit.nva.publication.model.business.logentry;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(name = LogOrganization.TYPE, value = LogOrganization.class),
+    @JsonSubTypes.Type(name = LogUser.TYPE, value = LogUser.class)})
+public interface LogAgent {
+
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogEntry.java
@@ -20,7 +20,7 @@ public interface LogEntry {
 
     Instant timestamp();
 
-    LogUser performedBy();
+    LogAgent performedBy();
 
     void persist(ResourceService resourceService);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogOrganization.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogOrganization.java
@@ -3,20 +3,21 @@ package no.unit.nva.publication.model.business.logentry;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
-import no.unit.nva.clients.CustomerDto;
+import java.util.Map;
+import no.unit.nva.clients.cristin.CristinOrganizationDto;
 
 @JsonTypeName(LogOrganization.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record LogOrganization(URI id, URI topLevelOrgCristinId, String shortName, String displayName) {
+public record LogOrganization(URI id, String acronym, Map<String, String> labels) implements LogAgent {
 
-    public static final String TYPE = "LogOrganization";
-
-    public static LogOrganization fromCustomerDto(CustomerDto getCustomerResponse) {
-        return new LogOrganization(getCustomerResponse.id(), getCustomerResponse.cristinId(),
-                                   getCustomerResponse.shortName(), getCustomerResponse.displayName());
-    }
+    public static final String TYPE = "Organization";
 
     public static LogOrganization fromCristinId(URI topLevelOrgCristinId) {
-        return new LogOrganization(null, topLevelOrgCristinId, null, null);
+        return new LogOrganization(topLevelOrgCristinId, null, null);
+    }
+
+    public static LogOrganization fromCristinOrganization(CristinOrganizationDto cristinOrganizationDto) {
+        return new LogOrganization(cristinOrganizationDto.id(), cristinOrganizationDto.acronym(),
+                            cristinOrganizationDto.labels());
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogUser.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogUser.java
@@ -4,26 +4,40 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
-import no.unit.nva.clients.CustomerDto;
-import no.unit.nva.clients.UserDto;
+import no.unit.nva.clients.cristin.CristinOrganizationDto;
+import no.unit.nva.clients.cristin.CristinPersonDto;
+import no.unit.nva.clients.cristin.TypedValue;
 import no.unit.nva.publication.model.business.User;
 
 @JsonTypeName(LogUser.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record LogUser(@JsonAlias("userName") String username, String givenName, String familyName, URI cristinId,
-                      LogOrganization onBehalfOf) {
+public record LogUser(@JsonAlias("userName") String username, URI id, String givenName, String familyName,
+                      String preferredFirstName, String preferredLastName,
+                      LogOrganization onBehalfOf) implements LogAgent {
 
-    public static final String TYPE = "LogUser";
+    public static final String TYPE = "Person";
+    public static final String PREFERRED_FIRST_NAME = "PreferredFirstName";
+    public static final String PREFERRED_LAST_NAME = "PreferredLastName";
 
     public static LogUser fromResourceEvent(User username, URI topLevelOrgCristinId) {
-        return new LogUser(username.toString(), null, null, null,
-                           new LogOrganization(null, topLevelOrgCristinId, null, null));
+        return new LogUser(username.toString(), null, null, null, null, null,
+                           new LogOrganization(topLevelOrgCristinId, null, null));
     }
 
-    public static LogUser create(UserDto getUserResponse, CustomerDto getCustomerResponse) {
-        return new LogUser(getUserResponse.username(), getUserResponse.givenName(), getUserResponse.familyName(),
-                           getUserResponse.cristinId(),
-                           new LogOrganization(getCustomerResponse.id(), getCustomerResponse.cristinId(),
-                                               getCustomerResponse.shortName(), getCustomerResponse.displayName()));
+    public static LogUser create(CristinPersonDto cristinPersonDto, CristinOrganizationDto cristinOrganizationDto) {
+        return new LogUser(null, cristinPersonDto.id(), cristinPersonDto.firstName().orElse(null),
+                           cristinPersonDto.lastName().orElse(null),
+                           getName(cristinPersonDto, PREFERRED_FIRST_NAME),
+                           getName(cristinPersonDto, PREFERRED_LAST_NAME),
+                           LogOrganization.fromCristinOrganization(cristinOrganizationDto));
+    }
+
+    private static String getName(CristinPersonDto cristinPersonDto, String nameType) {
+        return cristinPersonDto.names()
+                   .stream()
+                   .filter(typedValue -> nameType.equals(typedValue.type()))
+                   .map(TypedValue::value)
+                   .findFirst()
+                   .orElse(null);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/PublicationLogEntry.java
@@ -8,7 +8,7 @@ import no.unit.nva.publication.service.impl.ResourceService;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentifier resourceIdentifier, LogTopic topic,
-                                  Instant timestamp, LogUser performedBy, ImportSource importSource)
+                                  Instant timestamp, LogAgent performedBy, ImportSource importSource)
     implements LogEntry {
 
     public static final String TYPE = "PublicationLogEntry";
@@ -27,7 +27,7 @@ public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentif
         private SortableIdentifier resourceIdentifier;
         private LogTopic topic;
         private Instant timestamp;
-        private LogUser performedBy;
+        private LogAgent performedBy;
         private ImportSource importSource;
 
         private Builder() {
@@ -53,7 +53,7 @@ public record PublicationLogEntry(SortableIdentifier identifier, SortableIdentif
             return this;
         }
 
-        public Builder withPerformedBy(LogUser performedBy) {
+        public Builder withPerformedBy(LogAgent performedBy) {
             this.performedBy = performedBy;
             return this;
         }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/TicketLogEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/TicketLogEntry.java
@@ -6,7 +6,7 @@ import no.unit.nva.publication.service.impl.ResourceService;
 
 public record TicketLogEntry(SortableIdentifier identifier, SortableIdentifier ticketIdentifier,
                              SortableIdentifier resourceIdentifier, LogTopic topic, Instant timestamp,
-                             LogUser performedBy) implements LogEntry {
+                             LogAgent performedBy) implements LogEntry {
 
     public static final String TYPE = "TicketLogEntry";
 
@@ -25,7 +25,7 @@ public record TicketLogEntry(SortableIdentifier identifier, SortableIdentifier t
         private SortableIdentifier resourceIdentifier;
         private LogTopic topic;
         private Instant timestamp;
-        private LogUser performedBy;
+        private LogAgent performedBy;
 
         private Builder() {
         }
@@ -55,7 +55,7 @@ public record TicketLogEntry(SortableIdentifier identifier, SortableIdentifier t
             return this;
         }
 
-        public Builder withPerformedBy(LogUser performedBy) {
+        public Builder withPerformedBy(LogAgent performedBy) {
             this.performedBy = performedBy;
             return this;
         }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record CreatedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record CreatedResourceEvent(Instant date, User user, URI institution, Sor
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DeletedResourceEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record DeletedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record DeletedResourceEvent(Instant date, User user, URI institution, Sor
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiAssignedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiAssignedEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
 public record DoiAssignedEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -19,7 +19,7 @@ public record DoiAssignedEvent(Instant date, User user, URI institution, Sortabl
 
     @Override
     public TicketLogEntry toLogEntry(SortableIdentifier resourceIdentifier,
-                                     SortableIdentifier ticketIdentifier, LogUser user) {
+                                     SortableIdentifier ticketIdentifier, LogAgent user) {
         return TicketLogEntry.builder()
                    .withTicketIdentifier(ticketIdentifier)
                    .withResourceIdentifier(resourceIdentifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiRejectedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiRejectedEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
 public record DoiRejectedEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -19,7 +19,7 @@ public record DoiRejectedEvent(Instant date, User user, URI institution, Sortabl
 
     @Override
     public TicketLogEntry toLogEntry(SortableIdentifier resourceIdentifier,
-                                     SortableIdentifier ticketIdentifier, LogUser user) {
+                                     SortableIdentifier ticketIdentifier, LogAgent user) {
         return TicketLogEntry.builder()
                    .withTicketIdentifier(ticketIdentifier)
                    .withResourceIdentifier(resourceIdentifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiRequestedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiRequestedEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
 public record DoiRequestedEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -19,7 +19,7 @@ public record DoiRequestedEvent(Instant date, User user, URI institution, Sortab
 
     @Override
     public TicketLogEntry toLogEntry(SortableIdentifier resourceIdentifier,
-                                     SortableIdentifier ticketIdentifier, LogUser user) {
+                                     SortableIdentifier ticketIdentifier, LogAgent user) {
         return TicketLogEntry.builder()
                    .withTicketIdentifier(ticketIdentifier)
                    .withResourceIdentifier(resourceIdentifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiReservedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/DoiReservedEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record DoiReservedEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record DoiReservedEvent(Instant date, User user, URI institution, Sortabl
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileApprovedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileApprovedEvent.java
@@ -5,8 +5,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileApprovedEvent(Instant date, User user, SortableIdentifier identifier) implements FileEvent {
 
@@ -15,7 +15,7 @@ public record FileApprovedEvent(Instant date, User user, SortableIdentifier iden
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileDeletedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileDeletedEvent.java
@@ -5,8 +5,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileDeletedEvent(Instant date, User user, SortableIdentifier identifier) implements FileEvent {
 
@@ -15,7 +15,7 @@ public record FileDeletedEvent(Instant date, User user, SortableIdentifier ident
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileEvent.java
@@ -7,7 +7,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
-import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(FileUploadedEvent.class), @JsonSubTypes.Type(FileApprovedEvent.class),
@@ -22,5 +22,5 @@ public interface FileEvent {
 
     SortableIdentifier identifier();
 
-    FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user);
+    FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileHiddenEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileHiddenEvent.java
@@ -5,8 +5,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileHiddenEvent(Instant date, User user, SortableIdentifier identifier)
     implements FileEvent {
@@ -16,7 +16,7 @@ public record FileHiddenEvent(Instant date, User user, SortableIdentifier identi
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileImportedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileImportedEvent.java
@@ -6,8 +6,8 @@ import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileImportedEvent(Instant date, User user, SortableIdentifier identifier, ImportSource importSource)
     implements FileEvent {
@@ -17,7 +17,7 @@ public record FileImportedEvent(Instant date, User user, SortableIdentifier iden
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRejectedEvent.java
@@ -5,8 +5,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileRejectedEvent(Instant date, User user, SortableIdentifier identifier, String rejectedFileType)
     implements FileEvent {
@@ -16,7 +16,7 @@ public record FileRejectedEvent(Instant date, User user, SortableIdentifier iden
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRetractedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileRetractedEvent.java
@@ -5,8 +5,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 
 public record FileRetractedEvent(Instant date, User user, SortableIdentifier identifier)
     implements FileEvent {
@@ -16,7 +16,7 @@ public record FileRetractedEvent(Instant date, User user, SortableIdentifier ide
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -5,6 +5,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
@@ -15,7 +16,7 @@ public record FileUploadedEvent(Instant date, User user, SortableIdentifier iden
     }
 
     @Override
-    public FileLogEntry toLogEntry(FileEntry fileEntry, LogUser user) {
+    public FileLogEntry toLogEntry(FileEntry fileEntry, LogAgent user) {
         return FileLogEntry.builder()
                    .withIdentifier(identifier)
                    .withFileIdentifier(fileEntry.getIdentifier())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
@@ -6,8 +6,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record ImportedResourceEvent(Instant date, User user, URI institution, ImportSource importSource,
@@ -20,7 +20,7 @@ public record ImportedResourceEvent(Instant date, User user, URI institution, Im
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
@@ -6,8 +6,8 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record MergedResourceEvent(Instant date, User user, URI institution, ImportSource importSource,
@@ -20,7 +20,7 @@ public record MergedResourceEvent(Instant date, User user, URI institution, Impo
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record PublishedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record PublishedResourceEvent(Instant date, User user, URI institution, S
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/RepublishedResourceEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record RepublishedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record RepublishedResourceEvent(Instant date, User user, URI institution,
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
-import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -27,5 +27,5 @@ public interface ResourceEvent {
      */
     URI institution();
 
-    PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user);
+    PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/TicketEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/TicketEvent.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
@@ -25,5 +26,5 @@ public interface TicketEvent {
      */
     URI institution();
 
-    TicketLogEntry toLogEntry(SortableIdentifier resourceIdentifier, SortableIdentifier ticketIdentifier, LogUser user);
+    TicketLogEntry toLogEntry(SortableIdentifier resourceIdentifier, SortableIdentifier ticketIdentifier, LogAgent user);
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UnpublishedResourceEvent.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record UnpublishedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
@@ -18,7 +18,7 @@ public record UnpublishedResourceEvent(Instant date, User user, URI institution,
     }
 
     @Override
-    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogUser user) {
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
         return PublicationLogEntry.builder()
                    .withResourceIdentifier(resourceIdentifier)
                    .withIdentifier(identifier)

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/log/PersistLogEntryEventHandler.java
@@ -5,6 +5,7 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.Optional;
 import no.unit.nva.clients.IdentityServiceClient;
+import no.unit.nva.clients.cristin.CristinClient;
 import no.unit.nva.events.handlers.DestinationsEventBridgeEventHandler;
 import no.unit.nva.events.models.AwsEventBridgeDetail;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
@@ -27,14 +28,15 @@ public class PersistLogEntryEventHandler extends DestinationsEventBridgeEventHan
 
     @JacocoGenerated
     public PersistLogEntryEventHandler() {
-        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService(), IdentityServiceClient.prepare());
+        this(S3Driver.defaultS3Client().build(), ResourceService.defaultService(), IdentityServiceClient.prepare(),
+             CristinClient.defaultClient());
     }
 
     protected PersistLogEntryEventHandler(S3Client s3Client, ResourceService resourceService,
-                                          IdentityServiceClient identityServiceClient) {
+                                          IdentityServiceClient identityServiceClient, CristinClient cristinClient) {
         super(EventReference.class);
         this.s3Client = s3Client;
-        this.logEntryService = new LogEntryService(resourceService, identityServiceClient);
+        this.logEntryService = new LogEntryService(resourceService, identityServiceClient, cristinClient);
     }
 
     @Override

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
@@ -262,8 +262,8 @@ class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
 
     private static LogUser randomLogUser() {
         return new LogUser(randomString(),
-                           randomString(), randomString(), randomUri(),
-                           new LogOrganization(randomUri(), randomUri(), randomString(), randomString()));
+                           randomUri(), randomString(), randomString(), randomString(), randomString(),
+                           new LogOrganization(randomUri(), randomString(), Map.of()));
     }
 
     private TicketDao fetchTicketDao(SortableIdentifier identifier) throws NotFoundException {

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/FileLogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/FileLogEntryDto.java
@@ -6,12 +6,13 @@ import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
 
 @JsonTypeName(FileLogEntryDto.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record FileLogEntryDto(LogTopic topic, Instant timestamp, LogUser performedBy,
+public record FileLogEntryDto(LogTopic topic, Instant timestamp, LogAgent performedBy,
                               SortableIdentifier publicationIdentifier, SortableIdentifier fileIdentifier,
                               String filename, String fileType, ImportSource importSource) implements LogEntryDto {
 

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/LogEntryDto.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import java.time.Instant;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
@@ -21,6 +21,6 @@ public interface LogEntryDto {
 
     Instant timestamp();
 
-    LogUser performedBy();
+    LogAgent performedBy();
 
 }

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/PublicationLogEntryDto.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeName(PublicationLogEntry.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record PublicationLogEntryDto(LogTopic topic, Instant timestamp, LogUser performedBy,
+public record PublicationLogEntryDto(LogTopic topic, Instant timestamp, LogAgent performedBy,
                                      SortableIdentifier publicationIdentifier, ImportSource importSource)
     implements LogEntryDto {
 

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/TicketLogEntryDto.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/TicketLogEntryDto.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
-import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.logentry.TicketLogEntry;
 
 @JsonTypeName(TicketLogEntry.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public record TicketLogEntryDto(LogTopic topic, Instant timestamp, LogUser performedBy,
+public record TicketLogEntryDto(LogTopic topic, Instant timestamp, LogAgent performedBy,
                                 SortableIdentifier publicationIdentifier, SortableIdentifier ticketIdentifier)
     implements LogEntryDto {
 

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -1,12 +1,11 @@
 package no.unit.nva.publication.log.service;
 
-import static java.util.Objects.isNull;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.util.Optional;
-import no.unit.nva.clients.CustomerDto;
-import no.unit.nva.clients.UserDto;
 import no.unit.nva.clients.IdentityServiceClient;
+import no.unit.nva.clients.UserDto;
+import no.unit.nva.clients.cristin.CristinClient;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.Entity;
@@ -14,8 +13,11 @@ import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
+import no.unit.nva.publication.model.business.logentry.LogOrganization;
 import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.publicationstate.FileImportedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 import no.unit.nva.publication.service.impl.ResourceService;
 import org.slf4j.Logger;
@@ -29,10 +31,13 @@ public class LogEntryService {
     public static final Logger logger = LoggerFactory.getLogger(LogEntryService.class);
     private final ResourceService resourceService;
     private final IdentityServiceClient identityServiceClient;
+    private final CristinClient cristinClient;
 
-    public LogEntryService(ResourceService resourceService, IdentityServiceClient identityServiceClient) {
+    public LogEntryService(ResourceService resourceService, IdentityServiceClient identityServiceClient,
+                           CristinClient cristinClient) {
         this.resourceService = resourceService;
         this.identityServiceClient = identityServiceClient;
+        this.cristinClient = cristinClient;
     }
 
     public void persistLogEntry(Entity entity) {
@@ -74,43 +79,52 @@ public class LogEntryService {
 
     private void createLogEntry(DoiRequest doiRequest) {
         var ticketEvent = doiRequest.getTicketEvent();
-        var user = createUser(ticketEvent.user());
+        var user = createUser(ticketEvent.user(), ticketEvent.institution());
         ticketEvent.toLogEntry(doiRequest.getResourceIdentifier(), doiRequest.getIdentifier(), user)
             .persist(resourceService);
     }
 
     private LogEntry createLogEntry(Resource resource, ResourceEvent resourceEvent) {
-        if (resourceEvent instanceof ImportedResourceEvent importedResourceEvent && isNull(resourceEvent.user())) {
-            return importedResourceEvent.toLogEntry(resource.getIdentifier(), null);
+        if (resourceEvent instanceof ImportedResourceEvent || resourceEvent instanceof MergedResourceEvent) {
+            var organization = logOrganizationFromCristinId(resourceEvent.institution());
+            return resourceEvent.toLogEntry(resource.getIdentifier(), organization);
         } else {
-            var user = createUser(resourceEvent);
+            var user = createUser(resourceEvent.user(), resourceEvent.institution());
             return resourceEvent.toLogEntry(resource.getIdentifier(), user);
         }
     }
 
+    private LogOrganization logOrganizationFromCristinId(URI organizationId) {
+        return cristinClient.getOrganization(organizationId)
+                   .map(LogOrganization::fromCristinOrganization)
+                   .orElse(LogOrganization.fromCristinId(organizationId));
+    }
+
     private void persistFileLogEntry(FileEntry fileEntry) {
         var fileEvent = fileEntry.getFileEvent();
-        var user = createUser(fileEvent.user());
+        if (fileEvent instanceof FileImportedEvent) {
+            var userDto = getUser(fileEvent.user());
+            var organization = logOrganizationFromCristinId(userDto.institutionCristinId());
+            fileEvent.toLogEntry(fileEntry, organization).persist(resourceService);
+        } else {
+            var user = createUser(fileEvent.user(), null);
+            fileEvent.toLogEntry(fileEntry, user).persist(resourceService);
+        }
         var fileIdentifier = fileEntry.getIdentifier();
         var resourceIdentifier = fileEntry.getResourceIdentifier();
-        fileEvent.toLogEntry(fileEntry, user).persist(resourceService);
 
         logger.info(PERSISTING_FILE_LOG_ENTRY_MESSAGE, fileEntry.getFile().getClass().getSimpleName(), fileIdentifier, resourceIdentifier);
     }
 
-    private LogUser createUser(User user) {
-        return attempt(() -> getUser(user))
-                   .map(getUserResponse -> LogUser.create(getUserResponse, getCustomer(getUserResponse.institutionCristinId())))
-                   .orElse(failure -> LogUser.fromResourceEvent(user, null));
-    }
-
-    private LogUser createUser(ResourceEvent resourceEvent) {
-        return attempt(() -> LogUser.create(getUser(resourceEvent.user()), getCustomer(resourceEvent.institution())))
-                   .orElse(failure -> LogUser.fromResourceEvent(resourceEvent.user(), resourceEvent.institution()));
-    }
-
-    private CustomerDto getCustomer(URI institutionCristinId) {
-        return attempt(() -> identityServiceClient.getCustomerByCristinId(institutionCristinId)).orElseThrow();
+    private LogUser createUser(User user, URI institution) {
+        try {
+            var userDto = getUser(user);
+            var cristinPersonDto = cristinClient.getPerson(userDto.cristinId()).orElse(null);
+            var cristinOrganizationDto = cristinClient.getOrganization(userDto.institutionCristinId()).orElse(null);
+            return LogUser.create(cristinPersonDto, cristinOrganizationDto);
+        } catch (Exception e) {
+            return LogUser.fromResourceEvent(user, institution);
+        }
     }
 
     private UserDto getUser(User user) {

--- a/publication-log/src/test/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandlerTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandlerTest.java
@@ -141,8 +141,8 @@ class FetchPublicationLogHandlerTest extends ResourcesLocalTest {
     }
 
     private void persistLogEntries(Publication publication) throws ApiGatewayException {
-        var user = new LogUser(randomString(), randomString(), randomString(), randomUri(),
-                               new LogOrganization(randomUri(), randomUri(), randomString(), randomString()));
+        var user = new LogUser(randomString(), randomUri(), randomString(), randomString(), randomString(),
+                               randomString(), new LogOrganization(randomUri(), randomString(), Map.of()));
         Resource.resourceQueryObject(publication.getIdentifier())
             .fetch(resourceService)
             .orElseThrow()
@@ -151,15 +151,15 @@ class FetchPublicationLogHandlerTest extends ResourcesLocalTest {
             .persist(resourceService);
 
         var userInstance = UserInstance.fromPublication(publication);
-        var fileEntry = FileEntry.create(randomOpenFile(), publication.getIdentifier(),
-                                         userInstance);
+        var fileEntry = FileEntry.create(randomOpenFile(), publication.getIdentifier(), userInstance);
         fileEntry.persist(resourceService);
         fileEntry.getFileEvent().toLogEntry(fileEntry, user).persist(resourceService);
 
-        var doiRequest =
-            (DoiRequest) DoiRequest.create(Resource.fromPublication(publication), userInstance).persistNewTicket(ticketService);
+        var doiRequest = (DoiRequest) DoiRequest.create(Resource.fromPublication(publication), userInstance)
+                                          .persistNewTicket(ticketService);
         doiRequest.setTicketEvent(DoiRequestedEvent.create(userInstance, Instant.now()));
-        doiRequest.getTicketEvent().toLogEntry(publication.getIdentifier(), doiRequest.getIdentifier(), user)
+        doiRequest.getTicketEvent()
+            .toLogEntry(publication.getIdentifier(), doiRequest.getIdentifier(), user)
             .persist(resourceService);
     }
 

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -17,8 +17,9 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
 import no.unit.nva.clients.CustomerDto;
-import no.unit.nva.clients.UserDto;
 import no.unit.nva.clients.IdentityServiceClient;
+import no.unit.nva.clients.UserDto;
+import no.unit.nva.clients.cristin.CristinClient;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
 import no.unit.nva.publication.model.business.DoiRequest;
@@ -28,6 +29,7 @@ import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.LogUser;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.DoiRequestedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
@@ -47,6 +49,7 @@ class LogEntryServiceTest extends ResourcesLocalTest {
     private TicketService ticketService;
     private IdentityServiceClient identityServiceClient;
     private LogEntryService logEntryService;
+    private CristinClient cristinClient;
 
     @BeforeEach
     public void setUp() throws NotFoundException {
@@ -54,9 +57,10 @@ class LogEntryServiceTest extends ResourcesLocalTest {
         ticketService = getTicketService();
         resourceService = getResourceServiceBuilder().build();
         identityServiceClient = mock(IdentityServiceClient.class);
+        cristinClient = mock(CristinClient.class);
         when(identityServiceClient.getUser(any())).thenReturn(randomUser());
         when(identityServiceClient.getCustomerByCristinId(any())).thenReturn(randomCustomer());
-        logEntryService = new LogEntryService(resourceService, identityServiceClient);
+        logEntryService = new LogEntryService(resourceService, identityServiceClient, cristinClient);
     }
 
     @Test
@@ -101,9 +105,9 @@ class LogEntryServiceTest extends ResourcesLocalTest {
 
         var logEntries = Resource.fromPublication(publication).fetchLogEntries(resourceService);
 
-        var logUser = logEntries.getFirst().performedBy();
+        var logUser = (LogUser) logEntries.getFirst().performedBy();
         assertNotNull(logUser.username());
-        assertNull(logUser.cristinId());
+        assertNull(logUser.id());
     }
 
     @Test
@@ -133,7 +137,7 @@ class LogEntryServiceTest extends ResourcesLocalTest {
         logEntryService.persistLogEntry(fileEntry);
         var logEntries = Resource.fromPublication(publication).fetchLogEntries(resourceService);
 
-        var logUser = logEntries.getFirst().performedBy();
+        var logUser = (LogUser) logEntries.getFirst().performedBy();
         assertNotNull(logUser.username());
     }
 


### PR DESCRIPTION
Tasks:
https://sikt.atlassian.net/browse/NP-48603
https://sikt.atlassian.net/browse/NP-48602

New model for log messages as described in tasks.

Main change:

- Instead of constructing Person and Organization in log message based on NVA user in NVA database, we use CristinPerson and CristinOrganization to construct log message. 
- Log message topic/ action can now be performed by user or institution (LogAgent) -> important for migration jobs, cause there are no users involved, so we avoid persist "dummy" empty object. 
- We first fetch user from users-and-roles table -> than we fetch CristinPerson and CristinOrganization from Cristin and using these to construct log message. 
- Renaming LogUser and LogOrganization to Person and Organization when storing in database and serving via API.