### PR TITLE
listing user tickets

### DIFF
--- a/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/read/ListTicketsForPublicationHandler.java
@@ -72,6 +72,9 @@ public class ListTicketsForPublicationHandler extends TicketHandler<Void, Ticket
     }
 
     private boolean hasAccessToTicket(TicketEntry ticketEntry, UserInstance userInstance) {
+        if (ticketEntry.getOwner().equals(userInstance.getUser())) {
+            return true;
+        }
         if (ticketEntry instanceof GeneralSupportRequest) {
             return ticketEntry.hasSameOwnerAffiliationAs(userInstance);
         } else {


### PR DESCRIPTION
When listing tickets for publication
And there exists ticket user owns
Then ticket should be returned on publication landing page


This case is relevant now cause ticket can be owned by a user at organization X, but organization that handles this ticket is Y. (organization that owns channel claim handles ticket created by registrator at another organization)