### PR TITLE
fixing bug when persisting ticket for file

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
@@ -101,7 +101,7 @@ public final class PublishingRequestResolver {
     }
 
     private boolean shouldIncludeEntry(Resource resource, FilesApprovalEntry ticketEntry, UserInstance userInstance) {
-        return resource.isDegree() && !ticketEntry.getFilesForApproval().isEmpty()
+        return resource.getPrioritizedClaimedPublicationChannelWithinScope().isPresent() && !ticketEntry.getFilesForApproval().isEmpty()
                || ticketEntry.hasSameOwnerAffiliationAs(userInstance);
     }
 


### PR DESCRIPTION
Adding uploaded ticket to ticket owned by other institution (channel claim owner) only when publication with claimed channel within scope, instead of when publication is an Degree. 