### PR TITLE
Np 48995 allowed operation for approving files approval thesis

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ContributorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ContributorGrantStrategy.java
@@ -35,7 +35,8 @@ public final class ContributorGrantStrategy extends PublicationStrategyBase impl
                  SUPPORT_REQUEST_APPROVE,
                  TERMINATE,
                  DELETE,
-                 READ_HIDDEN_FILES -> false;
+                 READ_HIDDEN_FILES,
+                 THESIS_APPROVAL -> false;
         };
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/CuratorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/CuratorGrantStrategy.java
@@ -1,5 +1,7 @@
 package no.unit.nva.publication.permissions.publication.grant;
 
+import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
+import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
@@ -36,6 +38,7 @@ public final class CuratorGrantStrategy extends PublicationStrategyBase implemen
             case PUBLISHING_REQUEST_APPROVE,
                  READ_HIDDEN_FILES -> canManagePublishingRequests();
             case SUPPORT_REQUEST_APPROVE -> hasAccessRight(SUPPORT);
+            case THESIS_APPROVAL -> hasAccessRight(MANAGE_DEGREE) || hasAccessRight(MANAGE_DEGREE_EMBARGO);
             case REPUBLISH, DELETE, TERMINATE -> false;
         };
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/EditorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/EditorGrantStrategy.java
@@ -32,7 +32,8 @@ public final class EditorGrantStrategy extends PublicationStrategyBase implement
                  DOI_REQUEST_APPROVE,
                  PUBLISHING_REQUEST_APPROVE,
                  SUPPORT_REQUEST_APPROVE,
-                 UPLOAD_FILE -> false;
+                 UPLOAD_FILE,
+                 THESIS_APPROVAL -> false;
         };
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ResourceOwnerGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ResourceOwnerGrantStrategy.java
@@ -23,7 +23,7 @@ public final class ResourceOwnerGrantStrategy extends PublicationStrategyBase im
             case UNPUBLISH -> isPublished() && !hasApprovedFiles();
             case DELETE -> isDraft();
             case UPDATE_FILES, READ_HIDDEN_FILES, REPUBLISH, TERMINATE, DOI_REQUEST_APPROVE,
-                 PUBLISHING_REQUEST_APPROVE, SUPPORT_REQUEST_APPROVE -> false;
+                 PUBLISHING_REQUEST_APPROVE, SUPPORT_REQUEST_APPROVE, THESIS_APPROVAL -> false;
         };
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/TrustedThirdPartyGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/TrustedThirdPartyGrantStrategy.java
@@ -31,7 +31,8 @@ public final class TrustedThirdPartyGrantStrategy extends PublicationStrategyBas
                  PUBLISHING_REQUEST_CREATE,
                  PUBLISHING_REQUEST_APPROVE,
                  SUPPORT_REQUEST_CREATE,
-                 SUPPORT_REQUEST_APPROVE -> false;
+                 SUPPORT_REQUEST_APPROVE,
+                 THESIS_APPROVAL -> false;
         };
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/CuratorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/CuratorPermissionStrategyTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.publication.RequestUtil;
+import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -194,6 +195,23 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         Assertions.assertTrue(PublicationPermissions
                                   .create(publication, userInstance)
                                   .allowsAction(operation));
+    }
+
+    @Test
+    void shouldAllowCuratorToPerformThesisApprovalWhenDegreeAccessRightIsPresent()
+        throws JsonProcessingException, UnauthorizedException {
+        var cristinTopLevelId = randomUri();
+
+        var requestInfo = createUserRequestInfo(randomString(), randomUri(), List.of(AccessRight.MANAGE_DEGREE),
+                                                randomUri(), cristinTopLevelId);
+
+        var publication = createDegreePhd(randomString(), randomUri(), cristinTopLevelId);
+
+        var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
+
+        Assertions.assertTrue(PublicationPermissions
+                                  .create(publication, userInstance)
+                                  .allowsAction(PublicationOperation.THESIS_APPROVAL));
     }
     //endregion
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/PublishingServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/PublishingServiceTest.java
@@ -44,6 +44,7 @@ import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.StringUtils;
 import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 class PublishingServiceTest extends ResourcesLocalTest {
@@ -146,7 +147,7 @@ class PublishingServiceTest extends ResourcesLocalTest {
 
     @Test
     void shouldPersistPublishingRequestWhenPublicationToPublishHasPendingFiles() throws ApiGatewayException {
-        var publication = randomPublication().copy()
+        var publication = randomPublication(JournalArticle.class).copy()
                               .withStatus(PublicationStatus.DRAFT)
                               .withAssociatedArtifacts(List.of(randomPendingOpenFile()))
                               .build();

--- a/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
@@ -19,6 +19,7 @@ public enum PublicationOperation {
     DOI_REQUEST_APPROVE("doi-request-approve"),
     PUBLISHING_REQUEST_CREATE("publishing-request-create"),
     PUBLISHING_REQUEST_APPROVE("publishing-request-approve"),
+    THESIS_APPROVAL("thesis-approval"),
     SUPPORT_REQUEST_CREATE("support-request-create"),
     SUPPORT_REQUEST_APPROVE("support-request-approve"),
     UPLOAD_FILE("upload-file");


### PR DESCRIPTION
Introducing AllowedOperation for approving FilesApprovalThesis. Naming it `thesis-approval`, come with suggestions for better name :)
The name to match pattern should be files-approval-thesis-approve, but I mean it sound strange :)

We should probably also introduce new allowed operation for publishing, because right now frontend is using publishing-request-create, but we do not longer create ticket to publish publication. But publishing validation is also using channel-claims, so it should be done after we inject channel-claim to publication.