### PR TITLE
migrating rightsholder as legalNote on file

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapper.java
@@ -101,7 +101,6 @@ public final class BrageNvaMapper {
                               .withResourceOwner(customer.toResourceOwner(host))
                               .withAssociatedArtifacts(extractAssociatedArtifacts(brageRecord, customer))
                               .withAdditionalIdentifiers(extractAdditionalIdentifiers(brageRecord))
-                              .withRightsHolder(brageRecord.getRightsholder())
                               .withFundings(extractFundings(brageRecord))
                               .build();
         if (!isCristinRecord(brageRecord)) {
@@ -278,7 +277,9 @@ public final class BrageNvaMapper {
     }
 
     private static String extractLegalNote(Record brageRecord) {
-        return Optional.ofNullable(brageRecord).map(Record::getAccessCode).orElse(null);
+        return Optional.ofNullable(brageRecord)
+                   .map(Record::getAccessCode)
+                   .orElse(brageRecord.getRightsholder());
     }
 
     private static Instant extractEmbargoDate(ContentFile file) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
@@ -156,6 +156,21 @@ class BrageNvaMapperTest {
         assertEquals(insperaIdentifier, insperaAdditionalIdentifier.value());
     }
 
+    @Test
+    void shouldMapRightsHolderToFileLegalNotWhenAccessCodeIsNotPresent()
+        throws InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
+        var rightsHolder = randomString();
+        var licenseContentFile = createRandomContentFileWithBundleType(BundleType.ORIGINAL);
+        var generator =  new NvaBrageMigrationDataGenerator.Builder()
+                             .withRightsHolder(rightsHolder)
+                             .withType(new Type(List.of(), NvaType.CHAPTER.getValue()))
+                             .withResourceContent(new ResourceContent(List.of(licenseContentFile)))
+                             .build();
+        var file = (File) BrageNvaMapper.toNvaPublication(generator.getBrageRecord(), API_HOST, s3Client).getAssociatedArtifacts().getFirst();
+
+        assertEquals(rightsHolder, file.getLegalNote());
+    }
+
     private static no.unit.nva.model.additionalidentifiers.AdditionalIdentifierBase getAdditionalIdentifier(
         Publication publication, String source) {
         return publication.getAdditionalIdentifiers().stream()

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/BrageNvaMapperTest.java
@@ -157,7 +157,7 @@ class BrageNvaMapperTest {
     }
 
     @Test
-    void shouldMapRightsHolderToFileLegalNotWhenAccessCodeIsNotPresent()
+    void shouldMapRightsHolderToFileLegalNoteWhenAccessCodeIsNotPresent()
         throws InvalidIssnException, InvalidIsbnException, InvalidUnconfirmedSeriesException {
         var rightsHolder = randomString();
         var licenseContentFile = createRandomContentFileWithBundleType(BundleType.ORIGINAL);

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/NvaBrageMigrationDataGenerator.java
@@ -138,7 +138,6 @@ public class NvaBrageMigrationDataGenerator {
                    .withAssociatedArtifacts(builder.getAssociatedArtifacts())
                    .withResourceOwner(new no.unit.nva.model.ResourceOwner(new Username(HARDCODED_NTNU_USERNAME), HARDCODED_NTNU_CRISTIN_ID))
                    .withAdditionalIdentifiers(generateAdditionalIdentifiers(builder))
-                   .withRightsHolder(builder.getRightsHolder())
                    .withSubjects(builder.subjects.stream().toList())
                    .withFundings(List.of(convertProjectToFunding(builder.getProject())))
                    .build();


### PR DESCRIPTION
Instead of migrating rightsHolder from Brage as rightsHolder migrating it as legalNote for file when accessCode from Brage is missing. 

It makes that "Copyright..." string will be presented for each migrated file from Brage (when present).