### PR TITLE
updating default resource service consuming table name

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -156,7 +156,12 @@ public class ResourceService extends ServiceWithTransactions {
 
     @JacocoGenerated
     public static ResourceService defaultService(String tableName) {
-        return builder().withTableName(tableName).build();
+        var uriRetriever = new UriRetriever();
+        return builder()
+                   .withTableName(tableName)
+                   .withChannelClaimClient(ChannelClaimClient.create(uriRetriever))
+                   .withCustomerService(new CustomerService(new UriRetriever()))
+                   .build();
     }
 
     public static ResourceServiceBuilder builder() {


### PR DESCRIPTION
Lambdas consuming ResourceService without CustomerService are failing when attempting to fetch customers when populating curatingInstitutions -> updating defaultService which consumes table name. 