### PR TITLE
NP-48986 Use Resource instead of Publication as input to PermissionStrategy constructor

### DIFF
--- a/datacite-commons/src/main/java/no/unit/nva/doi/ReserveDoiRequestValidator.java
+++ b/datacite-commons/src/main/java/no/unit/nva/doi/ReserveDoiRequestValidator.java
@@ -25,7 +25,7 @@ public final class ReserveDoiRequestValidator {
     }
 
     private static boolean userHasNoRightsToCreateDoi(UserInstance userInstance, Resource resource) {
-        return !PublicationPermissions.create(resource.toPublication(), userInstance)
+        return !PublicationPermissions.create(resource, userInstance)
                     .allowsAction(PublicationOperation.DOI_REQUEST_CREATE);
     }
 

--- a/messages/src/main/java/no/unit/nva/publication/messages/create/NewCreateMessageHandler.java
+++ b/messages/src/main/java/no/unit/nva/publication/messages/create/NewCreateMessageHandler.java
@@ -14,6 +14,7 @@ import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.GeneralSupportRequest;
 import no.unit.nva.publication.model.business.Message;
 import no.unit.nva.publication.model.business.PublishingRequestCase;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.TicketStatus;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -97,7 +98,7 @@ public class NewCreateMessageHandler extends ApiGatewayHandler<CreateMessageRequ
 
     private PublicationPermissions fetchPermissions(RequestInfo requestInfo, Publication publication)
         throws UnauthorizedException {
-        return PublicationPermissions.create(publication, UserInstance.fromRequestInfo(requestInfo));
+        return PublicationPermissions.create(Resource.fromPublication(publication), UserInstance.fromRequestInfo(requestInfo));
     }
 
     private void isAuthorizedToManageTicket(PublicationPermissions permissions, TicketEntry ticket)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -4,7 +4,9 @@ import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.ResourceOwner;
 import nva.commons.apigateway.AccessRight;
@@ -94,7 +96,7 @@ public class UserInstance implements JsonSerializable {
 
     public static UserInstance fromPublication(Publication publication) {
         return new UserInstance(publication.getResourceOwner().getOwner().getValue(),
-                                publication.getPublisher().getId(),
+                                Optional.ofNullable(publication.getPublisher()).map(Organization::getId).orElse(null),
                                 publication.getResourceOwner().getOwnerAffiliation(),
                                 null, null, List.of(), UserClientType.INTERNAL);
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationPermissions.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationPermissions.java
@@ -4,8 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.grant.BackendClientGrantStrategy;
 import no.unit.nva.publication.permissions.publication.grant.ContributorGrantStrategy;
@@ -26,29 +26,29 @@ public class PublicationPermissions {
     private final Set<PublicationGrantStrategy> grantStrategies;
     private final Set<PublicationDenyStrategy> denyStrategies;
     private final UserInstance userInstance;
-    private final Publication publication;
+    private final Resource resource;
 
     public PublicationPermissions(
-        Publication publication,
+        Resource resource,
         UserInstance userInstance) {
         this.userInstance = userInstance;
-        this.publication = publication;
+        this.resource = resource;
         this.grantStrategies = Set.of(
-            new EditorGrantStrategy(publication, userInstance),
-            new CuratorGrantStrategy(publication, userInstance),
-            new ContributorGrantStrategy(publication, userInstance),
-            new ResourceOwnerGrantStrategy(publication, userInstance),
-            new TrustedThirdPartyGrantStrategy(publication, userInstance),
-            new BackendClientGrantStrategy(publication, userInstance)
+            new EditorGrantStrategy(resource, userInstance),
+            new CuratorGrantStrategy(resource, userInstance),
+            new ContributorGrantStrategy(resource, userInstance),
+            new ResourceOwnerGrantStrategy(resource, userInstance),
+            new TrustedThirdPartyGrantStrategy(resource, userInstance),
+            new BackendClientGrantStrategy(resource, userInstance)
         );
         this.denyStrategies = Set.of(
-            new DegreeDenyStrategy(publication, userInstance),
-            new DeletedUploadDenyStrategy(publication, userInstance)
+            new DegreeDenyStrategy(resource, userInstance),
+            new DeletedUploadDenyStrategy(resource, userInstance)
         );
     }
 
-    public static PublicationPermissions create(Publication publication, UserInstance userInstance) {
-        return new PublicationPermissions(publication, userInstance);
+    public static PublicationPermissions create(Resource resource, UserInstance userInstance) {
+        return new PublicationPermissions(resource, userInstance);
     }
 
     public boolean isCuratorOnPublication() {
@@ -112,7 +112,7 @@ public class PublicationPermissions {
             logger.info("User {} was denied access {} on publication {} from strategies {}",
                         userInstance.getUsername(),
                         requestedPermission,
-                        publication.getIdentifier(),
+                        resource.getIdentifier(),
                         String.join(COMMA_DELIMITER, strategies));
 
             throw new UnauthorizedException(formatUnauthorizedMessage(requestedPermission));
@@ -132,13 +132,13 @@ public class PublicationPermissions {
         logger.info("User {} was allowed {} on publication {} from strategies {}",
                     userInstance.getUsername(),
                     requestedPermission,
-                    publication.getIdentifier(),
+                    resource.getIdentifier(),
                     String.join(COMMA_DELIMITER, strategies));
     }
 
     private String formatUnauthorizedMessage(PublicationOperation requestedPermission) {
         return String.format("Unauthorized: %s is not allowed to perform %s on %s", userInstance.getUsername(),
-                             requestedPermission, publication.getIdentifier());
+                             requestedPermission, resource.getIdentifier());
     }
 
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
@@ -7,17 +7,17 @@ import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
 import static no.unit.nva.model.associatedartifacts.file.File.ACCEPTED_FILE_TYPES;
-import static nva.commons.core.attempt.Try.attempt;
 import java.util.Arrays;
 import java.util.Optional;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
-import no.unit.nva.model.Publication;
+import no.unit.nva.model.Identity;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import nva.commons.apigateway.AccessRight;
 import org.slf4j.Logger;
@@ -27,11 +27,11 @@ public class PublicationStrategyBase {
 
     public static final Logger logger = LoggerFactory.getLogger(PublicationStrategyBase.class);
 
-    protected final Publication publication;
+    protected final Resource resource;
     protected final UserInstance userInstance;
 
-    protected PublicationStrategyBase(Publication publication, UserInstance userInstance) {
-        this.publication = publication;
+    protected PublicationStrategyBase(Resource resource, UserInstance userInstance) {
+        this.resource = resource;
         this.userInstance = userInstance;
     }
 
@@ -40,7 +40,7 @@ public class PublicationStrategyBase {
     }
 
     protected boolean isProtectedDegreeInstanceType() {
-        return Optional.ofNullable(publication.getEntityDescription())
+        return Optional.ofNullable(resource.getEntityDescription())
                    .map(EntityDescription::getReference)
                    .map(Reference::getPublicationInstance)
                    .map(PublicationStrategyBase::publicationInstanceIsDegree)
@@ -59,22 +59,22 @@ public class PublicationStrategyBase {
         var userTopLevelOrg = userInstance.getTopLevelOrgCristinId();
 
         logger.info("found topLevels {} for user {} of {}.",
-                    publication.getCuratingInstitutions(),
+                    resource.getCuratingInstitutions(),
                     userInstance.getUser(),
                     userTopLevelOrg);
-        return publication.getCuratingInstitutions().stream().anyMatch(org -> org.id().equals(userTopLevelOrg));
+        return resource.getCuratingInstitutions().stream().anyMatch(org -> org.id().equals(userTopLevelOrg));
     }
 
     protected boolean userIsFromSameInstitutionAsPublicationOwner() {
-        if (isNull(userInstance) || isNull(userInstance.getTopLevelOrgCristinId()) || isNull(publication.getResourceOwner())) {
+        if (isNull(userInstance) || isNull(userInstance.getTopLevelOrgCristinId()) || isNull(resource.getResourceOwner())) {
             return false;
         }
 
-        return userInstance.getTopLevelOrgCristinId().equals(publication.getResourceOwner().getOwnerAffiliation());
+        return userInstance.getTopLevelOrgCristinId().equals(resource.getResourceOwner().getOwnerAffiliation());
     }
 
     protected boolean isProtectedDegreeInstanceTypeWithEmbargo() {
-        return isProtectedDegreeInstanceType() && publication.getAssociatedArtifacts().stream()
+        return isProtectedDegreeInstanceType() && resource.getAssociatedArtifacts().stream()
                                                       .filter(File.class::isInstance)
                                                       .map(File.class::cast)
                                                       .anyMatch(this::hasEmbargo);
@@ -85,38 +85,39 @@ public class PublicationStrategyBase {
     }
 
     protected boolean isVerifiedContributor(Contributor contributor) {
-        return contributor.getIdentity() != null && contributor.getIdentity().getId() != null;
+        return Optional.ofNullable(contributor.getIdentity()).map(Identity::getId).isPresent();
     }
 
     protected boolean hasApprovedFiles() {
-        return publication.getAssociatedArtifacts()
+        return resource.getAssociatedArtifacts()
                    .stream()
                    .anyMatch(artifact -> ACCEPTED_FILE_TYPES
                                              .contains(artifact.getClass()));
     }
 
     protected boolean hasOpenFiles() {
-        return publication.getAssociatedArtifacts()
+        return resource.getAssociatedArtifacts()
                    .stream()
                    .anyMatch(OpenFile.class::isInstance);
     }
 
     protected boolean isOwner() {
-        return nonNull(userInstance) && attempt(userInstance::getUsername)
-                   .map(username -> UserInstance.fromPublication(publication).getUsername().equals(username))
-                   .orElse(fail -> false);
+        var owner = UserInstance.fromPublication(resource.toPublication()).getUsername();
+        return Optional.ofNullable(userInstance)
+                   .map(userInstance -> owner.equals(userInstance.getUsername()))
+                   .orElse(false);
     }
 
     protected boolean isDraft() {
-        return publication.getStatus().equals(DRAFT);
+        return resource.getStatus().equals(DRAFT);
     }
 
     protected boolean isUnpublished() {
-        return publication.getStatus().equals(UNPUBLISHED);
+        return resource.getStatus().equals(UNPUBLISHED);
     }
 
     protected boolean isPublished() {
-        return publication.getStatus().equals(PUBLISHED);
+        return resource.getStatus().equals(PUBLISHED);
     }
 
     private static Boolean publicationInstanceIsDegree(PublicationInstance<? extends Pages> publicationInstance) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/BackendClientGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/BackendClientGrantStrategy.java
@@ -1,16 +1,16 @@
 package no.unit.nva.publication.permissions.publication.grant;
 
 import static java.util.Objects.nonNull;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationGrantStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public final class BackendClientGrantStrategy extends PublicationStrategyBase implements PublicationGrantStrategy {
 
-    public BackendClientGrantStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public BackendClientGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ContributorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ContributorGrantStrategy.java
@@ -4,16 +4,16 @@ import static java.util.Objects.nonNull;
 import java.util.List;
 import java.util.Optional;
 import no.unit.nva.model.EntityDescription;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationGrantStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public final class ContributorGrantStrategy extends PublicationStrategyBase implements PublicationGrantStrategy {
 
-    public ContributorGrantStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public ContributorGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override
@@ -43,7 +43,7 @@ public final class ContributorGrantStrategy extends PublicationStrategyBase impl
     private boolean userIsVerifiedContributor() {
         return nonNull(userInstance)
                 && nonNull(this.userInstance.getPersonCristinId())
-                && Optional.ofNullable(publication.getEntityDescription())
+                && Optional.ofNullable(resource.getEntityDescription())
                    .map(EntityDescription::getContributors)
                    .stream()
                    .flatMap(List::stream)
@@ -57,7 +57,7 @@ public final class ContributorGrantStrategy extends PublicationStrategyBase impl
     }
 
     private boolean userInstitutionIsCuratingInstitution() {
-        return publication.getCuratingInstitutions()
+        return resource.getCuratingInstitutions()
                    .stream()
                    .anyMatch(curatingInstitution ->
                                  curatingInstitution.id().equals(userInstance.getTopLevelOrgCristinId()));

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/CuratorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/CuratorGrantStrategy.java
@@ -7,7 +7,6 @@ import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCE_FILES;
 import static nva.commons.apigateway.AccessRight.SUPPORT;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -20,8 +19,8 @@ public final class CuratorGrantStrategy extends PublicationStrategyBase implemen
 
     public static final Logger logger = LoggerFactory.getLogger(CuratorGrantStrategy.class);
 
-    public CuratorGrantStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public CuratorGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override
@@ -44,7 +43,7 @@ public final class CuratorGrantStrategy extends PublicationStrategyBase implemen
     }
 
     private boolean canApproveFiles() {
-        return Resource.fromPublication(publication).isDegree()
+        return resource.isDegree()
                    ? hasAccessRight(MANAGE_DEGREE) || hasAccessRight(MANAGE_DEGREE_EMBARGO)
                    : canManagePublishingRequests();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/EditorGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/EditorGrantStrategy.java
@@ -1,17 +1,16 @@
 package no.unit.nva.publication.permissions.publication.grant;
 
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationGrantStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public final class EditorGrantStrategy extends PublicationStrategyBase implements PublicationGrantStrategy {
 
-    public EditorGrantStrategy(Publication publication,
-                               UserInstance userInstance) {
-        super(publication, userInstance);
+    public EditorGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ResourceOwnerGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/ResourceOwnerGrantStrategy.java
@@ -1,15 +1,15 @@
 package no.unit.nva.publication.permissions.publication.grant;
 
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationGrantStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public final class ResourceOwnerGrantStrategy extends PublicationStrategyBase implements PublicationGrantStrategy {
 
-    public ResourceOwnerGrantStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public ResourceOwnerGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/TrustedThirdPartyGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/grant/TrustedThirdPartyGrantStrategy.java
@@ -2,17 +2,16 @@ package no.unit.nva.publication.permissions.publication.grant;
 
 import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationGrantStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public final class TrustedThirdPartyGrantStrategy extends PublicationStrategyBase implements PublicationGrantStrategy {
 
-    public TrustedThirdPartyGrantStrategy(Publication publication,
-                                          UserInstance userInstance) {
-        super(publication, userInstance);
+    public TrustedThirdPartyGrantStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override
@@ -40,7 +39,7 @@ public final class TrustedThirdPartyGrantStrategy extends PublicationStrategyBas
         return nonNull(userInstance)
                && userInstance.isExternalClient()
                && attempt(
-                   () -> userInstance.getCustomerId().equals(publication.getPublisher().getId()))
+                   () -> userInstance.getCustomerId().equals(resource.getPublisher().getId()))
                       .orElse(fail -> false);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
@@ -9,9 +9,9 @@ import java.util.Collection;
 import java.util.Optional;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.CuratingInstitution;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.role.RoleType;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationDenyStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
@@ -21,8 +21,8 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
     private static final boolean DENY = true;
     private static final boolean PASS = false;
 
-    public DegreeDenyStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public DegreeDenyStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
     }
 
     private Optional<CuratingInstitution> getCuratingInstitutionsForCurrentUser() {
-        return Optional.ofNullable(publication.getCuratingInstitutions())
+        return Optional.ofNullable(resource.getCuratingInstitutions())
                    .stream()
                    .flatMap(Collection::stream)
                    .filter(org -> nonNull(userInstance) && org.id().equals(userInstance.getTopLevelOrgCristinId()))
@@ -89,7 +89,7 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
     }
 
     private Optional<Contributor> getContributor(URI contributorId) {
-        return publication.getEntityDescription()
+        return resource.getEntityDescription()
                    .getContributors()
                    .stream()
                    .filter(contributor -> contributorId.equals(contributor.getIdentity().getId()))

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
@@ -1,19 +1,19 @@
 package no.unit.nva.publication.permissions.publication.restrict;
 
 import static no.unit.nva.model.PublicationStatus.DELETED;
-import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationOperation;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.permissions.publication.PublicationDenyStrategy;
 import no.unit.nva.publication.permissions.publication.PublicationStrategyBase;
 
 public class DeletedUploadDenyStrategy extends PublicationStrategyBase implements PublicationDenyStrategy {
-    public DeletedUploadDenyStrategy(Publication publication, UserInstance userInstance) {
-        super(publication, userInstance);
+    public DeletedUploadDenyStrategy(Resource resource, UserInstance userInstance) {
+        super(resource, userInstance);
     }
 
     @Override
     public boolean deniesAction(PublicationOperation permission) {
-        return DELETED.equals(publication.getStatus()) && permission.equals(PublicationOperation.UPLOAD_FILE);
+        return DELETED.equals(resource.getStatus()) && permission.equals(PublicationOperation.UPLOAD_FILE);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/PublishingService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/PublishingService.java
@@ -76,7 +76,7 @@ public class PublishingService {
     }
 
     private static void validatePermissions(Resource resource, UserInstance userInstance) throws ForbiddenException {
-        var permissionStrategy = PublicationPermissions.create(resource.toPublication(), userInstance);
+        var permissionStrategy = PublicationPermissions.create(resource, userInstance);
         if (!permissionStrategy.allowsAction(PublicationOperation.UPDATE)) {
             throw new ForbiddenException();
         }

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
@@ -75,7 +75,7 @@ public class PublicationScenarioContext {
                     randomResource.getEntityDescription().copy().withContributors(contributors).build())
                 .build();
 
-        return new PublicationPermissions(resource.toPublication(), user);
+        return new PublicationPermissions(resource, user);
     }
 
     private static HashSet<CuratingInstitution> getCuratingInstitutions(boolean currentUserIsFileCurator,

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/UserInstanceTest.java
@@ -31,6 +31,15 @@ class UserInstanceTest {
         assertThat(userInstance.getCustomerId(), is(equalTo(publication.getPublisher().getId())));
     }
 
+    @Test
+    void shouldReturnUserInstanceFromPublicationWhenPublisherIsNull() {
+        var publication = randomPublication();
+        publication.setPublisher(null);
+        var userInstance = UserInstance.fromPublication(publication);
+        assertThat(userInstance.getUsername(), is(equalTo(publication.getResourceOwner().getOwner().getValue())));
+        assertThat(userInstance.getCustomerId(), is(equalTo(null)));
+    }
+
     @ParameterizedTest
     @MethodSource("no.unit.nva.publication.ticket.test.TicketTestUtils#ticketTypeAndPublicationStatusProvider")
     void shouldReturnUserInstanceFromMessage(Class<? extends TicketEntry> ticketType, PublicationStatus status) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/BackendClientStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/BackendClientStrategyTest.java
@@ -9,6 +9,7 @@ import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,7 +31,7 @@ class BackendClientStrategyTest extends PublicationPermissionStrategyTest {
                 .build();
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ContributorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ContributorPermissionStrategyTest.java
@@ -8,6 +8,7 @@ import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class ContributorPermissionStrategyTest extends PublicationPermissionStrategyTes
 
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -61,7 +62,7 @@ class ContributorPermissionStrategyTest extends PublicationPermissionStrategyTes
 
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -82,7 +83,7 @@ class ContributorPermissionStrategyTest extends PublicationPermissionStrategyTes
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -106,7 +107,7 @@ class ContributorPermissionStrategyTest extends PublicationPermissionStrategyTes
                                                            topLevelCristinOrgId);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication,
+                                   .create(Resource.fromPublication(publication),
                                            RequestUtil.createUserInstanceFromRequest(
                                                requestInfo,
                                                identityServiceClient))

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/CuratorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/CuratorPermissionStrategyTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
@@ -43,7 +44,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -70,7 +71,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -91,7 +92,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -104,7 +105,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var requestInfo = createUserRequestInfo(username, institution, getAccessRightsForCurator(), randomUri(),
                                                 cristinId);
         var publication = createNonDegreePublication(username, institution, cristinId);
-        var permissionStrategy = PublicationPermissions.create(publication,
+        var permissionStrategy = PublicationPermissions.create(Resource.fromPublication(publication),
                                                                RequestUtil.createUserInstanceFromRequest(
                                                                           requestInfo, identityServiceClient));
         assertThat(permissionStrategy.isCuratorOnPublication(), is(equalTo(true)));
@@ -128,7 +129,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -153,7 +154,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -171,7 +172,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -193,7 +194,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -210,7 +211,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(PublicationOperation.APPROVE_FILES));
     }
 
@@ -227,7 +228,7 @@ class CuratorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(PublicationOperation.APPROVE_FILES));
     }
     //endregion

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -28,6 +28,7 @@ import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
 import no.unit.nva.model.testing.associatedartifacts.util.RightsRetentionStrategyGenerator;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.testutils.RandomDataGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
@@ -51,8 +52,23 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                             registrator.topLevelCristinId);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, null)
+                                  .create(Resource.fromPublication(publication), null)
                                   .allowsAction(operation));
+    }
+
+    @ParameterizedTest(name = "Should deny anonymous user {0} operation on instance type {1} when degree has no open "
+                              + "files")
+    @MethodSource("argumentsForAnonymousUser")
+    void kjjh(PublicationOperation operation, Class<?> degreeInstanceClass) {
+        var registrator = User.random();
+        var publication = createPublicationWithoutOpenFiles(degreeInstanceClass,
+                                                            registrator.name,
+                                                            registrator.customer,
+                                                            registrator.topLevelCristinId);
+
+        Assertions.assertFalse(PublicationPermissions
+                                   .create(Resource.fromPublication(publication), null)
+                                   .allowsAction(operation));
     }
 
     @ParameterizedTest(name = "Should deny anonymous user {0} operation on instance type {1} when degree has open "
@@ -66,7 +82,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                         registrator.topLevelCristinId);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, null)
+                                   .create(Resource.fromPublication(publication), null)
                                    .allowsAction(operation));
     }
 
@@ -95,7 +111,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publicationWithStatus, userInstance)
+                                  .create(Resource.fromPublication(publicationWithStatus), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -114,7 +130,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -147,7 +163,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                       identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -176,7 +192,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -198,7 +214,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -220,7 +236,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -249,7 +265,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -279,7 +295,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -302,7 +318,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator), identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -325,7 +341,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator), identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -355,7 +371,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -386,7 +402,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -410,7 +426,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator), identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publicationWithPendingFileWithEmbargo, userInstance)
+                                  .create(Resource.fromPublication(publicationWithPendingFileWithEmbargo), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -432,7 +448,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator), identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publicationWithOpenFileWithEmbargo, userInstance)
+                                  .create(Resource.fromPublication(publicationWithOpenFileWithEmbargo), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -455,7 +471,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(embargoThesisCurator), identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publicationWithPendingFileWithEmbargo, userInstance)
+                                  .create(Resource.fromPublication(publicationWithPendingFileWithEmbargo), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -479,7 +495,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publicationWithOpenFileWithEmbargo, userInstance)
+                                  .create(Resource.fromPublication(publicationWithOpenFileWithEmbargo), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -515,7 +531,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -553,7 +569,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -587,7 +603,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -626,7 +642,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -658,7 +674,7 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                      identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -56,21 +56,6 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                   .allowsAction(operation));
     }
 
-    @ParameterizedTest(name = "Should deny anonymous user {0} operation on instance type {1} when degree has no open "
-                              + "files")
-    @MethodSource("argumentsForAnonymousUser")
-    void kjjh(PublicationOperation operation, Class<?> degreeInstanceClass) {
-        var registrator = User.random();
-        var publication = createPublicationWithoutOpenFiles(degreeInstanceClass,
-                                                            registrator.name,
-                                                            registrator.customer,
-                                                            registrator.topLevelCristinId);
-
-        Assertions.assertFalse(PublicationPermissions
-                                   .create(Resource.fromPublication(publication), null)
-                                   .allowsAction(operation));
-    }
-
     @ParameterizedTest(name = "Should deny anonymous user {0} operation on instance type {1} when degree has open "
                               + "files")
     @MethodSource("argumentsForAnonymousUser")

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/EditorPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/EditorPermissionStrategyTest.java
@@ -11,6 +11,7 @@ import no.unit.nva.model.CuratingInstitution;
 import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +39,7 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -57,7 +58,7 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(UPDATE));
     }
 
@@ -81,7 +82,7 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -99,7 +100,7 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -119,7 +120,7 @@ class EditorPermissionStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(REPUBLISH));
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
@@ -63,6 +63,7 @@ import no.unit.nva.model.pages.MonographPages;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -109,7 +110,7 @@ class PublicationPermissionStrategyTest {
         var publication = createPublication(randomString(), randomUri(), randomUri());
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, RequestUtil.createUserInstanceFromRequest(
+                                   .create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                                        requestInfo, identityServiceClient))
                                    .allowsAction(UNPUBLISH));
     }
@@ -123,7 +124,7 @@ class PublicationPermissionStrategyTest {
 
         Assertions.assertThrows(UnauthorizedException.class, () ->
                                                                  PublicationPermissions
-                                                                     .create(publication,
+                                                                     .create(Resource.fromPublication(publication),
                                                                              RequestUtil.createUserInstanceFromRequest(
                                                                                  requestInfo, identityServiceClient))
                                                                      .allowsAction(UNPUBLISH));
@@ -134,7 +135,7 @@ class PublicationPermissionStrategyTest {
         var publication = createDegreePhd(randomString(), randomUri());
         var requestInfo = createThirdPartyRequestInfo(getAccessRightsForCurator());
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
-        var strategy = PublicationPermissions.create(publication, userInstance);
+        var strategy = PublicationPermissions.create(Resource.fromPublication(publication), userInstance);
 
         Assertions.assertThrows(UnauthorizedException.class, () -> strategy.authorize(UPDATE));
     }
@@ -151,7 +152,7 @@ class PublicationPermissionStrategyTest {
         var publication = createPublication(resourceOwner, editorInstitution, randomUri());
 
         assertThat(
-            PublicationPermissions.create(publication, RequestUtil.createUserInstanceFromRequest(
+            PublicationPermissions.create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                     requestInfo, identityServiceClient))
                 .getAllAllowedActions(), is(empty()));
     }
@@ -170,7 +171,7 @@ class PublicationPermissionStrategyTest {
         var publication = createPublication(resourceOwner, editorInstitution, topLevelCristinOrgId);
 
         assertThat(
-            PublicationPermissions.create(publication, RequestUtil.createUserInstanceFromRequest(
+            PublicationPermissions.create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                     requestInfo, identityServiceClient))
                 .getAllAllowedActions(), hasItems(UPDATE, UNPUBLISH, UPDATE_FILES));
     }
@@ -189,7 +190,7 @@ class PublicationPermissionStrategyTest {
                                                            randomUri(), randomUri());
 
         PublicationPermissions
-            .create(publication, RequestUtil.createUserInstanceFromRequest(
+            .create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                 requestInfo, identityServiceClient))
             .authorize(UPDATE);
         assertThat(appender.getMessages(), containsString(contributorName));
@@ -211,7 +212,7 @@ class PublicationPermissionStrategyTest {
         var publication = createPublication(resourceOwner, editorInstitution, topLevelCristinOrgId);
 
         assertTrue(
-            PublicationPermissions.create(publication, RequestUtil.createUserInstanceFromRequest(
+            PublicationPermissions.create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                     requestInfo, identityServiceClient))
                 .isPublishingCuratorOnPublication());
     }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ResourceOwnerPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ResourceOwnerPermissionStrategyTest.java
@@ -22,6 +22,7 @@ import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.associatedartifacts.file.PendingInternalFile;
 import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +50,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -68,7 +69,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -91,7 +92,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(PublicationOperation.UNPUBLISH));
     }
 
@@ -114,7 +115,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertTrue(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(PublicationOperation.UNPUBLISH));
     }
     //endregion
@@ -134,7 +135,7 @@ class ResourceOwnerPermissionStrategyTest extends PublicationPermissionStrategyT
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/TrustedThirdPartyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/TrustedThirdPartyStrategyTest.java
@@ -14,6 +14,7 @@ import no.unit.nva.model.PublicationOperation;
 import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import org.junit.jupiter.api.Assertions;
@@ -40,7 +41,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
                 .build();
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(operation));
     }
 
@@ -55,7 +56,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(operation));
     }
 
@@ -72,7 +73,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
                 .build();
 
         Assertions.assertTrue(PublicationPermissions
-                                  .create(publication, userInstance)
+                                  .create(Resource.fromPublication(publication), userInstance)
                                   .allowsAction(DELETE));
     }
 
@@ -89,7 +90,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
                 .build();
 
         Assertions.assertFalse(PublicationPermissions
-                                   .create(publication, userInstance)
+                                   .create(Resource.fromPublication(publication), userInstance)
                                    .allowsAction(DELETE));
     }
 
@@ -101,7 +102,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
         var requestInfo = createThirdPartyRequestInfo();
 
         Assertions.assertFalse(
-            PublicationPermissions.create(publication, RequestUtil.createUserInstanceFromRequest(
+            PublicationPermissions.create(Resource.fromPublication(publication), RequestUtil.createUserInstanceFromRequest(
                     requestInfo, identityServiceClient))
                 .allowsAction(UPDATE));
     }
@@ -115,7 +116,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
                                           userInstanse.getTopLevelOrgCristinId());
 
         Assertions.assertTrue(
-            PublicationPermissions.create(publication, userInstanse)
+            PublicationPermissions.create(Resource.fromPublication(publication), userInstanse)
                 .allowsAction(UPDATE));
     }
 
@@ -128,7 +129,7 @@ class TrustedThirdPartyStrategyTest extends PublicationPermissionStrategyTest {
         var publication = createDegreePhd(randomString(), publisher, userInstanse.getTopLevelOrgCristinId());
 
         Assertions.assertFalse(
-            PublicationPermissions.create(publication, userInstanse)
+            PublicationPermissions.create(Resource.fromPublication(publication), userInstanse)
                 .allowsAction(UPDATE));
     }
 }

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
@@ -154,7 +154,7 @@ public class FileService {
 
     private static void validateUploadPermissions(UserInstance userInstance, Resource resource)
         throws ForbiddenException {
-        if (!new PublicationPermissions(resource.toPublication(), userInstance)
+        if (!new PublicationPermissions(resource, userInstance)
                  .allowsAction(PublicationOperation.UPLOAD_FILE)) {
             throw new ForbiddenException();
         }

--- a/publication-log/src/main/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandler.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/rest/FetchPublicationLogHandler.java
@@ -65,8 +65,7 @@ public class FetchPublicationLogHandler extends ApiGatewayHandler<Void, Publicat
 
     private static boolean userHasNoAccessToLog(RequestInfo requestInfo, Resource resource)
         throws UnauthorizedException {
-        return !PublicationPermissions.create(resource.toPublication(),
-                                              UserInstance.fromRequestInfo(requestInfo))
+        return !PublicationPermissions.create(resource, UserInstance.fromRequestInfo(requestInfo))
                     .allowsAction(PublicationOperation.UPDATE);
     }
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/PublicationResponseFactory.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/PublicationResponseFactory.java
@@ -27,7 +27,7 @@ public final class PublicationResponseFactory {
     public static PublicationResponse create(Resource resource, RequestInfo requestInfo,
                                              IdentityServiceClient identityServiceClient) {
         var userInstance = getUserInstance(requestInfo, identityServiceClient);
-        var publicationPermissions = PublicationPermissions.create(resource.toPublication(), userInstance);
+        var publicationPermissions = PublicationPermissions.create(resource, userInstance);
 
         if (hasAuthenticatedAccessOnPublication(publicationPermissions)) {
             return createAuthenticatedResponse(publicationPermissions, resource, userInstance);

--- a/publication-rest/src/main/java/no/unit/nva/publication/delete/DeletePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/delete/DeletePublicationHandler.java
@@ -7,6 +7,7 @@ import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.publication.RequestUtil;
+import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.permissions.publication.PublicationPermissions;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -60,7 +61,7 @@ public class DeletePublicationHandler extends ApiGatewayHandler<Void, Void> {
         var publication = resourceService.getPublicationByIdentifier(publicationIdentifier);
 
         if (publication.getStatus() == PublicationStatus.DRAFT) {
-            PublicationPermissions.create(publication, userInstance).authorize(DELETE);
+            PublicationPermissions.create(Resource.fromPublication(publication), userInstance).authorize(DELETE);
             resourceService.deleteDraftPublication(userInstance, publicationIdentifier);
         } else {
             unsupportedPublicationForDeletion(publication);

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -210,7 +210,7 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
     private Optional<PublicationPermissions> getPublicationPermissionStrategy(RequestInfo requestInfo,
                                                                               Resource resource) {
         return attempt(() -> RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient)).toOptional()
-                   .map(userInstance -> PublicationPermissions.create(resource.toPublication(), userInstance));
+                   .map(userInstance -> PublicationPermissions.create(resource, userInstance));
     }
 
     private String createDataCiteMetadata(Resource resource) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -140,7 +140,7 @@ public class UpdatePublicationHandler
         var existingResource = fetchResource(identifierInPath);
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
-        var permissionStrategy = PublicationPermissions.create(existingResource.toPublication(), userInstance);
+        var permissionStrategy = PublicationPermissions.create(existingResource, userInstance);
         var updatedPublication = switch (input) {
             case UpdatePublicationRequest publicationMetadata -> updateMetadata(publicationMetadata,
                                                                                 identifierInPath,

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -67,7 +67,7 @@ public class TicketResolver {
 
     private void validateUserPermissions(Resource resource, TicketDto ticketDto, UserInstance userInstance)
         throws ForbiddenException {
-        var permissionStrategy = PublicationPermissions.create(resource.toPublication(), userInstance);
+        var permissionStrategy = PublicationPermissions.create(resource, userInstance);
         if (!userHasPermissionToCreateTicket(permissionStrategy, ticketDto)) {
             logger.error(CREATING_TICKET_ERROR_MESSAGE,
                          ticketDto.ticketType().getSimpleName(),

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
@@ -89,7 +89,7 @@ public class ListTicketsForPublicationHandler extends TicketHandler<Void, Ticket
     }
 
     private boolean isAllowedToListTickets(UserInstance userInstance, Resource resource) {
-        return PublicationPermissions.create(resource.toPublication(), userInstance)
+        return PublicationPermissions.create(resource, userInstance)
                    .allowsAction(PublicationOperation.UPDATE);
     }
 


### PR DESCRIPTION
Before using PublicationChannels in PermissionStrategy, the strategy needs the Resource object to perform its duties. This PR changes the constructor of the PublicationPermissions class to receive a resource instead of publication. With this change, it might be worth the effort to rename the class to ResourcePermissions, but that can be a separate PR.