### PR TITLE
Ignore casing when getting PublicationChannel by identifier

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -266,7 +266,8 @@ public class Resource implements Entity {
     public Optional<PublicationChannel> getPublicationChannelByIdentifier(SortableIdentifier identifier) {
         return getPublicationChannels()
                    .stream()
-                   .filter(publicationChannel -> identifier.equals(publicationChannel.getIdentifier()))
+                   .filter(publicationChannel -> identifier.toString()
+                                                     .equalsIgnoreCase(publicationChannel.getIdentifier().toString()))
                    .findFirst();
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -266,8 +266,7 @@ public class Resource implements Entity {
     public Optional<PublicationChannel> getPublicationChannelByIdentifier(SortableIdentifier identifier) {
         return getPublicationChannels()
                    .stream()
-                   .filter(publicationChannel -> identifier.toString()
-                                                     .equalsIgnoreCase(publicationChannel.getIdentifier().toString()))
+                   .filter(publicationChannel -> identifier.equals(publicationChannel.getIdentifier()))
                    .findFirst();
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannelUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationchannel/PublicationChannelUtil.java
@@ -65,7 +65,7 @@ public final class PublicationChannelUtil {
                    .toDao();
     }
 
-    public static Optional<UUID> getPublisherIdentifier(Resource resource) {
+    public static Optional<UUID> getPublisherIdentifierWhenDegree(Resource resource) {
         return resource.getPublisherWhenDegree().map(Publisher::getIdentifier);
     }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
@@ -52,7 +52,9 @@ public class PublicationChannelDao extends Dao implements DynamoEntryByIdentifie
     }
 
     public static PublicationChannelDao fromPublicationChannel(PublicationChannel publicationChannel) {
-        return new PublicationChannelDao(publicationChannel.getIdentifier(), publicationChannel.getResourceIdentifier(),
+        var lowerCaseIdentifier = publicationChannel.getIdentifier().toString().toLowerCase();
+        return new PublicationChannelDao(new SortableIdentifier(lowerCaseIdentifier),
+                                         publicationChannel.getResourceIdentifier(),
                                          publicationChannel);
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Map;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identifiers.SortableIdentifier;
@@ -52,7 +53,7 @@ public class PublicationChannelDao extends Dao implements DynamoEntryByIdentifie
     }
 
     public static PublicationChannelDao fromPublicationChannel(PublicationChannel publicationChannel) {
-        var lowerCaseIdentifier = publicationChannel.getIdentifier().toString().toLowerCase();
+        var lowerCaseIdentifier = publicationChannel.getIdentifier().toString().toLowerCase(Locale.ROOT);
         return new PublicationChannelDao(new SortableIdentifier(lowerCaseIdentifier),
                                          publicationChannel.getResourceIdentifier(),
                                          publicationChannel);

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -5,7 +5,7 @@ import static no.unit.nva.model.PublicationStatus.DELETED;
 import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
 import static no.unit.nva.publication.model.business.publicationchannel.PublicationChannelUtil.createPublicationChannelDao;
-import static no.unit.nva.publication.model.business.publicationchannel.PublicationChannelUtil.getPublisherIdentifier;
+import static no.unit.nva.publication.model.business.publicationchannel.PublicationChannelUtil.getPublisherIdentifierWhenDegree;
 import static no.unit.nva.publication.service.impl.ReadResourceService.RESOURCE_NOT_FOUND_MESSAGE;
 import static no.unit.nva.publication.service.impl.ResourceServiceUtils.PRIMARY_KEY_EQUALITY_CHECK_EXPRESSION;
 import static no.unit.nva.publication.service.impl.ResourceServiceUtils.PRIMARY_KEY_EQUALITY_CONDITION_ATTRIBUTE_NAMES;
@@ -124,15 +124,15 @@ public class UpdateResourceService extends ServiceWithTransactions {
     }
 
     public List<TransactWriteItem> updatePublicationChannelsForPublisherWhenDegree(Resource resource,
-                                                                                Resource persistedResource) {
+                                                                                   Resource persistedResource) {
         var transactWriteItems = new ArrayList<TransactWriteItem>();
 
-        var oldPublisherIdentifier = getPublisherIdentifier(persistedResource);
-        var newPublisherIdentifier = getPublisherIdentifier(resource);
+        var oldPublisherIdentifier = getPublisherIdentifierWhenDegree(persistedResource);
+        var newPublisherIdentifier = getPublisherIdentifierWhenDegree(resource);
 
         if (!Objects.equals(oldPublisherIdentifier, newPublisherIdentifier)) {
-            oldPublisherIdentifier.ifPresent(id -> removePublicationChannel(persistedResource, id, transactWriteItems));
-            newPublisherIdentifier.ifPresent(id -> addPublicationChannel(resource, transactWriteItems));
+            oldPublisherIdentifier.ifPresent(identifier -> removePublicationChannel(persistedResource, identifier, transactWriteItems));
+            newPublisherIdentifier.ifPresent(identifier -> addPublicationChannel(resource, transactWriteItems));
         }
 
         return transactWriteItems;


### PR DESCRIPTION
The bug: Claimed publication channels are not removed from the resource.

Claimed publication channels are persisted with upper case identifiers in identity service, because that's what is served by the channel registry (or proxy?). This, in turn, makes it so that the `ClaimedPublicationChannel` entity is persisted with upper case identifier in the Resource table as well. But, when there is a `NonClaimedPublicationChannel` entity persisted, the identifier is fetched using `Publisher.getIdentifer()` (fetched from the publication context), which uses a `UUID.fromString()` to return a UUID after some uri manipulation. And `UUID.fromString()` makes it lower case. So now, every claimed publication channel is persisted upper case and every non claimed publication channel is persisted lower case, which makes the generic `Resource.getPublicationChannelByIdentifier()` fail because it is comparing upper case uuids against lower case uuids in half of the cases. 

~~The permanent fix should probably be to persist all PublicationChannels uniformly, but that will probably require a migration. So the quick fix is to ignore casing when comparing.~~

The fix will be storing every PublicationChannel with lower case identifier, and then clean up the database by unclaiming and reclaiming channels. Also, there will be a fix in SortableIdentifier in commons, that ignores casing when checking for equality.

Also renamed a function to be more precise.