### PR TITLE
Revert "removing publication channel migration code (#1992)"

### DIFF
--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/Journal.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/Journal.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.util.Objects;
+import no.unit.nva.model.contexttypes.utils.MigrateSerialPublicationUtil;
 import no.unit.nva.model.exceptions.InvalidSeriesException;
 import nva.commons.core.JacocoGenerated;
 
@@ -17,7 +18,7 @@ public class Journal implements Periodical {
     @JsonCreator
     public Journal(@JsonProperty("id") URI id) {
         validate(id);
-        this.id = id;
+        this.id = MigrateSerialPublicationUtil.migratePath(id);
     }
 
     public URI getId() {

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/Series.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/Series.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.util.Objects;
+import no.unit.nva.model.contexttypes.utils.MigrateSerialPublicationUtil;
 import no.unit.nva.model.exceptions.InvalidSeriesException;
 import nva.commons.core.JacocoGenerated;
 
@@ -17,7 +18,7 @@ public class Series implements BookSeries {
     @JsonCreator
     public Series(@JsonProperty("id") URI id) {
         validate(id);
-        this.id = id;
+        this.id = MigrateSerialPublicationUtil.migratePath(id);
     }
 
     public URI getId() {

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/utils/MigrateSerialPublicationUtil.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/utils/MigrateSerialPublicationUtil.java
@@ -1,0 +1,51 @@
+package no.unit.nva.model.contexttypes.utils;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import java.util.Optional;
+import nva.commons.core.paths.UriWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Deprecated
+public class MigrateSerialPublicationUtil {
+
+    public static final Logger logger = LoggerFactory.getLogger(MigrateSerialPublicationUtil.class.getName());
+    private static final String NEW_PATH_SERIAL_PUBLICATION = "serial-publication";
+    private static final String OLD_PATH_JOURNAL = "journal";
+    private static final String OLD_PATH_SERIES = "series";
+    private static final int INDEX_FROM_END_CHANNEL_TYPE_PATH_ELEMENT = 2;
+
+    @Deprecated
+    public static URI migratePath(URI id) {
+        var oldPath = attempt(() -> UriWrapper.fromUri(id)
+                                        .getPath()
+                                        .getPathElementByIndexFromEnd(INDEX_FROM_END_CHANNEL_TYPE_PATH_ELEMENT))
+                          .toOptional();
+        return oldPath.filter(MigrateSerialPublicationUtil::isDeprecated)
+                   .map(uri -> replaceOldPath(id))
+                   .orElseGet(() -> isAlreadyMigrated(oldPath) ? id : logUnexpectedUri(id));
+    }
+
+    private static boolean isDeprecated(String path) {
+        return OLD_PATH_JOURNAL.equals(path) || OLD_PATH_SERIES.equals(path);
+    }
+
+    private static boolean isAlreadyMigrated(Optional<String> oldPath) {
+        return oldPath.isPresent() && NEW_PATH_SERIAL_PUBLICATION.equals(oldPath.get());
+    }
+
+    private static URI logUnexpectedUri(URI id) {
+        logger.info(String.format("Unexpected URI. Expected id with path: %s or %s, but found id: %s",
+                                  OLD_PATH_JOURNAL, OLD_PATH_SERIES, id));
+        return id;
+    }
+
+    @Deprecated
+    private static URI replaceOldPath(URI id) {
+        return UriWrapper.fromUri(id)
+                   .replacePathElementByIndexFromEnd(INDEX_FROM_END_CHANNEL_TYPE_PATH_ELEMENT,
+                                                     NEW_PATH_SERIAL_PUBLICATION)
+                   .getUri();
+    }
+}

--- a/publication-model/src/test/java/no/unit/nva/model/contexttypes/MigrateJournalIdTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/contexttypes/MigrateJournalIdTest.java
@@ -1,0 +1,67 @@
+package no.unit.nva.model.contexttypes;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.unit.nva.utils.MigrateSerialPublicationsUtil.constructExampleIdWithPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import no.unit.nva.model.contexttypes.utils.MigrateSerialPublicationUtil;
+import nva.commons.core.paths.UriWrapper;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.Test;
+
+@Deprecated
+public class MigrateJournalIdTest {
+
+    @Test
+    void shouldUpdateOldJournalIdWithNewPathSerialPublication() {
+        var oldId = constructExampleIdWithPath("journal");
+        var expectedNewId = UriWrapper.fromUri(oldId)
+                                .replacePathElementByIndexFromEnd(2, "serial-publication")
+                                .getUri();
+        var journal = new Journal(oldId);
+        assertThat(journal.getId(), is(equalTo(expectedNewId)));
+    }
+
+    @Test
+    void shouldUpdateOldJournalIdWithNewPathSerialPublicationWhenOldPathIsSeries() {
+        var oldId = constructExampleIdWithPath("series");
+        var expectedNewId = UriWrapper.fromUri(oldId)
+                                .replacePathElementByIndexFromEnd(2, "serial-publication")
+                                .getUri();
+        var journal = new Journal(oldId);
+        assertThat(journal.getId(), is(equalTo(expectedNewId)));
+    }
+
+    @Test
+    void shouldLogUriIfOldIdHasUnexpectedPath() {
+        var oldId = constructExampleIdWithPath("unexpected-path");
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Journal(oldId);
+
+        assertThat(appender.getMessages(), containsString(oldId.toString()));
+    }
+
+    @Test
+    void shouldLogUriIfOldIdHasUnexpectedForm() {
+        var oldId = randomUri();
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Journal(oldId);
+
+        assertThat(appender.getMessages(), containsString(oldId.toString()));
+    }
+
+    @Test
+    void shouldNotLogUriIfIdIsAlreadyMigrated() {
+        var oldId = constructExampleIdWithPath("serial-publication");
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Journal(oldId);
+
+        assertThat(appender.getMessages(), not(containsString(oldId.toString())));
+    }
+}

--- a/publication-model/src/test/java/no/unit/nva/model/contexttypes/MigrateSeriesIdTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/contexttypes/MigrateSeriesIdTest.java
@@ -1,0 +1,67 @@
+package no.unit.nva.model.contexttypes;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.unit.nva.utils.MigrateSerialPublicationsUtil.constructExampleIdWithPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import no.unit.nva.model.contexttypes.utils.MigrateSerialPublicationUtil;
+import nva.commons.core.paths.UriWrapper;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.Test;
+
+@Deprecated
+public class MigrateSeriesIdTest {
+
+    @Test
+    void shouldUpdateOldSeriesIdWithNewPathSerialPublication() {
+        var oldId = constructExampleIdWithPath("series");
+        var expectedNewId = UriWrapper.fromUri(oldId)
+                                .replacePathElementByIndexFromEnd(2, "serial-publication")
+                                .getUri();
+        var series = new Series(oldId);
+        assertThat(series.getId(), is(equalTo(expectedNewId)));
+    }
+
+    @Test
+    void shouldUpdateOldSeriesIdWithNewPathSerialPublicationWhenOldPathIsJournal() {
+        var oldId = constructExampleIdWithPath("journal");
+        var expectedNewId = UriWrapper.fromUri(oldId)
+                                .replacePathElementByIndexFromEnd(2, "serial-publication")
+                                .getUri();
+        var series = new Series(oldId);
+        assertThat(series.getId(), is(equalTo(expectedNewId)));
+    }
+
+    @Test
+    void shouldLogUriIfOldIdHasUnexpectedPath() {
+        var oldId = constructExampleIdWithPath("unexpected-path");
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Series(oldId);
+
+        assertThat(appender.getMessages(), containsString(oldId.toString()));
+    }
+
+    @Test
+    void shouldLogUriIfOldIdHasUnexpectedForm() {
+        var oldId = randomUri();
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Series(oldId);
+
+        assertThat(appender.getMessages(), containsString(oldId.toString()));
+    }
+
+    @Test
+    void shouldNotLogUriIfIdIsAlreadyMigrated() {
+        var oldId = constructExampleIdWithPath("serial-publication");
+        var appender = LogUtils.getTestingAppender(MigrateSerialPublicationUtil.class);
+
+        new Series(oldId);
+
+        assertThat(appender.getMessages(), not(containsString(oldId.toString())));
+    }
+}


### PR DESCRIPTION
This reverts commit 058be2075c921d57ae7a8b4bfab93643238557a3.


Some channels have been migrated from Cristin with series and journal in path. This is now fixed in import, but I think we can have this migration til we have deprecated "old" endpoints and removed them from api. 