### PR TITLE
comparing journals

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/lambda/PublicationComparator.java
@@ -9,7 +9,9 @@ import java.util.stream.Stream;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.PublicationContext;
+import no.unit.nva.model.contexttypes.UnconfirmedJournal;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.event.Lecture;
 import no.unit.nva.model.instancetypes.report.ConferenceReport;
@@ -49,8 +51,16 @@ public final class PublicationComparator {
             return existingPublicationInstance instanceof Lecture
                 || existingPublicationContext.equals(incomingPublicationContext);
         } else {
+            if (isJournal(incomingPublicationContext)) {
+                return isJournal(existingPublicationContext);
+            }
             return existingPublicationContext.equals(incomingPublicationContext);
         }
+    }
+
+    private static boolean isJournal(Class<? extends PublicationContext> incomingPublicationContext) {
+        return incomingPublicationContext.equals(Journal.class) ||
+               incomingPublicationContext.equals(UnconfirmedJournal.class);
     }
 
     private static boolean typesAreMissing(Publication incomingPublication) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
@@ -142,6 +142,23 @@ class PublicationComparatorTest {
                                                      publicationWithUnconfirmedJournal));
     }
 
+    @Test
+    void shouldReturnTrueWhenMergingJournalWithUnconfirmedJournalWithJournalWithConfirmedJournal() throws InvalidIssnException {
+        var confirmedJournal = new Journal(randomUri());
+        var unconfirmedJournal = new UnconfirmedJournal(randomString(), null, null);
+
+        var publication = randomPublication(JournalArticle.class);
+
+        var publicationWithConfirmedJournal = publication.copy().build();
+        publicationWithConfirmedJournal.getEntityDescription().getReference().setPublicationContext(confirmedJournal);
+
+        var publicationWithUnconfirmedJournal = publication.copy().build();
+        publicationWithUnconfirmedJournal.getEntityDescription().getReference().setPublicationContext(unconfirmedJournal);
+
+        assertTrue(publicationsMatch(publicationWithUnconfirmedJournal,
+                                     publicationWithConfirmedJournal));
+    }
+
     private static Contributor contributorWithLastName(String lastName) {
         return new Contributor.Builder()
                    .withIdentity(identityWithLastName(lastName))

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/lambda/PublicationComparatorTest.java
@@ -1,6 +1,8 @@
 package no.sikt.nva.brage.migration.lambda;
 
+import static no.sikt.nva.brage.migration.lambda.PublicationComparator.publicationsMatch;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,10 +14,13 @@ import no.unit.nva.model.Identity.Builder;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.Reference;
+import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.Report;
+import no.unit.nva.model.contexttypes.UnconfirmedJournal;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
 import no.unit.nva.model.instancetypes.event.Lecture;
+import no.unit.nva.model.instancetypes.journal.JournalArticle;
 import no.unit.nva.model.instancetypes.report.ConferenceReport;
 import no.unit.nva.model.pages.MonographPages;
 import org.junit.jupiter.api.Test;
@@ -33,7 +38,7 @@ class PublicationComparatorTest {
         var incomingConferenceReport = existingLecture.copy()
                                            .withEntityDescription(createConferenceReport(existingLecture))
                                            .build();
-        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
+        assertTrue(publicationsMatch(existingLecture, incomingConferenceReport));
     }
 
     @Test
@@ -44,7 +49,7 @@ class PublicationComparatorTest {
         var incomingConferenceReport = existingLecture.copy()
                                            .withEntityDescription(createConferenceReport(existingLecture))
                                            .build();
-        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
+        assertTrue(publicationsMatch(existingLecture, incomingConferenceReport));
     }
 
     @Test
@@ -54,7 +59,7 @@ class PublicationComparatorTest {
         var incomingConferenceReport = existingPublication.copy()
                                            .withEntityDescription(addEmptyReference(existingPublication))
                                            .build();
-        assertTrue(PublicationComparator.publicationsMatch(existingPublication, incomingConferenceReport));
+        assertTrue(publicationsMatch(existingPublication, incomingConferenceReport));
     }
 
     @Test
@@ -64,7 +69,7 @@ class PublicationComparatorTest {
         var incomingConferenceReport = existingPublication.copy()
                                            .withEntityDescription(addEmptyReference(existingPublication))
                                            .build();
-        assertTrue(PublicationComparator.publicationsMatch(existingPublication, incomingConferenceReport));
+        assertTrue(publicationsMatch(existingPublication, incomingConferenceReport));
     }
 
     @Test
@@ -77,7 +82,7 @@ class PublicationComparatorTest {
                                            .withEntityDescription(createConferenceReport(existingLecture))
                                            .build();
         incomingConferenceReport.getEntityDescription().setMainTitle(HEADLINE_STYLE);
-        assertTrue(PublicationComparator.publicationsMatch(existingLecture, incomingConferenceReport));
+        assertTrue(publicationsMatch(existingLecture, incomingConferenceReport));
     }
 
     @Test
@@ -91,7 +96,7 @@ class PublicationComparatorTest {
                                                                  .build())
                                           .build();
 
-        assertTrue(PublicationComparator.publicationsMatch(existingPublication, incomingPublication));
+        assertTrue(publicationsMatch(existingPublication, incomingPublication));
     }
 
     @Test
@@ -104,7 +109,7 @@ class PublicationComparatorTest {
                                                                  .build())
                                       .build();
 
-        assertFalse(PublicationComparator.publicationsMatch(existingPublication, incomingPublication));
+        assertFalse(publicationsMatch(existingPublication, incomingPublication));
     }
 
     @Test
@@ -117,7 +122,24 @@ class PublicationComparatorTest {
                                                                  .build())
                                       .build();
 
-        assertFalse(PublicationComparator.publicationsMatch(existingPublication, incomingPublication));
+        assertFalse(publicationsMatch(existingPublication, incomingPublication));
+    }
+
+    @Test
+    void shouldReturnTrueWhenMergingJournalWithConfirmedJournalWithJournalWithUnconfirmedJournal() throws InvalidIssnException {
+        var confirmedJournal = new Journal(randomUri());
+        var unconfirmedJournal = new UnconfirmedJournal(randomString(), null, null);
+
+        var publication = randomPublication(JournalArticle.class);
+
+        var publicationWithConfirmedJournal = publication.copy().build();
+        publicationWithConfirmedJournal.getEntityDescription().getReference().setPublicationContext(confirmedJournal);
+
+        var publicationWithUnconfirmedJournal = publication.copy().build();
+        publicationWithUnconfirmedJournal.getEntityDescription().getReference().setPublicationContext(unconfirmedJournal);
+
+        assertTrue(publicationsMatch(publicationWithConfirmedJournal,
+                                                     publicationWithUnconfirmedJournal));
     }
 
     private static Contributor contributorWithLastName(String lastName) {


### PR DESCRIPTION
When merging existing publication with publication from Brage, we compare context types. It shows that contextType for "Journal" can have two values -> "Journal" and "UnconfirmedJournal". Handling that case when merging.