### PR TITLE
Rename approved files to finalized files in gherkin tests

### DIFF
--- a/publication-commons/src/test/java/cucumber/permissions/enums/FileConfig.java
+++ b/publication-commons/src/test/java/cucumber/permissions/enums/FileConfig.java
@@ -2,7 +2,7 @@ package cucumber.permissions.enums;
 
 public enum FileConfig {
     NO_FILES,
-    NON_APPROVED_FILES_ONLY,
-    APPROVED_FILES
+    NON_FINALIZED_FILES,
+    FINALIZED_FILES
 }
 

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationAccessFeatures.java
@@ -47,10 +47,10 @@ public class PublicationAccessFeatures {
     public void publicationHasFiles(String fileTypes) {
         if ("no".equalsIgnoreCase(fileTypes)) {
             scenarioContext.setFileConfig(FileConfig.NO_FILES);
-        } else if ("no approved".equalsIgnoreCase(fileTypes)) {
-            scenarioContext.setFileConfig(FileConfig.NON_APPROVED_FILES_ONLY);
-        } else if ("approved".equalsIgnoreCase(fileTypes)) {
-            scenarioContext.setFileConfig(FileConfig.APPROVED_FILES);
+        } else if ("no finalized".equalsIgnoreCase(fileTypes)) {
+            scenarioContext.setFileConfig(FileConfig.NON_FINALIZED_FILES);
+        } else if ("finalized".equalsIgnoreCase(fileTypes)) {
+            scenarioContext.setFileConfig(FileConfig.FINALIZED_FILES);
         } else {
             throw new IllegalArgumentException("Non valid input: " + fileTypes);
         }

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
@@ -275,8 +275,8 @@ public class PublicationScenarioContext {
     private AssociatedArtifactList createAssociatedArtifacts() {
         return switch (getFileConfig()) {
             case NO_FILES -> AssociatedArtifactList.empty();
-            case NON_APPROVED_FILES_ONLY -> new AssociatedArtifactList(randomNonFinalizedFiles());
-            case APPROVED_FILES -> new AssociatedArtifactList(randomFinalizedFiles());
+            case NON_FINALIZED_FILES -> new AssociatedArtifactList(randomNonFinalizedFiles());
+            case FINALIZED_FILES -> new AssociatedArtifactList(randomFinalizedFiles());
         };
     }
 

--- a/publication-commons/src/test/java/cucumber/permissions/ticket/TicketAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/ticket/TicketAccessFeatures.java
@@ -49,10 +49,10 @@ public class TicketAccessFeatures {
     public void publicationHasFiles(String fileTypes) {
         if ("no".equalsIgnoreCase(fileTypes)) {
             publicationScenarioContext.setFileConfig(FileConfig.NO_FILES);
-        } else if ("no approved".equalsIgnoreCase(fileTypes)) {
-            publicationScenarioContext.setFileConfig(FileConfig.NON_APPROVED_FILES_ONLY);
-        } else if ("approved".equalsIgnoreCase(fileTypes)) {
-            publicationScenarioContext.setFileConfig(FileConfig.APPROVED_FILES);
+        } else if ("no finalized".equalsIgnoreCase(fileTypes)) {
+            publicationScenarioContext.setFileConfig(FileConfig.NON_FINALIZED_FILES);
+        } else if ("finalized".equalsIgnoreCase(fileTypes)) {
+            publicationScenarioContext.setFileConfig(FileConfig.FINALIZED_FILES);
         } else {
             throw new IllegalArgumentException("Non valid input: " + fileTypes);
         }

--- a/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
@@ -4,9 +4,9 @@ Feature: Permissions given claimed publisher
   So that only authorized users can perform operation
 
   Scenario Outline: Verify operation when user is not from the same organization as claimed
-  publisher and publication has approved files
+  publisher and publication has finalized files
     Given a "degree"
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "not users institution"
     And channel claim has "editing" policy "OwnerOnly"
     When the user have the role "<UserRole>"
@@ -59,9 +59,9 @@ Feature: Permissions given claimed publisher
 
 
   Scenario Outline: Verify update operation when user is from the same organization as claimed
-  publisher and publication has no approved files
+  publisher and publication has no finalized files
     Given a "degree"
-    And publication has "no approved" files
+    And publication has "no finalized" files
     And publication has publisher claimed by "users institution"
     And channel claim has "publishing" policy "everyone"
     When the user have the role "<UserRole>"
@@ -85,9 +85,9 @@ Feature: Permissions given claimed publisher
       | Related external client | Allowed     |
 
   Scenario Outline: Verify update operation when user is not from the same organization as claimed
-  publisher and publication has no approved files
+  publisher and publication has no finalized files
     Given a "degree"
-    And publication has "no approved" files
+    And publication has "no finalized" files
     And publication has publisher claimed by "not users institution"
     And channel claim has "publishing" policy "everyone"
     When the user have the role "<UserRole>"
@@ -110,10 +110,10 @@ Feature: Permissions given claimed publisher
       | Related external client | Allowed     |
 
   Scenario Outline: Verify update operation when user is not from the same organization as claimed
-  publisher, publication is an imported student thesis and has no approved files
+  publisher, publication is an imported student thesis and has no finalized files
     Given a "degree"
     And publication is an imported degree
-    And publication has "no approved" files
+    And publication has "no finalized" files
     And publication has publisher claimed by "not users institution"
     And channel claim has "publishing" policy "everyone"
     When the user have the role "<UserRole>"
@@ -136,10 +136,10 @@ Feature: Permissions given claimed publisher
       | Related external client | Allowed     |
 
   Scenario Outline: Verify update operation when user is not from the same organization as claimed
-  publisher, publication is an imported student thesis and has approved files
+  publisher, publication is an imported student thesis and has finalized files
     Given a "degree"
     And publication is an imported degree
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "not users institution"
     And channel claim has "editing" policy "ownerOnly"
     When the user have the role "<UserRole>"
@@ -165,7 +165,7 @@ Feature: Permissions given claimed publisher
   Scenario Outline: Verify permission when
   user is from the same organization as claimed publisher
     Given a "degree"
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "users institution"
     And channel claim has "editing" policy "ownerOnly"
     When the user have the role "<UserRole>"

--- a/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
@@ -6,7 +6,7 @@ Feature: Publication update permissions
   Scenario Outline: Verify operation when
     Given a "degree"
     And publication is an imported degree
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "users institution"
     When the user have the role "<UserRole>"
     And the user attempts to "<Operation>"
@@ -30,7 +30,7 @@ Feature: Publication update permissions
 
   Scenario Outline: Verify operation when
     Given a "degree"
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "users institution"
     When the user have the role "<UserRole>"
     And the user attempts to "<Operation>"
@@ -54,7 +54,7 @@ Feature: Publication update permissions
 
   Scenario Outline: Verify operation when
     Given a "publication"
-    And publication has "approved" files
+    And publication has "finalized" files
     And publication has publisher claimed by "users institution"
     When the user have the role "<UserRole>"
     And the user attempts to "<Operation>"

--- a/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
+++ b/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
@@ -115,11 +115,11 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "Not Allowed"
 
     Examples:
-      | Files       | ClaimedBy             |
-      | No          | not users institution |
-      | No approved | not users institution |
-      | Approved    | not users institution |
+      | Files        | ClaimedBy             |
+      | No           | not users institution |
+      | No finalized | not users institution |
+      | Finalized    | not users institution |
 
-      | No          | users institution     |
-      | No approved | users institution     |
-      | Approved    | users institution     |
+      | No           | users institution     |
+      | No finalized | users institution     |
+      | Finalized    | users institution     |


### PR DESCRIPTION
We have been using the term "approved files" to describe Open, Internal, and Hidden files. Hidden files are never approved, so a better description would be "finalized files".