### PR TITLE
Use accepted file instead of open file to determine turning point for channel claim policy

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
@@ -6,7 +6,6 @@ import static no.unit.nva.publication.model.business.publicationchannel.ChannelP
 import static no.unit.nva.publication.model.business.publicationchannel.ChannelPolicy.OWNER_ONLY;
 import java.net.URI;
 import no.unit.nva.model.PublicationOperation;
-import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.publicationchannel.ChannelPolicy;
@@ -50,13 +49,9 @@ public class ClaimedChannelDenyStrategy extends PublicationStrategyBase implemen
         var publishingPolicy = channelConstraint.publishingPolicy();
         var organization = claimedPublicationChannel.getOrganizationId();
 
-        return hasOpenFiles()
+        return hasApprovedFiles()
                    ? channelPolicyDenies(editingPolicy, organization)
                    : channelPolicyDenies(publishingPolicy, organization);
-    }
-
-    private boolean hasOpenFiles() {
-        return resource.getFiles().stream().anyMatch(OpenFile.class::isInstance);
     }
 
     private boolean channelPolicyDenies(ChannelPolicy policy, URI organizationId) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ClaimedChannelPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ClaimedChannelPermissionStrategyTest.java
@@ -42,7 +42,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -62,10 +62,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = operation == PublicationOperation.UNPUBLISH
-                              ? createNonDegreePublicationWithoutOpenOrInternalFiles(registrator)
-                              : createNonDegreePublicationWithoutOpenFiles(registrator);
-
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
                                         .build();
@@ -88,7 +85,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -110,9 +107,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = operation == PublicationOperation.UNPUBLISH
-                              ? createNonDegreePublicationWithoutOpenOrInternalFiles(registrator)
-                              : createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -136,9 +131,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = operation == PublicationOperation.UNPUBLISH
-                              ? createNonDegreePublicationWithoutOpenOrInternalFiles(registrator)
-                              : createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -163,7 +156,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -186,7 +179,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -209,10 +202,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = operation == PublicationOperation.UNPUBLISH
-                              ? createNonDegreePublicationWithoutOpenOrInternalFiles(registrator)
-                              : createNonDegreePublicationWithoutOpenFiles(registrator);
-
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
                                         .build();
@@ -238,7 +228,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -312,7 +302,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(owningInstitution.registrator());
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(owningInstitution.registrator());
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -412,7 +402,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -437,7 +427,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(owningInstitution.registrator());
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(owningInstitution.registrator());
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -461,7 +451,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, EVERYONE);
@@ -484,7 +474,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, EVERYONE);
@@ -507,7 +497,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var contributor = owningInstitution.contributor();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -531,7 +521,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -556,7 +546,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -582,7 +572,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -606,7 +596,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -629,7 +619,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -676,7 +666,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -701,7 +691,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -727,7 +717,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -751,7 +741,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -775,7 +765,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, nonCuratingInstitution, EVERYONE, EVERYONE);
@@ -798,7 +788,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator).copy()
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator).copy()
                               .withStatus(operation == PublicationOperation.REPUBLISH ? UNPUBLISHED : PUBLISHED)
                               .build();
 
@@ -823,7 +813,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator).copy()
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator).copy()
                               .withStatus(operation == PublicationOperation.REPUBLISH ? UNPUBLISHED : PUBLISHED)
                               .build();
 
@@ -848,7 +838,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator).copy()
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator).copy()
                               .withStatus(operation == PublicationOperation.REPUBLISH ? UNPUBLISHED : PUBLISHED)
                               .build();
 
@@ -869,7 +859,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
 
@@ -886,7 +876,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
 
@@ -904,7 +894,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, contributor);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -923,7 +913,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, contributor);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -942,7 +932,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
 
@@ -960,7 +950,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
 
@@ -979,7 +969,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -999,7 +989,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1019,7 +1009,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -1039,7 +1029,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1060,7 +1050,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -1081,7 +1071,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1097,7 +1087,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
     void shouldAllowExternalUserWhenPublishingPolicyOwnerOnly() {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createNonDegreePublicationWithoutOpenFiles(registrator);
+        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -1112,7 +1102,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
     void shouldAllowExternalUserWhenEditingPolicyOwnerOnly() {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -1131,7 +1121,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1150,7 +1140,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curator = owningInstitution.curator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1169,7 +1159,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var editor = owningInstitution.editor();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithOpenFile(registrator);
+        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1264,24 +1254,17 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
                                      user.topLevelCristinId());
     }
 
-    private Publication createNonDegreePublicationWithOpenFile(User registrator) {
-        return createPublicationWithOpenFile(AcademicArticle.class,
-                                             registrator.name(),
-                                             registrator.customer(),
-                                             registrator.topLevelCristinId());
-    }
-
-    private Publication createNonDegreePublicationWithoutOpenFiles(User registrator) {
-        return createPublicationWithoutOpenFiles(AcademicArticle.class,
+    private Publication createNonDegreePublicationWithAcceptedFile(User registrator) {
+        return createPublicationWithAcceptedFile(AcademicArticle.class,
                                                  registrator.name(),
                                                  registrator.customer(),
                                                  registrator.topLevelCristinId());
     }
 
     private Publication createNonDegreePublicationWithoutOpenOrInternalFiles(User registrator) {
-        return createPublicationWithoutOpenOrInternalFiles(AcademicArticle.class,
-                                                           registrator.name(),
-                                                           registrator.customer(),
-                                                           registrator.topLevelCristinId());
+        return createPublicationWithoutAcceptedFiles(AcademicArticle.class,
+                                                     registrator.name(),
+                                                     registrator.customer(),
+                                                     registrator.topLevelCristinId());
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -50,10 +50,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
     void shouldDenyAnonymousUserOperationsOnDegreeWithoutOpenFiles(PublicationOperation operation,
                                                                    Class<?> degreeInstanceClass) {
         var registrator = User.random();
-        var publication = createPublicationWithoutOpenFiles(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                registrator.name(),
+                                                                registrator.customer(),
+                                                                registrator.topLevelCristinId());
 
         Assertions.assertFalse(PublicationPermissions
                                    .create(Resource.fromPublication(publication), null)
@@ -66,10 +66,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
     void shouldDenyAnonymousUserOperationsOnDegreeWithOpenFiles(PublicationOperation operation,
                                                                 Class<?> degreeInstanceClass) {
         var registrator = User.random();
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         Assertions.assertFalse(PublicationPermissions
                                    .create(Resource.fromPublication(publication), null)
@@ -83,10 +83,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                              Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceClass,
-                                                                          registrator.name(),
-                                                                          registrator.customer(),
-                                                                          registrator.topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                registrator.name(),
+                                                                registrator.customer(),
+                                                                registrator.topLevelCristinId());
 
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
@@ -105,10 +105,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                               Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
@@ -125,10 +125,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         throws JsonProcessingException, UnauthorizedException {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceClass,
-                                                                            registrator.name(),
-                                                                            registrator.customer(),
-                                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                registrator.name(),
+                                                                registrator.customer(),
+                                                                registrator.topLevelCristinId());
 
         setContributor(publication, institution.contributor());
 
@@ -148,10 +148,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         setContributor(publication, institution.contributor());
 
@@ -172,10 +172,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                registrator.name(),
+                                                                registrator.customer(),
+                                                                registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
@@ -193,10 +193,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
@@ -215,10 +215,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                owningInstitution.registrator().name(),
+                                                                owningInstitution.registrator().customer(),
+                                                                owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -240,10 +240,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -266,10 +266,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var thesisCurator = institution.thesisCurator();
 
-        var publication = createPublicationWithoutOpenFiles(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                registrator.name(),
+                                                                registrator.customer(),
+                                                                registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator),
                                                                      identityServiceClient);
@@ -290,10 +290,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var thesisCurator = institution.thesisCurator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator),
                                                                      identityServiceClient);
@@ -314,10 +314,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
+                                                                owningInstitution.registrator().name(),
+                                                                owningInstitution.registrator().customer(),
+                                                                owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -339,10 +339,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -458,10 +458,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -483,10 +483,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -509,10 +509,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -536,10 +536,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var contributor = createContributor(Role.CREATOR, curatingInstitution.contributor().cristinId(),
                                             curatingInstitution.contributor().topLevelCristinId());
@@ -570,10 +570,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -598,10 +598,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -624,10 +624,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -650,10 +650,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -677,10 +677,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -704,10 +704,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -733,10 +733,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var curatingInstitution = suite.curatingInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -762,10 +762,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var curatingInstitution = suite.curatingInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        owningInstitution.registrator().name(),
-                                                        owningInstitution.registrator().customer(),
-                                                        owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            owningInstitution.registrator().name(),
+                                                            owningInstitution.registrator().customer(),
+                                                            owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -822,10 +822,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutOpenOrInternalFiles(degreeInstanceTypeClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().cristinId());
+        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceTypeClass,
+                                                                owningInstitution.registrator().name(),
+                                                                owningInstitution.registrator().customer(),
+                                                                owningInstitution.registrator().cristinId());
 
         publication.getEntityDescription().setContributors(List.of());
         publication.setCuratingInstitutions(
@@ -846,10 +846,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
@@ -867,10 +867,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
         setContributor(publication, contributor);
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(contributor), identityServiceClient);
@@ -891,10 +891,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
         setContributor(publication, curatingInstitution.contributor());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curatingInstitution.contributor()),
@@ -916,10 +916,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithOpenFile(degreeInstanceClass,
-                                                        registrator.name(),
-                                                        registrator.customer(),
-                                                        registrator.topLevelCristinId());
+        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
+                                                            registrator.name(),
+                                                            registrator.customer(),
+                                                            registrator.topLevelCristinId());
         setContributor(publication, curatingInstitution.contributor());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curatingInstitution.curator()),

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
@@ -8,8 +8,8 @@ import static no.unit.nva.model.PublicationOperation.UPDATE_FILES;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.testing.PublicationGenerator.fromInstanceClassesExcluding;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAssociatedArtifactsExcluding;
-import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomOpenFile;
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAcceptedFile;
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAssociatedArtifactsExcludingAcceptedFiles;
 import static no.unit.nva.publication.PublicationServiceConfig.ENVIRONMENT;
 import static no.unit.nva.publication.permissions.PermissionsTestUtils.getAccessRightsForCurator;
 import static no.unit.nva.testutils.HandlerRequestBuilder.CLIENT_ID_CLAIM;
@@ -56,8 +56,6 @@ import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.file.File;
-import no.unit.nva.model.associatedartifacts.file.InternalFile;
-import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import no.unit.nva.model.instancetypes.degree.UnconfirmedDocument;
 import no.unit.nva.model.pages.MonographPages;
@@ -241,30 +239,21 @@ class PublicationPermissionStrategyTest {
                    .build();
     }
 
-    static Publication createPublicationWithOpenFile(Class<?> instanceTypeClass,
-                                                     String resourceOwner,
-                                                     URI customer,
-                                                     URI cristinId) {
-        return createPublication(instanceTypeClass, resourceOwner, customer, cristinId).copy()
-                   .withAssociatedArtifacts(List.of(randomOpenFile()))
-                   .build();
-    }
-
-    static Publication createPublicationWithoutOpenFiles(Class<?> instanceTypeClass,
+    static Publication createPublicationWithAcceptedFile(Class<?> instanceTypeClass,
                                                          String resourceOwner,
                                                          URI customer,
                                                          URI cristinId) {
         return createPublication(instanceTypeClass, resourceOwner, customer, cristinId).copy()
-                          .withAssociatedArtifacts(randomAssociatedArtifactsExcluding(List.of(OpenFile.class)))
-                          .build();
+                   .withAssociatedArtifacts(List.of(randomAcceptedFile()))
+                   .build();
     }
 
-    static Publication createPublicationWithoutOpenOrInternalFiles(Class<?> instanceTypeClass,
-                                                                   String resourceOwner,
-                                                                   URI customer,
-                                                                   URI cristinId) {
+    static Publication createPublicationWithoutAcceptedFiles(Class<?> instanceTypeClass,
+                                                             String resourceOwner,
+                                                             URI customer,
+                                                             URI cristinId) {
         return createPublication(instanceTypeClass, resourceOwner, customer, cristinId).copy()
-                   .withAssociatedArtifacts(randomAssociatedArtifactsExcluding(List.of(OpenFile.class, InternalFile.class)))
+                   .withAssociatedArtifacts(randomAssociatedArtifactsExcludingAcceptedFiles())
                    .build();
     }
 

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
@@ -1,11 +1,13 @@
 package no.unit.nva.model.testing.associatedartifacts;
 
+import static no.unit.nva.model.associatedartifacts.file.File.ACCEPTED_FILE_TYPES;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
@@ -33,10 +35,10 @@ public final class AssociatedArtifactsGenerator {
                                           randomAssociatedLink(), randomHiddenFile());
     }
 
-    public static List<AssociatedArtifact> randomAssociatedArtifactsExcluding(List<Class<?>> clazz) {
+    public static List<AssociatedArtifact> randomAssociatedArtifactsExcludingAcceptedFiles() {
         return randomAssociatedArtifacts()
                    .stream()
-                   .filter(artifact -> !clazz.contains(artifact.getClass()))
+                   .filter(artifact -> !ACCEPTED_FILE_TYPES.contains(artifact.getClass()))
                    .toList();
     }
 
@@ -54,6 +56,13 @@ public final class AssociatedArtifactsGenerator {
 
     public static File randomOpenFile() {
         return randomFileBuilder().buildOpenFile();
+    }
+
+    public static File randomAcceptedFile() {
+        var acceptedFilesTypes = ACCEPTED_FILE_TYPES.stream().toList();
+        var randomIndex = new Random().nextInt(acceptedFilesTypes.size());
+        var acceptedFileType = acceptedFilesTypes.get(randomIndex);
+        return randomFileBuilder().build(acceptedFileType);
     }
 
     public static File randomPendingInternalFile() {


### PR DESCRIPTION
Until now, an `OpenFile.class` would "lock down" the publication. But now `InternalFile.class` should be included as well, thus accepted files is used instead.