### PR TITLE
Make all task inputs normalized parameters

### DIFF
--- a/scopus-generate/build.gradle
+++ b/scopus-generate/build.gradle
@@ -16,6 +16,13 @@ dependencies {
 @CacheableTask
 abstract class Xsd2Pojo extends DefaultTask {
 
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract RegularFileProperty getBindingFile()
+
+    @Input
+    abstract Property<String> getSchemaUri();
+
     @Classpath
     abstract ConfigurableFileCollection getXjcClasspath()
 
@@ -25,21 +32,25 @@ abstract class Xsd2Pojo extends DefaultTask {
     @TaskAction
     void generate() {
         getOutputDir().get().asFile.mkdirs()
+        def normalizedClasspath = getXjcClasspath().files.toSorted()
+
         ant.taskdef(
                 name: 'xjc',
                 classname: 'com.sun.tools.xjc.XJC2Task',
-                classpath: getXjcClasspath().asPath
+                classpath: normalizedClasspath.collect { it.absolutePath }.join(File.pathSeparator)
         )
         ant.xjc(
                 destdir: getOutputDir().get().asFile,
                 package: 'no.scopus.generated',
-                schema: 'https://schema.elsevier.com/dtds/document/abstracts/xocs-ani515.xsd',
-                binding: 'src/main/resources/xocs-ani515.xjb'
+                schema: getSchemaUri().get(),
+                binding: getBindingFile().get().asFile.path
         )
     }
 }
 
 tasks.register('xsd2java', Xsd2Pojo) {
+    schemaUri = 'https://schema.elsevier.com/dtds/document/abstracts/xocs-ani515.xsd'
+    bindingFile = file('src/main/resources/xocs-ani515.xjb')
     xjcClasspath = configurations.xjc
     outputDir = jaxbTargetDir
 }


### PR DESCRIPTION
Adds params to the xjc2pojo task as normalised inputs
- Gather inputs in one place in task, allows for re-use
- Bindings file is found and input as a file, rather than a static string
- Schema URI is now an input rather than a static string
- We now normalise the classpath data so we don't get non-deterministic misses for the same input when processing this data