### PR TITLE
making accepted publishing request handler handle FilesApprovalThesis

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/FilesApprovalEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/FilesApprovalEntry.java
@@ -61,6 +61,15 @@ public abstract class FilesApprovalEntry extends TicketEntry {
         return this.complete(publication, userInstance).persistNewTicket(ticketService);
     }
 
+    public void rejectRejectedFiles(ResourceService resourceService) {
+        getFilesForApproval().stream()
+            .map(PendingFile.class::cast)
+            .forEach(file -> FileEntry.queryObject(file.getIdentifier(), getResourceIdentifier())
+                                 .fetch(resourceService)
+                                 .ifPresent(fileEntry -> fileEntry.reject(resourceService,
+                                                                          new User(getFinalizedBy().getValue()))));
+    }
+
     @Override
     public abstract TicketEntry copy();
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -11,11 +11,9 @@ import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.associatedartifacts.file.File;
-import no.unit.nva.model.associatedartifacts.file.PendingFile;
 import no.unit.nva.publication.model.FilesApprovalEntry;
 import no.unit.nva.publication.model.storage.PublishingRequestDao;
 import no.unit.nva.publication.model.storage.TicketDao;
-import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.core.JacocoGenerated;
 
@@ -104,15 +102,6 @@ public class PublishingRequestCase extends FilesApprovalEntry {
     public PublishingRequestCase withFilesForApproval(Set<File> filesForApproval) {
         setFilesForApproval(filesForApproval);
         return this;
-    }
-
-    public void rejectRejectedFiles(ResourceService resourceService) {
-        getFilesForApproval().stream()
-            .map(PendingFile.class::cast)
-            .forEach(file -> FileEntry.queryObject(file.getIdentifier(), getResourceIdentifier())
-                                 .fetch(resourceService)
-                                 .ifPresent(fileEntry -> fileEntry.reject(resourceService,
-                                                                          new User(getFinalizedBy().getValue()))));
     }
 
     @Override

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandlerTest.java
@@ -46,6 +46,7 @@ import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.associatedartifacts.file.RejectedFile;
 import no.unit.nva.publication.events.bodies.DataEntryUpdateEvent;
 import no.unit.nva.publication.model.business.DoiRequest;
+import no.unit.nva.publication.model.business.FilesApprovalThesis;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
 import no.unit.nva.publication.model.business.PublishingWorkflow;
 import no.unit.nva.publication.model.business.Resource;
@@ -535,6 +536,19 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         assertEquals(publishingRequest.getOwner().toString(), resource.getResourceEvent().user().toString());
     }
 
+    @Test
+    void shouldHandleFilesApprovalThesis() throws ApiGatewayException, IOException {
+        var publication =
+            TicketTestUtils.createPersistedDegreePublication(PublicationStatus.PUBLISHED, resourceService);
+        var filesApprovalThesis = pendingFilesApprovalThesis(publication);
+        var approvedTicket = filesApprovalThesis
+                .complete(publication, USER_INSTANCE)
+                .persistNewTicket(ticketService);
+        var event = createEvent(filesApprovalThesis, approvedTicket);
+
+        assertDoesNotThrow(() -> handler.handleRequest(event, outputStream, CONTEXT));
+    }
+
     private PublishingRequestCase persistCompletedPublishingRequestWithApprovedFiles(
             Publication publication, File file) throws ApiGatewayException {
         var userInstance = UserInstance.fromPublication(publication);
@@ -638,6 +652,14 @@ class AcceptedPublishingRequestEventHandlerTest extends ResourcesLocalTest {
         var userInstance = new UserInstance(randomString(), randomUri(), randomUri(), randomUri(), randomUri(),
                                             List.of(), UserClientType.INTERNAL);
         return PublishingRequestCase.create(Resource.fromPublication(publication), userInstance,
+                                            REGISTRATOR_PUBLISHES_METADATA_ONLY);
+
+    }
+
+    private FilesApprovalThesis pendingFilesApprovalThesis(Publication publication) {
+        var userInstance = new UserInstance(randomString(), randomUri(), randomUri(), randomUri(), randomUri(),
+                                            List.of(), UserClientType.INTERNAL);
+        return FilesApprovalThesis.create(Resource.fromPublication(publication), userInstance,
                                             REGISTRATOR_PUBLISHES_METADATA_ONLY);
 
     }

--- a/template.yaml
+++ b/template.yaml
@@ -1668,7 +1668,9 @@ Resources:
             Pattern:
               detail:
                 responsePayload:
-                  topic: [ "PublicationService.PublishingRequest.Update" ]
+                  topic:
+                    - "PublicationService.PublishingRequest.Update"
+                    - "PublicationService.FilesApprovalThesis.Update"
 
   HandleIdentifierEventHandler:
     DependsOn: EventsLambdaManagedPolicy


### PR DESCRIPTION
Making AcceptedPublishingRequestEventHandler consume FileApprovalEntry, which is a base class for PublishingRequestCase and FilesApprovalThesis. In will handle publishing of files for thesis when FilesApprovalThesis is approved by curators. 