### PR TITLE
adding relation to associatedLink

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -48,6 +48,7 @@ import no.unit.nva.model.additionalidentifiers.SourceName;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
 import no.unit.nva.model.associatedartifacts.NullAssociatedArtifact;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails;
 import no.unit.nva.model.associatedartifacts.file.ImportUploadDetails.Source;
@@ -140,7 +141,7 @@ public final class BrageNvaMapper {
                    .map(Record::getSubjects)
                    .stream()
                    .flatMap(Collection::stream)
-                   .map(uri -> new AssociatedLink(uri, null, null))
+                   .map(uri -> new AssociatedLink(uri, null, null, RelationType.SAME_AS))
                    .toList();
     }
 
@@ -160,7 +161,7 @@ public final class BrageNvaMapper {
     }
 
     private static AssociatedLink extractAssociatedLink(Record brageRecord) {
-        return nonNull(brageRecord.getLink()) ? new AssociatedLink(brageRecord.getLink(), null, null) : null;
+        return nonNull(brageRecord.getLink()) ? new AssociatedLink(brageRecord.getLink(), null, null, RelationType.SAME_AS) : null;
     }
 
     private static Set<AdditionalIdentifierBase> extractAdditionalIdentifiers(Record brageRecord) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMergerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMergerTest.java
@@ -46,6 +46,7 @@ import no.unit.nva.model.additionalidentifiers.SourceName;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.HiddenFile;
 import no.unit.nva.model.contexttypes.Anthology;
@@ -77,7 +78,6 @@ import no.unit.nva.model.instancetypes.report.ReportResearch;
 import no.unit.nva.model.instancetypes.researchdata.DataSet;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class CristinImportPublicationMergerTest {
@@ -382,7 +382,7 @@ class CristinImportPublicationMergerTest {
     }
 
     private static AssociatedLink randomAssociatedLink() {
-        return new AssociatedLink(randomUri(), null, null);
+        return new AssociatedLink(randomUri(), null, null, RelationType.SAME_AS);
     }
 
     @Test

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
@@ -53,6 +53,7 @@ import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.funding.Funding;
 import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.pages.MonographPages;
@@ -412,14 +413,14 @@ public class NvaBrageMigrationDataGenerator {
         public List<AssociatedArtifact> getAssociatedArtifacts() {
             var artifacts = new ArrayList<AssociatedArtifact>();
             if (nonNull(link)) {
-                artifacts.add(new AssociatedLink(link, null, null));
+                artifacts.add(new AssociatedLink(link, null, null, RelationType.SAME_AS));
             }
             if (nonNull(associatedArtifacts)) {
                 artifacts.addAll(this.associatedArtifacts);
             }
             if (!subjects.isEmpty()) {
                 subjects.stream()
-                    .map(uri -> new AssociatedLink(uri, null, null))
+                    .map(uri -> new AssociatedLink(uri, null, null, RelationType.SAME_AS))
                     .forEach(artifacts::add);
             }
             return new AssociatedArtifactList(artifacts);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AssociatedLinkExtractor.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/AssociatedLinkExtractor.java
@@ -3,10 +3,14 @@ package no.unit.nva.cristin.mapper;
 import java.util.List;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 
 public final class AssociatedLinkExtractor {
 
-    private static final List<String> ASSOCIATED_URI_TYPES = List.of("DATA", "FULLTEKST", "OMTALE");
+    public static final String DATA = "DATA";
+    public static final String FULLTEKST = "FULLTEKST";
+    public static final String OMTALE = "OMTALE";
+    private static final List<String> ASSOCIATED_URI_TYPES = List.of(DATA, FULLTEKST, OMTALE);
     private static final String HANDLE_DOMAIN = "handle";
 
     private AssociatedLinkExtractor() {
@@ -27,7 +31,16 @@ public final class AssociatedLinkExtractor {
     }
 
     private static AssociatedArtifact toAssociatedLink(CristinAssociatedUri cristinAssociatedUri) {
-        return new AssociatedLink(cristinAssociatedUri.toURI(), null, null);
+        return new AssociatedLink(cristinAssociatedUri.toURI(), null, null, getRelationType(cristinAssociatedUri));
+    }
+
+    private static RelationType getRelationType(CristinAssociatedUri cristinAssociatedUri) {
+        return switch (cristinAssociatedUri.getUrlType()) {
+            case DATA -> RelationType.DATASET;
+            case FULLTEKST -> RelationType.SAME_AS;
+            case OMTALE -> RelationType.MENTION;
+            default -> null;
+        };
     }
 
     private static boolean isAssociatedLink(CristinAssociatedUri cristinAssociatedUri) {

--- a/cristin-import/src/test/java/cucumber/MediaContributionFeatures.java
+++ b/cristin-import/src/test/java/cucumber/MediaContributionFeatures.java
@@ -14,9 +14,7 @@ import no.unit.nva.cristin.CristinDataGenerator;
 import no.unit.nva.cristin.mapper.CristinAssociatedUri;
 import no.unit.nva.cristin.mapper.CristinMainCategory;
 import no.unit.nva.cristin.mapper.CristinMediumTypeCode;
-import no.unit.nva.cristin.mapper.CristinObject;
 import no.unit.nva.cristin.mapper.CristinSecondaryCategory;
-import no.unit.nva.cristin.mapper.MediaContributionBuilder;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
 import no.unit.nva.model.contexttypes.MediaContribution;
 import no.unit.nva.model.contexttypes.PublicationContext;
@@ -104,7 +102,7 @@ public class MediaContributionFeatures {
                                  .findFirst()
                                  .orElseThrow();
 
-        assertThat(associatedLink.getId(), is(equalTo(URI.create(string))));
+        assertThat(associatedLink.id(), is(equalTo(URI.create(string))));
     }
 
     @Given("the Cristin Result has main category MEDIEBIDRAG")

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -1073,7 +1073,7 @@ class CristinEntryEventConsumerTest extends AbstractCristinImportTest {
         var actualAssociatedLink = (AssociatedLink) publication.getAssociatedArtifacts().getFirst();
         var expectedAssociatedLinkValue = URI.create(value.trim());
 
-        assertThat(actualAssociatedLink.getId(), is(equalTo(expectedAssociatedLinkValue)));
+        assertThat(actualAssociatedLink.id(), is(equalTo(expectedAssociatedLinkValue)));
     }
 
     @Test

--- a/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
+++ b/expansion/src/test/java/no/unit/nva/expansion/ResourceExpansionServiceTest.java
@@ -63,6 +63,7 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
@@ -239,7 +240,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
     void shouldReturnIndexDocumentContainingLicense(String licenseUri, LicenseType expectedLicense)
         throws JsonProcessingException, NotFoundException, BadRequestException {
         var fileWithLicense = randomOpenFileWithLicense(URI.create(licenseUri));
-        var associatedLink = new AssociatedLink(randomUri(), null, null);
+        var associatedLink = new AssociatedLink(randomUri(), null, null, RelationType.SAME_AS);
         var publication = PublicationGenerator.randomPublication(AcademicArticle.class)
                                       .copy()
                                       .withAssociatedArtifacts(List.of(fileWithLicense, associatedLink))
@@ -260,7 +261,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
     void shouldReturnIndexDocumentWithoutLicenseWhenNoLicense()
         throws JsonProcessingException, NotFoundException, BadRequestException {
         var fileWithoutLicense = File.builder().withIdentifier(randomUUID()).buildOpenFile();
-        var link = new AssociatedLink(randomUri(), null, null);
+        var link = new AssociatedLink(randomUri(), null, null, RelationType.SAME_AS);
         var publication = PublicationGenerator.randomPublication()
                               .copy()
                               .withAssociatedArtifacts(List.of(fileWithoutLicense, link))
@@ -712,7 +713,7 @@ class ResourceExpansionServiceTest extends ResourcesLocalTest {
         var publication = TicketTestUtils.createPersistedPublicationWithDoi(PUBLISHED, resourceService);
         FakeUriResponse.setupFakeForType(publication, fakeUriRetriever, resourceService);
         var doi = publication.getEntityDescription().getReference().getDoi();
-        publication.getAssociatedArtifacts().add(new AssociatedLink(doi, randomString(), randomString()));
+        publication.getAssociatedArtifacts().add(new AssociatedLink(doi, randomString(), randomString(), RelationType.SAME_AS));
         var publicationWithIdenticalDoiValues = resourceService.updatePublication(publication);
         var resourceUpdate = Resource.fromPublication(publicationWithIdenticalDoiValues);
         var expansionService = expansionServiceReturningNviCandidate(publication, nviCandidateResponse(), 404);

--- a/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
+++ b/expansion/src/test/java/no/unit/nva/publication/indexing/ExpandedResourceTest.java
@@ -55,6 +55,7 @@ import no.unit.nva.model.Identity;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.contexttypes.Anthology;
 import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.Journal;
@@ -847,7 +848,7 @@ class ExpandedResourceTest extends ResourcesLocalTest {
         return PublicationGenerator.randomPublication(BookAnthology.class)
                    .copy()
                    .withDoi(doi)
-                   .withAssociatedArtifacts(List.of(new AssociatedLink(doi, null, null)))
+                   .withAssociatedArtifacts(List.of(new AssociatedLink(doi, null, null, RelationType.SAME_AS)))
                    .build();
     }
 
@@ -856,7 +857,7 @@ class ExpandedResourceTest extends ResourcesLocalTest {
         return PublicationGenerator.randomPublication(BookAnthology.class)
                    .copy()
                    .withHandle(handle)
-                   .withAssociatedArtifacts(List.of(new AssociatedLink(handle, null, null)))
+                   .withAssociatedArtifacts(List.of(new AssociatedLink(handle, null, null, RelationType.SAME_AS)))
                    .build();
     }
 
@@ -865,7 +866,7 @@ class ExpandedResourceTest extends ResourcesLocalTest {
         return PublicationGenerator.randomPublication(BookAnthology.class)
                    .copy()
                    .withLink(link)
-                   .withAssociatedArtifacts(List.of(new AssociatedLink(link, null, null)))
+                   .withAssociatedArtifacts(List.of(new AssociatedLink(link, null, null, RelationType.SAME_AS)))
                    .build();
     }
 

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/UpdatePublicationsInBatchesHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/UpdatePublicationsInBatchesHandlerTest.java
@@ -23,6 +23,7 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.Book.BookBuilder;
@@ -202,7 +203,7 @@ class UpdatePublicationsInBatchesHandlerTest extends ResourcesLocalTest {
         return List.of(File.builder().withLicense(license).withIdentifier(randomUUID()).buildOpenFile(),
                        File.builder().withLicense(license).withIdentifier(randomUUID()).buildInternalFile(),
                        File.builder().withLicense(license).withIdentifier(randomUUID()).buildPendingInternalFile(),
-                       new AssociatedLink(randomUri(), randomString(), randomString()));
+                       new AssociatedLink(randomUri(), randomString(), randomString(), RelationType.SAME_AS));
     }
 
     private List<Publication> createMultiplePublicationsWithPublisher(URI publisherId) {

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
@@ -12,6 +12,7 @@ import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
 import no.unit.nva.model.associatedartifacts.NullRightsRetentionStrategy;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.RightsRetentionStrategyConfiguration;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.File.Builder;
@@ -33,7 +34,7 @@ public final class AssociatedArtifactsGenerator {
     }
 
     public static AssociatedLink randomAssociatedLink() {
-        return new AssociatedLink(randomUri(), randomString(), randomString());
+        return new AssociatedLink(randomUri(), randomString(), randomString(), RelationType.SAME_AS);
     }
 
     public static File randomPendingOpenFile() {

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedLink.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedLink.java
@@ -1,74 +1,16 @@
 package no.unit.nva.model.associatedartifacts;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.Objects;
-import nva.commons.core.JacocoGenerated;
-import nva.commons.core.SingletonCollector;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(AssociatedLink.TYPE_NAME)
-public class AssociatedLink implements AssociatedArtifact {
+public record AssociatedLink(URI id, String name, String description, RelationType relation)
+    implements AssociatedArtifact {
 
-    public static final String ID_FIELD = "id";
-    public static final String NAME_FIELD = "name";
-    public static final String DESCRIPTION_FIELD = "description";
     public static final String TYPE_NAME = "AssociatedLink";
-    @JsonProperty(ID_FIELD)
-    private final URI id;
-    @JsonProperty(NAME_FIELD)
-    private final String name;
-    @JsonProperty(DESCRIPTION_FIELD)
-    private final String description;
-
-    @JsonCreator
-    public AssociatedLink(@JsonProperty(ID_FIELD) URI id,
-                          @JsonProperty(NAME_FIELD) String name,
-                          @JsonProperty(DESCRIPTION_FIELD) String description) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-    }
-
-    public URI getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    
-    @Override
-    @JacocoGenerated
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof AssociatedLink)) {
-            return false;
-        }
-        AssociatedLink that = (AssociatedLink) o;
-        return Objects.equals(getId(), that.getId())
-                && Objects.equals(getName(), that.getName())
-                && Objects.equals(getDescription(), that.getDescription());
-    }
-
-    @Override
-    @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(getId(), getName(), getDescription());
-    }
 
     @Override
     public String getArtifactType() {
@@ -77,29 +19,6 @@ public class AssociatedLink implements AssociatedArtifact {
 
     @Override
     public AssociatedArtifactDto toDto() {
-        return new AssociatedLinkDto(id, name, description);
-    }
-
-    public enum RelationType {
-        GENERIC_LINKED_RESOURCE("GenericLinkedResource");
-
-        private final String type;
-
-        RelationType(String type) {
-
-            this.type = type;
-        }
-
-        @JsonValue
-        public String getType() {
-            return type;
-        }
-
-        @JsonCreator
-        public RelationType lookup(String candidate) {
-            return Arrays.stream(RelationType.values())
-                       .filter(item -> item.getType().equals(candidate))
-                       .collect(SingletonCollector.collect());
-        }
+        return new AssociatedLinkDto(id, name, description, relation);
     }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedLinkDto.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedLinkDto.java
@@ -1,14 +1,11 @@
 package no.unit.nva.model.associatedartifacts;
 
-import static no.unit.nva.model.associatedartifacts.AssociatedLink.DESCRIPTION_FIELD;
-import static no.unit.nva.model.associatedartifacts.AssociatedLink.ID_FIELD;
-import static no.unit.nva.model.associatedartifacts.AssociatedLink.NAME_FIELD;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 
-public record AssociatedLinkDto(@JsonProperty(ID_FIELD) URI id,
-                                @JsonProperty(NAME_FIELD) String name,
-                                @JsonProperty(DESCRIPTION_FIELD) String description) implements AssociatedArtifactDto {
+public record AssociatedLinkDto(URI id,
+                                String name,
+                                String description, RelationType relation) implements AssociatedArtifactDto {
 
     private static final String TYPE_NAME_FIELD = "type";
 

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RelationType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RelationType.java
@@ -1,0 +1,19 @@
+package no.unit.nva.model.associatedartifacts;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum RelationType {
+
+    METADATA_SOURCE("metadataSource"), SAME_AS("sameAs"), DATASET("dataset"), MENTION("mention");
+
+    private final String value;
+
+    RelationType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/publication-model/src/test/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactListTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/associatedartifacts/AssociatedArtifactListTest.java
@@ -1,10 +1,15 @@
 package no.unit.nva.model.associatedartifacts;
 
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.utils.JsonTestingUtils;
 import org.junit.jupiter.api.Test;
 
 class AssociatedArtifactListTest {
@@ -46,5 +51,14 @@ class AssociatedArtifactListTest {
 
         assertTrue(associatedArtifactList.contains(nullAssociatedArtifact));
         assertEquals(1, associatedArtifactList.size());
+    }
+
+    @Test
+    void associatedLinkShouldMakeRoundTrip() throws JsonProcessingException {
+        var associatedLink = new AssociatedLink(randomUri(), randomString(), randomString(), RelationType.SAME_AS);
+        var json = JsonUtils.dtoObjectMapper.writeValueAsString(associatedLink);
+        var roundTrippedLink = JsonUtils.dtoObjectMapper.readValue(json, AssociatedArtifact.class);
+
+        assertEquals(associatedLink, roundTrippedLink);
     }
 }

--- a/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
+++ b/tickets-test/src/main/java/no/unit/nva/publication/ticket/test/TicketTestUtils.java
@@ -40,6 +40,7 @@ import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.AssociatedLink;
+import no.unit.nva.model.associatedartifacts.RelationType;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.model.instancetypes.degree.DegreePhd;
@@ -461,7 +462,7 @@ public final class TicketTestUtils {
         return fromInstanceClassesExcluding(PROTECTED_DEGREE_INSTANCE_TYPES)
                 .copy()
                 .withStatus(status)
-                .withAssociatedArtifacts(List.of(new AssociatedLink(randomUri(), null, null)))
+                .withAssociatedArtifacts(List.of(new AssociatedLink(randomUri(), null, null, RelationType.SAME_AS)))
                 .build();
     }
 


### PR DESCRIPTION
Adding enum RelationType to AssociatedLink class. Relation will have following values to support imported links from Cristin:
`METADATA_SOURCE("metadataSource"), SAME_AS("sameAs"), DATASET("dataset"), MENTION("mention");`

Taking in use following value when migrating links from:
Brage - migrating with `sameAs` relation
Cristin - migrating with relation from Cristin: `OMTALE -> mention, DATA -> dataset, FULLTEKST -> sameAs`

This will make it possible for frontend to differentiate between DOI which is placed in `EntityDescription.reference.doi` and other links/dois from associatedArtifacts. 

In the future we should consider migrating `reference.doi` to associatedArtifacts as well. 