### PR TITLE
Make ant task cacheable

### DIFF
--- a/buildSrc/src/main/groovy/nva.publication.api.rootplugin.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.rootplugin.gradle
@@ -1,9 +1,8 @@
-plugins{
+plugins {
     id 'jacoco-report-aggregation'
     id 'base'
     id 'java-library'
 }
-
 
 repositories {
     mavenCentral()
@@ -19,15 +18,11 @@ dependencies {
 reporting {
     reports {
         testCodeCoverageReport(JacocoCoverageReport) {
-            testType = TestSuiteType.UNIT_TEST
-        }
-        integrationTestCodeCoverageReport(JacocoCoverageReport) {
-            testType = TestSuiteType.INTEGRATION_TEST
+            testSuiteName = 'test'
         }
     }
 }
 
 tasks.named('check') {
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
-    dependsOn tasks.named('integrationTestCodeCoverageReport', JacocoReport)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/scopus-generate/build.gradle
+++ b/scopus-generate/build.gradle
@@ -5,26 +5,49 @@ project.ext {
 sourceSets.main.java.srcDirs += jaxbTargetDir
 
 configurations {
-    jaxb
+    xjc
 }
 
 dependencies {
-    jaxb libs.bundles.xsd2java
+    xjc 'com.sun.xml.bind:jaxb-xjc:2.3.3'
+    xjc 'com.sun.xml.bind:jaxb-core:2.3.3'
+    xjc libs.bundles.xsd2java
     implementation libs.bundles.xsd2java
 }
 
-tasks.register('xsd2java') {
-    doLast {
-        jaxbTargetDir.mkdirs()
-        ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJC2Task', classpath: configurations.jaxb.asPath)
-        ant.jaxbTargetDir = jaxbTargetDir
+@CacheableTask
+abstract class Xsd2Pojo extends DefaultTask {
+
+    @Classpath
+    abstract ConfigurableFileCollection getXjcClasspath()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @TaskAction
+    void generate() {
+        getOutputDir().get().asFile.mkdirs()
+        ant.taskdef(
+                name: 'xjc',
+                classname: 'com.sun.tools.xjc.XJC2Task',
+                classpath: getXjcClasspath().asPath
+        )
         ant.xjc(
-                destdir: '${jaxbTargetDir}',
+                destdir: getOutputDir().get().asFile,
                 package: 'no.scopus.generated',
                 schema: 'https://schema.elsevier.com/dtds/document/abstracts/xocs-ani515.xsd',
                 binding: 'src/main/resources/xocs-ani515.xjb'
         )
     }
+}
+
+tasks.register('xsd2java', Xsd2Pojo) {
+    xjcClasspath = configurations.xjc
+    outputDir = jaxbTargetDir
+}
+
+tasks.withType(Jar).configureEach {
+    outputs.cacheIf { true }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/scopus-generate/build.gradle
+++ b/scopus-generate/build.gradle
@@ -9,8 +9,6 @@ configurations {
 }
 
 dependencies {
-    xjc 'com.sun.xml.bind:jaxb-xjc:2.3.3'
-    xjc 'com.sun.xml.bind:jaxb-core:2.3.3'
     xjc libs.bundles.xsd2java
     implementation libs.bundles.xsd2java
 }


### PR DESCRIPTION
This should reduce build times…by ensuring incremental builds and build cache can be used.

Steps to reproduce:
- build the branch (it should execute all the scopus-related tasks so no info after the task)
- build it again (it should say "UP-TO-DATE" on the scopus-related tasks — from incremental build)
- ./gradlew  clean, build again (it should say "FROM-CACHE" on the scopus related tasks — from the local cache)