### PR TITLE
Use same roles and order of roles across gherkins

### DIFF
--- a/publication-commons/src/test/java/cucumber/permissions/PermissionsRole.java
+++ b/publication-commons/src/test/java/cucumber/permissions/PermissionsRole.java
@@ -12,7 +12,7 @@ public enum PermissionsRole {
     FILE_CURATOR_DEGREE_EMBARGO("degree embargo file curator"),
     FILE_CURATOR_DEGREE("degree file curator"),
     UNAUTHENTICATED("unauthenticated"),
-    AUTHENTICATED_BUT_NO_ACCESS("everyone"),
+    AUTHENTICATED_BUT_NO_ACCESS("everyone", "authenticated"),
     OTHER_CONTRIBUTORS("other contributors", "contributor"),
     NOT_RELATED_EXTERNAL_CLIENT("not related external client",  "external client"),
     RELATED_EXTERNAL_CLIENT("related external client"),
@@ -32,7 +32,7 @@ public enum PermissionsRole {
 //    RELATED_EXTERNAL_CLIENT("related external client"),
 //    EDITOR("editor"),
 //    UNAUTHENTICATED("unauthenticated"),
-//    AUTHENTICATED_BUT_NO_ACCESS("everyone");
+//    AUTHENTICATED_BUT_NO_ACCESS("authenticated");
 
     private final String[] values;
 

--- a/publication-commons/src/test/java/cucumber/permissions/ticket/TicketScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/ticket/TicketScenarioContext.java
@@ -2,6 +2,9 @@ package cucumber.permissions.ticket;
 
 import static cucumber.permissions.publication.PublicationScenarioContext.CURATING_INSTITUTION;
 import static cucumber.permissions.publication.PublicationScenarioContext.NON_CURATING_INSTITUTION;
+import static java.util.Objects.nonNull;
+import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import cucumber.permissions.enums.PublicationTypeConfig;
 import cucumber.permissions.publication.PublicationScenarioContext;
 import java.net.URI;
@@ -48,19 +51,21 @@ public class TicketScenarioContext {
     }
 
     private TicketEntry getTicketEntry(Resource resource, UserInstance userInstance) {
+        var ticketCreator = nonNull(userInstance) ? userInstance : UserInstance.create(randomString(), randomUri());
+
         if (PublicationTypeConfig.DEGREE.equals(publicationScenarioContext.getPublicationTypeConfig())) {
             return switch(publicationScenarioContext.getChannelClaimConfig()) {
                 case NON_CLAIMED -> FilesApprovalThesis.createForUserInstitution(resource, userInstance, null);
                 case CLAIMED_BY_USERS_INSTITUTION -> FilesApprovalThesis.createForChannelOwningInstitution(
                     resource,
-                    userInstance,
-                    userInstance.getTopLevelOrgCristinId(),
+                    ticketCreator,
+                    ticketCreator.getTopLevelOrgCristinId(),
                     SortableIdentifier.next(),
                     null);
                 case CLAIMED_BY_NOT_USERS_INSTITUTION -> FilesApprovalThesis.createForChannelOwningInstitution(
                     resource,
-                    userInstance,
-                    NON_CURATING_INSTITUTION.equals(userInstance.getTopLevelOrgCristinId())
+                    ticketCreator,
+                    NON_CURATING_INSTITUTION.equals(ticketCreator.getTopLevelOrgCristinId())
                         ? CURATING_INSTITUTION
                         : NON_CURATING_INSTITUTION,
                     SortableIdentifier.next(),
@@ -68,6 +73,6 @@ public class TicketScenarioContext {
             };
         }
 
-        return PublishingRequestCase.create(resource, userInstance, null);
+        return PublishingRequestCase.create(resource, ticketCreator, null);
     }
 }

--- a/publication-commons/src/test/resources/features/publication/file_access_upload.feature
+++ b/publication-commons/src/test/resources/features/publication/file_access_upload.feature
@@ -6,7 +6,6 @@ Feature: File upload permissions
   Background:
   This will be exposed on publication level, not file level like the other access rights. (in terms of json allowed operations structure).
 
-
   Scenario Outline: Verify file upload permissions
     Given a "publication"
     And publication has status "<PublicationStatus>"
@@ -17,7 +16,7 @@ Feature: File upload permissions
     Examples:
       | UserRole               | PublicationStatus | Outcome     |
       | Unauthenticated        | draft             | Not Allowed |
-      | Everyone               | draft             | Not Allowed |
+      | Authenticated          | draft             | Not Allowed |
       | Publication creator    | draft             | Allowed     |
       | Contributor            | draft             | Allowed     |
       | Publishing curator     | draft             | Allowed     |
@@ -30,7 +29,7 @@ Feature: File upload permissions
       | External client        | draft             | Not Allowed |
 
       | Unauthenticated        | published         | Not Allowed |
-      | Everyone               | published         | Not Allowed |
+      | Authenticated          | published         | Not Allowed |
       | Publication creator    | published         | Allowed     |
       | Contributor            | published         | Allowed     |
       | NVI curator            | published         | Allowed     |
@@ -42,7 +41,7 @@ Feature: File upload permissions
       | External client        | published         | Not Allowed |
 
       | Unauthenticated        | unpublished       | Not Allowed |
-      | Everyone               | unpublished       | Not Allowed |
+      | Authenticated          | unpublished       | Not Allowed |
       | Publication creator    | unpublished       | Allowed     |
       | Contributor            | unpublished       | Allowed     |
       | NVI curator            | unpublished       | Allowed     |
@@ -54,7 +53,7 @@ Feature: File upload permissions
       | External client        | unpublished       | Not Allowed |
 
       | Unauthenticated        | deleted           | Not Allowed |
-      | Everyone               | deleted           | Not Allowed |
+      | Authenticated          | deleted           | Not Allowed |
       | Publication creator    | deleted           | Not Allowed |
       | Contributor            | deleted           | Not Allowed |
       | NVI curator            | deleted           | Not Allowed |

--- a/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
@@ -13,7 +13,7 @@ Feature: Publication action permissions
     Examples:
       | UserRole                    | Operation                 | Outcome     |
       | Unauthenticated             | update                    | Not Allowed |
-      | Everyone                    | update                    | Not Allowed |
+      | Authenticated               | update                    | Not Allowed |
       | Publication creator         | update                    | Allowed     |
       | Contributor                 | update                    | Allowed     |
       | Publishing curator          | update                    | Allowed     |
@@ -27,7 +27,7 @@ Feature: Publication action permissions
       | Not related external client | update                    | Not Allowed |
 
       | Unauthenticated             | partial-update            | Not Allowed |
-      | Everyone                    | partial-update            | Not Allowed |
+      | Authenticated               | partial-update            | Not Allowed |
       | Publication creator         | partial-update            | Allowed     |
       | Contributor                 | partial-update            | Allowed     |
       | Publishing curator          | partial-update            | Allowed     |
@@ -41,7 +41,7 @@ Feature: Publication action permissions
       | Not related external client | partial-update            | Not Allowed |
 
       | Unauthenticated             | update-including-files    | Not Allowed |
-      | Everyone                    | update-including-files    | Not Allowed |
+      | Authenticated               | update-including-files    | Not Allowed |
       | Publication creator         | update-including-files    | Not Allowed |
       | Contributor                 | update-including-files    | Not Allowed |
       | Publishing curator          | update-including-files    | Allowed     |
@@ -55,7 +55,7 @@ Feature: Publication action permissions
       | Not related external client | update-including-files    | Not Allowed |
 
       | Unauthenticated             | read-hidden-files         | Not Allowed |
-      | Everyone                    | read-hidden-files         | Not Allowed |
+      | Authenticated               | read-hidden-files         | Not Allowed |
       | Publication creator         | read-hidden-files         | Not Allowed |
       | Contributor                 | read-hidden-files         | Not Allowed |
       | Publishing curator          | read-hidden-files         | Allowed     |
@@ -69,7 +69,7 @@ Feature: Publication action permissions
       | Not related external client | read-hidden-files         | Not Allowed |
 
       | Unauthenticated             | unpublish                 | Not Allowed |
-      | Everyone                    | unpublish                 | Not Allowed |
+      | Authenticated               | unpublish                 | Not Allowed |
       | Publication creator         | unpublish                 | Allowed     |
       | Contributor                 | unpublish                 | Allowed     |
       | Publishing curator          | unpublish                 | Allowed     |
@@ -84,7 +84,7 @@ Feature: Publication action permissions
 
       # Publication has status PUBLISHED
       | Unauthenticated             | republish                 | Not Allowed |
-      | Everyone                    | republish                 | Not Allowed |
+      | Authenticated               | republish                 | Not Allowed |
       | Publication creator         | republish                 | Not Allowed |
       | Contributor                 | republish                 | Not Allowed |
       | Publishing curator          | republish                 | Not Allowed |
@@ -99,7 +99,7 @@ Feature: Publication action permissions
 
       # Publication has status PUBLISHED
       | Unauthenticated             | delete                    | Not Allowed |
-      | Everyone                    | delete                    | Not Allowed |
+      | Authenticated               | delete                    | Not Allowed |
       | Publication creator         | delete                    | Not Allowed |
       | Contributor                 | delete                    | Not Allowed |
       | Publishing curator          | delete                    | Not Allowed |
@@ -114,7 +114,7 @@ Feature: Publication action permissions
 
       # Publication has status PUBLISHED
       | Unauthenticated             | terminate                 | Not Allowed |
-      | Everyone                    | terminate                 | Not Allowed |
+      | Authenticated               | terminate                 | Not Allowed |
       | Publication creator         | terminate                 | Not Allowed |
       | Contributor                 | terminate                 | Not Allowed |
       | Publishing curator          | terminate                 | Not Allowed |
@@ -128,7 +128,7 @@ Feature: Publication action permissions
       | Not related external client | terminate                 | Not Allowed |
 
       | Unauthenticated             | doi-request-create        | Not Allowed |
-      | Everyone                    | doi-request-create        | Not Allowed |
+      | Authenticated               | doi-request-create        | Not Allowed |
       | Publication creator         | doi-request-create        | Allowed     |
       | Contributor                 | doi-request-create        | Allowed     |
       | Publishing curator          | doi-request-create        | Allowed     |
@@ -142,7 +142,7 @@ Feature: Publication action permissions
       | Not related external client | doi-request-create        | Not Allowed |
 
       | Unauthenticated             | doi-request-approve       | Not Allowed |
-      | Everyone                    | doi-request-approve       | Not Allowed |
+      | Authenticated               | doi-request-approve       | Not Allowed |
       | Publication creator         | doi-request-approve       | Not Allowed |
       | Contributor                 | doi-request-approve       | Not Allowed |
       | Publishing curator          | doi-request-approve       | Not Allowed |
@@ -156,7 +156,7 @@ Feature: Publication action permissions
       | Not related external client | doi-request-approve       | Not Allowed |
 
       | Unauthenticated             | publishing-request-create | Not Allowed |
-      | Everyone                    | publishing-request-create | Not Allowed |
+      | Authenticated               | publishing-request-create | Not Allowed |
       | Publication creator         | publishing-request-create | Allowed     |
       | Contributor                 | publishing-request-create | Allowed     |
       | Publishing curator          | publishing-request-create | Allowed     |
@@ -170,7 +170,7 @@ Feature: Publication action permissions
       | Not related external client | publishing-request-create | Not Allowed |
 
       | Unauthenticated             | approve-files             | Not Allowed |
-      | Everyone                    | approve-files             | Not Allowed |
+      | Authenticated               | approve-files             | Not Allowed |
       | Publication creator         | approve-files             | Not Allowed |
       | Contributor                 | approve-files             | Not Allowed |
       | Publishing curator          | approve-files             | Allowed     |
@@ -184,7 +184,7 @@ Feature: Publication action permissions
       | Not related external client | approve-files             | Not Allowed |
 
       | Unauthenticated             | support-request-create    | Not Allowed |
-      | Everyone                    | support-request-create    | Not Allowed |
+      | Authenticated               | support-request-create    | Not Allowed |
       | Publication creator         | support-request-create    | Allowed     |
       | Contributor                 | support-request-create    | Allowed     |
       | Publishing curator          | support-request-create    | Allowed     |
@@ -198,7 +198,7 @@ Feature: Publication action permissions
       | Not related external client | support-request-create    | Not Allowed |
 
       | Unauthenticated             | support-request-approve   | Not Allowed |
-      | Everyone                    | support-request-approve   | Not Allowed |
+      | Authenticated               | support-request-approve   | Not Allowed |
       | Publication creator         | support-request-approve   | Not Allowed |
       | Contributor                 | support-request-approve   | Not Allowed |
       | Publishing curator          | support-request-approve   | Not Allowed |
@@ -212,7 +212,7 @@ Feature: Publication action permissions
       | Not related external client | support-request-approve   | Not Allowed |
 
       | Unauthenticated             | upload-file               | Not Allowed |
-      | Everyone                    | upload-file               | Not Allowed |
+      | Authenticated               | upload-file               | Not Allowed |
       | Publication creator         | upload-file               | Allowed     |
       | Contributor                 | upload-file               | Allowed     |
       | Publishing curator          | upload-file               | Allowed     |

--- a/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_action_permissions.feature
@@ -5,7 +5,6 @@ Feature: Publication action permissions
 
   Scenario Outline: Verify publication permissions
     Given a "publication"
-    And publication has "no" files
     When the user have the role "<UserRole>"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"

--- a/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_channel_claim_based_access.feature
@@ -16,7 +16,7 @@ Feature: Permissions given claimed publisher
     Examples:
       | UserRole                | Operation      | Outcome     |
       | Unauthenticated         | partial-update | Not Allowed |
-      | Everyone                | partial-update | Not Allowed |
+      | Authenticated           | partial-update | Not Allowed |
       | External client         | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
@@ -30,7 +30,7 @@ Feature: Permissions given claimed publisher
       | Related external client | partial-update | Allowed     |
 
       | Unauthenticated         | update         | Not Allowed |
-      | Everyone                | update         | Not Allowed |
+      | Authenticated           | update         | Not Allowed |
       | External client         | update         | Not Allowed |
       | Publication creator     | update         | Not Allowed |
       | Contributor             | update         | Not Allowed |
@@ -44,7 +44,7 @@ Feature: Permissions given claimed publisher
       | Related external client | update         | Allowed     |
 
       | Unauthenticated         | unpublish      | Not Allowed |
-      | Everyone                | unpublish      | Not Allowed |
+      | Authenticated           | unpublish      | Not Allowed |
       | External client         | unpublish      | Not Allowed |
       | Publication creator     | unpublish      | Not Allowed |
       | Contributor             | unpublish      | Not Allowed |
@@ -71,7 +71,7 @@ Feature: Permissions given claimed publisher
     Examples:
       | UserRole                | Outcome     |
       | Unauthenticated         | Not Allowed |
-      | Everyone                | Not Allowed |
+      | Authenticated           | Not Allowed |
       | External client         | Not Allowed |
       | Publication creator     | Allowed     |
       | Contributor             | Allowed     |
@@ -95,19 +95,20 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Outcome     |
-      | Everyone else           | Not Allowed |
-      | External client         | Not Allowed |
-      | Publication creator     | Allowed     |
-      | Contributor             | Allowed     |
-      | Publishing curator      | Allowed     |
-      | NVI curator             | Allowed     |
-      | DOI curator             | Allowed     |
-      | Support curator         | Allowed     |
-      | Thesis curator          | Allowed     |
-      | Embargo thesis curator  | Allowed     |
-      | Editor                  | Allowed     |
-      | Related external client | Allowed     |
+      | UserRole                    | Outcome     |
+      | Unauthenticated             | Not Allowed |
+      | Authenticated               | Not Allowed |
+      | Publication creator         | Allowed     |
+      | Contributor                 | Allowed     |
+      | Publishing curator          | Allowed     |
+      | NVI curator                 | Allowed     |
+      | DOI curator                 | Allowed     |
+      | Support curator             | Allowed     |
+      | Thesis curator              | Allowed     |
+      | Embargo thesis curator      | Allowed     |
+      | Editor                      | Allowed     |
+      | Related external client     | Allowed     |
+      | Not related external client | Not Allowed |
 
   Scenario Outline: Verify update operation when user is not from the same organization as claimed
   publisher, publication is an imported student thesis and has no finalized files
@@ -121,19 +122,20 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Outcome     |
-      | Everyone else           | Not Allowed |
-      | External client         | Not Allowed |
-      | Publication creator     | Not Allowed |
-      | Contributor             | Not Allowed |
-      | Publishing curator      | Not Allowed |
-      | NVI curator             | Not Allowed |
-      | DOI curator             | Not Allowed |
-      | Support curator         | Not Allowed |
-      | Thesis curator          | Not Allowed |
-      | Embargo thesis curator  | Not Allowed |
-      | Editor                  | Not Allowed |
-      | Related external client | Allowed     |
+      | UserRole                    | Outcome     |
+      | Unauthenticated             | Not Allowed |
+      | Authenticated               | Not Allowed |
+      | Publication creator         | Not Allowed |
+      | Contributor                 | Not Allowed |
+      | Publishing curator          | Not Allowed |
+      | NVI curator                 | Not Allowed |
+      | DOI curator                 | Not Allowed |
+      | Support curator             | Not Allowed |
+      | Thesis curator              | Not Allowed |
+      | Embargo thesis curator      | Not Allowed |
+      | Editor                      | Not Allowed |
+      | Related external client     | Allowed     |
+      | Not related external client | Not Allowed |
 
   Scenario Outline: Verify update operation when user is not from the same organization as claimed
   publisher, publication is an imported student thesis and has finalized files
@@ -147,19 +149,20 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Outcome     |
-      | Everyone else           | Not Allowed |
-      | External client         | Not Allowed |
-      | Publication creator     | Not Allowed |
-      | Contributor             | Not Allowed |
-      | Publishing curator      | Not Allowed |
-      | NVI curator             | Not Allowed |
-      | DOI curator             | Not Allowed |
-      | Support curator         | Not Allowed |
-      | Thesis curator          | Not Allowed |
-      | Embargo thesis curator  | Not Allowed |
-      | Editor                  | Not Allowed |
-      | Related external client | Allowed     |
+      | UserRole                    | Outcome     |
+      | Unauthenticated             | Not Allowed |
+      | Authenticated               | Not Allowed |
+      | Publication creator         | Not Allowed |
+      | Contributor                 | Not Allowed |
+      | Publishing curator          | Not Allowed |
+      | NVI curator                 | Not Allowed |
+      | DOI curator                 | Not Allowed |
+      | Support curator             | Not Allowed |
+      | Thesis curator              | Not Allowed |
+      | Embargo thesis curator      | Not Allowed |
+      | Editor                      | Not Allowed |
+      | Related external client     | Allowed     |
+      | Not related external client | Not Allowed |
 
 
   Scenario Outline: Verify permission when
@@ -173,46 +176,48 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Operation     | Outcome     |
-      | Everyone else           | update        | Not Allowed |
-      | External client         | update        | Not Allowed |
-      | Publication creator     | update        | Not Allowed |
-      | Contributor             | update        | Not Allowed |
-      | Publishing curator      | update        | Not Allowed |
-      | NVI curator             | update        | Not Allowed |
-      | DOI curator             | update        | Not Allowed |
-      | Support curator         | update        | Not Allowed |
-      | Thesis curator          | update        | Allowed     |
-      # Burde vært motsatt? Degree kan, da burde også Embargo degree?
-      | Embargo thesis curator  | update        | Not Allowed |
-      | Editor                  | update        | Allowed     |
-      | Related external client | update        | Allowed     |
+      | UserRole                    | Operation     | Outcome     |
+      | Unauthenticated             | update        | Not Allowed |
+      | Authenticated               | update        | Not Allowed |
+      | External client             | update        | Not Allowed |
+      | Publication creator         | update        | Not Allowed |
+      | Contributor                 | update        | Not Allowed |
+      | Publishing curator          | update        | Not Allowed |
+      | NVI curator                 | update        | Not Allowed |
+      | DOI curator                 | update        | Not Allowed |
+      | Support curator             | update        | Not Allowed |
+      | Thesis curator              | update        | Allowed     |
+      | Embargo thesis curator      | update        | Not Allowed |
+      | Editor                      | update        | Allowed     |
+      | Related external client     | update        | Allowed     |
+      | Not related external client | update        | Not Allowed |
 
-      | Everyone else           | unpublish     | Not Allowed |
-      | External client         | unpublish     | Not Allowed |
-      | Publication creator     | unpublish     | Not Allowed |
-      | Contributor             | unpublish     | Not Allowed |
-      | Publishing curator      | unpublish     | Not Allowed |
-      | NVI curator             | unpublish     | Not Allowed |
-      | DOI curator             | unpublish     | Not Allowed |
-      | Support curator         | unpublish     | Not Allowed |
-      | Thesis curator          | unpublish     | Allowed     |
-      # Burde vært motsatt? Degree kan, da burde også Embargo degree?
-      | Embargo thesis curator  | unpublish     | Not Allowed |
-      | Editor                  | unpublish     | Allowed     |
-      | Related external client | unpublish     | Allowed     |
+      | Unauthenticated             | unpublish     | Not Allowed |
+      | Authenticated               | unpublish     | Not Allowed |
+      | Publication creator         | unpublish     | Not Allowed |
+      | Contributor                 | unpublish     | Not Allowed |
+      | Publishing curator          | unpublish     | Not Allowed |
+      | NVI curator                 | unpublish     | Not Allowed |
+      | DOI curator                 | unpublish     | Not Allowed |
+      | Support curator             | unpublish     | Not Allowed |
+      | Thesis curator              | unpublish     | Allowed     |
+      | Embargo thesis curator      | unpublish     | Not Allowed |
+      | Editor                      | unpublish     | Allowed     |
+      | Related external client     | unpublish     | Allowed     |
+      | Not related external client | unpublish     | Not Allowed |
 
-      | Everyone else           | approve-files | Not Allowed |
-      | External client         | approve-files | Not Allowed |
-      | Publication creator     | approve-files | Not Allowed |
-      | Contributor             | approve-files | Not Allowed |
-      | Publishing curator      | approve-files | Not Allowed |
-      | NVI curator             | approve-files | Not Allowed |
-      | DOI curator             | approve-files | Not Allowed |
-      | Support curator         | approve-files | Not Allowed |
-      | Thesis curator          | approve-files | Allowed     |
-      | Embargo thesis curator  | approve-files | Allowed     |
-      | Editor                  | approve-files | Not Allowed |
-      | Related external client | approve-files | Not Allowed |
+      | Unauthenticated             | approve-files | Not Allowed |
+      | Authenticated               | approve-files | Not Allowed |
+      | Publication creator         | approve-files | Not Allowed |
+      | Contributor                 | approve-files | Not Allowed |
+      | Publishing curator          | approve-files | Not Allowed |
+      | NVI curator                 | approve-files | Not Allowed |
+      | DOI curator                 | approve-files | Not Allowed |
+      | Support curator             | approve-files | Not Allowed |
+      | Thesis curator              | approve-files | Allowed     |
+      | Embargo thesis curator      | approve-files | Allowed     |
+      | Editor                      | approve-files | Not Allowed |
+      | Related external client     | approve-files | Not Allowed |
+      | Not related external client | approve-files | Not Allowed |
 
 

--- a/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
+++ b/publication-commons/src/test/resources/features/publication/publication_update_partial.feature
@@ -14,18 +14,18 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Not Allowed |
       | Contributor             | update         | Not Allowed |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |
 
   Scenario Outline: Verify operation when
@@ -38,18 +38,18 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Not Allowed |
       | Contributor             | update         | Not Allowed |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |
 
   Scenario Outline: Verify operation when
@@ -62,18 +62,18 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Allowed     |
       | Contributor             | update         | Allowed     |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |
 
   Scenario Outline: Verify operation when
@@ -87,18 +87,18 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Not Allowed |
       | Contributor             | update         | Not Allowed |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |
 
   Scenario Outline: Verify operation when
@@ -111,18 +111,18 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Allowed     |
       | Contributor             | update         | Allowed     |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |
 
   Scenario Outline: Verify operation when
@@ -135,16 +135,16 @@ Feature: Publication update permissions
 
     Examples:
       | UserRole                | Operation      | Outcome     |
+      | Authenticated           | partial-update | Not Allowed |
       | Publication creator     | partial-update | Allowed     |
       | Contributor             | partial-update | Allowed     |
       | Thesis curator          | partial-update | Allowed     |
       | Editor                  | partial-update | Allowed     |
-      | Everyone                | partial-update | Not Allowed |
       | Related external client | partial-update | Allowed     |
 
+      | Authenticated           | update         | Not Allowed |
       | Publication creator     | update         | Allowed     |
       | Contributor             | update         | Allowed     |
       | Thesis curator          | update         | Allowed     |
       | Editor                  | update         | Allowed     |
-      | Everyone                | update         | Not Allowed |
       | Related external client | update         | Allowed     |

--- a/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
+++ b/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
@@ -13,24 +13,28 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Operation | Outcome     |
+      | UserRole                    | Operation | Outcome     |
+      | Unauthenticated             | approve   | Not Allowed |
+      | Authenticated               | approve   | Not Allowed |
+      | Publication creator         | approve   | Not Allowed |
+      | Contributor                 | approve   | Not Allowed |
+      | Publishing curator          | approve   | Not Allowed |
+      | Thesis curator              | approve   | Allowed     |
+      | Embargo thesis curator      | approve   | Allowed     |
+      | Editor                      | approve   | Not Allowed |
+      | Related external client     | approve   | Not Allowed |
+      | Not related external client | approve   | Not Allowed |
 
-      | Everyone else           | approve   | Not Allowed |
-      | External client         | approve   | Not Allowed |
-      | Publication owner       | approve   | Not Allowed |
-      | Contributor             | approve   | Not Allowed |
-      | publishing curator      | approve   | Not Allowed |
-      | Editor                  | approve   | Not Allowed |
-      | Degree file curator     | approve   | Allowed     |
-      | Related external client | approve   | Not Allowed |
-      | Everyone else           | transfer  | Not Allowed |
-      | External client         | transfer  | Not Allowed |
-      | Publication owner       | transfer  | Not Allowed |
-      | Contributor             | transfer  | Not Allowed |
-      | Publishing curator      | transfer  | Not Allowed |
-      | Editor                  | transfer  | Not Allowed |
-      | Degree file curator     | transfer  | Not Allowed |
-      | Related external client | transfer  | Not Allowed |
+      | Unauthenticated             | transfer  | Not Allowed |
+      | Authenticated               | transfer  | Not Allowed |
+      | Publication creator         | transfer  | Not Allowed |
+      | Contributor                 | transfer  | Not Allowed |
+      | Publishing curator          | transfer  | Not Allowed |
+      | Editor                      | transfer  | Not Allowed |
+      | Thesis curator              | transfer  | Not Allowed |
+      | Embargo thesis curator      | transfer  | Not Allowed |
+      | Related external client     | transfer  | Not Allowed |
+      | Not related external client | transfer  | Not Allowed |
 
   Scenario Outline: Verify permission when
   user is NOT from the same organization as claimed publisher
@@ -41,25 +45,28 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Operation | Outcome     |
+      | UserRole                    | Operation | Outcome     |
+      | Unauthenticated             | approve   | Not Allowed |
+      | Authenticated               | approve   | Not Allowed |
+      | Publication owner           | approve   | Not Allowed |
+      | Contributor                 | approve   | Not Allowed |
+      | Publishing curator          | approve   | Not Allowed |
+      | Thesis curator              | approve   | Not Allowed |
+      | Embargo thesis curator      | approve   | Not Allowed |
+      | Editor                      | approve   | Not Allowed |
+      | Related external client     | approve   | Not Allowed |
+      | Not related external client | approve   | Not Allowed |
 
-      | Everyone else           | approve   | Not Allowed |
-      | External client         | approve   | Not Allowed |
-      | Publication owner       | approve   | Not Allowed |
-      | Contributor             | approve   | Not Allowed |
-      | publishing curator      | approve   | Not Allowed |
-      | Editor                  | approve   | Not Allowed |
-      | Degree file curator     | approve   | Not Allowed |
-      | Related external client | approve   | Not Allowed |
-      | Everyone else           | transfer  | Not Allowed |
-      | External client         | transfer  | Not Allowed |
-      | Publication owner       | transfer  | Not Allowed |
-      | Contributor             | transfer  | Not Allowed |
-      | publishing curator      | transfer  | Not Allowed |
-      | Editor                  | transfer  | Not Allowed |
-      | Degree file curator     | transfer  | Not Allowed |
-      | Related external client | transfer  | Not Allowed |
-
+      | Unauthenticated             | transfer  | Not Allowed |
+      | Authenticated               | transfer  | Not Allowed |
+      | Publication owner           | transfer  | Not Allowed |
+      | Contributor                 | transfer  | Not Allowed |
+      | Publishing curator          | transfer  | Not Allowed |
+      | Thesis curator              | transfer  | Not Allowed |
+      | Embargo thesis curator      | transfer  | Not Allowed |
+      | Editor                      | transfer  | Not Allowed |
+      | Related external client     | transfer  | Not Allowed |
+      | Not related external client | transfer  | Not Allowed |
 
   Scenario Outline: Verify permission when
   user is from a contributor organization and publisher is unclaimed
@@ -71,24 +78,28 @@ Feature: Permissions given claimed publisher
     Then the action outcome is "<Outcome>"
 
     Examples:
-      | UserRole                | Operation | Outcome     |
+      | UserRole                    | Operation | Outcome     |
+      | Unauthenticated             | approve   | Not Allowed |
+      | Authenticated               | approve   | Not Allowed |
+      | Publication owner           | approve   | Not Allowed |
+      | Contributor                 | approve   | Not Allowed |
+      | Publishing curator          | approve   | Allowed     |
+      | Editor                      | approve   | Not Allowed |
+      | Thesis curator              | approve   | Not Allowed |
+      | Embargo thesis curator      | approve   | Not Allowed |
+      | Related external client     | approve   | Not Allowed |
+      | Not related external client | approve   | Not Allowed |
 
-      | Everyone else           | approve   | Not Allowed |
-      | External client         | approve   | Not Allowed |
-      | Publication owner       | approve   | Not Allowed |
-      | Contributor             | approve   | Not Allowed |
-      | publishing curator      | approve   | Allowed     |
-      | Editor                  | approve   | Not Allowed |
-      | Degree file curator     | approve   | Not Allowed |
-      | Related external client | approve   | Not Allowed |
-      | Everyone else           | transfer  | Not Allowed |
-      | External client         | transfer  | Not Allowed |
-      | Publication owner       | transfer  | Not Allowed |
-      | Contributor             | transfer  | Not Allowed |
-      | publishing curator      | transfer  | Allowed     |
-      | Editor                  | transfer  | Not Allowed |
-      | Degree file curator     | transfer  | Not Allowed |
-      | Related external client | transfer  | Not Allowed |
+      | Unauthenticated             | transfer  | Not Allowed |
+      | Authenticated               | transfer  | Not Allowed |
+      | Publication owner           | transfer  | Not Allowed |
+      | Contributor                 | transfer  | Not Allowed |
+      | Publishing curator          | transfer  | Allowed     |
+      | Editor                      | transfer  | Not Allowed |
+      | Thesis curator              | transfer  | Not Allowed |
+      | Embargo thesis curator      | transfer  | Not Allowed |
+      | Related external client     | transfer  | Not Allowed |
+      | Not related external client | transfer  | Not Allowed |
 
 
   Scenario: Verify transfer permission when user have no relations to publication, but owns the ticket

--- a/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
+++ b/publication-commons/src/test/resources/features/ticket/ticket_access_approve.feature
@@ -106,23 +106,23 @@ Feature: Permissions given claimed publisher
     Given a "publication"
     And the user belongs to "non curating institution"
     And the ticket receiver is "users institution"
-    When the user attempts to "transfer"
-    And the user have the role "publishing curator"
+    When the user have the role "publishing curator"
+    And the user attempts to "transfer"
     Then the action outcome is "Allowed"
 
   Scenario: Should not give transfer permission when only available curation institution is same as user
     Given a "publication"
-    When the user attempts to "transfer"
-    And the user have the role "publishing curator"
     And the user belongs to "curating institution"
+    When the user have the role "publishing curator"
+    And the user attempts to "transfer"
     Then the action outcome is "Not Allowed"
 
   Scenario Outline: Should deny ticket transfer when channel is claimed
     Given a "degree"
     And publication has "<Files>" files
     And publication has publisher claimed by "<ClaimedBy>"
-    When the user attempts to "transfer"
-    And the user have the role "thesis curator"
+    When the user have the role "thesis curator"
+    And the user attempts to "transfer"
     Then the action outcome is "Not Allowed"
 
     Examples:


### PR DESCRIPTION
Cleaning up gherkins one step at a time. This time naming the role "authenticated" instead of "everyone" and "thesis curator" instead of "degree curator". Have also reordered the rows so that they are the same across tests, and have added a few rows to have better test coverage.

Did run into an issue when creating ticket when the user is unauthenticated. The ticket is created with the test user as creator, which probably should be managed/configured down the road. For now it's enough to have a random creator when the user is unauthenticated. 

File Gherkins are ignored for now. Will be a bigger refactor.