### PR TITLE
NP-49087 Remove institution check when validating student thesis with open file

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
@@ -49,9 +49,10 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
         if (!hasAccessRight(MANAGE_DEGREE)) {
             return DENY;
         }
-        if (!userIsFromSameInstitutionAsPublicationOwner()) {
-            return DENY;
-        }
+        // TODO: Implement when channelClaim is available in publication object
+//        if (!userIsFromSameInstitutionAsPublicationOwner()) {
+//            return DENY;
+//        }
         return PASS;
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -32,7 +32,9 @@ import no.unit.nva.testutils.RandomDataGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -358,6 +360,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                   .allowsAction(operation));
     }
 
+    @Disabled("Until channel claim is available in publication object")
     @ParameterizedTest(name = "Should deny Thesis Curator from curating institution {0} operation on instance "
                               + "type {1} when degree has open files")
     @MethodSource("argumentsForThesisCurator")
@@ -517,6 +520,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                   .allowsAction(operation));
     }
 
+    @Disabled("Until channel claim is available in publication object")
     @ParameterizedTest(name = "Should deny Thesis Curator from curating institution {0} operation on instance type "
                               + "{1} when curating institution has supervisor only and publication has open files")
     @MethodSource("argumentsForThesisCurator")

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -32,7 +32,6 @@ import no.unit.nva.testutils.RandomDataGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
To allow rapid testing, and work around the blocking of channel claim implementation in publication-api, the validation of student thesis is opened up a bit. When there is a student thesis with an open file, only the presence of a student thesis role is checked. Whether the user is affiliated with the correct institution according to the rule set is ignored, and up to the frontend to implement itself.