### PR TITLE
feature(file-permissions): allow metadata and download to editor #NP-…

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FilePermissions.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FilePermissions.java
@@ -18,6 +18,7 @@ import no.unit.nva.publication.permissions.file.deny.UploadedFileDenyStrategy;
 import no.unit.nva.publication.permissions.file.grant.ContributorFileGrantStrategy;
 import no.unit.nva.publication.permissions.file.grant.DegreeCuratorFileGrantStrategy;
 import no.unit.nva.publication.permissions.file.grant.DegreeEmbargoCuratorFileGrantStrategy;
+import no.unit.nva.publication.permissions.file.grant.EditorFileGrantStrategy;
 import no.unit.nva.publication.permissions.file.grant.EmbargoCuratorFileGrantStrategy;
 import no.unit.nva.publication.permissions.file.grant.EveryoneGrantStrategy;
 import no.unit.nva.publication.permissions.file.grant.CuratorFileGrantStrategy;
@@ -50,7 +51,8 @@ public class FilePermissions {
             new ExternalClientGrantStrategy(file, userInstance, resource),
             new DegreeEmbargoCuratorFileGrantStrategy(file, userInstance, resource),
             new DegreeCuratorFileGrantStrategy(file, userInstance, resource),
-            new EmbargoCuratorFileGrantStrategy(file, userInstance, resource)
+            new EmbargoCuratorFileGrantStrategy(file, userInstance, resource),
+            new EditorFileGrantStrategy(file, userInstance, resource)
         );
         this.denyStrategies = Set.of(
             new HiddenFileDenyStrategy(file, userInstance, resource),

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
@@ -119,7 +119,7 @@ public class FileStrategyBase {
         return resource.getCuratingInstitutions().stream().anyMatch(org -> org.id().equals(userTopLevelOrg));
     }
 
-    private boolean userRelatesToPublication() {
+    public boolean userRelatesToPublication() {
         return userIsFromSameInstitutionAsPublicationOwner() || userBelongsToCuratingInstitution() ||
                userBelongsToPublicationChannelOwner();
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/grant/EditorFileGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/grant/EditorFileGrantStrategy.java
@@ -1,0 +1,35 @@
+package no.unit.nva.publication.permissions.file.grant;
+
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
+import no.unit.nva.model.FileOperation;
+import no.unit.nva.model.associatedartifacts.file.PendingInternalFile;
+import no.unit.nva.model.associatedartifacts.file.PendingOpenFile;
+import no.unit.nva.publication.model.business.FileEntry;
+import no.unit.nva.publication.model.business.Resource;
+import no.unit.nva.publication.model.business.UserInstance;
+import no.unit.nva.publication.permissions.file.FileGrantStrategy;
+import no.unit.nva.publication.permissions.file.FileStrategyBase;
+
+public class EditorFileGrantStrategy extends FileStrategyBase implements FileGrantStrategy {
+
+    public EditorFileGrantStrategy(FileEntry file, UserInstance userInstance, Resource resource) {
+        super(file, userInstance, resource);
+    }
+
+    @Override
+    public boolean allowsAction(FileOperation permission) {
+        if (hasAccessRight(MANAGE_RESOURCES_ALL)) {
+            return switch (permission) {
+                case READ_METADATA, DOWNLOAD -> userRelatesToPublication() || isAllowedFileType();
+                case WRITE_METADATA, DELETE -> false;
+            };
+        }
+
+        return false;
+    }
+
+    private boolean isAllowedFileType() {
+        return !(file.getFile() instanceof PendingInternalFile
+               || file.getFile() instanceof PendingOpenFile && file.getFile().hasActiveEmbargo());
+    }
+}

--- a/publication-commons/src/test/java/cucumber/permissions/enums/FileOwnerConfig.java
+++ b/publication-commons/src/test/java/cucumber/permissions/enums/FileOwnerConfig.java
@@ -3,5 +3,6 @@ package cucumber.permissions.enums;
 public enum FileOwnerConfig {
     USER,
     PUBLICATION_CREATOR,
-    CONTRIBUTOR_AT_CURATING_INSTITUTION
+    CONTRIBUTOR_AT_CURATING_INSTITUTION,
+    SOMEONE_ELSE
 }

--- a/publication-commons/src/test/java/cucumber/permissions/file/FileAccessFeatures.java
+++ b/publication-commons/src/test/java/cucumber/permissions/file/FileAccessFeatures.java
@@ -41,6 +41,8 @@ public class FileAccessFeatures {
             fileScenarioContext.setFileOwnerConfig(FileOwnerConfig.PUBLICATION_CREATOR);
         } else if ("contributor at curating institution".equalsIgnoreCase(fileOwner)) {
             fileScenarioContext.setFileOwnerConfig(FileOwnerConfig.CONTRIBUTOR_AT_CURATING_INSTITUTION);
+        } else if ("someone else".equalsIgnoreCase(fileOwner)) {
+            fileScenarioContext.setFileOwnerConfig(FileOwnerConfig.SOMEONE_ELSE);
         } else {
             throw new IllegalArgumentException("Non valid input: " + fileOwner);
         }

--- a/publication-commons/src/test/java/cucumber/permissions/file/FileScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/file/FileScenarioContext.java
@@ -2,13 +2,17 @@ package cucumber.permissions.file;
 
 import static cucumber.permissions.enums.FileEmbargoConfig.HAS_EMBARGO;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import cucumber.permissions.enums.FileEmbargoConfig;
 import cucumber.permissions.enums.FileOwnerConfig;
 import cucumber.permissions.publication.PublicationScenarioContext;
 import java.time.Instant;
+import java.util.Collections;
 import no.unit.nva.model.FileOperation;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.file.File;
+import no.unit.nva.model.associatedartifacts.file.File.Builder;
 import no.unit.nva.model.associatedartifacts.file.UploadedFile;
 import no.unit.nva.model.associatedartifacts.file.UserUploadDetails;
 import no.unit.nva.publication.model.business.FileEntry;
@@ -76,6 +80,8 @@ public final class FileScenarioContext {
         return switch (getFileOwnerConfig()) {
             case FileOwnerConfig.USER -> userInstance;
             case FileOwnerConfig.PUBLICATION_CREATOR -> UserInstance.fromPublication(resource.toPublication());
+            case FileOwnerConfig.SOMEONE_ELSE -> UserInstance.create(randomString(), randomUri(), randomUri(),
+                                                                     Collections.emptyList(), randomUri());
             case FileOwnerConfig.CONTRIBUTOR_AT_CURATING_INSTITUTION -> throw new UnsupportedOperationException();
         };
     }
@@ -89,7 +95,7 @@ public final class FileScenarioContext {
         return file.build(getFileClassFromString());
     }
 
-    private void addEmbargo(File.Builder fileBuilder, Class<File> fileType) {
+    private void addEmbargo(Builder fileBuilder, Class<File> fileType) {
         if (UploadedFile.class.equals(fileType)) {
             throw new IllegalArgumentException("'UploadedFile.class' does not support embargo");
         }

--- a/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
+++ b/publication-commons/src/test/java/cucumber/permissions/publication/PublicationScenarioContext.java
@@ -7,8 +7,8 @@ import static cucumber.permissions.PermissionsRole.NOT_RELATED_EXTERNAL_CLIENT;
 import static cucumber.permissions.PermissionsRole.RELATED_EXTERNAL_CLIENT;
 import static cucumber.permissions.PermissionsRole.UNAUTHENTICATED;
 import static cucumber.permissions.RolesToAccessRights.roleToAccessRightsMap;
-import static cucumber.permissions.enums.UserInstitutionConfig.BELONGS_TO_CREATING_INSTITUTION;
 import static cucumber.permissions.enums.UserInstitutionConfig.BELONGS_TO_CURATING_INSTITUTION;
+import static cucumber.permissions.enums.UserInstitutionConfig.BELONGS_TO_NON_CURATING_INSTITUTION;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.model.testing.PublicationGenerator.randomDegreePublication;
@@ -81,7 +81,7 @@ public class PublicationScenarioContext {
     private ChannelPolicy channelClaimPublishingPolicy;
     private ChannelPolicy channelClaimEditingPolicy;
     private Set<PermissionsRole> roles = new HashSet<>();
-    private UserInstitutionConfig userInstitutionConfig = BELONGS_TO_CREATING_INSTITUTION;
+    private UserInstitutionConfig userInstitutionConfig = BELONGS_TO_NON_CURATING_INSTITUTION;
     private PublicationOperation operation;
 
     public PublicationTypeConfig getPublicationTypeConfig() {
@@ -217,7 +217,7 @@ public class PublicationScenarioContext {
             case BELONGS_TO_CURATING_INSTITUTION -> CURATING_INSTITUTION;
             case BELONGS_TO_NON_CURATING_INSTITUTION -> NON_CURATING_INSTITUTION;
         };
-        return UserInstance.create(USER_NAME, userInstitution, USER_CRISTIN_ID, accessRights, userInstitution);
+        return UserInstance.create(USER_NAME, randomUri(), USER_CRISTIN_ID, accessRights, userInstitution);
     }
 
     private HashSet<CuratingInstitution> createCuratingInstitutions() {

--- a/publication-commons/src/test/resources/features/file/file_access_embargo_degree.feature
+++ b/publication-commons/src/test/resources/features/file/file_access_embargo_degree.feature
@@ -8,6 +8,7 @@ Feature: File permissions for embargo and degree files
     And the file is owned by "publication creator"
     And publication is of type "degree"
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -94,6 +95,7 @@ Feature: File permissions for embargo and degree files
     And the file is owned by "publication creator"
     And the file has embargo
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -266,6 +268,7 @@ Feature: File permissions for embargo and degree files
     And publication is of type "degree"
     And publication has publisher claimed by "not users institution"
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/file/file_access_read.feature
+++ b/publication-commons/src/test/resources/features/file/file_access_read.feature
@@ -7,6 +7,7 @@ Feature: File metadata read and file download permissions
     Given a file of type "<FileType>"
     And the file is owned by "publication creator"
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "read-metadata"
     Then the action outcome is "<Outcome>"
 
@@ -18,6 +19,7 @@ Feature: File metadata read and file download permissions
       | UploadedFile        | Contributor             | Not Allowed |
       | UploadedFile        | Publishing curator      | Allowed     |
       | UploadedFile        | Related external client | Not Allowed |
+      | UploadedFile        | Editor                  | Not Allowed |
 
       | PendingOpenFile     | Unauthenticated         | Not Allowed |
       | PendingOpenFile     | Authenticated           | Not Allowed |
@@ -25,6 +27,7 @@ Feature: File metadata read and file download permissions
       | PendingOpenFile     | Contributor             | Allowed     |
       | PendingOpenFile     | Publishing curator      | Allowed     |
       | PendingOpenFile     | Related external client | Not Allowed |
+      | PendingOpenFile     | Editor                  | Allowed     |
 
       | PendingInternalFile | Unauthenticated         | Not Allowed |
       | PendingInternalFile | Authenticated           | Not Allowed |
@@ -32,6 +35,7 @@ Feature: File metadata read and file download permissions
       | PendingInternalFile | Contributor             | Allowed     |
       | PendingInternalFile | Publishing curator      | Allowed     |
       | PendingInternalFile | Related external client | Not Allowed |
+      | PendingInternalFile | Editor                  | Allowed     |
 
       | OpenFile            | Unauthenticated         | Allowed     |
       | OpenFile            | Authenticated           | Allowed     |
@@ -39,6 +43,7 @@ Feature: File metadata read and file download permissions
       | OpenFile            | Contributor             | Allowed     |
       | OpenFile            | Publishing curator      | Allowed     |
       | OpenFile            | Related external client | Allowed     |
+      | OpenFile            | Editor                  | Allowed     |
 
       | InternalFile        | Unauthenticated         | Not Allowed |
       | InternalFile        | Authenticated           | Not Allowed |
@@ -46,6 +51,7 @@ Feature: File metadata read and file download permissions
       | InternalFile        | Contributor             | Allowed     |
       | InternalFile        | Publishing curator      | Allowed     |
       | InternalFile        | Related external client | Allowed     |
+      | InternalFile        | Editor                  | Allowed     |
 
       | HiddenFile          | Authenticated           | Not Allowed |
       | HiddenFile          | Unauthenticated         | Not Allowed |
@@ -53,12 +59,13 @@ Feature: File metadata read and file download permissions
       | HiddenFile          | Contributor             | Not Allowed |
       | HiddenFile          | Publishing curator      | Allowed     |
       | HiddenFile          | Related external client | Not Allowed |
+      | HiddenFile          | Editor                  | Not Allowed |
 
-  Scenario Outline: Verify file metadata read permissions when user is not from file owners institution
+  Scenario Outline: Verify file metadata read permissions when user is not from file owners institution, but still belongs to contributing institution
     Given a file of type "<FileType>"
-    And the file is owned by "publication creator"
+    And the file is owned by "someone else"
     When the user have the role "<UserRole>"
-    And the user belongs to "curating institution"
+    And the user belongs to "creating institution"
     And the user attempts to "read-metadata"
     Then the action outcome is "<Outcome>"
 
@@ -68,28 +75,84 @@ Feature: File metadata read and file download permissions
       | UploadedFile        | Contributor                 | Not Allowed |
       | UploadedFile        | Publishing curator          | Not Allowed |
       | UploadedFile        | Not related external client | Not Allowed |
+      | UploadedFile        | Editor                      | Not Allowed |
 
       | PendingOpenFile     | Authenticated               | Not Allowed |
       | PendingOpenFile     | Contributor                 | Allowed     |
       | PendingOpenFile     | Publishing curator          | Allowed     |
       | PendingOpenFile     | Not related external client | Not Allowed |
+      | PendingOpenFile     | Editor                      | Allowed     |
 
       | PendingInternalFile | Authenticated               | Not Allowed |
       | PendingInternalFile | Contributor                 | Allowed     |
       | PendingInternalFile | Publishing curator          | Allowed     |
       | PendingInternalFile | Not related external client | Not Allowed |
+      | PendingInternalFile | Editor                      | Allowed     |
 
       | OpenFile            | Authenticated               | Allowed     |
       | OpenFile            | Contributor                 | Allowed     |
       | OpenFile            | Publishing curator          | Allowed     |
       | OpenFile            | Not related external client | Allowed     |
+      | OpenFile            | Editor                      | Allowed     |
 
       | InternalFile        | Authenticated               | Not Allowed |
       | InternalFile        | Contributor                 | Allowed     |
       | InternalFile        | Publishing curator          | Allowed     |
       | InternalFile        | Not related external client | Not Allowed |
+      | InternalFile        | Editor                      | Allowed     |
 
       | HiddenFile          | Authenticated               | Not Allowed |
       | HiddenFile          | Contributor                 | Not Allowed |
       | HiddenFile          | Publishing curator          | Not Allowed |
       | HiddenFile          | Not related external client | Not Allowed |
+      | HiddenFile          | Editor                      | Not Allowed |
+
+  Scenario Outline: Verify file metadata read permissions when user is not from file owners institution or contributing institution
+    Given a file of type "<FileType>"
+    And the file is owned by "publication creator"
+    When the user have the role "<UserRole>"
+    And the user belongs to "non curating institution"
+    And the user attempts to "read-metadata"
+    Then the action outcome is "<Outcome>"
+
+    Examples:
+      | FileType            | UserRole           | Outcome     |
+      | UploadedFile        | Authenticated      | Not Allowed |
+      | UploadedFile        | Contributor        | Not Allowed |
+      | UploadedFile        | Publishing curator | Not Allowed |
+      | UploadedFile        | Editor             | Not Allowed |
+
+      | PendingOpenFile     | Authenticated      | Not Allowed |
+      | PendingOpenFile     | Contributor        | Allowed     |
+      | PendingOpenFile     | Publishing curator | Not Allowed |
+      | PendingOpenFile     | Editor             | Allowed     |
+
+      | PendingInternalFile | Authenticated      | Not Allowed |
+      | PendingInternalFile | Contributor        | Allowed     |
+      | PendingInternalFile | Publishing curator | Not Allowed |
+      | PendingInternalFile | Editor             | Not Allowed |
+
+      | OpenFile            | Authenticated      | Allowed     |
+      | OpenFile            | Contributor        | Allowed     |
+      | OpenFile            | Publishing curator | Allowed     |
+      | OpenFile            | Editor             | Allowed     |
+
+      | InternalFile        | Authenticated      | Not Allowed |
+      | InternalFile        | Contributor        | Allowed     |
+      | InternalFile        | Publishing curator | Not Allowed |
+      | InternalFile        | Editor             | Allowed     |
+
+      | HiddenFile          | Authenticated      | Not Allowed |
+      | HiddenFile          | Contributor        | Not Allowed |
+      | HiddenFile          | Publishing curator | Not Allowed |
+      | HiddenFile          | Editor             | Not Allowed |
+
+
+  Scenario: Verify file download permissions when user is not contributing institution and PendingOpenFile has embargo
+    Given a file of type "PendingOpenFile"
+    And the file is owned by "publication creator"
+    And the file has embargo
+    When the user have the role "Editor"
+    And the user belongs to "non curating institution"
+    And the user attempts to "download"
+    Then the action outcome is "Not Allowed"

--- a/publication-commons/src/test/resources/features/file/file_access_write.feature
+++ b/publication-commons/src/test/resources/features/file/file_access_write.feature
@@ -10,6 +10,7 @@ Feature: File metadata write and file delete permissions
     Given a file of type "<FileType>"
     And the file is owned by "publication creator"
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "write-metadata"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/channelclaim/finalized_files_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/channelclaim/finalized_files_permission_strategy.feature
@@ -7,6 +7,7 @@ Feature: Publication action permissions for publications with claimed channel an
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -218,6 +219,7 @@ Feature: Publication action permissions for publications with claimed channel an
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/channelclaim/no_finalized_files_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/channelclaim/no_finalized_files_permission_strategy.feature
@@ -7,6 +7,7 @@ Feature: Publication action permissions for publications with claimed channel an
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -218,6 +219,7 @@ Feature: Publication action permissions for publications with claimed channel an
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/channelclaim/outside_of_scope_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/channelclaim/outside_of_scope_permission_strategy.feature
@@ -11,6 +11,7 @@ Feature: Publication action permissions for publications with claimed channel ou
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -222,6 +223,7 @@ Feature: Publication action permissions for publications with claimed channel ou
     And channel claim has "publishing" policy "everyone"
     And channel claim has "editing" policy "ownerOnly"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/degree/degree_finalized_file_permissions_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/degree/degree_finalized_file_permissions_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for degrees with finalized files
     Given a "degree"
     And publication has "finalized" files
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/degree/degree_imported_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/degree/degree_imported_permission_strategy.feature
@@ -5,6 +5,7 @@ Feature: Publication action permissions for imported degrees
     And publication is an imported degree
     And publication has "no" files
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 
@@ -172,6 +173,7 @@ Feature: Publication action permissions for imported degrees
     And publication is an imported degree
     And publication has "finalized" files
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/degree/degree_no_finalized_files_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/degree/degree_no_finalized_files_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for degrees when user relates to publica
     Given a "degree"
     And publication has "no finalized" files
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/filestatus/finalized_files_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/filestatus/finalized_files_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for publication with finalized files
     Given a "publication"
     And publication has "finalized" files
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/filestatus/no_finalized_files_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/filestatus/no_finalized_files_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for publication with no finalized files
     Given a "publication"
     And publication has "no finalized" files
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/status/deleted_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/status/deleted_permission_strategy.feature
@@ -5,6 +5,7 @@ Feature: Publication action permissions for publication status DELETED
     And publication has status "deleted"
     And the user have the role "<UserRole>"
     When the user attempts to "<Operation>"
+    And the user belongs to "creating institution"
     Then the action outcome is "<Outcome>"
 
     Examples:

--- a/publication-commons/src/test/resources/features/publication/status/draft_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/status/draft_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for publication status Draft
     Given a "publication"
     And publication has status "draft"
     When the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     And the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/status/published_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/status/published_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for publication status PUBLISHED
     Given a "publication"
     And publication has status "published"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/publication/status/unpublished_permission_strategy.feature
+++ b/publication-commons/src/test/resources/features/publication/status/unpublished_permission_strategy.feature
@@ -4,6 +4,7 @@ Feature: Publication action permissions for publication status UNPUBLISHED
     Given a "publication"
     And publication has status "unpublished"
     And the user have the role "<UserRole>"
+    And the user belongs to "creating institution"
     When the user attempts to "<Operation>"
     Then the action outcome is "<Outcome>"
 

--- a/publication-commons/src/test/resources/features/ticket/ticket_access_transfer.feature
+++ b/publication-commons/src/test/resources/features/ticket/ticket_access_transfer.feature
@@ -86,6 +86,7 @@ Feature: Permissions given claimed publisher
   Scenario: Should not give transfer permission when only available curation institution is same as user
     Given a "publication"
     When the user have the role "publishing curator"
+    And the user belongs to "creating institution"
     And the user attempts to "transfer"
     Then the action outcome is "Not Allowed"
 
@@ -94,6 +95,7 @@ Feature: Permissions given claimed publisher
     And publication has "<Files>" files
     And publication has publisher claimed by "<ClaimedBy>"
     When the user have the role "thesis curator"
+    And the user belongs to "creating institution"
     And the user attempts to "transfer"
     Then the action outcome is "Not Allowed"
 


### PR DESCRIPTION
…49402

Added editor as a access pattern for files. Editor should be able to see file metadata and download files with exception for PendingInternal and pending embargo when the person is not related to the file.

Made this explicit "And the user belongs to "creating institution" in each test instead of implicit.

Added test support for file ownership for "someone else"