### PR TITLE
fix: Handle changed stream ARN in policy definition

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1901,6 +1901,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn:
       - DatabaseAccessLambdaManagedPolicy
+      - DynamoDbStreamsAccessPolicy
     Properties:
       CodeUri: publication-event-handlers
       Handler: no.unit.nva.publication.events.handlers.dynamodbstream.DynamodbStreamToEventBridgeHandler::handleRequest
@@ -1929,6 +1930,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn:
       - DatabaseAccessLambdaManagedPolicy
+      - DynamoDbStreamsAccessPolicy
     Properties:
       CodeUri: publication-event-handlers
       Handler: no.unit.nva.publication.events.handlers.dynamodbstream.ImportCandidateDynamoDbStreamToEventBridgeHandler::handleRequest

--- a/template.yaml
+++ b/template.yaml
@@ -247,8 +247,6 @@ Resources:
       Tags:
         - Key: IncludedInBackup
           Value: 'true'
-        - Key: TemporaryTag
-          Value: 'this_is_a_test_to_trigger_stack_update'
 
   # NB! for compatibility reasons NvaImportCandidatesTable should be a copy of NvaResourcesTable
   NvaImportCandidatesTable:
@@ -324,8 +322,6 @@ Resources:
       Tags:
         - Key: IncludedInBackup
           Value: 'true'
-        - Key: TemporaryTag
-          Value: 'this_is_a_test_to_trigger_stack_update'
 
   DownloadUrlShorteningTable:
     Type: AWS::DynamoDB::Table
@@ -572,8 +568,8 @@ Resources:
               - dynamodb:ListStreams
               - dynamodb:GetRecords
             Resource:
-              - !GetAtt NvaResourcesTable.StreamArn
-              - !GetAtt NvaImportCandidatesTable.StreamArn
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${NvaResourcesTable}/stream/*'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${NvaImportCandidatesTable}/stream/*'
 
 
   EventsLambdaManagedPolicy:


### PR DESCRIPTION
This changes the `DynamoDbStreamsAccessPolicy` so that it applies to any stream associated with the DynamoDB tables, rather than referencing specific stream resources. This avoids issues with CloudFormation deploys after streams are disabled and re-enabled where CFN fails to detect that the stream ARN has changed.