### PR TITLE
publication channel model in publication-api

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ChannelPolicy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ChannelPolicy.java
@@ -1,0 +1,26 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import static java.util.Arrays.stream;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ChannelPolicy {
+
+    OWNER_ONLY("OwnerOnly"), EVERYONE("Everyone");
+
+    private final String value;
+
+    ChannelPolicy(String value) {
+        this.value = value;
+    }
+
+    public static ChannelPolicy fromValue(String value) {
+        return stream(values()).filter(publicationStatus -> publicationStatus.getValue().equalsIgnoreCase(value))
+                   .findAny()
+                   .orElseThrow();
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ChannelType.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ChannelType.java
@@ -1,0 +1,26 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import static java.util.Arrays.stream;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ChannelType {
+
+    PUBLISHER("Publisher"), SERIAL_PUBLICATION("SerialPublication");
+
+    private final String value;
+
+    ChannelType(String value) {
+        this.value = value;
+    }
+
+    public static ChannelType fromValue(String value) {
+        return stream(values()).filter(publicationStatus -> publicationStatus.getValue().equalsIgnoreCase(value))
+                   .findAny()
+                   .orElseThrow();
+    }
+
+    @JsonProperty
+    public String getValue() {
+        return value;
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ClaimedPublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ClaimedPublicationChannel.java
@@ -1,0 +1,179 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Objects;
+import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.publication.model.business.Entity;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.storage.Dao;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.JacocoGenerated;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonTypeName(ClaimedPublicationChannel.TYPE)
+public final class ClaimedPublicationChannel implements PublicationChannel, Entity, JsonSerializable {
+
+    static final String TYPE = "ClaimedPublicationChannel";
+
+    private final URI id;
+    private final URI customerId;
+    private final URI organizationId;
+    private final Constraint constraint;
+    private final ChannelType channelType;
+    private final SortableIdentifier identifier;
+    private final SortableIdentifier resourceIdentifier;
+    private final Instant createdDate;
+    private final Instant modifiedDate;
+
+    @JsonCreator
+    public ClaimedPublicationChannel(@JsonProperty(ID_FIELD) URI id, @JsonProperty(CUSTOMER_ID_FIELD) URI customerId,
+                                     @JsonProperty(ORGANIZATION_ID_FIELD) URI organizationId,
+                                     @JsonProperty(CONSTRAINT_FIELD) Constraint constraint,
+                                     @JsonProperty(CHANNEL_TYPE_FIELD) ChannelType channelType,
+                                     @JsonProperty(IDENTIFIER_FIELD) SortableIdentifier identifier,
+                                     @JsonProperty(RESOURCE_IDENTIFIER_FIELD) SortableIdentifier resourceIdentifier,
+                                     @JsonProperty(CREATED_DATE_FIELD) Instant createdDate,
+                                     @JsonProperty(MODIFIED_DATE_FIELD) Instant modifiedDate) {
+        this.id = id;
+        this.customerId = customerId;
+        this.organizationId = organizationId;
+        this.constraint = constraint;
+        this.channelType = channelType;
+        this.identifier = identifier;
+        this.resourceIdentifier = resourceIdentifier;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getCustomerId(), getOrganizationId(), getConstraint(), getChannelType(),
+                            getIdentifier(), getResourceIdentifier(), getCreatedDate(), getModifiedDate());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ClaimedPublicationChannel that)) {
+            return false;
+        }
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getCustomerId(), that.getCustomerId()) &&
+               Objects.equals(getOrganizationId(), that.getOrganizationId()) &&
+               Objects.equals(getConstraint(), that.getConstraint()) && getChannelType() == that.getChannelType() &&
+               Objects.equals(getIdentifier(), that.getIdentifier()) &&
+               Objects.equals(getResourceIdentifier(), that.getResourceIdentifier()) &&
+               Objects.equals(getCreatedDate(), that.getCreatedDate()) &&
+               Objects.equals(getModifiedDate(), that.getModifiedDate());
+    }
+
+    @JacocoGenerated
+    @Override
+    public URI getId() {
+        return id;
+    }
+
+    @JacocoGenerated
+    @Override
+    public SortableIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setIdentifier(SortableIdentifier identifier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public Publication toPublication(ResourceService resourceService) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @JsonIgnore
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @JacocoGenerated
+    @Override
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setCreatedDate(Instant now) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public Instant getModifiedDate() {
+        return modifiedDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setModifiedDate(Instant now) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public User getOwner() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public URI getCustomerId() {
+        return customerId;
+    }
+
+    @JacocoGenerated
+    @Override
+    public Dao toDao() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public String getStatusString() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public SortableIdentifier getResourceIdentifier() {
+        return resourceIdentifier;
+    }
+
+    @JacocoGenerated
+    @Override
+    public ChannelType getChannelType() {
+        return channelType;
+    }
+
+    @JacocoGenerated
+    public URI getOrganizationId() {
+        return organizationId;
+    }
+
+    @JacocoGenerated
+    public Constraint getConstraint() {
+        return constraint;
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/Constraint.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/Constraint.java
@@ -1,0 +1,32 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import java.util.List;
+import nva.commons.core.JacocoGenerated;
+
+public class Constraint {
+
+    private final ChannelPolicy publishingPolicy;
+    private final ChannelPolicy editingPolicy;
+    private final List<String> scope;
+
+    public Constraint(ChannelPolicy publishingPolicy, ChannelPolicy editingPolicy, List<String> scope) {
+        this.publishingPolicy = publishingPolicy;
+        this.editingPolicy = editingPolicy;
+        this.scope = scope;
+    }
+
+    @JacocoGenerated
+    public ChannelPolicy getPublishingPolicy() {
+        return publishingPolicy;
+    }
+
+    @JacocoGenerated
+    public ChannelPolicy getEditingPolicy() {
+        return editingPolicy;
+    }
+
+    @JacocoGenerated
+    public List<String> getScope() {
+        return scope;
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/NonClaimedPublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/NonClaimedPublicationChannel.java
@@ -1,0 +1,157 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Objects;
+import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Publication;
+import no.unit.nva.publication.model.business.Entity;
+import no.unit.nva.publication.model.business.User;
+import no.unit.nva.publication.model.storage.Dao;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.JacocoGenerated;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonTypeName(NonClaimedPublicationChannel.TYPE)
+public final class NonClaimedPublicationChannel implements PublicationChannel, Entity, JsonSerializable {
+
+    static final String TYPE = "NonClaimedPublicationChannel";
+
+    private final URI id;
+    private final ChannelType channelType;
+    private final SortableIdentifier identifier;
+    private final SortableIdentifier resourceIdentifier;
+    private final Instant createdDate;
+    private final Instant modifiedDate;
+
+    public NonClaimedPublicationChannel(@JsonProperty(ID_FIELD) URI id,
+                                        @JsonProperty(CHANNEL_TYPE_FIELD) ChannelType channelType,
+                                        @JsonProperty(IDENTIFIER_FIELD) SortableIdentifier identifier,
+                                        @JsonProperty(RESOURCE_IDENTIFIER_FIELD) SortableIdentifier resourceIdentifier,
+                                        @JsonProperty(CREATED_DATE_FIELD) Instant createdDate,
+                                        @JsonProperty(MODIFIED_DATE_FIELD) Instant modifiedDate) {
+        this.id = id;
+        this.channelType = channelType;
+        this.identifier = identifier;
+        this.resourceIdentifier = resourceIdentifier;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getChannelType(), getIdentifier(), getResourceIdentifier(), getCreatedDate(),
+                            getModifiedDate());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NonClaimedPublicationChannel that)) {
+            return false;
+        }
+        return Objects.equals(getId(), that.getId()) && getChannelType() == that.getChannelType() &&
+               Objects.equals(getIdentifier(), that.getIdentifier()) &&
+               Objects.equals(getResourceIdentifier(), that.getResourceIdentifier()) &&
+               Objects.equals(getCreatedDate(), that.getCreatedDate()) &&
+               Objects.equals(getModifiedDate(), that.getModifiedDate());
+    }
+
+    @JacocoGenerated
+    @Override
+    public URI getId() {
+        return id;
+    }
+
+    @JacocoGenerated
+    @Override
+    public SortableIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    @JacocoGenerated
+    @Override
+    public SortableIdentifier getResourceIdentifier() {
+        return resourceIdentifier;
+    }
+
+    @JacocoGenerated
+    @Override
+    public ChannelType getChannelType() {
+        return channelType;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setIdentifier(SortableIdentifier identifier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public Publication toPublication(ResourceService resourceService) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @JsonIgnore
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @JacocoGenerated
+    @Override
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setCreatedDate(Instant now) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public Instant getModifiedDate() {
+        return modifiedDate;
+    }
+
+    @JacocoGenerated
+    @Override
+    public void setModifiedDate(Instant now) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JacocoGenerated
+    @Override
+    public User getOwner() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public URI getCustomerId() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public Dao toDao() {
+        return null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public String getStatusString() {
+        return null;
+    }
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannel.java
@@ -1,0 +1,30 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.net.URI;
+import no.unit.nva.identifiers.SortableIdentifier;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(name = ClaimedPublicationChannel.TYPE, value = ClaimedPublicationChannel.class),
+    @JsonSubTypes.Type(name = NonClaimedPublicationChannel.TYPE, value = NonClaimedPublicationChannel.class)})
+public sealed interface PublicationChannel permits ClaimedPublicationChannel, NonClaimedPublicationChannel {
+
+    String RESOURCE_IDENTIFIER_FIELD = "resourceIdentifier";
+    String CREATED_DATE_FIELD = "createdDate";
+    String MODIFIED_DATE_FIELD = "modifiedDate";
+    String ORGANIZATION_ID_FIELD = "organizationId";
+    String CONSTRAINT_FIELD = "constraint";
+    String CHANNEL_TYPE_FIELD = "channelType";
+    String IDENTIFIER_FIELD = "identifier";
+    String ID_FIELD = "id";
+    String CUSTOMER_ID_FIELD = "customerId";
+
+    URI getId();
+
+    SortableIdentifier getIdentifier();
+
+    SortableIdentifier getResourceIdentifier();
+
+    ChannelType getChannelType();
+}

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannelTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannelTest.java
@@ -1,0 +1,61 @@
+package no.unit.nva.publication.model.business.publicationchannel;
+
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.identifiers.SortableIdentifier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PublicationChannelTest {
+
+    public static Stream<Arguments> publicationChannelProvider() {
+        return Stream.of(Arguments.of(randomNonClaimedPublicationChannel(), randomClaimedPublicationChannel()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("publicationChannelProvider")
+    void shouldDoRoundTripWithoutLossOfInformation(PublicationChannel publicationChannel)
+        throws JsonProcessingException {
+        var json = JsonUtils.dtoObjectMapper.writeValueAsString(publicationChannel);
+        var roundTripped = JsonUtils.dtoObjectMapper.readValue(json, PublicationChannel.class);
+
+        assertEquals(publicationChannel, roundTripped);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Publisher", "SerialPublication"})
+    void shouldConvertStringToChannelType(String value) {
+        var channelType = ChannelType.fromValue(value);
+
+        assertEquals(value, channelType.getValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"OwnerOnly", "Everyone"})
+    void shouldConvertStringToChannelPolicy(String value) {
+        var channelPolicy = ChannelPolicy.fromValue(value);
+
+        assertEquals(value, channelPolicy.getValue());
+    }
+
+    private static ClaimedPublicationChannel randomClaimedPublicationChannel() {
+        return new ClaimedPublicationChannel(randomUri(), randomUri(), randomUri(),
+                                             new Constraint(ChannelPolicy.EVERYONE, ChannelPolicy.OWNER_ONLY,
+                                                            List.of(randomString())), ChannelType.PUBLISHER,
+                                             SortableIdentifier.next(), SortableIdentifier.next(), Instant.now(),
+                                             Instant.now());
+    }
+
+    private static NonClaimedPublicationChannel randomNonClaimedPublicationChannel() {
+        return new NonClaimedPublicationChannel(randomUri(), ChannelType.PUBLISHER, SortableIdentifier.next(),
+                                                SortableIdentifier.next(), Instant.now(), Instant.now());
+    }
+}


### PR DESCRIPTION
PublicationChannel model for publication-api. These two classes will be used in permission strategies when validating user access. These objects will also be persisted in "data" field in DynamoDB.