### PR TITLE
Use the term finalized files instead of approved files

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
@@ -4,6 +4,7 @@ import static java.util.Objects.nonNull;
 import static no.unit.nva.model.FileOperation.DELETE;
 import static no.unit.nva.model.FileOperation.DOWNLOAD;
 import static no.unit.nva.model.FileOperation.WRITE_METADATA;
+import static no.unit.nva.model.associatedartifacts.file.File.FINALIZED_FILE_TYPES;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
 import java.net.URI;
@@ -14,9 +15,6 @@ import no.unit.nva.model.Contributor;
 import no.unit.nva.model.CuratingInstitution;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.FileOperation;
-import no.unit.nva.model.associatedartifacts.file.HiddenFile;
-import no.unit.nva.model.associatedartifacts.file.InternalFile;
-import no.unit.nva.model.associatedartifacts.file.OpenFile;
 import no.unit.nva.publication.model.business.FileEntry;
 import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.UserInstance;
@@ -71,8 +69,7 @@ public class FileStrategyBase {
     }
 
     protected boolean fileIsFinalized() {
-        return file.getFile() instanceof OpenFile || file.getFile() instanceof InternalFile ||
-               file.getFile() instanceof HiddenFile;
+        return FINALIZED_FILE_TYPES.contains(file.getFile().getClass());
     }
 
     protected boolean isExternalClientWithRelation() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
@@ -6,7 +6,8 @@ import static no.unit.nva.PublicationUtil.PROTECTED_DEGREE_INSTANCE_TYPES;
 import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
-import static no.unit.nva.model.associatedartifacts.file.File.ACCEPTED_FILE_TYPES;
+import static no.unit.nva.model.associatedartifacts.file.File.APPROVED_FILE_TYPES;
+import static no.unit.nva.model.associatedartifacts.file.File.FINALIZED_FILE_TYPES;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
@@ -103,8 +104,13 @@ public class PublicationStrategyBase {
     protected boolean hasApprovedFiles() {
         return resource.getAssociatedArtifacts()
                    .stream()
-                   .anyMatch(artifact -> ACCEPTED_FILE_TYPES
-                                             .contains(artifact.getClass()));
+                   .anyMatch(artifact -> APPROVED_FILE_TYPES.contains(artifact.getClass()));
+    }
+
+    protected boolean hasFinalizedFiles() {
+        return resource.getAssociatedArtifacts()
+                   .stream()
+                   .anyMatch(artifact -> FINALIZED_FILE_TYPES.contains(artifact.getClass()));
     }
 
     protected boolean isImportedStudentThesis() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
@@ -23,7 +23,7 @@ public class ClaimedChannelDenyStrategy extends PublicationStrategyBase implemen
         }
         return isDeniedOperation(operation)
                && isPublished()
-               && (hasApprovedFiles() || isImportedStudentThesis())
+               && (hasFinalizedFiles() || isImportedStudentThesis())
                && isDeniedUserByClaimedChannelWithinScope();
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
@@ -37,14 +37,14 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
     }
 
     private boolean handleDegree() {
-        if (hasApprovedFiles() || isImportedStudentThesis()) {
-            return approvedFileStrategy();
+        if (hasFinalizedFiles() || isImportedStudentThesis()) {
+            return finalizedFilesStrategy();
         } else {
-            return nonApprovedFileStrategy();
+            return nonFinalizedFileStrategy();
         }
     }
 
-    private boolean approvedFileStrategy() {
+    private boolean finalizedFilesStrategy() {
         if (!hasAccessRight(MANAGE_DEGREE)) {
             return DENY;
         }
@@ -54,7 +54,7 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
         return PASS;
     }
 
-    private boolean nonApprovedFileStrategy() {
+    private boolean nonFinalizedFileStrategy() {
         if (!userRelatesToPublication()) {
             return DENY;
         }

--- a/publication-commons/src/test/java/cucumber/permissions/enums/FileConfig.java
+++ b/publication-commons/src/test/java/cucumber/permissions/enums/FileConfig.java
@@ -3,6 +3,6 @@ package cucumber.permissions.enums;
 public enum FileConfig {
     NO_FILES,
     NON_APPROVED_FILES_ONLY,
-    APPROVED_FILE
+    APPROVED_FILES
 }
 

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
@@ -50,7 +50,7 @@ public class PublicationAccessFeatures {
         } else if ("no approved".equalsIgnoreCase(fileTypes)) {
             scenarioContext.setFileConfig(FileConfig.NON_APPROVED_FILES_ONLY);
         } else if ("approved".equalsIgnoreCase(fileTypes)) {
-            scenarioContext.setFileConfig(FileConfig.APPROVED_FILE);
+            scenarioContext.setFileConfig(FileConfig.APPROVED_FILES);
         } else {
             throw new IllegalArgumentException("Non valid input: " + fileTypes);
         }

--- a/publication-commons/src/test/java/cucumber/permissions/ticket/TicketAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/ticket/TicketAccessFeatures.java
@@ -52,7 +52,7 @@ public class TicketAccessFeatures {
         } else if ("no approved".equalsIgnoreCase(fileTypes)) {
             publicationScenarioContext.setFileConfig(FileConfig.NON_APPROVED_FILES_ONLY);
         } else if ("approved".equalsIgnoreCase(fileTypes)) {
-            publicationScenarioContext.setFileConfig(FileConfig.APPROVED_FILE);
+            publicationScenarioContext.setFileConfig(FileConfig.APPROVED_FILES);
         } else {
             throw new IllegalArgumentException("Non valid input: " + fileTypes);
         }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ClaimedChannelPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/ClaimedChannelPermissionStrategyTest.java
@@ -45,7 +45,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -65,7 +65,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
                                         .build();
@@ -88,7 +88,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -110,7 +110,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -134,7 +134,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -159,7 +159,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -182,7 +182,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -205,7 +205,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
                                         .build();
@@ -231,7 +231,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -255,7 +255,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var contributor = owningInstitution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -280,7 +280,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -305,7 +305,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(owningInstitution.registrator());
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(owningInstitution.registrator());
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -329,7 +329,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
@@ -356,7 +356,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -380,7 +380,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var contributor = owningInstitution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -404,7 +404,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(owningInstitution.registrator());
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(owningInstitution.registrator());
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -430,7 +430,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -454,7 +454,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, EVERYONE);
@@ -477,7 +477,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, EVERYONE);
@@ -500,7 +500,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var contributor = owningInstitution.contributor();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -524,7 +524,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -549,7 +549,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -575,7 +575,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -599,7 +599,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -622,7 +622,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curator = owningInstitution.curator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -645,7 +645,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var contributor = owningInstitution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, contributor);
 
         var resource = Resource.fromPublication(publication);
@@ -669,7 +669,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -693,7 +693,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -719,7 +719,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
 
         var resource = Resource.fromPublication(publication);
@@ -743,7 +743,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -767,7 +767,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, nonCuratingInstitution, EVERYONE, EVERYONE);
@@ -790,7 +790,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator).copy()
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator).copy()
                               .withStatus(operation == PublicationOperation.REPUBLISH ? UNPUBLISHED : PUBLISHED)
                               .build();
 
@@ -814,7 +814,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -834,7 +834,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -853,7 +853,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
 
@@ -870,7 +870,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
 
@@ -888,7 +888,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, contributor);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -907,7 +907,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, contributor);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -926,7 +926,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
 
@@ -944,7 +944,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
 
@@ -963,7 +963,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -983,7 +983,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1003,7 +1003,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -1023,7 +1023,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1044,7 +1044,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         resource.setPublicationChannels(List.of());
@@ -1065,7 +1065,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curatingInstitution = suite.curatingInstitution();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         setContributor(publication, curatingInstitution.contributor());
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, owningInstitution, OWNER_ONLY, OWNER_ONLY);
@@ -1081,7 +1081,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
     void shouldAllowExternalUserWhenPublishingPolicyOwnerOnly() {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createNonDegreePublicationWithoutOpenOrInternalFiles(registrator);
+        var publication = createNonDegreePublicationWithoutFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -1096,7 +1096,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
     void shouldAllowExternalUserWhenEditingPolicyOwnerOnly() {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithinScope(resource, institution, OWNER_ONLY, OWNER_ONLY);
@@ -1115,7 +1115,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var registrator = owningInstitution.registrator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1134,7 +1134,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var curator = owningInstitution.curator();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1153,7 +1153,7 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
         var editor = owningInstitution.editor();
         var nonCuratingInstitution = suite.nonCuratingInstitution();
 
-        var publication = createNonDegreePublicationWithAcceptedFile(registrator);
+        var publication = createNonDegreePublicationWithFinalizedFiles(registrator);
         var resource = Resource.fromPublication(publication);
         setPublicationChannelOutsideOfScope(resource, nonCuratingInstitution, OWNER_ONLY, OWNER_ONLY);
 
@@ -1233,17 +1233,17 @@ public class ClaimedChannelPermissionStrategyTest extends PublicationPermissionS
                                      user.topLevelCristinId());
     }
 
-    private Publication createNonDegreePublicationWithAcceptedFile(User registrator) {
-        return createPublicationWithAcceptedFile(AcademicArticle.class,
-                                                 registrator.name(),
-                                                 registrator.customer(),
-                                                 registrator.topLevelCristinId());
+    private Publication createNonDegreePublicationWithFinalizedFiles(User registrator) {
+        return createPublicationWithFinalizedFiles(AcademicArticle.class,
+                                                   registrator.name(),
+                                                   registrator.customer(),
+                                                   registrator.topLevelCristinId());
     }
 
-    private Publication createNonDegreePublicationWithoutOpenOrInternalFiles(User registrator) {
-        return createPublicationWithoutAcceptedFiles(AcademicArticle.class,
-                                                     registrator.name(),
-                                                     registrator.customer(),
-                                                     registrator.topLevelCristinId());
+    private Publication createNonDegreePublicationWithoutFinalizedFiles(User registrator) {
+        return createPublicationWithoutFinalizedFiles(AcademicArticle.class,
+                                                      registrator.name(),
+                                                      registrator.customer(),
+                                                      registrator.topLevelCristinId());
     }
 }

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/DegreeDenyStrategyTest.java
@@ -42,10 +42,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
     void shouldDenyAnonymousUserOperationsOnDegreeWithoutOpenFiles(PublicationOperation operation,
                                                                    Class<?> degreeInstanceClass) {
         var registrator = User.random();
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                registrator.name(),
-                                                                registrator.customer(),
-                                                                registrator.topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 registrator.name(),
+                                                                 registrator.customer(),
+                                                                 registrator.topLevelCristinId());
 
         Assertions.assertFalse(PublicationPermissions
                                    .create(Resource.fromPublication(publication), null)
@@ -58,10 +58,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
     void shouldDenyAnonymousUserOperationsOnDegreeWithOpenFiles(PublicationOperation operation,
                                                                 Class<?> degreeInstanceClass) {
         var registrator = User.random();
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         Assertions.assertFalse(PublicationPermissions
                                    .create(Resource.fromPublication(publication), null)
@@ -75,10 +75,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                              Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                registrator.name(),
-                                                                registrator.customer(),
-                                                                registrator.topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 registrator.name(),
+                                                                 registrator.customer(),
+                                                                 registrator.topLevelCristinId());
 
         var publicationWithStatus = publication.copy()
                                         .withStatus(operation == PublicationOperation.DELETE ? DRAFT : PUBLISHED)
@@ -97,10 +97,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                               Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
@@ -117,10 +117,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         throws JsonProcessingException, UnauthorizedException {
         var institution = Institution.random();
         var registrator = institution.registrator();
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                registrator.name(),
-                                                                registrator.customer(),
-                                                                registrator.topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 registrator.name(),
+                                                                 registrator.customer(),
+                                                                 registrator.topLevelCristinId());
 
         setContributor(publication, institution.contributor());
 
@@ -140,10 +140,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var institution = Institution.random();
         var registrator = institution.registrator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         setContributor(publication, institution.contributor());
 
@@ -164,10 +164,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                registrator.name(),
-                                                                registrator.customer(),
-                                                                registrator.topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 registrator.name(),
+                                                                 registrator.customer(),
+                                                                 registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
@@ -184,10 +184,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var curator = institution.curator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curator), identityServiceClient);
 
@@ -206,10 +206,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                owningInstitution.registrator().name(),
-                                                                owningInstitution.registrator().customer(),
-                                                                owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 owningInstitution.registrator().name(),
+                                                                 owningInstitution.registrator().customer(),
+                                                                 owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -230,10 +230,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -256,10 +256,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var thesisCurator = institution.thesisCurator();
 
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                registrator.name(),
-                                                                registrator.customer(),
-                                                                registrator.topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 registrator.name(),
+                                                                 registrator.customer(),
+                                                                 registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator),
                                                                      identityServiceClient);
@@ -280,10 +280,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var thesisCurator = institution.thesisCurator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(thesisCurator),
                                                                      identityServiceClient);
@@ -304,10 +304,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceClass,
-                                                                owningInstitution.registrator().name(),
-                                                                owningInstitution.registrator().customer(),
-                                                                owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceClass,
+                                                                 owningInstitution.registrator().name(),
+                                                                 owningInstitution.registrator().customer(),
+                                                                 owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -328,10 +328,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -353,10 +353,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -377,10 +377,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -403,10 +403,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var registrator = owningInstitution.registrator();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, owningInstitution, EVERYONE, OWNER_ONLY);
@@ -429,10 +429,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var contributor = createContributor(Role.CREATOR, curatingInstitution.contributor().cristinId(),
                                             curatingInstitution.contributor().topLevelCristinId());
@@ -461,10 +461,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         setContributor(publication, curatingInstitution.contributor());
 
@@ -489,10 +489,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -514,10 +514,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -539,10 +539,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, anotherInstitution, EVERYONE, OWNER_ONLY);
@@ -565,10 +565,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -592,10 +592,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -621,10 +621,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var curatingInstitution = suite.curatingInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -650,10 +650,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var curatingInstitution = suite.curatingInstitution();
         var anotherInstitution = suite.nonCuratingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            owningInstitution.registrator().name(),
-                                                            owningInstitution.registrator().customer(),
-                                                            owningInstitution.registrator().topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              owningInstitution.registrator().name(),
+                                                              owningInstitution.registrator().customer(),
+                                                              owningInstitution.registrator().topLevelCristinId());
 
         var resource = Resource.fromPublication(publication);
         setPublicationChannelWithDegreeScope(resource, curatingInstitution, EVERYONE, OWNER_ONLY);
@@ -708,10 +708,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var owningInstitution = suite.owningInstitution();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithoutAcceptedFiles(degreeInstanceTypeClass,
-                                                                owningInstitution.registrator().name(),
-                                                                owningInstitution.registrator().customer(),
-                                                                owningInstitution.registrator().cristinId());
+        var publication = createPublicationWithoutFinalizedFiles(degreeInstanceTypeClass,
+                                                                 owningInstitution.registrator().name(),
+                                                                 owningInstitution.registrator().customer(),
+                                                                 owningInstitution.registrator().cristinId());
 
         publication.getEntityDescription().setContributors(List.of());
         publication.setCuratingInstitutions(
@@ -732,10 +732,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
                                                                Class<?> degreeInstanceClass)
         throws JsonProcessingException, UnauthorizedException {
         var registrator = User.random();
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(registrator), identityServiceClient);
 
@@ -753,10 +753,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = institution.registrator();
         var contributor = institution.contributor();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
         setContributor(publication, contributor);
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(contributor), identityServiceClient);
@@ -777,10 +777,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
         setContributor(publication, curatingInstitution.contributor());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curatingInstitution.contributor()),
@@ -802,10 +802,10 @@ class DegreeDenyStrategyTest extends PublicationPermissionStrategyTest {
         var registrator = owningInstitution.registrator();
         var curatingInstitution = suite.curatingInstitution();
 
-        var publication = createPublicationWithAcceptedFile(degreeInstanceClass,
-                                                            registrator.name(),
-                                                            registrator.customer(),
-                                                            registrator.topLevelCristinId());
+        var publication = createPublicationWithFinalizedFiles(degreeInstanceClass,
+                                                              registrator.name(),
+                                                              registrator.customer(),
+                                                              registrator.topLevelCristinId());
         setContributor(publication, curatingInstitution.contributor());
 
         var userInstance = RequestUtil.createUserInstanceFromRequest(toRequestInfo(curatingInstitution.curator()),

--- a/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/permissions/publication/PublicationPermissionStrategyTest.java
@@ -8,8 +8,8 @@ import static no.unit.nva.model.PublicationOperation.UPDATE_FILES;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static no.unit.nva.model.testing.PublicationGenerator.fromInstanceClassesExcluding;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
-import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAcceptedFile;
-import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAssociatedArtifactsExcludingAcceptedFiles;
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomFinalizedFiles;
+import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomNonFinalizedFiles;
 import static no.unit.nva.publication.PublicationServiceConfig.ENVIRONMENT;
 import static no.unit.nva.publication.permissions.PermissionsTestUtils.getAccessRightsForCurator;
 import static no.unit.nva.testutils.HandlerRequestBuilder.CLIENT_ID_CLAIM;
@@ -239,21 +239,21 @@ class PublicationPermissionStrategyTest {
                    .build();
     }
 
-    static Publication createPublicationWithAcceptedFile(Class<?> instanceTypeClass,
-                                                         String resourceOwner,
-                                                         URI customer,
-                                                         URI cristinId) {
+    static Publication createPublicationWithFinalizedFiles(Class<?> instanceTypeClass,
+                                                           String resourceOwner,
+                                                           URI customer,
+                                                           URI cristinId) {
         return createPublication(instanceTypeClass, resourceOwner, customer, cristinId).copy()
-                   .withAssociatedArtifacts(List.of(randomAcceptedFile()))
+                   .withAssociatedArtifacts(randomFinalizedFiles())
                    .build();
     }
 
-    static Publication createPublicationWithoutAcceptedFiles(Class<?> instanceTypeClass,
-                                                             String resourceOwner,
-                                                             URI customer,
-                                                             URI cristinId) {
+    static Publication createPublicationWithoutFinalizedFiles(Class<?> instanceTypeClass,
+                                                              String resourceOwner,
+                                                              URI customer,
+                                                              URI cristinId) {
         return createPublication(instanceTypeClass, resourceOwner, customer, cristinId).copy()
-                   .withAssociatedArtifacts(randomAssociatedArtifactsExcludingAcceptedFiles())
+                   .withAssociatedArtifacts(randomNonFinalizedFiles())
                    .build();
     }
 

--- a/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
@@ -11,201 +11,216 @@ Feature: Publication action permissions
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Operation                 | Outcome     |
-      | Unauthenticated         | update                    | Not Allowed |
-      | Everyone                | update                    | Not Allowed |
-      | Publication creator     | update                    | Allowed     |
-      | Contributor             | update                    | Allowed     |
-      | Publishing curator      | update                    | Allowed     |
-      | NVI curator             | update                    | Allowed     |
-      | DOI curator             | update                    | Allowed     |
-      | Support curator         | update                    | Allowed     |
-      | Thesis curator          | update                    | Allowed     |
-      | Embargo thesis curator  | update                    | Allowed     |
-      | Editor                  | update                    | Allowed     |
-      | Related external client | update                    | Allowed     |
+      | UserRole                    | Operation                 | Outcome     |
+      | Unauthenticated             | update                    | Not Allowed |
+      | Everyone                    | update                    | Not Allowed |
+      | Publication creator         | update                    | Allowed     |
+      | Contributor                 | update                    | Allowed     |
+      | Publishing curator          | update                    | Allowed     |
+      | NVI curator                 | update                    | Allowed     |
+      | DOI curator                 | update                    | Allowed     |
+      | Support curator             | update                    | Allowed     |
+      | Thesis curator              | update                    | Allowed     |
+      | Embargo thesis curator      | update                    | Allowed     |
+      | Editor                      | update                    | Allowed     |
+      | Related external client     | update                    | Allowed     |
+      | Not related external client | update                    | Not Allowed |
 
-      | Unauthenticated         | partial-update            | Not Allowed |
-      | Everyone                | partial-update            | Not Allowed |
-      | Publication creator     | partial-update            | Allowed     |
-      | Contributor             | partial-update            | Allowed     |
-      | Publishing curator      | partial-update            | Allowed     |
-      | NVI curator             | partial-update            | Allowed     |
-      | DOI curator             | partial-update            | Allowed     |
-      | Support curator         | partial-update            | Allowed     |
-      | Thesis curator          | partial-update            | Allowed     |
-      | Embargo thesis curator  | partial-update            | Allowed     |
-      | Editor                  | partial-update            | Allowed     |
-      | Related external client | partial-update            | Allowed     |
+      | Unauthenticated             | partial-update            | Not Allowed |
+      | Everyone                    | partial-update            | Not Allowed |
+      | Publication creator         | partial-update            | Allowed     |
+      | Contributor                 | partial-update            | Allowed     |
+      | Publishing curator          | partial-update            | Allowed     |
+      | NVI curator                 | partial-update            | Allowed     |
+      | DOI curator                 | partial-update            | Allowed     |
+      | Support curator             | partial-update            | Allowed     |
+      | Thesis curator              | partial-update            | Allowed     |
+      | Embargo thesis curator      | partial-update            | Allowed     |
+      | Editor                      | partial-update            | Allowed     |
+      | Related external client     | partial-update            | Allowed     |
+      | Not related external client | partial-update            | Not Allowed |
 
-      | Unauthenticated         | update-including-files    | Not Allowed |
-      | Everyone                | update-including-files    | Not Allowed |
-      | Publication creator     | update-including-files    | Not Allowed |
-      | Contributor             | update-including-files    | Not Allowed |
-      | Publishing curator      | update-including-files    | Allowed     |
-      | NVI curator             | update-including-files    | Not Allowed |
-      | DOI curator             | update-including-files    | Not Allowed |
-      | Support curator         | update-including-files    | Not Allowed |
-      | Thesis curator          | update-including-files    | Not Allowed |
-      | Embargo thesis curator  | update-including-files    | Not Allowed |
-      | Editor                  | update-including-files    | Not Allowed |
-      | Related external client | update-including-files    | Not Allowed |
+      | Unauthenticated             | update-including-files    | Not Allowed |
+      | Everyone                    | update-including-files    | Not Allowed |
+      | Publication creator         | update-including-files    | Not Allowed |
+      | Contributor                 | update-including-files    | Not Allowed |
+      | Publishing curator          | update-including-files    | Allowed     |
+      | NVI curator                 | update-including-files    | Not Allowed |
+      | DOI curator                 | update-including-files    | Not Allowed |
+      | Support curator             | update-including-files    | Not Allowed |
+      | Thesis curator              | update-including-files    | Not Allowed |
+      | Embargo thesis curator      | update-including-files    | Not Allowed |
+      | Editor                      | update-including-files    | Not Allowed |
+      | Related external client     | update-including-files    | Not Allowed |
+      | Not related external client | update-including-files    | Not Allowed |
 
-      | Unauthenticated         | read-hidden-files         | Not Allowed |
-      | Everyone                | read-hidden-files         | Not Allowed |
-      | Publication creator     | read-hidden-files         | Not Allowed |
-      | Contributor             | read-hidden-files         | Not Allowed |
-      | Publishing curator      | read-hidden-files         | Allowed     |
-      | NVI curator             | read-hidden-files         | Not Allowed |
-      | DOI curator             | read-hidden-files         | Not Allowed |
-      | Support curator         | read-hidden-files         | Not Allowed |
-      | Thesis curator          | read-hidden-files         | Not Allowed |
-      | Embargo thesis curator  | read-hidden-files         | Not Allowed |
-      | Editor                  | read-hidden-files         | Allowed     |
-      | Related external client | read-hidden-files         | Allowed     |
+      | Unauthenticated             | read-hidden-files         | Not Allowed |
+      | Everyone                    | read-hidden-files         | Not Allowed |
+      | Publication creator         | read-hidden-files         | Not Allowed |
+      | Contributor                 | read-hidden-files         | Not Allowed |
+      | Publishing curator          | read-hidden-files         | Allowed     |
+      | NVI curator                 | read-hidden-files         | Not Allowed |
+      | DOI curator                 | read-hidden-files         | Not Allowed |
+      | Support curator             | read-hidden-files         | Not Allowed |
+      | Thesis curator              | read-hidden-files         | Not Allowed |
+      | Embargo thesis curator      | read-hidden-files         | Not Allowed |
+      | Editor                      | read-hidden-files         | Allowed     |
+      | Related external client     | read-hidden-files         | Allowed     |
+      | Not related external client | read-hidden-files         | Not Allowed |
 
-      | Unauthenticated         | unpublish                 | Not Allowed |
-      | Everyone                | unpublish                 | Not Allowed |
-      | Publication creator     | unpublish                 | Allowed     |
-      | Contributor             | unpublish                 | Allowed     |
-      | Publishing curator      | unpublish                 | Allowed     |
-      | NVI curator             | unpublish                 | Allowed     |
-      | DOI curator             | unpublish                 | Allowed     |
-      | Support curator         | unpublish                 | Allowed     |
-      | Thesis curator          | unpublish                 | Allowed     |
-      | Embargo thesis curator  | unpublish                 | Allowed     |
-      | Editor                  | unpublish                 | Allowed     |
-      | Related external client | unpublish                 | Allowed     |
-
-      # Publication has status PUBLISHED
-      | Unauthenticated         | republish                 | Not Allowed |
-      | Everyone                | republish                 | Not Allowed |
-      | Publication creator     | republish                 | Not Allowed |
-      | Contributor             | republish                 | Not Allowed |
-      | Publishing curator      | republish                 | Not Allowed |
-      | NVI curator             | republish                 | Not Allowed |
-      | DOI curator             | republish                 | Not Allowed |
-      | Support curator         | republish                 | Not Allowed |
-      | Thesis curator          | republish                 | Not Allowed |
-      | Embargo thesis curator  | republish                 | Not Allowed |
-      | Editor                  | republish                 | Not Allowed |
-      | Related external client | republish                 | Not Allowed |
+      | Unauthenticated             | unpublish                 | Not Allowed |
+      | Everyone                    | unpublish                 | Not Allowed |
+      | Publication creator         | unpublish                 | Allowed     |
+      | Contributor                 | unpublish                 | Allowed     |
+      | Publishing curator          | unpublish                 | Allowed     |
+      | NVI curator                 | unpublish                 | Allowed     |
+      | DOI curator                 | unpublish                 | Allowed     |
+      | Support curator             | unpublish                 | Allowed     |
+      | Thesis curator              | unpublish                 | Allowed     |
+      | Embargo thesis curator      | unpublish                 | Allowed     |
+      | Editor                      | unpublish                 | Allowed     |
+      | Related external client     | unpublish                 | Allowed     |
+      | Not related external client | unpublish                 | Not Allowed |
 
       # Publication has status PUBLISHED
-      | Unauthenticated         | delete                    | Not Allowed |
-      | Everyone                | delete                    | Not Allowed |
-      | Publication creator     | delete                    | Not Allowed |
-      | Contributor             | delete                    | Not Allowed |
-      | Publishing curator      | delete                    | Not Allowed |
-      | NVI curator             | delete                    | Not Allowed |
-      | DOI curator             | delete                    | Not Allowed |
-      | Support curator         | delete                    | Not Allowed |
-      | Thesis curator          | delete                    | Not Allowed |
-      | Embargo thesis curator  | delete                    | Not Allowed |
-      | Editor                  | delete                    | Not Allowed |
-      | Related external client | delete                    | Not Allowed |
+      | Unauthenticated             | republish                 | Not Allowed |
+      | Everyone                    | republish                 | Not Allowed |
+      | Publication creator         | republish                 | Not Allowed |
+      | Contributor                 | republish                 | Not Allowed |
+      | Publishing curator          | republish                 | Not Allowed |
+      | NVI curator                 | republish                 | Not Allowed |
+      | DOI curator                 | republish                 | Not Allowed |
+      | Support curator             | republish                 | Not Allowed |
+      | Thesis curator              | republish                 | Not Allowed |
+      | Embargo thesis curator      | republish                 | Not Allowed |
+      | Editor                      | republish                 | Not Allowed |
+      | Related external client     | republish                 | Not Allowed |
+      | Not related external client | republish                 | Not Allowed |
 
       # Publication has status PUBLISHED
-      | Unauthenticated         | terminate                 | Not Allowed |
-      | Everyone                | terminate                 | Not Allowed |
-      | Publication creator     | terminate                 | Not Allowed |
-      | Contributor             | terminate                 | Not Allowed |
-      | Publishing curator      | terminate                 | Not Allowed |
-      | NVI curator             | terminate                 | Not Allowed |
-      | DOI curator             | terminate                 | Not Allowed |
-      | Support curator         | terminate                 | Not Allowed |
-      | Thesis curator          | terminate                 | Not Allowed |
-      | Embargo thesis curator  | terminate                 | Not Allowed |
-      | Editor                  | terminate                 | Not Allowed |
-      | Related external client | terminate                 | Allowed     |
+      | Unauthenticated             | delete                    | Not Allowed |
+      | Everyone                    | delete                    | Not Allowed |
+      | Publication creator         | delete                    | Not Allowed |
+      | Contributor                 | delete                    | Not Allowed |
+      | Publishing curator          | delete                    | Not Allowed |
+      | NVI curator                 | delete                    | Not Allowed |
+      | DOI curator                 | delete                    | Not Allowed |
+      | Support curator             | delete                    | Not Allowed |
+      | Thesis curator              | delete                    | Not Allowed |
+      | Embargo thesis curator      | delete                    | Not Allowed |
+      | Editor                      | delete                    | Not Allowed |
+      | Related external client     | delete                    | Not Allowed |
+      | Not related external client | delete                    | Not Allowed |
 
-      | Unauthenticated         | doi-request-create        | Not Allowed |
-      | Everyone                | doi-request-create        | Not Allowed |
-      | Publication creator     | doi-request-create        | Allowed     |
-      | Contributor             | doi-request-create        | Allowed     |
-      | Publishing curator      | doi-request-create        | Allowed     |
-      | NVI curator             | doi-request-create        | Allowed     |
-      | DOI curator             | doi-request-create        | Allowed     |
-      | Support curator         | doi-request-create        | Allowed     |
-      | Thesis curator          | doi-request-create        | Allowed     |
-      | Embargo thesis curator  | doi-request-create        | Allowed     |
-      | Editor                  | doi-request-create        | Allowed     |
-      | Related external client | doi-request-create        | Not Allowed |
+      # Publication has status PUBLISHED
+      | Unauthenticated             | terminate                 | Not Allowed |
+      | Everyone                    | terminate                 | Not Allowed |
+      | Publication creator         | terminate                 | Not Allowed |
+      | Contributor                 | terminate                 | Not Allowed |
+      | Publishing curator          | terminate                 | Not Allowed |
+      | NVI curator                 | terminate                 | Not Allowed |
+      | DOI curator                 | terminate                 | Not Allowed |
+      | Support curator             | terminate                 | Not Allowed |
+      | Thesis curator              | terminate                 | Not Allowed |
+      | Embargo thesis curator      | terminate                 | Not Allowed |
+      | Editor                      | terminate                 | Not Allowed |
+      | Related external client     | terminate                 | Allowed     |
+      | Not related external client | terminate                 | Not Allowed |
 
-      | Unauthenticated         | doi-request-approve       | Not Allowed |
-      | Everyone                | doi-request-approve       | Not Allowed |
-      | Publication creator     | doi-request-approve       | Not Allowed |
-      | Contributor             | doi-request-approve       | Not Allowed |
-      | Publishing curator      | doi-request-approve       | Not Allowed |
-      | NVI curator             | doi-request-approve       | Not Allowed |
-      | DOI curator             | doi-request-approve       | Allowed     |
-      | Support curator         | doi-request-approve       | Not Allowed |
-      | Thesis curator          | doi-request-approve       | Not Allowed |
-      | Embargo thesis curator  | doi-request-approve       | Not Allowed |
-      | Editor                  | doi-request-approve       | Not Allowed |
-      | Related external client | doi-request-approve       | Not Allowed |
+      | Unauthenticated             | doi-request-create        | Not Allowed |
+      | Everyone                    | doi-request-create        | Not Allowed |
+      | Publication creator         | doi-request-create        | Allowed     |
+      | Contributor                 | doi-request-create        | Allowed     |
+      | Publishing curator          | doi-request-create        | Allowed     |
+      | NVI curator                 | doi-request-create        | Allowed     |
+      | DOI curator                 | doi-request-create        | Allowed     |
+      | Support curator             | doi-request-create        | Allowed     |
+      | Thesis curator              | doi-request-create        | Allowed     |
+      | Embargo thesis curator      | doi-request-create        | Allowed     |
+      | Editor                      | doi-request-create        | Allowed     |
+      | Related external client     | doi-request-create        | Not Allowed |
+      | Not related external client | doi-request-create        | Not Allowed |
 
-      | Unauthenticated         | publishing-request-create | Not Allowed |
-      | Everyone                | publishing-request-create | Not Allowed |
-      | Publication creator     | publishing-request-create | Allowed     |
-      | Contributor             | publishing-request-create | Allowed     |
-      | Publishing curator      | publishing-request-create | Allowed     |
-      | NVI curator             | publishing-request-create | Allowed     |
-      | DOI curator             | publishing-request-create | Allowed     |
-      | Support curator         | publishing-request-create | Allowed     |
-      | Thesis curator          | publishing-request-create | Allowed     |
-      | Embargo thesis curator  | publishing-request-create | Allowed     |
-      | Editor                  | publishing-request-create | Allowed     |
-      | Related external client | publishing-request-create | Not Allowed |
+      | Unauthenticated             | doi-request-approve       | Not Allowed |
+      | Everyone                    | doi-request-approve       | Not Allowed |
+      | Publication creator         | doi-request-approve       | Not Allowed |
+      | Contributor                 | doi-request-approve       | Not Allowed |
+      | Publishing curator          | doi-request-approve       | Not Allowed |
+      | NVI curator                 | doi-request-approve       | Not Allowed |
+      | DOI curator                 | doi-request-approve       | Allowed     |
+      | Support curator             | doi-request-approve       | Not Allowed |
+      | Thesis curator              | doi-request-approve       | Not Allowed |
+      | Embargo thesis curator      | doi-request-approve       | Not Allowed |
+      | Editor                      | doi-request-approve       | Not Allowed |
+      | Related external client     | doi-request-approve       | Not Allowed |
+      | Not related external client | doi-request-approve       | Not Allowed |
 
-      | Unauthenticated         | approve-files             | Not Allowed |
-      | Everyone                | approve-files             | Not Allowed |
-      | Publication creator     | approve-files             | Not Allowed |
-      | Contributor             | approve-files             | Not Allowed |
-      | Publishing curator      | approve-files             | Allowed     |
-      | NVI curator             | approve-files             | Not Allowed |
-      | DOI curator             | approve-files             | Not Allowed |
-      | Support curator         | approve-files             | Not Allowed |
-      | Thesis curator          | approve-files             | Not Allowed |
-      | Embargo thesis curator  | approve-files             | Not Allowed |
-      | Editor                  | approve-files             | Not Allowed |
-      | Related external client | approve-files             | Not Allowed |
+      | Unauthenticated             | publishing-request-create | Not Allowed |
+      | Everyone                    | publishing-request-create | Not Allowed |
+      | Publication creator         | publishing-request-create | Allowed     |
+      | Contributor                 | publishing-request-create | Allowed     |
+      | Publishing curator          | publishing-request-create | Allowed     |
+      | NVI curator                 | publishing-request-create | Allowed     |
+      | DOI curator                 | publishing-request-create | Allowed     |
+      | Support curator             | publishing-request-create | Allowed     |
+      | Thesis curator              | publishing-request-create | Allowed     |
+      | Embargo thesis curator      | publishing-request-create | Allowed     |
+      | Editor                      | publishing-request-create | Allowed     |
+      | Related external client     | publishing-request-create | Not Allowed |
+      | Not related external client | publishing-request-create | Not Allowed |
 
-      | Unauthenticated         | support-request-create    | Not Allowed |
-      | Everyone                | support-request-create    | Not Allowed |
-      | Publication creator     | support-request-create    | Allowed     |
-      | Contributor             | support-request-create    | Allowed     |
-      | Publishing curator      | support-request-create    | Allowed     |
-      | NVI curator             | support-request-create    | Allowed     |
-      | DOI curator             | support-request-create    | Allowed     |
-      | Support curator         | support-request-create    | Allowed     |
-      | Thesis curator          | support-request-create    | Allowed     |
-      | Embargo thesis curator  | support-request-create    | Allowed     |
-      | Editor                  | support-request-create    | Allowed     |
-      | Related external client | support-request-create    | Not Allowed |
+      | Unauthenticated             | approve-files             | Not Allowed |
+      | Everyone                    | approve-files             | Not Allowed |
+      | Publication creator         | approve-files             | Not Allowed |
+      | Contributor                 | approve-files             | Not Allowed |
+      | Publishing curator          | approve-files             | Allowed     |
+      | NVI curator                 | approve-files             | Not Allowed |
+      | DOI curator                 | approve-files             | Not Allowed |
+      | Support curator             | approve-files             | Not Allowed |
+      | Thesis curator              | approve-files             | Not Allowed |
+      | Embargo thesis curator      | approve-files             | Not Allowed |
+      | Editor                      | approve-files             | Not Allowed |
+      | Related external client     | approve-files             | Not Allowed |
+      | Not related external client | approve-files             | Not Allowed |
 
-      | Unauthenticated         | support-request-approve   | Not Allowed |
-      | Everyone                | support-request-approve   | Not Allowed |
-      | Publication creator     | support-request-approve   | Not Allowed |
-      | Contributor             | support-request-approve   | Not Allowed |
-      | Publishing curator      | support-request-approve   | Not Allowed |
-      | NVI curator             | support-request-approve   | Not Allowed |
-      | DOI curator             | support-request-approve   | Not Allowed |
-      | Support curator         | support-request-approve   | Allowed     |
-      | Thesis curator          | support-request-approve   | Not Allowed |
-      | Embargo thesis curator  | support-request-approve   | Not Allowed |
-      | Editor                  | support-request-approve   | Not Allowed |
-      | Related external client | support-request-approve   | Not Allowed |
+      | Unauthenticated             | support-request-create    | Not Allowed |
+      | Everyone                    | support-request-create    | Not Allowed |
+      | Publication creator         | support-request-create    | Allowed     |
+      | Contributor                 | support-request-create    | Allowed     |
+      | Publishing curator          | support-request-create    | Allowed     |
+      | NVI curator                 | support-request-create    | Allowed     |
+      | DOI curator                 | support-request-create    | Allowed     |
+      | Support curator             | support-request-create    | Allowed     |
+      | Thesis curator              | support-request-create    | Allowed     |
+      | Embargo thesis curator      | support-request-create    | Allowed     |
+      | Editor                      | support-request-create    | Allowed     |
+      | Related external client     | support-request-create    | Not Allowed |
+      | Not related external client | support-request-create    | Not Allowed |
 
-      | Unauthenticated         | upload-file               | Not Allowed |
-      | Everyone                | upload-file               | Not Allowed |
-      | Publication creator     | upload-file               | Allowed     |
-      | Contributor             | upload-file               | Allowed     |
-      | Publishing curator      | upload-file               | Allowed     |
-      | NVI curator             | upload-file               | Allowed     |
-      | DOI curator             | upload-file               | Allowed     |
-      | Support curator         | upload-file               | Allowed     |
-      | Thesis curator          | upload-file               | Allowed     |
-      | Embargo thesis curator  | upload-file               | Allowed     |
-      | Editor                  | upload-file               | Not Allowed |
-      | Related external client | upload-file               | Allowed     |
+      | Unauthenticated             | support-request-approve   | Not Allowed |
+      | Everyone                    | support-request-approve   | Not Allowed |
+      | Publication creator         | support-request-approve   | Not Allowed |
+      | Contributor                 | support-request-approve   | Not Allowed |
+      | Publishing curator          | support-request-approve   | Not Allowed |
+      | NVI curator                 | support-request-approve   | Not Allowed |
+      | DOI curator                 | support-request-approve   | Not Allowed |
+      | Support curator             | support-request-approve   | Allowed     |
+      | Thesis curator              | support-request-approve   | Not Allowed |
+      | Embargo thesis curator      | support-request-approve   | Not Allowed |
+      | Editor                      | support-request-approve   | Not Allowed |
+      | Related external client     | support-request-approve   | Not Allowed |
+      | Not related external client | support-request-approve   | Not Allowed |
+
+      | Unauthenticated             | upload-file               | Not Allowed |
+      | Everyone                    | upload-file               | Not Allowed |
+      | Publication creator         | upload-file               | Allowed     |
+      | Contributor                 | upload-file               | Allowed     |
+      | Publishing curator          | upload-file               | Allowed     |
+      | NVI curator                 | upload-file               | Allowed     |
+      | DOI curator                 | upload-file               | Allowed     |
+      | Support curator             | upload-file               | Allowed     |
+      | Thesis curator              | upload-file               | Allowed     |
+      | Embargo thesis curator      | upload-file               | Allowed     |
+      | Editor                      | upload-file               | Not Allowed |
+      | Related external client     | upload-file               | Allowed     |
+      | Not related external client | upload-file               | Not Allowed |

--- a/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
+++ b/publication-model-testing/src/main/java/no/unit/nva/model/testing/associatedartifacts/AssociatedArtifactsGenerator.java
@@ -1,13 +1,12 @@
 package no.unit.nva.model.testing.associatedartifacts;
 
-import static no.unit.nva.model.associatedartifacts.file.File.ACCEPTED_FILE_TYPES;
+import static no.unit.nva.model.associatedartifacts.file.File.FINALIZED_FILE_TYPES;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
@@ -31,14 +30,30 @@ public final class AssociatedArtifactsGenerator {
     }
 
     public static List<AssociatedArtifact> randomAssociatedArtifacts() {
-        return new AssociatedArtifactList(randomPendingOpenFile(), randomOpenFile(), randomInternalFile(),
-                                          randomAssociatedLink(), randomHiddenFile());
+        return new AssociatedArtifactList(randomPendingOpenFile(), randomOpenFile(), randomPendingInternalFile(),
+                                          randomInternalFile(), randomAssociatedLink(), randomHiddenFile());
     }
 
-    public static List<AssociatedArtifact> randomAssociatedArtifactsExcludingAcceptedFiles() {
-        return randomAssociatedArtifacts()
+    public static List<AssociatedArtifact> randomAssociatedArtifactsIncludingUploadedFileAndRejectedFile() {
+        var artifacts = randomAssociatedArtifacts();
+        artifacts.add(randomUploadedFile());
+        artifacts.add(randomRejectedFile());
+        return artifacts;
+    }
+
+    public static List<AssociatedArtifact> randomNonFinalizedFiles() {
+        return randomAssociatedArtifactsIncludingUploadedFileAndRejectedFile()
                    .stream()
-                   .filter(artifact -> !ACCEPTED_FILE_TYPES.contains(artifact.getClass()))
+                   .filter(File.class::isInstance)
+                   .filter(artifact -> !FINALIZED_FILE_TYPES.contains(artifact.getClass()))
+                   .toList();
+    }
+
+    public static List<AssociatedArtifact> randomFinalizedFiles() {
+        return randomAssociatedArtifactsIncludingUploadedFileAndRejectedFile()
+                   .stream()
+                   .filter(File.class::isInstance)
+                   .filter(artifact -> FINALIZED_FILE_TYPES.contains(artifact.getClass()))
                    .toList();
     }
 
@@ -54,15 +69,12 @@ public final class AssociatedArtifactsGenerator {
         return randomFileBuilder().buildUploadedFile();
     }
 
-    public static File randomOpenFile() {
-        return randomFileBuilder().buildOpenFile();
+    public static File randomRejectedFile() {
+        return randomFileBuilder().buildRejectedFile();
     }
 
-    public static File randomAcceptedFile() {
-        var acceptedFilesTypes = ACCEPTED_FILE_TYPES.stream().toList();
-        var randomIndex = new Random().nextInt(acceptedFilesTypes.size());
-        var acceptedFileType = acceptedFilesTypes.get(randomIndex);
-        return randomFileBuilder().build(acceptedFileType);
+    public static File randomOpenFile() {
+        return randomFileBuilder().buildOpenFile();
     }
 
     public static File randomPendingInternalFile() {

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -48,11 +48,9 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     public static final String UPLOAD_DETAILS_FIELD = "uploadDetails";
     public static final String MISSING_LICENSE = "This file public and should therefore have a license";
     public static final String LEGAL_NOTE_FIELD = "legalNote";
-    public static final Set<Class<? extends File>> ACCEPTED_FILE_TYPES = Set.of(OpenFile.class, InternalFile.class);
-    public static final Set<Class<? extends File>> INITIAL_FILE_TYPES = Set.of(PendingOpenFile.class,
-                                                                               PendingInternalFile.class,
-                                                                               HiddenFile.class,
-                                                                               UploadedFile.class);
+    public static final Set<Class<? extends File>> APPROVED_FILE_TYPES = Set.of(OpenFile.class, InternalFile.class);
+    public static final Set<Class<? extends File>> FINALIZED_FILE_TYPES = Set.of(OpenFile.class, InternalFile.class,
+                                                                                HiddenFile.class);
     @JsonProperty(IDENTIFIER_FIELD)
     private final UUID identifier;
     @JsonProperty(NAME_FIELD)


### PR DESCRIPTION
Apologies for messy PR.

Four things done in this PR, all related to channel ownership in some way:
1) Add `"Not related external client"` to publication permissions test for wider test coverage
2) Use the term `approved files` instead of `accepted files` for `OpenFile` and `InternalFile`
3) Use `finalized files` instead of `approved files` for `ChannelClaimDenyStrategy` as hidden files are not part of `approved files`
4) Included `PendingInternalFile` to `randomAssociatedArtifactBuilder`