### PR TITLE
Np 49206 persist report when unconfirmed channels

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedJournalException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedJournalException.java
@@ -1,0 +1,12 @@
+package no.unit.nva.cristin.mapper.nva.exceptions;
+
+    public final class UnconfirmedJournalException extends RuntimeException {
+
+        private UnconfirmedJournalException() {
+            super();
+        }
+
+        public static String name() {
+            return UnconfirmedJournalException.class.getSimpleName();
+        }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedPublisherException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedPublisherException.java
@@ -1,0 +1,12 @@
+package no.unit.nva.cristin.mapper.nva.exceptions;
+
+public final class UnconfirmedPublisherException extends RuntimeException {
+
+    private UnconfirmedPublisherException() {
+        super();
+    }
+
+    public static String name() {
+        return UnconfirmedPublisherException.class.getSimpleName();
+    }
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedSeriesException.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/UnconfirmedSeriesException.java
@@ -1,0 +1,13 @@
+package no.unit.nva.cristin.mapper.nva.exceptions;
+
+public final class UnconfirmedSeriesException extends RuntimeException {
+
+    private UnconfirmedSeriesException() {
+        super();
+    }
+
+    public static String name() {
+        return UnconfirmedSeriesException.class.getSimpleName();
+    }
+
+}

--- a/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
+++ b/cristin-import/src/test/java/no/unit/nva/cristin/lambda/CristinEntryEventConsumerTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
Persisting error reports for unconfirmed publication channels when mapping from Cristin.