### PR TITLE
Np 48801 update publication only when with effective changes

### DIFF
--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
@@ -3,6 +3,7 @@ package no.sikt.nva.brage.migration.testutils;
 import static java.util.Objects.nonNull;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import no.sikt.nva.brage.migration.NvaType;
@@ -561,12 +562,12 @@ public final class ReferenceGenerator {
     }
 
     private static HashSet<RelatedDocument> extractUnconfirmedDocuments(Builder builder) {
-        return Optional.ofNullable(builder)
-                   .map(Builder::getHasPart)
-                   .orElseGet(Collections::emptyList)
-                   .stream()
-                   .map(UnconfirmedDocument::fromValue)
-                   .collect(Collectors.toCollection(HashSet::new));
+        var values = Optional.ofNullable(builder.getHasPart()).orElseGet(Collections::emptyList);
+        var relatedDocuments = new LinkedHashSet<RelatedDocument>();
+        for (int i = 0; i < values.size(); i++) {
+            relatedDocuments.add(new UnconfirmedDocument(values.get(i), i + 1));
+        }
+        return relatedDocuments;
     }
 
     private static ReportBasic generatePublicationInstanceForReport(Builder builder) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -215,7 +216,28 @@ public class Resource implements Entity {
             .orElse(false);
     }
 
-   private static boolean instanceIsDegree(PublicationInstance<? extends Pages> publicationInstance) {
+    @JsonIgnore
+    public boolean hasAffectiveChanges(Resource resource) {
+        return !(Objects.equals(getIdentifier(), resource.getIdentifier())
+                 && getStatus() == resource.getStatus()
+                 && Objects.equals(getResourceOwner(), resource.getResourceOwner())
+                 && Objects.equals(getPublisher(), resource.getPublisher())
+                 && Objects.equals(getLink(), resource.getLink())
+                 && Objects.equals(getProjects(), resource.getProjects())
+                 && Objects.equals(getEntityDescription(), resource.getEntityDescription())
+                 && Objects.equals(getDoi(), resource.getDoi())
+                 && Objects.equals(getHandle(), resource.getHandle())
+                 && Objects.equals(getAdditionalIdentifiers(), resource.getAdditionalIdentifiers())
+                 && new HashSet<>(getAssociatedArtifacts()).containsAll(resource.getAssociatedArtifacts())
+                 && Objects.equals(getFundings(), resource.getFundings())
+                 && Objects.equals(getPublicationNotes(), resource.getPublicationNotes())
+                 && Objects.equals(getDuplicateOf(), resource.getDuplicateOf())
+                 && Objects.equals(getSubjects(), resource.getSubjects())
+                 && Objects.equals(getCuratingInstitutions(), resource.getCuratingInstitutions())
+                 && Objects.equals(getImportDetails(), resource.getImportDetails()));
+    }
+
+    private static boolean instanceIsDegree(PublicationInstance<? extends Pages> publicationInstance) {
         return Arrays.stream(PROTECTED_DEGREE_INSTANCE_TYPES)
                    .anyMatch(instanceTypeClass -> instanceTypeClass.equals(publicationInstance.getClass()));
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationPermissions.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationPermissions.java
@@ -14,7 +14,7 @@ import no.unit.nva.publication.permissions.publication.grant.EditorGrantStrategy
 import no.unit.nva.publication.permissions.publication.grant.ResourceOwnerGrantStrategy;
 import no.unit.nva.publication.permissions.publication.grant.TrustedThirdPartyGrantStrategy;
 import no.unit.nva.publication.permissions.publication.restrict.DegreeDenyStrategy;
-import no.unit.nva.publication.permissions.publication.restrict.DeletedUplaodDenyStrategy;
+import no.unit.nva.publication.permissions.publication.restrict.DeletedUploadDenyStrategy;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,7 @@ public class PublicationPermissions {
         );
         this.denyStrategies = Set.of(
             new DegreeDenyStrategy(publication, userInstance),
-            new DeletedUplaodDenyStrategy(publication, userInstance)
+            new DeletedUploadDenyStrategy(publication, userInstance)
         );
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
@@ -7,8 +7,8 @@ import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationDenyStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
-public class DeletedUplaodDenyStrategy extends PublicationStrategyBase implements PublicationDenyStrategy {
-    public DeletedUplaodDenyStrategy(Publication publication, UserInstance userInstance) {
+public class DeletedUploadDenyStrategy extends PublicationStrategyBase implements PublicationDenyStrategy {
+    public DeletedUploadDenyStrategy(Publication publication, UserInstance userInstance) {
         super(publication, userInstance);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -118,13 +118,17 @@ public class UpdateResourceService extends ServiceWithTransactions {
 
     public Resource updateResource(Resource resource, UserInstance userInstance) {
         var persistedResource = fetchExistingResource(resource.toPublication());
-        resource.setCreatedDate(persistedResource.getCreatedDate());
-        resource.setModifiedDate(clockForTimestamps.instant());
 
-        updateCuratingInstitutions(resource, persistedResource);
+        if (resource.hasAffectiveChanges(persistedResource)) {
+            resource.setCreatedDate(persistedResource.getCreatedDate());
+            resource.setModifiedDate(clockForTimestamps.instant());
 
-        sendTransactionWriteRequest(new TransactWriteItemsRequest().withTransactItems(
-            createUpdateResourceTransactionItems(resource, userInstance, persistedResource)));
+            updateCuratingInstitutions(resource, persistedResource);
+
+            sendTransactionWriteRequest(new TransactWriteItemsRequest().withTransactItems(
+                createUpdateResourceTransactionItems(resource, userInstance, persistedResource)));
+            return resource;
+        }
         return resource;
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1596,7 +1596,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         var userInstance = UserInstance.fromPublication(publication);
         var resource = Resource.fromPublication(publication)
                            .persistNew(resourceService, userInstance);
-
+        resource.setDoi(randomDoi());
         Resource.fromPublication(resource).updateResourceFromImport(resourceService, ImportSource.fromSource(Source.SCOPUS));
         var updatedResource = resourceService.getResourceByIdentifier(resource.getIdentifier());
 
@@ -1677,7 +1677,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
         publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
 
         var ticket = createDoiRequest(publication);
-
+        publication.setDoi(randomUri());
         Resource.fromPublication(publication).update(resourceService, userInstance);
 
         var refreshedTicket = ticket.fetch(ticketService);
@@ -1728,8 +1728,25 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void shouldNotUpdatePublicationInDatabaseWhenNoEffectiveChange() {
+    void shouldNotUpdatePublicationInDatabaseWhenNoEffectiveChange() throws BadRequestException {
+        var publication = randomPublication();
+        var userInstance = UserInstance.fromPublication(publication);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+        var updatedResource = Resource.fromPublication(publication).update(resourceService, userInstance);
 
+        assertEquals(publication, updatedResource.toPublication());
+    }
+
+    @Test
+    void shouldUpdatePublicationInDatabaseWhenThereAreEffectiveChange() throws BadRequestException {
+        var publication = randomPublication();
+        var userInstance = UserInstance.fromPublication(publication);
+        publication = Resource.fromPublication(publication).persistNew(resourceService, userInstance);
+
+        publication.setDoi(randomUri());
+        var updatedResource = Resource.fromPublication(publication).update(resourceService, userInstance);
+
+        assertNotEquals(publication, updatedResource.toPublication());
     }
 
     private static AssociatedArtifactList createEmptyArtifactList() {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1727,6 +1727,11 @@ class ResourceServiceTest extends ResourcesLocalTest {
                                               Collections.emptyList()));
     }
 
+    @Test
+    void shouldNotUpdatePublicationInDatabaseWhenNoEffectiveChange() {
+
+    }
+
     private static AssociatedArtifactList createEmptyArtifactList() {
         return new AssociatedArtifactList(emptyList());
     }

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
@@ -32,6 +32,7 @@ import no.unit.nva.clients.GetExternalClientResponse;
 import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.PublicationStatus;
+import no.unit.nva.model.instancetypes.chapter.AcademicChapter;
 import no.unit.nva.publication.commons.customer.Customer;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.file.upload.restmodel.CreateUploadRequestBody;
@@ -44,6 +45,7 @@ import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
@@ -157,7 +159,7 @@ public class CreateUploadHandlerTest {
     void createUploadWithRuntimeErrorReturnsServerError() throws IOException, NotFoundException {
         when(s3client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
             .thenThrow(RuntimeException.class);
-        var resource = Resource.fromPublication(randomPublication());
+        var resource = Resource.fromPublication(randomPublication().copy().withStatus(PublicationStatus.DRAFT).build());
         when(resourceService.getResourceByIdentifier(any())).thenReturn(resource);
         createUploadHandler.handleRequest(
             createUploadRequestWithBody(SortableIdentifier.next(), createUploadRequestBody(),

--- a/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
+++ b/publication-file/src/test/java/no/unit/nva/publication/file/upload/CreateUploadHandlerTest.java
@@ -32,7 +32,7 @@ import no.unit.nva.clients.GetExternalClientResponse;
 import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.PublicationStatus;
-import no.unit.nva.model.instancetypes.chapter.AcademicChapter;
+import no.unit.nva.model.instancetypes.journal.JournalArticle;
 import no.unit.nva.publication.commons.customer.Customer;
 import no.unit.nva.publication.commons.customer.CustomerApiClient;
 import no.unit.nva.publication.file.upload.restmodel.CreateUploadRequestBody;
@@ -141,7 +141,9 @@ public class CreateUploadHandlerTest {
     void createUploadWithS3ErrorReturnsNotFound() throws IOException, NotFoundException {
         when(s3client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
             .thenThrow(SdkClientException.class);
-        var resource = Resource.fromPublication(randomPublication());
+        var resource = Resource.fromPublication(randomPublication(JournalArticle.class)
+                                                    .copy().withStatus(PublicationStatus.DRAFT)
+                                                    .build());
         when(resourceService.getResourceByIdentifier(any())).thenReturn(resource);
         createUploadHandler.handleRequest(
             createUploadRequestWithBody(resource.getIdentifier(), createUploadRequestBody(),

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.log.service;
 
+import static no.unit.nva.model.testing.PublicationGenerator.randomDoi;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
@@ -149,6 +150,7 @@ class LogEntryServiceTest extends ResourcesLocalTest {
         resource.setResourceEvent(ImportedResourceEvent.fromImportSource(
             ImportSource.fromBrageArchive("A"), userInstance,
             Instant.now()));
+        resource.setDoi(randomDoi());
         resourceService.updateResource(resource, userInstance);
         logEntryService.persistLogEntry(Resource.fromPublication(publication));
 

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/DegreePhd.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/DegreePhd.java
@@ -31,7 +31,7 @@ public class DegreePhd extends DegreeBase {
         if (!super.equals(o)) {
             return false;
         }
-        return getRelated().containsAll(degreePhd.getRelated());
+        return Objects.equals(getRelated(), degreePhd.getRelated());
     }
 
     @JacocoGenerated

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/DegreePhd.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/degree/DegreePhd.java
@@ -3,9 +3,11 @@ package no.unit.nva.model.instancetypes.degree;
 import static no.unit.nva.model.instancetypes.PublicationInstance.Constants.PAGES_FIELD;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Objects;
 import java.util.Set;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.pages.MonographPages;
+import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class DegreePhd extends DegreeBase {
@@ -18,6 +20,24 @@ public class DegreePhd extends DegreeBase {
                      @JsonProperty(RELATED_PUBLICATIONS_FIELD) Set<RelatedDocument> related) {
         super(pages, submittedDate);
         this.related = related;
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DegreePhd degreePhd)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        return getRelated().containsAll(degreePhd.getRelated());
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getRelated());
     }
 
     public Set<RelatedDocument> getRelated() {


### PR DESCRIPTION
Not updating publication when there are no effective changes. For now effective change is any change except updated "date", no matter what kind of date it is. 

Following values are ignored when checking for effective changes - createdDate, publishedDate, modifiedDate, indexedDate. 