### PR TITLE
Move curatingInstitutions from ElevatedResponse to Response

### DIFF
--- a/publication-model/src/main/java/no/unit/nva/api/PublicationResponse.java
+++ b/publication-model/src/main/java/no/unit/nva/api/PublicationResponse.java
@@ -22,6 +22,7 @@ import no.unit.nva.WithInternal;
 import no.unit.nva.WithMetadata;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.CuratingInstitution;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.Organization;
@@ -61,6 +62,7 @@ public class PublicationResponse implements WithIdentifier, WithInternal, WithMe
     private List<URI> subjects;
     private List<AssociatedArtifactDto> associatedArtifacts;
     private List<ImportDetail> importDetails;
+    private Set<CuratingInstitution> curatingInstitutions;
 
     private Set<AdditionalIdentifierBase> additionalIdentifiers;
     private String rightsHolder;
@@ -95,6 +97,7 @@ public class PublicationResponse implements WithIdentifier, WithInternal, WithMe
         response.setAllowedOperations(Set.of());
         response.setImportDetails(publication.getImportDetails());
         response.setPendingOpenFileCount(publication.getPendingOpenFileCount());
+        response.setCuratingInstitutions(publication.getCuratingInstitutions());
         return response;
     }
 
@@ -323,6 +326,14 @@ public class PublicationResponse implements WithIdentifier, WithInternal, WithMe
         this.importDetails = new ArrayList<>(importDetails);
     }
 
+    public Set<CuratingInstitution> getCuratingInstitutions() {
+        return curatingInstitutions;
+    }
+
+    public void setCuratingInstitutions(Set<CuratingInstitution> curatingInstitutions) {
+        this.curatingInstitutions = curatingInstitutions;
+    }
+
     @Override
     public Set<AdditionalIdentifierBase> getAdditionalIdentifiers() {
         return additionalIdentifiers;
@@ -374,7 +385,8 @@ public class PublicationResponse implements WithIdentifier, WithInternal, WithMe
                             getRightsHolder(),
                             getAllowedOperations(),
                             getImportDetails(),
-                            getPendingOpenFileCount());
+                            getPendingOpenFileCount(),
+                            getCuratingInstitutions());
     }
 
     @Override
@@ -408,6 +420,7 @@ public class PublicationResponse implements WithIdentifier, WithInternal, WithMe
                && Objects.equals(getRightsHolder(), that.getRightsHolder())
                && Objects.equals(getAllowedOperations(), that.getAllowedOperations())
                && Objects.equals(getImportDetails(), that.getImportDetails())
-               && Objects.equals(getPendingOpenFileCount(), that.getPendingOpenFileCount());
+               && Objects.equals(getPendingOpenFileCount(), that.getPendingOpenFileCount())
+               && Objects.equals(getCuratingInstitutions(), that.getCuratingInstitutions());
     }
 }

--- a/publication-model/src/main/java/no/unit/nva/api/PublicationResponseElevatedUser.java
+++ b/publication-model/src/main/java/no/unit/nva/api/PublicationResponseElevatedUser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import no.unit.nva.model.CuratingInstitution;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationNoteBase;
 import no.unit.nva.model.PublicationOperation;
@@ -19,7 +18,6 @@ import nva.commons.core.JacocoGenerated;
 public class PublicationResponseElevatedUser extends PublicationResponse {
 
     private List<PublicationNoteBase> publicationNotes;
-    private Set<CuratingInstitution> curatingInstitutions;
 
     public static PublicationResponseElevatedUser fromPublication(Publication publication) {
         var response = new PublicationResponseElevatedUser();
@@ -70,14 +68,6 @@ public class PublicationResponseElevatedUser extends PublicationResponse {
         this.publicationNotes = publicationNotes;
     }
 
-    public Set<CuratingInstitution> getCuratingInstitutions() {
-        return curatingInstitutions;
-    }
-
-    public void setCuratingInstitutions(Set<CuratingInstitution> curatingInstitutions) {
-        this.curatingInstitutions = curatingInstitutions;
-    }
-
     @Override
     public List<AssociatedArtifactDto> getAssociatedArtifacts() {
         return super.getAssociatedArtifactsForElevatedUser();
@@ -86,7 +76,7 @@ public class PublicationResponseElevatedUser extends PublicationResponse {
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), publicationNotes, curatingInstitutions);
+        return Objects.hash(super.hashCode(), publicationNotes);
     }
 
     @JacocoGenerated
@@ -102,7 +92,6 @@ public class PublicationResponseElevatedUser extends PublicationResponse {
             return false;
         }
         PublicationResponseElevatedUser that = (PublicationResponseElevatedUser) o;
-        return Objects.equals(publicationNotes, that.publicationNotes)
-               && Objects.equals(curatingInstitutions, that.curatingInstitutions);
+        return Objects.equals(publicationNotes, that.publicationNotes);
     }
 }


### PR DESCRIPTION
Moved to non elevated response for debuggin purposes. Have created a task in Jira to remind removal of this response field. Might cause problems on monster posts with thousands of contributors.