### PR TITLE
Np 48752 part 2 of file upload for all categories

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
@@ -163,6 +164,13 @@ public class Resource implements Entity {
                    .filter(File.class::isInstance)
                    .map(File.class::cast)
                    .toList();
+    }
+
+    @JsonIgnore
+    public Optional<File> getFileByIdentifier(UUID identifier) {
+        return getFiles().stream()
+                   .filter(file -> file.getIdentifier().equals(identifier))
+                   .findFirst();
     }
 
     public Set<File> getPendingFiles() {
@@ -656,6 +664,14 @@ public class Resource implements Entity {
 
     public void setImportDetails(Collection<ImportDetail> importDetails) {
         this.importDetails = nonNull(importDetails) ? new ArrayList<>(importDetails) : new ArrayList<>();
+    }
+
+    @JsonIgnore
+    public Optional<String> getInstanceType() {
+        return Optional.ofNullable(getEntityDescription())
+            .map(EntityDescription::getReference)
+            .map(Reference::getPublicationInstance)
+            .map(PublicationInstance::getInstanceType);
     }
 
     public ResourceBuilder copy() {

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
@@ -139,7 +139,7 @@ public class CreateUploadHandlerTest {
     void createUploadWithS3ErrorReturnsNotFound() throws IOException, NotFoundException {
         when(s3client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
             .thenThrow(SdkClientException.class);
-        var resource = Resource.fromPublication(randomPublication());
+        var resource = Resource.fromPublication(randomPublication().copy().withStatus(PublicationStatus.DRAFT).build());
         when(resourceService.getResourceByIdentifier(any())).thenReturn(resource);
         createUploadHandler.handleRequest(
             createUploadRequestWithBody(resource.getIdentifier(), createUploadRequestBody(),

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -1876,7 +1876,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldThrowUnauthorizedWhenUpdatingFileToOpenPendingFileWhenCustomerDoesNotAllowOpenPendingFilesForPublication()
+    void shouldThrowForbiddenWhenUpdatingFileToOpenPendingFileWhenCustomerDoesNotAllowOpenPendingFilesForPublication()
         throws IOException, ApiGatewayException {
         var uploadedFile = randomUploadedFile();
         var publication = randomPublication().copy()
@@ -1897,7 +1897,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
         handler.handleRequest(input, output, context);
         var gatewayResponse = GatewayResponse.fromOutputStream(output, Publication.class);
 
-        assertThat(gatewayResponse.getStatusCode(), is(equalTo(HTTP_UNAUTHORIZED)));
+        assertThat(gatewayResponse.getStatusCode(), is(equalTo(HTTP_FORBIDDEN)));
     }
 
 


### PR DESCRIPTION
Part II of allowing to upload files for category which "does not support" files. 

Part I: makes it possible to upload file for all publication types.
Part II: does not allow to update uploaded file to OpenFile (PendingOpenFile).