### PR TITLE
adjusting merging of files in brage import

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMerger.java
@@ -12,6 +12,8 @@ import no.unit.nva.model.associatedartifacts.file.OpenFile;
 
 public final class AssociatedArtifactsMerger {
 
+    private static final int SINGLETON = 1;
+
     private AssociatedArtifactsMerger() {
     }
 
@@ -25,12 +27,23 @@ public final class AssociatedArtifactsMerger {
         } else if (hasNoOpenFilesWithPublishedVersion(existing)) {
             associatedArtifacts.addAll(convertOpenFilesToInternal(existing));
             associatedArtifacts.addAll(getOpenFilesWithPublishedVersion(incoming));
+        } else if (hasOnlyOneOpenFileWithPublishedVersion(existing) && hasOnlyOneOpenFileWithPublishedVersion(incoming)) {
+            associatedArtifacts.addAll(getOpenFiles(existing));
         } else if (hasOpenFilesWithPublishedVersion(existing)) {
             associatedArtifacts.addAll(getOpenFiles(existing));
             associatedArtifacts.addAll(
                 getOpenFilesWithPublishedVersionAndDifferentNamesThanExisting(existing, incoming));
         }
         return new AssociatedArtifactList(associatedArtifacts);
+    }
+
+    private static boolean hasOnlyOneOpenFileWithPublishedVersion(AssociatedArtifactList associatedArtifacts) {
+        return associatedArtifacts.stream()
+                   .filter(File.class::isInstance)
+                   .map(File.class::cast)
+                   .filter(OpenFile.class::isInstance)
+                   .filter(file -> PUBLISHED_VERSION.equals(file.getPublisherVersion()))
+                   .toList().size() == SINGLETON;
     }
 
     private static boolean hasOpenFilesWithPublishedVersion(AssociatedArtifactList existing) {

--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMergerTest.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMergerTest.java
@@ -64,17 +64,6 @@ class AssociatedArtifactsMergerTest {
     }
 
     @Test
-    void shouldKeepIncomingOpenFileWithPublishedVersionWhenThereIsNoExistingOpenFileWithPublishedVersionWithTheSameFileName() {
-        var existing = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION)));
-        var incoming = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION)));
-
-        var result = AssociatedArtifactsMerger.merge(existing, incoming);
-
-        assertTrue(result.containsAll(existing));
-        assertTrue(result.containsAll(incoming));
-    }
-
-    @Test
     void shouldKeepExistingOpenFileWithPublishedVersionWhenIncomingOpenFileWithPublishedVersionHasTheSameFileName() {
 
         var filename = randomString();
@@ -87,13 +76,29 @@ class AssociatedArtifactsMergerTest {
     }
 
     @Test
-    void shouldNotKeepIncomingOpenFileWithPublishedVersionWhenThereExistsOpenFileWithPublishedVersionWithTheSameFileName() {
+    void shouldNotKeepIncomingOpenFilesWithPublishedVersionWhenThereExistsOpenFileWithPublishedVersionWithTheSameFileName() {
         var filename = randomString();
+        var fileWithNewFilename = randomOpenFile(PUBLISHED_VERSION, randomString());
+        var fileWithExistingFilename = randomOpenFile(PUBLISHED_VERSION, filename);
         var existing = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION, filename)));
-        var incoming = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION, filename)));
+        var incoming = new AssociatedArtifactList(List.of(fileWithExistingFilename,
+                                                          fileWithNewFilename));
 
         var result = AssociatedArtifactsMerger.merge(existing, incoming);
 
+        assertTrue(result.containsAll(existing));
+        assertTrue(result.contains(fileWithNewFilename));
+        assertFalse(result.contains(fileWithExistingFilename));
+    }
+
+    @Test
+    void shouldKeepExistingOpenFileWithPublishedVersionWhenIncomingPublicationHasOnlyOneOpenFileWithPublishedVersion() {
+        var existing = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION, randomString())));
+        var incoming = new AssociatedArtifactList(List.of(randomOpenFile(PUBLISHED_VERSION, randomString())));
+
+        var result = AssociatedArtifactsMerger.merge(existing, incoming);
+
+        assertTrue(result.containsAll(existing));
         assertFalse(result.containsAll(incoming));
     }
 }


### PR DESCRIPTION
Satisfying following conditions:

Regler:

Dersom det finnes 1 Åpen fil med publisert versjon fra før av, og det kommer inn 1 Åpen fil med publisert versjon → Den nye filen ignoreres. (Antas at filen som allerede ligger der er riktig/ er samme fil)


Dersom det finnes en eller flere åpne filer med publisert versjon og det kommer inn en eller flere åpne filer med publisert versjon → Legg til alle nye som har forskjellige navn. 