### PR TITLE
not emitting event for deleted file entry

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
@@ -36,7 +35,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(FileEntry.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public final class FileEntry implements Entity, QueryObject<FileEntry>, JsonSerializable {
+public final class FileEntry implements Entity, QueryObject<FileEntry> {
 
     public static final String TYPE = "File";
     public static final String DO_NOT_USE_THIS_METHOD = "Do not use this method";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FileEntry.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
@@ -35,7 +36,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(FileEntry.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public final class FileEntry implements Entity, QueryObject<FileEntry> {
+public final class FileEntry implements Entity, QueryObject<FileEntry>, JsonSerializable {
 
     public static final String TYPE = "File";
     public static final String DO_NOT_USE_THIS_METHOD = "Do not use this method";

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
@@ -98,8 +98,12 @@ public class DataEntryUpdateEvent implements JsonSerializable {
     }
     
     @JsonIgnore
-    public boolean notEmpty() {
-        return nonNull(oldData) || nonNull(newData);
+    public boolean shouldProcessUpdate() {
+        if (extractDataEntryType() instanceof FileEntry) {
+            return hasNewImage();
+        } else {
+            return nonNull(oldData) || nonNull(newData);
+        }
     }
     
     @JsonProperty("topic")
@@ -118,7 +122,7 @@ public class DataEntryUpdateEvent implements JsonSerializable {
             default -> throw new IllegalArgumentException("Unknown entry type: " + type);
         };
     }
-    
+
     private Entity extractDataEntryType() {
         return nonNull(newData) ? newData : oldData;
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandler.java
@@ -76,7 +76,7 @@ public class DynamodbStreamToEventBridgeHandler implements RequestHandler<Dynamo
     public EventReference handleRequest(DynamodbEvent inputEvent, Context context) {
         var dynamodbStreamRecord = inputEvent.getRecords().getFirst();
         var dataEntryUpdateEvent = convertToDataEntryUpdateEvent(dynamodbStreamRecord);
-        return dataEntryUpdateEvent.notEmpty() ? sendEvent(dataEntryUpdateEvent, context) : DO_NOT_EMIT_EVENT;
+        return dataEntryUpdateEvent.shouldProcessUpdate() ? sendEvent(dataEntryUpdateEvent, context) : DO_NOT_EMIT_EVENT;
     }
 
     private static SortableIdentifier getIdentifier(DataEntryUpdateEvent blobObject) {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandlerTest.java
@@ -113,16 +113,19 @@ class DynamodbStreamToEventBridgeHandlerTest {
 
     @Test
     void shouldNotEmitEventWhenDataEntryUpdateEventForFileEntryDoesNotHaveNewImage() {
-        var event = randomEventWithSingleDynamoRecord(FileEntry.create(randomOpenFile(),
-                                                           SortableIdentifier.next(), UserInstance.create(randomString(), randomUri())),
-                                          null);
+        var event = randomEventWithSingleDynamoRecord(randomFileEntry(), null);
         handler.handleRequest(event, context);
         var s3Driver = new S3Driver(s3Client, EVENTS_BUCKET);
         var persistedEvents = s3Driver.getFiles(UnixPath.ROOT_PATH);
 
         assertTrue(persistedEvents.isEmpty());
     }
-    
+
+    private static FileEntry randomFileEntry() {
+        return FileEntry.create(randomOpenFile(),
+                                SortableIdentifier.next(), UserInstance.create(randomString(), randomUri()));
+    }
+
     private static DynamodbEvent randomEventWithSingleDynamoRecord(Entity oldImage, Entity newImage) {
         var event = new DynamodbEvent();
         var record = randomDynamoRecord();


### PR DESCRIPTION
Following method for DataEntryUpdateEvent throws exception when FileEntry does not have newImage. I think we do not want to throw exception here, we simply do not want to emit event when file has been deleted. 
```
    @JsonProperty("topic")
    public String getTopic() {
        var type = extractDataEntryType();
        return switch (type) {
            case Resource resource -> RESOURCE_UPDATE_EVENT_TOPIC;
            case DoiRequest doiRequest -> DOI_REQUEST_UPDATE_EVENT_TOPIC;
            case PublishingRequestCase publishingRequestCase -> PUBLISHING_REQUEST_UPDATE_EVENT_TOPIC;
            case Message message -> MESSAGE_UPDATE_EVENT_TOPIC;
            case GeneralSupportRequest generalSupportRequest -> GENERAL_SUPPORT_REQUEST_UPDATE_EVENT_TOPIC;
            case UnpublishRequest unpublishRequest -> UNPUBLISH_REQUEST_UPDATE_EVENT_TOPIC;
            case FileEntry fileEntry when hasNewImage() -> fileEntry.getFileEvent() instanceof FileDeletedEvent
                                            ? FILE_ENTRY_DELETE_EVENT_TOPIC
                                            : FILE_ENTRY_UPDATE_EVENT_TOPIC;
            default -> throw new IllegalArgumentException("Unknown entry type: " + type);
        };
    }
```

Solution:

Not emitting event when new image for file entry is null:
```
return dataEntryUpdateEvent.shouldProcessUpdate() ? sendEvent(dataEntryUpdateEvent, context) : DO_NOT_EMIT_EVENT;
        
public boolean shouldProcessUpdate() {
        if (extractDataEntryType() instanceof FileEntry) {
            return hasNewImage();
        } else {
            return nonNull(oldData) || nonNull(newData);
        }
    }
```