### PR TITLE
fixing exception in cristin import

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import no.unit.nva.cristin.lambda.ErrorReport;
 import no.unit.nva.cristin.mapper.artisticproduction.CristinArtisticProduction;
 import no.unit.nva.cristin.mapper.channelregistry.ChannelRegistryMapper;
 import no.unit.nva.cristin.mapper.exhibition.CristinExhibition;
@@ -274,8 +275,10 @@ public class CristinMapper extends CristinMappingModule {
                 DoesNotHaveEmptyValues.checkForEmptyFields(publication, IGNORED_AND_POSSIBLY_EMPTY_PUBLICATION_FIELDS);
             }
         } catch (Exception error) {
-            String message = error.getMessage();
-            throw new MissingFieldsException(message);
+            ErrorReport.exceptionName(MissingFieldsException.name())
+                .withBody(error.getMessage())
+                .withCristinId(cristinObject.getId())
+                .persist(s3Client);
         }
     }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/MissingFieldsException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/MissingFieldsException.java
@@ -1,8 +1,12 @@
 package no.unit.nva.cristin.mapper;
 
-public class MissingFieldsException extends RuntimeException {
+public final class MissingFieldsException extends RuntimeException {
 
-    public MissingFieldsException(String message) {
-        super(message);
+    private MissingFieldsException() {
+        super();
+    }
+
+    public static String name() {
+        return MissingFieldsException.class.getSimpleName();
     }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -59,7 +59,6 @@ import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.time.Period;
 import no.unit.nva.model.time.Time;
-import nva.commons.core.SingletonCollector;
 import nva.commons.doi.DoiConverter;
 import nva.commons.doi.DoiValidator;
 import nva.commons.doi.InvalidDoiException;
@@ -254,9 +253,10 @@ public class ReferenceBuilder extends CristinMappingModule {
 
     private URI extractDoi() {
         var doi = Stream.of(getBookOrReportPart(), getBookOrReportDoi(), getJournalDOi())
-                   .filter(Objects::nonNull)
-                   .distinct()
-                   .collect(SingletonCollector.collectOrElse(null));
+                      .filter(Objects::nonNull)
+                      .distinct()
+                      .findFirst()
+                      .orElse(null);
         try {
             return doiConverter.toUri(doi);
         } catch (Exception e) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ContributorWithoutAffiliationException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ContributorWithoutAffiliationException.java
@@ -1,11 +1,12 @@
 package no.unit.nva.cristin.mapper.nva.exceptions;
 
-public class ContributorWithoutAffiliationException extends RuntimeException {
+public final class ContributorWithoutAffiliationException extends RuntimeException {
 
-    public static final String ERROR_MESSAGE =
-        "The contributor has no affiliation. All contributors must have affiliations.";
+    private ContributorWithoutAffiliationException() {
+        super();
+    }
 
-    public ContributorWithoutAffiliationException() {
-        super(ERROR_MESSAGE);
+    public static String name() {
+        return ContributorWithoutAffiliationException.class.getSimpleName();
     }
 }

--- a/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
+++ b/cristin-import/src/test/java/cucumber/GeneralMappingRules.java
@@ -17,6 +17,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import cucumber.utils.ContributorFlattenedDetails;
 import cucumber.utils.exceptions.MisformattedScenarioException;
 import cucumber.utils.transformers.CristinContributorTransformer;
@@ -666,6 +667,11 @@ public class GeneralMappingRules {
                                                                       .withSourceCode(code)
                                                                       .withSourceIdentifier(value)
                                                                       .build()));
+    }
+
+    @Then("the NVA resource is imported")
+    public void theNVAResourceIsImported() {
+        assertTrue(scenarioContext.mappingIsSuccessful());
     }
 
     private void injectAffiliationsIntoContributors(List<CristinContributorsAffiliation> desiredInjectedAffiliations,

--- a/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/mapper/CristinMapperTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import java.net.URI;
 import java.nio.file.Path;
@@ -427,15 +426,11 @@ class CristinMapperTest extends AbstractCristinImportTest {
                 .withPublicationOwner(randomString())
                 .withContributors(List.of(contributorWithMissingName))
                 .build();
-        var error = assertThrows(MissingFieldsException.class,
-                                 () -> mapToPublication(cristinObjectWithContributorsWithoutRole));
-        assertThat(error.getMessage(), containsString("entityDescription.contributors.identity.name"));
-    }
+        var mappedContributor = mapToPublication(cristinObjectWithContributorsWithoutRole).getEntityDescription()
+                              .getContributors()
+                              .getFirst();
 
-    @Test
-    void mapThrowsMissingFieldsExceptionWhenNonIgnoredFieldIsMissing() {
-        //re-use the test for the author's name
-        mapSetsNameToNullWhenBothFamilyNameAndGivenNameAreMissing();
+        assertNull(mappedContributor.getIdentity().getName());
     }
 
     @Test

--- a/cristin-import/src/test/resources/features/GeneralMappingRules.feature
+++ b/cristin-import/src/test/resources/features/GeneralMappingRules.feature
@@ -168,14 +168,6 @@ Feature: Mappings that hold for all types of Cristin Results
     Then  the NVA contributor has no affiliation
     And the NVA Contributor has the role "EDITOR"
 
-  Scenario: Contributors missing affiliations caues errors during mapping
-    Given that the Cristin Result has the Contributors with names and sequence:
-      | Given Name | Family Name | Ordinal Number |
-      | FirstGiven | FirstFamily | 1              |
-    And the contributor is missing affiliation
-    When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
-
   Scenario: unverified cristin contributors does not get their contributor identifiers mapped to NVA
     Given a cristin result with a single contributor that is not verified
     When the Cristin Result is converted to an NVA Resource
@@ -326,7 +318,7 @@ Feature: Mappings that hold for all types of Cristin Results
   Scenario: Mapping reports error when Cristin Contributor has no name
     Given that the Cristin Result has a Contributor with no family and no given name
     When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
+    Then the NVA resource is imported
 
   Scenario: Mapping cristin Funding with NFR should create nva Funding with id set.
     Given that Cristin Result has a grant with properties finansieringsreferanse "3013" and sourceCodeEnglish "NFR":

--- a/cristin-import/src/test/resources/features/JournalArticleRules.feature
+++ b/cristin-import/src/test/resources/features/JournalArticleRules.feature
@@ -73,10 +73,10 @@ Feature: Mapping of "Article in business/trade/industry journal", "Academic arti
     When the Cristin Result is converted to an NVA Resource
     Then the Nva Resource has a Reference object with doi equal to "https://doi.org/10.1093/ajae/aaq063"
 
-  Scenario: Mapping fails when a Cristin Result of type JournalArticle has no information about the Journal title.
+  Scenario: Mapping not fails when a Cristin Result of type JournalArticle has no information about the Journal title.
     Given that the Journal Article entry has an empty "publisherName" field
     When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
+    Then the NVA resource is imported
 
 
   Scenario: When the the Cristin entry has a reference to an NSD journal then the
@@ -92,7 +92,7 @@ Feature: Mapping of "Article in business/trade/industry journal", "Academic arti
        then an exception is thrown
     Given the Journal Publication has a reference to an NSD journal with identifier 12345
     When the Cristin Result is converted to an NVA Resource
-    Then an error is reported.
+    Then the NVA resource is imported
 
   Scenario: When the cristin entry is an article
     Given article has an article number 55


### PR DESCRIPTION
Making multiple exceptions in cristin-import to error reports:

- ContributorWithoutAffiliationException
- MissingFieldsException

Importing first DOI we get as DOI instead of throwing exception when multiple dois.