### PR TITLE
ci: Update buildspec

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -1,5 +1,14 @@
 version: 0.2
 
+env:
+  variables:
+    GRADLE_USER_HOME: '/root/.gradle'
+    SAM_CLI_TELEMETRY: "0"
+
+cache:
+  paths:
+    - '/root/.gradle/caches/**/*'
+
 phases:
   install:
     runtime-versions:


### PR DESCRIPTION
This should significantly improve build times in AWS CodeBuild by:

- Skipping re-install of SAM CLI if already present
- Using S3 to store Gradle cache files