### PR TITLE
fixing pk2 keys for files and log entries

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/Dao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/Dao.java
@@ -243,6 +243,8 @@ public abstract class Dao
                                      new AttributeValue(TicketDao.TICKETS_INDEXING_TYPE + KEY_FIELDS_DELIMITER));
             case DOI_REQUEST ->
                 Map.entry(keyField.getKeyField(), new AttributeValue("DoiRequest" + KEY_FIELDS_DELIMITER));
+            case FILE_ENTRY ->
+                Map.entry(keyField.getKeyField(), new AttributeValue("File" + KEY_FIELDS_DELIMITER));
         };
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FileDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FileDao.java
@@ -9,6 +9,7 @@ import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_AN
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_AND_IDENTIFIER_INDEX_SORT_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_CUSTOMER_STATUS_INDEX_PARTITION_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_CUSTOMER_STATUS_INDEX_SORT_KEY_NAME;
+import static no.unit.nva.publication.storage.model.DatabaseConstants.KEY_FIELDS_DELIMITER;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.PRIMARY_KEY_PARTITION_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.PRIMARY_KEY_SORT_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.RESOURCES_TABLE_NAME;
@@ -23,6 +24,7 @@ import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -40,9 +42,10 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(FileDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public final class FileDao extends Dao implements DynamoEntryByIdentifier {
+public final class FileDao extends Dao implements DynamoEntryByIdentifier, JoinWithResource {
 
     public static final String TYPE = "File";
+    private static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "a";
     @JsonProperty("identifier")
     private final SortableIdentifier identifier;
     private final SortableIdentifier resourceIdentifier;
@@ -122,6 +125,12 @@ public final class FileDao extends Dao implements DynamoEntryByIdentifier {
     @Override
     public SortableIdentifier getIdentifier() {
         return identifier;
+    }
+
+    @Override
+    @JsonIgnore
+    public String joinByResourceOrderedType() {
+        return BY_RESOURCE_INDEX_ORDER_PREFIX + KEY_FIELDS_DELIMITER + getData().getType();
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/JoinWithResource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/JoinWithResource.java
@@ -24,6 +24,7 @@ import no.unit.nva.identifiers.SortableIdentifier;
     @JsonSubTypes.Type(name = "PublishingRequest", value = PublishingRequestDao.class),
     @JsonSubTypes.Type(name = "UnpublishRequest", value = UnpublishRequestDao.class),
     @JsonSubTypes.Type(name = "MessageDao", value = MessageDao.class),
+    @JsonSubTypes.Type(name = FileDao.TYPE, value = FileDao.class),
 })
 public interface JoinWithResource {
     

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/KeyField.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/KeyField.java
@@ -10,7 +10,8 @@ public enum KeyField {
     RESOURCE(ResourceDao.TYPE),
     MESSAGE(MessageDao.TYPE),
     TICKET(TicketDao.TICKETS_INDEXING_TYPE),
-    DOI_REQUEST("DoiRequest");
+    DOI_REQUEST(DoiRequestDao.TYPE),
+    FILE_ENTRY(FileDao.TYPE);
 
     public static final String KEY_FIELDS_DELIMITER = ":";
     private static final String SEPARATOR = ",";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/LogEntryDao.java
@@ -1,6 +1,8 @@
 package no.unit.nva.publication.model.storage;
 
 import static no.unit.nva.publication.model.business.StorageModelConfig.dynamoDbObjectMapper;
+import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_CUSTOMER_RESOURCE_INDEX_PARTITION_KEY_NAME;
+import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_CUSTOMER_RESOURCE_INDEX_SORT_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_AND_IDENTIFIER_INDEX_PARTITION_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_TYPE_AND_IDENTIFIER_INDEX_SORT_KEY_NAME;
 import static no.unit.nva.publication.storage.model.DatabaseConstants.PRIMARY_KEY_PARTITION_KEY_NAME;
@@ -60,6 +62,16 @@ public record LogEntryDao(SortableIdentifier identifier, SortableIdentifier reso
 
     @JsonProperty(PRIMARY_KEY_SORT_KEY_NAME)
     private String getPrimaryKeySortKey() {
+        return KEY_PATTERN.formatted(TYPE, identifier());
+    }
+
+    @JsonProperty(BY_CUSTOMER_RESOURCE_INDEX_PARTITION_KEY_NAME)
+    private String getCustomerResourcePartitionKey() {
+        return KEY_PATTERN.formatted(Resource.TYPE, resourceIdentifier());
+    }
+
+    @JsonProperty(BY_CUSTOMER_RESOURCE_INDEX_SORT_KEY_NAME)
+    private String getCustomerResourceSortKey() {
         return KEY_PATTERN.formatted(TYPE, identifier());
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -776,7 +776,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldScanEntriesInDatabaseAfterSpecifiedMarker(
         Class<? extends TicketEntry> ticketType, PublicationStatus status) throws ApiGatewayException {
-        var publication = TicketTestUtils.createPersistedPublication(status, resourceService);
+        var publication = TicketTestUtils.createPersistedPublicationWithAssociatedLink(status, resourceService);
         var ticket = TicketTestUtils.createPersistedTicket(publication, ticketType, ticketService);
 
         var userInstance = UserInstance.fromPublication(publication);
@@ -1900,6 +1900,14 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var migratedDoiRequest = (DoiRequest) doiRequest.fetch(ticketService);
 
         assertInstanceOf(DoiAssignedEvent.class, migratedDoiRequest.getTicketEvent());
+    }
+
+    @Test
+    void scanResourcesShouldScanFileEntries() throws BadRequestException {
+        createPersistedPublicationWithDoi();
+        var entries =  resourceService.scanResources(BIG_PAGE, ListingResult.empty().getStartMarker(), Collections.emptyList());
+
+        assertTrue(entries.getDatabaseEntries().stream().anyMatch(FileEntry.class::isInstance));
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/EventBasedBatchScanHandlerTest.java
@@ -59,7 +59,7 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
 class EventBasedBatchScanHandlerTest extends ResourcesLocalTest {
 
-    public static final int LARGE_PAGE = 10;
+    public static final int LARGE_PAGE = 100;
     public static final int ONE_ENTRY_PER_EVENT = 1;
     public static final Map<String, AttributeValue> START_FROM_BEGINNING = null;
     public static final String OUTPUT_EVENT_TOPIC = "OUTPUT_EVENT_TOPIC";


### PR DESCRIPTION
Found out yesterday the BatchScan runs against PK2 and not PK0 (default table keys). Files and log entries do not have these keys, as they are not necessary here. Adding PK2 keys to File and LogEntry in order to be able to run BatchScan and handle these objects. 