### PR TITLE
Adding dlq to dynamodb stream consumer

### DIFF
--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1552,9 +1552,6 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @Test
-    void updatingResourceFromImportShouldSetMergedResourceEventWithInstitutionFrom
-
-    @Test
     void shouldSetFileTypeRetractedEventWhenRetractingFinalizedFile() throws BadRequestException {
         var publication = randomPublication().copy().withAssociatedArtifacts(List.of()).build();
         var userInstance = UserInstance.fromPublication(publication);

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1552,6 +1552,9 @@ class ResourceServiceTest extends ResourcesLocalTest {
     }
 
     @Test
+    void updatingResourceFromImportShouldSetMergedResourceEventWithInstitutionFrom
+
+    @Test
     void shouldSetFileTypeRetractedEventWhenRetractingFinalizedFile() throws BadRequestException {
         var publication = randomPublication().copy().withAssociatedArtifacts(List.of()).build();
         var userInstance = UserInstance.fromPublication(publication);

--- a/template.yaml
+++ b/template.yaml
@@ -1911,7 +1911,6 @@ Resources:
       Environment:
         Variables:
           EVENTS_BUCKET: !Ref NvaEventsBucketsName
-          DLQ_URL: !Ref DynamodbEventFanoutStreamRecordsDLQ
           MAX_ATTEMPT: !Ref EventBridgeMaxAttempt
           EVENT_BUS_NAME: !GetAtt InternalBus.Name
           RECOVERY_QUEUE: !Ref RecoveryQueue
@@ -1924,6 +1923,12 @@ Resources:
             StartingPosition: TRIM_HORIZON
             BatchSize: 1
             Enabled: true
+            MaximumRetryAttempts: 3
+            MaximumRecordAgeInSeconds: 3600
+            BisectBatchOnFunctionError: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt DynamodbEventFanoutStreamRecordsDLQ.Arn
 
   ImportCandidateDynamodbStreamToEventBridgeHandler:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -1924,7 +1924,6 @@ Resources:
             BatchSize: 1
             Enabled: true
             MaximumRetryAttempts: 3
-            MaximumRecordAgeInSeconds: 3600
             BisectBatchOnFunctionError: true
             DestinationConfig:
               OnFailure:


### PR DESCRIPTION
Adding dlq config to DynamoDbStream consumer as we did in identity-service. This will allow us to see if events are timing out during cristin-import and batch scan jobs