### PR TITLE
Np 49166 allow student thesis on publications without files through channel ownership

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
@@ -55,7 +55,7 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
     }
 
     private boolean nonApprovedFileStrategy() {
-        if (!userRelatesToPublicationThroughPublicationOwnerOrCuratingInstitution()) {
+        if (!userRelatesToPublication()) {
             return DENY;
         }
         return PASS;

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
@@ -88,4 +88,9 @@ public class PublicationAccessFeatures {
     public void theUserIsFromTheSameOrganizationAsClaimedPublisher() {
         scenarioContext.setUserOrganization(ORGANIZATION);
     }
+
+    @And("publication has no approved files")
+    public void publicationHasNoApprovedFiles() {
+        scenarioContext.setIsMetadataOnly(true);
+    }
 }

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
@@ -58,7 +58,7 @@ public class PublicationScenarioContext {
                                                 "DegreePhd",
                                                 "ArtisticDegreePhd",
                                                 "OtherStudentWork");
-    private boolean isImported = true;
+    private boolean isImported = false;
     private boolean isMetadataOnly = false;
 
     public void setOperation(PublicationOperation operation) {

--- a/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
@@ -43,6 +43,29 @@ Feature: Permissions given claimed publisher
       | Related external client           | unpublish      | Allowed     |
 
 
+  Scenario Outline: Verify update operation when user is not from the same organization as claimed
+  publisher and publication has no approved files
+    Given a "published" publication
+    And publication has no approved files
+    And publication is a degree
+    And publication has claimed publisher
+    When the user have the role "<UserRole>"
+    And the user attempts to "update"
+    Then the action outcome is "<Outcome>"
+
+    Examples:
+      | UserRole                          | Outcome     |
+
+      | Everyone else                     | Not Allowed |
+      | External client                   | Not Allowed |
+      | Publication owner                 | Allowed     |
+      | Contributor                       | Allowed     |
+      | File, support, doi or nvi curator | Allowed     |
+      | Editor                            | Allowed     |
+      | Degree file curator               | Allowed     |
+      | Related external client           | Allowed     |
+
+
   Scenario Outline: Verify permission when
   user is from the same organization as claimed publisher
     Given a "published" publication

--- a/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
@@ -43,13 +43,15 @@ Feature: Permissions given claimed publisher
       | Related external client           | unpublish      | Allowed     |
 
 
-  Scenario Outline: Verify update operation when user is not from the same organization as claimed
+  Scenario Outline: Verify update operation when user is from the same organization as claimed
   publisher and publication has no approved files
     Given a "published" publication
     And publication has no approved files
     And publication is a degree
     And publication has claimed publisher
+    And publisher is claimed by organization
     When the user have the role "<UserRole>"
+    And the user is from the same organization as claimed publisher
     And the user attempts to "update"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
@@ -78,8 +78,8 @@ Feature: Publication update permissions
       | Degree file curator     | MetadataOnly,Degree,Imported | update         | Allowed     |
       | Everyone else           | MetadataOnly,Degree,Imported | update         | Not Allowed |
       | Related external client | MetadataOnly,Degree,Imported | update         | Allowed     |
-      | Publication owner       | MetadataOnly,Degree          | update         | Not Allowed |
-      | Contributor             | MetadataOnly,Degree          | update         | Not Allowed |
+      | Publication owner       | MetadataOnly,Degree          | update         | Allowed     |
+      | Contributor             | MetadataOnly,Degree          | update         | Allowed     |
       | Degree file curator     | MetadataOnly,Degree          | update         | Allowed     |
       | Everyone else           | MetadataOnly,Degree          | update         | Not Allowed |
       | Related external client | MetadataOnly,Degree          | update         | Allowed     |


### PR DESCRIPTION
Channel ownership should grant student thesis curator update access to degrees even if there are no approved files.

Created a specific and minimal test suite, as the entire Context needs to be refactored. We have some false positives.