### PR TITLE
wrapping error report s3 content in json

### DIFF
--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinReport.java
@@ -1,0 +1,7 @@
+package no.unit.nva.cristin.lambda;
+
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record CristinReport(String value) implements JsonSerializable {
+
+}

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/ErrorReport.java
@@ -25,7 +25,7 @@ public final class ErrorReport {
     }
 
     public ErrorReport withBody(String body) {
-        return copy().withBody(body).build();
+        return copy().withBody(new CristinReport(body).toJsonString()).build();
     }
 
     public void persist(S3Client s3Client) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PeriodicalBuilder.java
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class PeriodicalBuilder extends CristinMappingModule {
 
-    private static final String UNCONFIRMED_JOURNAL = "Unconfirmed journal";
     private final CristinObject cristinObject;
 
     public PeriodicalBuilder(CristinObject cristinObject, ChannelRegistryMapper channelRegistryMapper,
@@ -42,11 +41,12 @@ public class PeriodicalBuilder extends CristinMappingModule {
     }
 
     private UnconfirmedJournal createUnconfirmedJournalAndPersistErrorReport() throws InvalidIssnException {
+        var title = extractPublisherTitle();
         ErrorReport.exceptionName(UnconfirmedJournalException.name())
-            .withBody(UNCONFIRMED_JOURNAL)
+            .withBody(title)
             .withCristinId(cristinObject.getId())
             .persist(s3Client);
-        return new UnconfirmedJournal(extractPublisherTitle(), extractIssn(), extractIssnOnline());
+        return new UnconfirmedJournal(title, extractIssn(), extractIssnOnline());
     }
 
     private Periodical createJournal() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookLikeBuilder.java
@@ -99,7 +99,7 @@ public class NvaBookLikeBuilder extends CristinMappingModule {
 
     private UnconfirmedPublisher createUnconfirmedPublisher(String publisherName) {
         ErrorReport.exceptionName(UnconfirmedPublisherException.name())
-            .withBody(UNCONFIRMED_PUBLISHER)
+            .withBody(publisherName)
             .withCristinId(cristinObject.getId())
             .persist(s3Client);
         return new UnconfirmedPublisher(publisherName);

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookSeriesBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NvaBookSeriesBuilder.java
@@ -45,10 +45,11 @@ public class NvaBookSeriesBuilder extends CristinMappingModule {
         var issn = bookSeries.getIssn();
         var issnOnline = bookSeries.getIssnOnline();
         try {
-            var unconfirmedSeries = new UnconfirmedSeries(bookSeries.getJournalTitle(), issn, issnOnline);
+            var journalTitle = bookSeries.getJournalTitle();
+            var unconfirmedSeries = new UnconfirmedSeries(journalTitle, issn, issnOnline);
             ErrorReport.exceptionName(UnconfirmedSeriesException.name())
                 .withCristinId(cristinObject.getId())
-                .withBody(UNCONFIRMED_SERIES)
+                .withBody(journalTitle)
                 .persist(s3Client);
             return unconfirmedSeries;
         } catch (InvalidIssnException e) {


### PR DESCRIPTION
Wrapping content of error reports in Cristin import in json, so I can use the same Crawler config for all kind of reports. 