### PR TITLE
updating the way tikautils fetches file

### DIFF
--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/TikaUtils.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/TikaUtils.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.scopus.conversion.files;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import nva.commons.core.JacocoGenerated;
@@ -14,8 +15,8 @@ public class TikaUtils {
     public TikaUtils() {
     }
 
-    public TikaInputStream fetch(URI uri) throws IOException {
-        return TikaInputStream.get(uri);
+    public TikaInputStream fetch(URI uri) {
+        return TikaInputStream.get(uri.toString().getBytes());
     }
 
     public String getMimeType(TikaInputStream inputStream) throws IOException {


### PR DESCRIPTION
Updating the way tika utils fetches file from download url.

`TikaInputStream.get(uri)` returns 403 Forbidden for some files, while "simple" HttpClient receives 200 OK on the same API call. 
Using `TikaInputStream.get(uri.toString().getBytes())` as it handles fetching file differently/ better. 

Some of files that TikaInputStream is failing to fetch are:
https://medicaljournalssweden.se/actaoncologica/article/download/42991/50434
https://academic.oup.com/mnras/advance-article-pdf/doi/10.1093/mnras/staf853/63373111/staf853.pdf
https://academic.oup.com/eep/advance-article-pdf/doi/10.1093/eep/dvaf008/62826055/dvaf008.pdf