### PR TITLE
NP-49254 Use instance type instead of context when fetching publisher for degree

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -45,7 +45,7 @@ import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactList;
 import no.unit.nva.model.associatedartifacts.file.File;
 import no.unit.nva.model.associatedartifacts.file.PendingFile;
-import no.unit.nva.model.contexttypes.Degree;
+import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.funding.Funding;
 import no.unit.nva.model.funding.FundingList;
@@ -294,12 +294,16 @@ public class Resource implements Entity {
     public Optional<Publisher> getPublisherWhenDegree() {
         return Optional.ofNullable(getEntityDescription())
                    .map(EntityDescription::getReference)
+                   .filter(Resource::instanceIsDegree)
                    .map(Reference::getPublicationContext)
-                   .filter(Degree.class::isInstance)
-                   .map(Degree.class::cast)
-                   .map(Degree::getPublisher)
+                   .map(Book.class::cast)
+                   .map(Book::getPublisher)
                    .filter(Publisher.class::isInstance)
                    .map(Publisher.class::cast);
+    }
+
+    private static boolean instanceIsDegree(Reference reference) {
+        return nonNull(reference.getPublicationInstance()) && instanceIsDegree(reference.getPublicationInstance());
     }
 
     private static boolean instanceIsDegree(PublicationInstance<? extends Pages> publicationInstance) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceTest.java
@@ -19,7 +19,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.Reference;
+import no.unit.nva.model.contexttypes.Book;
+import no.unit.nva.model.contexttypes.Publisher;
+import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
 import no.unit.nva.model.testing.PublicationInstanceBuilder;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import org.javers.core.Javers;
@@ -151,6 +156,22 @@ public class ResourceTest {
         var fileByIdentifier = Resource.fromPublication(publication).getFileByIdentifier(file.getIdentifier());
 
         assertEquals(file, fileByIdentifier.orElseThrow());
+    }
+
+    @Test
+    void shouldReturnPublisherWhenInstanceTypeIsSubtypeOfDegreeButContextIsNotDegree() {
+        var publisher = new Publisher(randomUri());
+        var book = new Book(null, null, publisher, null, null);
+        var bachelor = new DegreeBachelor(null, null);
+        var reference = new Reference.Builder().withPublishingContext(book).withPublicationInstance(bachelor).build();
+        var entityDescription = new EntityDescription.Builder().withReference(reference).build();
+        var publication = randomPublication().copy().withEntityDescription(entityDescription).build();
+
+        var resource = Resource.fromPublication(publication);
+        var publisherFromResource = resource.getPublisherWhenDegree();
+
+        assertTrue(publisherFromResource.isPresent());
+        assertEquals(publisher, publisherFromResource.get());
     }
 
     private static Stream<Class<?>> publicationInstanceProvider() {

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/UpdatePublicationsInBatchesHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/UpdatePublicationsInBatchesHandlerTest.java
@@ -4,6 +4,7 @@ import static java.util.UUID.randomUUID;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -209,8 +210,10 @@ class UpdatePublicationsInBatchesHandlerTest extends ResourcesLocalTest {
 
     private static URI createChannelIdWithIdentifier(String channelIdentifier) {
         return UriWrapper.fromHost(new Environment().readEnv("API_HOST"))
+                   .addChild("publication-channels-v2")
+                   .addChild("publisher")
                    .addChild(channelIdentifier)
-                   .addChild(randomString())
+                   .addChild(randomInteger().toString())
                    .getUri();
     }
 


### PR DESCRIPTION
There have been some (erroneous?) instances where publication context have been Book and instance type have been a degree type. Instead of checking if publication is of context Degree, the publication have to be checked against the list of degree instance types.