### PR TITLE
log message for publication update

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -51,6 +51,7 @@ import no.unit.nva.publication.model.business.logentry.LogEntry;
 import no.unit.nva.publication.model.business.publicationstate.DeletedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.UpdatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.RepublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
@@ -220,6 +221,7 @@ public class Resource implements Entity {
     }
 
     public Resource update(ResourceService resourceService, UserInstance userInstance) {
+        this.setResourceEvent(UpdatedResourceEvent.create(userInstance, Instant.now()));
         return resourceService.updateResource(this, userInstance);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/logentry/LogTopic.java
@@ -18,6 +18,7 @@ public enum LogTopic {
     DOI_REJECTED("DoiRejected"),
     DOI_ASSIGNED("DoiAssigned"),
     PUBLICATION_CREATED("PublicationCreated"),
+    PUBLICATION_UPDATED("PublicationUpdated"),
     PUBLICATION_DELETED("PublicationDeleted"),
     PUBLICATION_PUBLISHED("PublicationPublished"),
     PUBLICATION_REPUBLISHED("PublicationRepublished"),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ResourceEvent.java
@@ -10,10 +10,11 @@ import no.unit.nva.publication.model.business.logentry.LogAgent;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(PublishedResourceEvent.class),
-    @JsonSubTypes.Type(UnpublishedResourceEvent.class), @JsonSubTypes.Type(DeletedResourceEvent.class),
-    @JsonSubTypes.Type(RepublishedResourceEvent.class), @JsonSubTypes.Type(ImportedResourceEvent.class),
-    @JsonSubTypes.Type(DoiReservedEvent.class), @JsonSubTypes.Type(MergedResourceEvent.class)})
+@JsonSubTypes({@JsonSubTypes.Type(CreatedResourceEvent.class), @JsonSubTypes.Type(UpdatedResourceEvent.class),
+    @JsonSubTypes.Type(PublishedResourceEvent.class), @JsonSubTypes.Type(UnpublishedResourceEvent.class),
+    @JsonSubTypes.Type(DeletedResourceEvent.class), @JsonSubTypes.Type(RepublishedResourceEvent.class),
+    @JsonSubTypes.Type(ImportedResourceEvent.class), @JsonSubTypes.Type(DoiReservedEvent.class),
+    @JsonSubTypes.Type(MergedResourceEvent.class)})
 public interface ResourceEvent {
 
     Instant date();

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
@@ -1,0 +1,30 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import java.net.URI;
+import java.time.Instant;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.model.business.logentry.LogAgent;
+import no.unit.nva.publication.model.business.logentry.LogTopic;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
+
+public record UpdatedResourceEvent(Instant date, User user, URI institution, SortableIdentifier identifier)
+    implements ResourceEvent {
+
+    public static UpdatedResourceEvent create(UserInstance userInstance, Instant date) {
+        return new UpdatedResourceEvent(date, userInstance.getUser(), userInstance.getTopLevelOrgCristinId(),
+                                        SortableIdentifier.next());
+    }
+
+    @Override
+    public PublicationLogEntry toLogEntry(SortableIdentifier resourceIdentifier, LogAgent user) {
+        return PublicationLogEntry.builder()
+                   .withResourceIdentifier(resourceIdentifier)
+                   .withIdentifier(identifier)
+                   .withTopic(LogTopic.PUBLICATION_UPDATED)
+                   .withTimestamp(date)
+                   .withPerformedBy(user)
+                   .build();
+    }
+}

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
@@ -15,6 +15,7 @@ import no.unit.nva.publication.model.business.publicationstate.DeletedResourceEv
 import no.unit.nva.publication.model.business.publicationstate.DoiReservedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.UpdatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.UnpublishedResourceEvent;
@@ -41,7 +42,10 @@ public class ResourceEventTest {
                          Arguments.of(
                              MergedResourceEvent.fromImportSource(new ImportSource(Source.BRAGE, "A"),
                                                                   UserInstance.create(randomString(), randomUri()),
-                                                                  Instant.now())));
+                                                                  Instant.now())),
+                         Arguments.of(
+                             UpdatedResourceEvent.create(UserInstance.create(randomString(), randomUri()),
+                                                         Instant.now())));
     }
 
     @ParameterizedTest

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -11,6 +11,7 @@ import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATI
 import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_PUBLISHED;
 import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_REPUBLISHED;
 import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_UNPUBLISHED;
+import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATION_UPDATED;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +45,9 @@ class ResourceEventTest {
                 PUBLICATION_IMPORTED),
                          Arguments.of(DoiReservedEvent.create(randomUserInstance(), Instant.now()), DOI_RESERVED),
                          Arguments.of(MergedResourceEvent.fromImportSource(getImportSource(), randomUserInstance(),
-                                                                           Instant.now()), PUBLICATION_MERGED));
+                                                                           Instant.now()), PUBLICATION_MERGED),
+                         Arguments.of(UpdatedResourceEvent.create(randomUserInstance(),
+                                                                           Instant.now()), PUBLICATION_UPDATED));
     }
 
     public static Stream<Arguments> ticketEventProvider() {


### PR DESCRIPTION
Creating LogEntry with topic PublicationUpdated which will be persisted each time we do an update on publication.

Next step should be to stop backend from updating database entry when there is no change in publication, so we do not updates without effective changes, otherwise there will be persisted PublicationUpdated log message for each "Update publication API call"