### PR TITLE
Fix gradle-specific, space-assignment deprecation warnings

### DIFF
--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     // This is required until Gradle TestSuites are used, note no version is specified as this syncs
     // with JUnit from gradle.
-    testRuntimeOnly(group: 'org.junit.platform', name: 'junit-platform-launcher')
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //To support dynamodb local when testing, using mac m1
     if (System.getProperty("os.arch") == "aarch64") {
@@ -30,20 +30,20 @@ dependencies {
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
+    maven { url = 'https://jitpack.io' }
+    maven { url = "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
 }
 
 tasks.named('test') {
-    environment "API_HOST", "localhost"
+    environment("API_HOST", "localhost")
     useJUnitPlatform {
-        excludeTags "RemoteTest", "integrationTest", "KarateTest"
+        excludeTags  = [ "RemoteTest", "integrationTest", "KarateTest" ]
     }
     failFast = false
     testLogging {
-        events 'skipped', 'passed', 'failed'
-        showCauses true
-        exceptionFormat "full"
+        events = [ 'skipped', 'passed', 'failed' ]
+        showCauses = true
+        exceptionFormat = "full"
     }
 }
 
@@ -63,7 +63,7 @@ tasks.withType(Checkstyle) .configureEach{
     reports {
         xml.required
         html.required
-        html.stylesheet rootProject.resources.text.fromFile('config/checkstyle/checkstyle-simple.xsl')
+        html.stylesheet = rootProject.resources.text.fromFile('config/checkstyle/checkstyle-simple.xsl')
     }
 }
 
@@ -98,13 +98,13 @@ spotless {
         googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
     }
 
-    format 'misc', {
-        target '.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle'
+    format('misc', {
+        target = [ '.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle' ]
         leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()
-    }
-    enforceCheck false // Temporarily disable checking during build until the project is reformatted
+    })
+    enforceCheck = false // Temporarily disable checking during build until the project is reformatted
 }
 
 // Commented out for now, uncomment when the project is reformatted and ready to enforce the formatting rules

--- a/buildSrc/src/main/groovy/nva.publication.api.rootplugin.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.rootplugin.gradle
@@ -6,7 +6,7 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
+    maven { url = 'https://jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
This PR removes deprecation warnings observed when building this project, see results at:
- https://scans.gradle.com/s/2rsycguigbwoq/deprecations
- https://scans.gradle.com/s/2rsycguigbwoq/console-log?anchor=0&page=1

Details:
- Fixes various warnings where the deprecated, gradle-specific space-based assignment like `myProp myValue`, which may be replaced by `myProp = myValue` or, `myProp(myValueKey, myValue)`
- Because these deprecated usages were in `root-plugin` and `java-conventions-plugin`, the number of errors was propagated to every project using these plugins.