### PR TITLE
fix: Use correct syntax for Spotless task

### DIFF
--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -98,8 +98,16 @@ spotless {
         googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
     }
 
+    groovyGradle {
+        target('**/*.gradle')
+        greclipse()
+        leadingTabsToSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+
     format 'misc', {
-        target('.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle')
+        target('.gitignore', '.gitattributes', '.editorconfig')
         leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()

--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -107,7 +107,7 @@ spotless {
     }
 
     format 'misc', {
-        target('.gitignore', '.gitattributes', '.editorconfig')
+        target('.gitignore', '.gitattributes', '.editorconfig', '**/*.md')
         leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()

--- a/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.api.java-conventions.gradle
@@ -98,12 +98,12 @@ spotless {
         googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
     }
 
-    format('misc', {
-        target = [ '.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle' ]
+    format 'misc', {
+        target('.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle')
         leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()
-    })
+    }
     enforceCheck = false // Temporarily disable checking during build until the project is reformatted
 }
 


### PR DESCRIPTION
Changes:

- fix: Use correct syntax for Spotless task
- style: Use greclipse formatter for Gradle files
- style: Add `.md` files to default formatting task