### PR TITLE
constructing customer uri for production

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.brage.migration.mapper;
 
+import static no.sikt.nva.brage.migration.mapper.Customer.Environment.PROD;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -7,6 +8,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Map.Entry;
 import no.sikt.nva.brage.migration.record.UnknownCustomerException;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.model.Organization;
@@ -58,8 +60,16 @@ public record Customer(String name,
                    .stream()
                    .filter(entry -> host.contains(entry.getKey().getValue()))
                    .findFirst()
-                   .orElseThrow()
+                   .orElseGet(this::getProductionIdentifier)
                    .getValue();
+    }
+
+    private Entry<Environment, String> getProductionIdentifier() {
+        return identifiers.entrySet()
+                   .stream()
+                   .filter(environmentStringEntry -> PROD.equals(environmentStringEntry.getKey()))
+                   .findFirst()
+                   .orElseThrow();
     }
 
     public enum Environment {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/CustomerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/mapper/CustomerTest.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.brage.migration.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import nva.commons.core.paths.UriWrapper;
+import org.junit.jupiter.api.Test;
+
+class CustomerTest {
+
+    @Test
+    void shouldReturnOrganizationFromCustomerWhenHostDoesNotContainEnvironmentShortName() {
+        var customer = Customer.fromBrageArchiveName("ffi");
+        var host = "https://api.nva.unit.no";
+        var organization = customer.toPublisher(host);
+
+        var expected = UriWrapper.fromHost(host)
+                           .addChild("customer")
+                           .addChild("eb732391-19ec-4d9f-9cb3-a77c8876a18f")
+                           .getUri();
+
+        assertEquals(expected, organization.getId());
+    }
+}


### PR DESCRIPTION
Constructing customer uri for publication for production environment. 

We had an assumption that all hosts contain "environment short name" as test, dev and sandbox. Production host does not have the same pattern and we should handle it. 