### PR TITLE
Use authorize instead of allowsAction in CreateNewMessageHandler

### DIFF
--- a/messages/src/main/java/no/unit/nva/publication/messages/create/NewCreateMessageHandler.java
+++ b/messages/src/main/java/no/unit/nva/publication/messages/create/NewCreateMessageHandler.java
@@ -26,7 +26,6 @@ import no.unit.nva.publication.utils.RequestUtils;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.ForbiddenException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -76,14 +75,15 @@ public class NewCreateMessageHandler extends ApiGatewayHandler<CreateMessageRequ
         return HttpURLConnection.HTTP_CREATED;
     }
 
-    private static boolean userHasPermissionToCreateMessageForTicket(PublicationPermissions permissionStrategy,
-                                                                     TicketEntry ticketDto) {
-        return switch (ticketDto) {
-            case DoiRequest ignored -> permissionStrategy.allowsAction(DOI_REQUEST_CREATE);
-            case FilesApprovalEntry ignored -> permissionStrategy.allowsAction(PUBLISHING_REQUEST_CREATE);
-            case GeneralSupportRequest ignored -> permissionStrategy.allowsAction(PARTIAL_UPDATE);
-            case null, default -> false;
-        };
+    private static void userHasPermissionToCreateMessageForTicket(PublicationPermissions permissionStrategy,
+                                                                     TicketEntry ticketDto)
+        throws UnauthorizedException {
+        switch (ticketDto) {
+            case DoiRequest ignored -> permissionStrategy.authorize(DOI_REQUEST_CREATE);
+            case FilesApprovalEntry ignored -> permissionStrategy.authorize(PUBLISHING_REQUEST_CREATE);
+            case GeneralSupportRequest ignored -> permissionStrategy.authorize(PARTIAL_UPDATE);
+            default -> throw new IllegalStateException("Unexpected value: " + ticketDto);
+        }
     }
 
     private static String createLocationHeader(Message message) {
@@ -102,10 +102,8 @@ public class NewCreateMessageHandler extends ApiGatewayHandler<CreateMessageRequ
     }
 
     private void isAuthorizedToManageTicket(PublicationPermissions permissions, TicketEntry ticket)
-        throws ForbiddenException {
-        if (!userHasPermissionToCreateMessageForTicket(permissions, ticket)) {
-            throw new ForbiddenException();
-        }
+        throws UnauthorizedException {
+        userHasPermissionToCreateMessageForTicket(permissions, ticket);
     }
 
     private void injectAssigneeWhenUnassignedTicket(TicketEntry ticket, RequestUtils requestUtils) {

--- a/messages/src/test/java/no/unit/nva/publication/messages/create/NewCreateMessageHandlerTest.java
+++ b/messages/src/test/java/no/unit/nva/publication/messages/create/NewCreateMessageHandlerTest.java
@@ -1,7 +1,7 @@
 package no.unit.nva.publication.messages.create;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
-import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static no.unit.nva.publication.PublicationServiceConfig.API_HOST;
 import static no.unit.nva.publication.PublicationServiceConfig.PUBLICATION_IDENTIFIER_PATH_PARAMETER_NAME;
 import static no.unit.nva.publication.messages.MessageApiConfig.LOCATION_HEADER;
@@ -85,7 +85,7 @@ class NewCreateMessageHandlerTest extends ResourcesLocalTest {
         var request = createNewMessageRequestForResourceOwner(publication, ticket, user, randomString());
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Void.class);
-        assertThat(response.getStatusCode(), is(equalTo(HTTP_FORBIDDEN)));
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_UNAUTHORIZED)));
     }
 
     @ParameterizedTest
@@ -101,7 +101,7 @@ class NewCreateMessageHandlerTest extends ResourcesLocalTest {
 
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Void.class);
-        assertThat(response.getStatusCode(), is(equalTo(HTTP_FORBIDDEN)));
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_UNAUTHORIZED)));
     }
 
     @ParameterizedTest
@@ -118,7 +118,7 @@ class NewCreateMessageHandlerTest extends ResourcesLocalTest {
 
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Void.class);
-        assertThat(response.getStatusCode(), is(equalTo(HTTP_FORBIDDEN)));
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_UNAUTHORIZED)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
So that we log why an action was denied, for debugging purposes.