### PR TITLE
Np 49098 publications channels batch update handler

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ClaimedPublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/ClaimedPublicationChannel.java
@@ -188,4 +188,13 @@ public final class ClaimedPublicationChannel implements PublicationChannel, Json
     public Constraint getConstraint() {
         return constraint;
     }
+
+    public ClaimedPublicationChannel update(URI customerId, URI organizationId, Constraint constraint) {
+        return new ClaimedPublicationChannel(id, customerId, organizationId, constraint, channelType, identifier,
+                                             resourceIdentifier, createdDate, Instant.now());
+    }
+
+    public NonClaimedPublicationChannel toNonClaimedChannel() {
+        return new NonClaimedPublicationChannel(id, channelType, identifier, resourceIdentifier, createdDate, Instant.now());
+    }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/NonClaimedPublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/NonClaimedPublicationChannel.java
@@ -159,4 +159,9 @@ public final class NonClaimedPublicationChannel implements PublicationChannel, J
     public String getStatusString() {
         return null;
     }
+
+    public ClaimedPublicationChannel toClaimedChannel(URI customerId, URI organizationId, Constraint constraint) {
+        return new ClaimedPublicationChannel(id, customerId, organizationId, constraint, channelType, identifier,
+                                             resourceIdentifier, createdDate, Instant.now());
+    }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannel.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.Entity;
+import no.unit.nva.publication.model.storage.PublicationChannelDao;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(name = ClaimedPublicationChannel.TYPE, value = ClaimedPublicationChannel.class),
@@ -30,4 +31,7 @@ public sealed interface PublicationChannel extends Entity
     SortableIdentifier getResourceIdentifier();
 
     ChannelType getChannelType();
+
+    @Override
+    PublicationChannelDao toDao();
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -414,6 +414,18 @@ public class ResourceService extends ServiceWithTransactions {
         return new ListingResult<>(values, result.getLastEvaluatedKey(), isTruncated);
     }
 
+    public void batchUpdateChannels(List<PublicationChannel> publicationChannels) {
+        var writeRequests = publicationChannels.stream()
+                                .map(PublicationChannel::toDao)
+                                .map(dao -> new PutRequest().withItem(dao.toDynamoFormat()))
+                                .map(WriteRequest::new)
+                                .toList();
+        Lists.partition(writeRequests, 25)
+            .stream()
+            .map(items -> new BatchWriteItemRequest().withRequestItems(Map.of(tableName, items)))
+            .forEach(this::writeBatchToDynamo);
+    }
+
     private static List<PublicationChannel> getPublicationChannels(QueryResult result) {
         return result.getItems().stream().map(value -> parseAttributeValuesMap(value, Dao.class))
                    .filter(PublicationChannelDao.class::isInstance)

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/ChannelUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/ChannelUpdateEvent.java
@@ -1,0 +1,23 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import java.net.URI;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.model.business.publicationchannel.Constraint;
+import nva.commons.core.paths.UriWrapper;
+
+public record ChannelUpdateEvent(Action action, PublicationChannelSummary publicationChannelSummary) {
+
+    public SortableIdentifier getChannelIdentifier() {
+        var identifier = UriWrapper.fromUri(publicationChannelSummary().id()).getLastPathElement();
+        return new SortableIdentifier(identifier);
+    }
+
+    public enum Action {
+        ADDED, UPDATED, REMOVED
+    }
+
+    public record PublicationChannelSummary(URI id, URI channelId, URI customerId, URI organizationId,
+                                            Constraint constraint) {
+
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/ChannelUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/ChannelUpdateEvent.java
@@ -1,11 +1,15 @@
 package no.unit.nva.publication.events.handlers.batch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
+import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.publicationchannel.Constraint;
 import nva.commons.core.paths.UriWrapper;
 
-public record ChannelUpdateEvent(Action action, PublicationChannelSummary publicationChannelSummary) {
+public record ChannelUpdateEvent(Action action,
+                                 @JsonProperty("data") PublicationChannelSummary publicationChannelSummary)
+    implements JsonSerializable {
 
     public SortableIdentifier getChannelIdentifier() {
         var identifier = UriWrapper.fromUri(publicationChannelSummary().id()).getLastPathElement();

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateService.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateService.java
@@ -9,9 +9,13 @@ import no.unit.nva.publication.model.business.publicationchannel.ClaimedPublicat
 import no.unit.nva.publication.model.business.publicationchannel.NonClaimedPublicationChannel;
 import no.unit.nva.publication.model.business.publicationchannel.PublicationChannel;
 import no.unit.nva.publication.service.impl.ResourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PublicationChannelsBatchUpdateService {
 
+    private static final Logger logger = LoggerFactory.getLogger(PublicationChannelsBatchUpdateService.class);
+    protected static final String UPDATED_PUBLICATION_CHANNELS_MESSAGE = "Updated {} publication channels with identifier {}";
     private final ResourceService resourceService;
 
     public PublicationChannelsBatchUpdateService(ResourceService resourceService) {
@@ -24,6 +28,8 @@ public class PublicationChannelsBatchUpdateService {
 
         var updatedChannels = publicationChannels.stream().map(channel -> update(channel, event)).toList();
         resourceService.batchUpdateChannels(updatedChannels);
+
+        logger.info(UPDATED_PUBLICATION_CHANNELS_MESSAGE, updatedChannels.size(), identifier);
     }
 
     private static ClaimedPublicationChannel updateClaimedChannel(PublicationChannelSummary summary,
@@ -60,7 +66,6 @@ public class PublicationChannelsBatchUpdateService {
     private ArrayList<PublicationChannel> listAllPublicationChannelsWithIdentifier(SortableIdentifier identifier) {
         Map<String, AttributeValue> startMarker = null;
         var publicationChannels = new ArrayList<PublicationChannel>();
-
         boolean isTruncated;
         do {
             var listingResult = resourceService.fetchAllPublicationChannelsByIdentifier(identifier, startMarker);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateService.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateService.java
@@ -1,0 +1,73 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.ArrayList;
+import java.util.Map;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.PublicationChannelSummary;
+import no.unit.nva.publication.model.business.publicationchannel.ClaimedPublicationChannel;
+import no.unit.nva.publication.model.business.publicationchannel.NonClaimedPublicationChannel;
+import no.unit.nva.publication.model.business.publicationchannel.PublicationChannel;
+import no.unit.nva.publication.service.impl.ResourceService;
+
+public class PublicationChannelsBatchUpdateService {
+
+    private final ResourceService resourceService;
+
+    public PublicationChannelsBatchUpdateService(ResourceService resourceService) {
+        this.resourceService = resourceService;
+    }
+
+    public void updateChannels(ChannelUpdateEvent event) {
+        var identifier = event.getChannelIdentifier();
+        var publicationChannels = listAllPublicationChannelsWithIdentifier(identifier);
+
+        var updatedChannels = publicationChannels.stream().map(channel -> update(channel, event)).toList();
+        resourceService.batchUpdateChannels(updatedChannels);
+    }
+
+    private static ClaimedPublicationChannel updateClaimedChannel(PublicationChannelSummary summary,
+                                                                  ClaimedPublicationChannel claimed) {
+        return claimed.update(summary.customerId(), summary.organizationId(), summary.constraint());
+    }
+
+    private static ClaimedPublicationChannel updateNonClaimedToClaimed(PublicationChannelSummary summary,
+                                                                       NonClaimedPublicationChannel nonClaimed) {
+        return nonClaimed.toClaimedChannel(summary.customerId(), summary.organizationId(), summary.constraint());
+    }
+
+    private ClaimedPublicationChannel updateToClaimed(PublicationChannel channel, PublicationChannelSummary summary) {
+        return switch (channel) {
+            case NonClaimedPublicationChannel nonClaimed -> updateNonClaimedToClaimed(summary, nonClaimed);
+            case ClaimedPublicationChannel claimed -> updateClaimedChannel(summary, claimed);
+        };
+    }
+
+    private PublicationChannel update(PublicationChannel channel, ChannelUpdateEvent event) {
+        return switch (event.action()) {
+            case ADDED, UPDATED -> updateToClaimed(channel, event.publicationChannelSummary());
+            case REMOVED -> updateToNonClaimed(channel);
+        };
+    }
+
+    private NonClaimedPublicationChannel updateToNonClaimed(PublicationChannel channel) {
+        return switch (channel) {
+            case NonClaimedPublicationChannel nonClaimed -> nonClaimed;
+            case ClaimedPublicationChannel claimed -> claimed.toNonClaimedChannel();
+        };
+    }
+
+    private ArrayList<PublicationChannel> listAllPublicationChannelsWithIdentifier(SortableIdentifier identifier) {
+        Map<String, AttributeValue> startMarker = null;
+        var publicationChannels = new ArrayList<PublicationChannel>();
+
+        boolean isTruncated;
+        do {
+            var listingResult = resourceService.fetchAllPublicationChannelsByIdentifier(identifier, startMarker);
+            publicationChannels.addAll(listingResult.getDatabaseEntries());
+            startMarker = listingResult.getStartMarker();
+            isTruncated = listingResult.isTruncated();
+        } while (isTruncated);
+        return publicationChannels;
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandler.java
@@ -6,9 +6,15 @@ import no.unit.nva.events.models.AwsEventBridgeDetail;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PublicationChannelsUpdateHandler extends DestinationsEventBridgeEventHandler<ChannelUpdateEvent, Void> {
 
+    protected static final String UPDATING_CHANNELS_FAILED_MESSAGE = "Something went wrong updating publication " +
+                                                                     "channels for channel {}";
+    protected static final String CONSUMED_EVENT_MESSAGE = "Consumed event {}";
+    private static final Logger logger = LoggerFactory.getLogger(PublicationChannelsUpdateHandler.class);
     private final PublicationChannelsBatchUpdateService service;
 
     @JacocoGenerated
@@ -25,7 +31,12 @@ public class PublicationChannelsUpdateHandler extends DestinationsEventBridgeEve
     protected Void processInputPayload(ChannelUpdateEvent event,
                                        AwsEventBridgeEvent<AwsEventBridgeDetail<ChannelUpdateEvent>> awsEventBridgeEvent,
                                        Context context) {
-        service.updateChannels(event);
+        logger.info(CONSUMED_EVENT_MESSAGE, event);
+        try {
+            service.updateChannels(event);
+        } catch (Exception e) {
+            logger.error(UPDATING_CHANNELS_FAILED_MESSAGE, event.getChannelIdentifier());
+        }
         return null;
     }
 }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandler.java
@@ -1,0 +1,31 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import no.unit.nva.events.handlers.DestinationsEventBridgeEventHandler;
+import no.unit.nva.events.models.AwsEventBridgeDetail;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.JacocoGenerated;
+
+public class PublicationChannelsUpdateHandler extends DestinationsEventBridgeEventHandler<ChannelUpdateEvent, Void> {
+
+    private final PublicationChannelsBatchUpdateService service;
+
+    @JacocoGenerated
+    protected PublicationChannelsUpdateHandler() {
+        this(new PublicationChannelsBatchUpdateService(ResourceService.defaultService()));
+    }
+
+    public PublicationChannelsUpdateHandler(PublicationChannelsBatchUpdateService service) {
+        super(ChannelUpdateEvent.class);
+        this.service = service;
+    }
+
+    @Override
+    protected Void processInputPayload(ChannelUpdateEvent event,
+                                       AwsEventBridgeEvent<AwsEventBridgeDetail<ChannelUpdateEvent>> awsEventBridgeEvent,
+                                       Context context) {
+        service.updateChannels(event);
+        return null;
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateServiceTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsBatchUpdateServiceTest.java
@@ -1,0 +1,164 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import static java.util.UUID.randomUUID;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.Action.ADDED;
+import static no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.Action.REMOVED;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.Action;
+import no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.PublicationChannelSummary;
+import no.unit.nva.publication.model.business.publicationchannel.ChannelPolicy;
+import no.unit.nva.publication.model.business.publicationchannel.ChannelType;
+import no.unit.nva.publication.model.business.publicationchannel.ClaimedPublicationChannel;
+import no.unit.nva.publication.model.business.publicationchannel.Constraint;
+import no.unit.nva.publication.model.business.publicationchannel.NonClaimedPublicationChannel;
+import no.unit.nva.publication.model.business.publicationchannel.PublicationChannel;
+import no.unit.nva.publication.service.PublicationChannelLocalTestUtil;
+import no.unit.nva.publication.service.impl.ResourceService;
+import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PublicationChannelsBatchUpdateServiceTest extends PublicationChannelLocalTestUtil {
+
+    private PublicationChannelsBatchUpdateService service;
+    private ResourceService resourceService;
+
+    @BeforeEach
+    void setUp() {
+        super.init();
+        resourceService = getResourceServiceBuilder().build();
+        service = new PublicationChannelsBatchUpdateService(resourceService);
+    }
+
+    @Test
+    void shouldUpdateNonClaimedChannelToClaimedWhenChannelIsBeingClaimed() {
+        var identifier = randomUUID();
+        var channel = NonClaimedPublicationChannel.create(toChannelClaimId(identifier), SortableIdentifier.next(),
+                                                          ChannelType.PUBLISHER);
+        super.persistPublicationChannel(channel);
+        var event = createEvent(identifier, ADDED);
+
+        service.updateChannels(event);
+
+        var updatedChannel = getUpdatedChannels(identifier).getFirst();
+        var expectedChannel = createExpectedClaimedChannel(channel, event, updatedChannel.getModifiedDate());
+
+        assertEquals(expectedChannel, updatedChannel);
+    }
+
+    @Test
+    void shouldUpdateClaimedChannelWhenChannelIsBeingClaimed() {
+        var identifier = randomUUID();
+        var channel = randomClaimedChannel(identifier);
+        super.persistPublicationChannel(channel);
+        var event = createEvent(identifier, ADDED);
+
+        service.updateChannels(event);
+
+        var updatedChannel = getUpdatedChannels(identifier).getFirst();
+        var expectedChannel = createExpectedClaimedChannel(channel, event, updatedChannel.getModifiedDate());
+
+        assertEquals(expectedChannel, updatedChannel);
+    }
+
+    @Test
+    void shouldUpdateClaimedChannelToNonClaimedWhenChannelIsBeingUnclaimed() {
+        var identifier = randomUUID();
+        var channel = randomClaimedChannel(identifier);
+        super.persistPublicationChannel(channel);
+        var event = createEvent(identifier, REMOVED);
+
+        service.updateChannels(event);
+
+        var updatedChannel = getUpdatedChannels(identifier).getFirst();
+        var expectedChannel = createExpectedNonClaimedChannel(channel, event, updatedChannel.getModifiedDate());
+
+        assertEquals(expectedChannel, updatedChannel);
+    }
+
+    @Test
+    void shouldUpdateMultipleChannels() {
+        var identifier = randomUUID();
+        var channel1 = randomClaimedChannel(identifier);
+        super.persistPublicationChannel(channel1);
+        var channel2 = randomClaimedChannel(identifier);
+        super.persistPublicationChannel(channel2);
+
+        var event = createEvent(identifier, ADDED);
+
+        service.updateChannels(event);
+
+        getUpdatedChannels(identifier).stream().map(ClaimedPublicationChannel.class::cast).forEach(channel -> {
+            assertEquals(event.publicationChannelSummary().constraint(),channel.getConstraint());
+            assertEquals(event.publicationChannelSummary().organizationId(),channel.getOrganizationId());
+            assertEquals(event.publicationChannelSummary().customerId(),channel.getCustomerId());
+        });
+    }
+
+    private static ClaimedPublicationChannel createExpectedClaimedChannel(PublicationChannel channel,
+                                                                          ChannelUpdateEvent event, Instant modifiedDate) {
+        return new ClaimedPublicationChannel(event.publicationChannelSummary().id(),
+                                             event.publicationChannelSummary().customerId(),
+                                             event.publicationChannelSummary().organizationId(),
+                                        event.publicationChannelSummary().constraint(),
+                                        channel.getChannelType(),
+                                        channel.getIdentifier(),
+                                        channel.getResourceIdentifier(),
+                                        channel.getCreatedDate(),
+                                        modifiedDate);
+    }
+
+    private static NonClaimedPublicationChannel createExpectedNonClaimedChannel(PublicationChannel channel,
+                                                                          ChannelUpdateEvent event, Instant modifiedDate) {
+        return new NonClaimedPublicationChannel(event.publicationChannelSummary().id(),
+                                             channel.getChannelType(),
+                                             channel.getIdentifier(),
+                                             channel.getResourceIdentifier(),
+                                             channel.getCreatedDate(),
+                                             modifiedDate);
+    }
+
+    private static ClaimedPublicationChannel randomClaimedChannel(UUID identifier) {
+        return new ClaimedPublicationChannel(toChannelClaimId(identifier),
+                                             randomUri(),
+                                             randomUri(),
+                                             new Constraint(ChannelPolicy.EVERYONE, ChannelPolicy.OWNER_ONLY,
+                                                            List.of(randomString())),
+                                             ChannelType.SERIAL_PUBLICATION,
+                                             new SortableIdentifier(identifier.toString()),
+                                             SortableIdentifier.next(),
+                                             Instant.now(),
+                                             Instant.now());
+    }
+
+    private static ChannelUpdateEvent createEvent(UUID identifier, Action action) {
+        return new ChannelUpdateEvent(action,
+                                      new PublicationChannelSummary(toChannelClaimId(identifier), randomUri(),
+                                                                    randomUri(), randomUri(),
+                                                                    new Constraint(ChannelPolicy.EVERYONE,
+                                                                                   ChannelPolicy.EVERYONE,
+                                                                                   List.of(randomString()))));
+    }
+
+    private static URI toChannelClaimId(UUID channelClaimIdentifier) {
+        return UriWrapper.fromHost(new Environment().readEnv("API_HOST"))
+                   .addChild("customer")
+                   .addChild("channel-claim")
+                   .addChild(channelClaimIdentifier.toString())
+                   .getUri();
+    }
+
+    private List<PublicationChannel> getUpdatedChannels(UUID identifier) {
+        var sortableIdentifier = new SortableIdentifier(identifier.toString());
+        return resourceService.fetchAllPublicationChannelsByIdentifier(sortableIdentifier, null).getDatabaseEntries();
+    }
+}
+

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/PublicationChannelsUpdateHandlerTest.java
@@ -1,0 +1,56 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.UUID;
+import no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.Action;
+import no.unit.nva.publication.events.handlers.batch.ChannelUpdateEvent.PublicationChannelSummary;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.EventBridgeEventBuilder;
+import nva.commons.core.paths.UriWrapper;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PublicationChannelsUpdateHandlerTest {
+
+    private PublicationChannelsUpdateHandler handler;
+    private PublicationChannelsBatchUpdateService service;
+    private ByteArrayOutputStream output;
+
+    @BeforeEach
+    void setUp() {
+        output = new ByteArrayOutputStream();
+        service = mock(PublicationChannelsBatchUpdateService.class);
+        handler = new PublicationChannelsUpdateHandler(service);
+    }
+
+    @Test
+    void shouldUpdatePublicationChannels() {
+        handler.handleRequest(event(), output, new FakeContext());
+    }
+
+    @Test
+    void shouldLogWhenSomethingWentWrongUpdatingPublicationChannels() {
+        doThrow(RuntimeException.class).when(service).updateChannels(any());
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        handler.handleRequest(event(), output, new FakeContext());
+
+        assertTrue(appender.getMessages().contains("Something went wrong updating publication channels"));
+    }
+
+    private static ChannelUpdateEvent randomChannelUpdateEvent() {
+        return new ChannelUpdateEvent(Action.UPDATED, new PublicationChannelSummary(
+            UriWrapper.fromUri(randomUri()).addChild(UUID.randomUUID().toString()).getUri(), randomUri(), randomUri(),
+            randomUri(), null));
+    }
+
+    private InputStream event() {
+        return EventBridgeEventBuilder.sampleLambdaDestinationsEvent(randomChannelUpdateEvent());
+    }
+}

--- a/publication-testing/src/main/java/no/unit/nva/publication/service/PublicationChannelLocalTestUtil.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/service/PublicationChannelLocalTestUtil.java
@@ -1,0 +1,19 @@
+package no.unit.nva.publication.service;
+
+import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
+import java.util.List;
+import no.unit.nva.publication.model.business.publicationchannel.PublicationChannel;
+import no.unit.nva.publication.storage.model.DatabaseConstants;
+
+public class PublicationChannelLocalTestUtil extends ResourcesLocalTest {
+
+    public PublicationChannelLocalTestUtil() {
+        super();
+    }
+
+    public void persistPublicationChannel(PublicationChannel publicationChannel) {
+        var transaction = publicationChannel.toDao().toPutNewTransactionItem(DatabaseConstants.RESOURCES_TABLE_NAME);
+        var request = new TransactWriteItemsRequest().withTransactItems(List.of(transaction));
+        client.transactWriteItems(request);
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -378,6 +378,8 @@ Resources:
     Type: "AWS::SQS::Queue"
   DeleteFileFromS3EventHandlerDLQ:
     Type: "AWS::SQS::Queue"
+  PublicationChannelBatchUpdateDLQ:
+    Type: "AWS::SQS::Queue"
 
 
 
@@ -2037,6 +2039,34 @@ Resources:
             Type: SQS
             Destination: !GetAtt DeleteFileFromS3EventHandlerDLQ.Arn
 
+  PublicationChannelBatchUpdateFunction:
+    DependsOn: EventsLambdaManagedPolicy
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: publication-event-handlers
+      Handler: no.unit.nva.publication.events.handlers.batch.PublicationChannelsUpdateHandler::handleRequest
+      Policies:
+        - !GetAtt EventsLambdaManagedPolicy.PolicyArn
+        - !GetAtt DatabaseAccessLambdaManagedPolicy.PolicyArn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref NvaResourcesTable
+      Events:
+        EventBridgeEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: !Ref NewNvaEventBusName
+            Pattern:
+              detail:
+                responsePayload:
+                  topic:
+                    - NotImplementedYet
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt PublicationChannelBatchUpdateDLQ.Arn
+
   #==========================Manually triggered functions=============================================
 
   BatchScanStartHandler:
@@ -2728,6 +2758,24 @@ Resources:
       Dimensions:
         - Name: QueueName
           Value: !GetAtt RecoveryQueue.QueueName
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref SlackSnsArn
+
+  PublicationChannelBatchUpdateDLQQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: PublicationChannelBatchUpdate failed events threshold exceeded
+      AlarmDescription: If this alarm is triggered, then check sqs messages on publication-api PublicationChannelBatchUpdateDLQ.
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Sum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt PublicationChannelBatchUpdateDLQ.QueueName
       Period: 300
       EvaluationPeriods: 1
       Threshold: 1


### PR DESCRIPTION
Implementing `PublicationChannelBatchUpdateHandler`

Handler will consume event from `nva-event-default-bus` sent by `identity-service`, list all the publication channels with `identifier` for publication and update them.

In first iteration I am attempting to update all channels with the same identifier by single Lambda invocation. We will see if we will manage to update about 100' database entries in single invocation. If not, I will introduce new event which will trigger this handler iteratively, till all entries are updated. 