### PR TITLE
NP-49654 Add contributorsCount to PublicationSummary

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -45,6 +45,8 @@ public class PublicationSummary {
     private Instant publishedDate;
     @JsonProperty
     private List<Contributor> contributors;
+    @JsonProperty
+    private int contributorsCount;
     @JsonProperty("abstract")
     private String mainLanguageAbstract;
 
@@ -98,7 +100,12 @@ public class PublicationSummary {
     }
 
     public void setContributors(List<Contributor> contributors) {
-        this.contributors = contributors;
+        this.contributorsCount = contributors.size();
+        this.contributors = sortAndLimitNumberOfContributors(contributors);
+    }
+
+    public int getContributorsCount() {
+        return contributorsCount;
     }
 
     public SortableIdentifier getIdentifier() {
@@ -161,7 +168,8 @@ public class PublicationSummary {
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getStatus(),
-                            getPublicationInstance(), getPublishedDate(), getContributors(), getAbstract());
+                            getPublicationInstance(), getPublishedDate(), getContributors(), getContributorsCount(),
+                            getAbstract());
     }
 
     @Override
@@ -181,6 +189,7 @@ public class PublicationSummary {
                && Objects.equals(getPublicationInstance(), that.getPublicationInstance())
                && Objects.equals(getPublishedDate(), that.getPublishedDate())
                && Objects.equals(getContributors(), that.getContributors())
+               && Objects.equals(getContributorsCount(), that.getContributorsCount())
                && Objects.equals(getAbstract(), that.getAbstract());
     }
 
@@ -191,8 +200,11 @@ public class PublicationSummary {
     private static List<Contributor> extractContributors(EntityDescription entityDescription) {
         return Optional.ofNullable(entityDescription)
                    .map(EntityDescription::getContributors)
-                   .orElse(Collections.emptyList())
-                   .stream()
+                   .orElse(Collections.emptyList());
+    }
+
+    private static List<Contributor> sortAndLimitNumberOfContributors(List<Contributor> contributors) {
+        return contributors.stream()
                    .sorted(Comparator.comparing(Contributor::getSequence))
                    .limit(MAX_SIZE_CONTRIBUTOR_LIST)
                    .collect(Collectors.toList());

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -46,7 +46,7 @@ public class PublicationSummary {
     @JsonProperty
     private List<Contributor> contributors;
     @JsonProperty
-    private int contributorsCount;
+    private int contributorCount;
     @JsonProperty("abstract")
     private String mainLanguageAbstract;
 
@@ -100,12 +100,12 @@ public class PublicationSummary {
     }
 
     public void setContributors(List<Contributor> contributors) {
-        this.contributorsCount = contributors.size();
+        this.contributorCount = contributors.size();
         this.contributors = sortAndLimitNumberOfContributors(contributors);
     }
 
-    public int getContributorsCount() {
-        return contributorsCount;
+    public int getContributorCount() {
+        return contributorCount;
     }
 
     public SortableIdentifier getIdentifier() {
@@ -168,7 +168,7 @@ public class PublicationSummary {
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getStatus(),
-                            getPublicationInstance(), getPublishedDate(), getContributors(), getContributorsCount(),
+                            getPublicationInstance(), getPublishedDate(), getContributors(), getContributorCount(),
                             getAbstract());
     }
 
@@ -189,7 +189,7 @@ public class PublicationSummary {
                && Objects.equals(getPublicationInstance(), that.getPublicationInstance())
                && Objects.equals(getPublishedDate(), that.getPublishedDate())
                && Objects.equals(getContributors(), that.getContributors())
-               && Objects.equals(getContributorsCount(), that.getContributorsCount())
+               && Objects.equals(getContributorCount(), that.getContributorCount())
                && Objects.equals(getAbstract(), that.getAbstract());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -96,7 +96,7 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         var entityDescription = publication.getEntityDescription();
         entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
         var summary = PublicationSummary.create(publication);
-        assertThat(summary.getContributorsCount(), is(equalTo(entityDescription.getContributors().size())));
+        assertThat(summary.getContributorCount(), is(equalTo(entityDescription.getContributors().size())));
     }
 
     @Test

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -72,7 +72,7 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         var publication = PublicationGenerator.publicationWithIdentifier();
         var entityDescription = publication.getEntityDescription();
         entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
-        PublicationSummary summary = PublicationSummary.create(publication);
+        var summary = PublicationSummary.create(publication);
         assertThat(summary.getContributors().size(), is(equalTo(MAX_SIZE_CONTRIBUTOR_LIST)));
     }
 
@@ -81,13 +81,22 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         var publication = PublicationGenerator.publicationWithIdentifier();
         var entityDescription = publication.getEntityDescription();
         entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
-        PublicationSummary summary = PublicationSummary.create(publication);
+        var summary = PublicationSummary.create(publication);
         assertThat(summary.getContributors(), containsInAnyOrder(entityDescription.getContributors()
                                                                      .stream()
                                                                      .sorted(
                                                                          Comparator.comparing(Contributor::getSequence))
                                                                      .limit(MAX_SIZE_CONTRIBUTOR_LIST)
                                                                      .toArray()));
+    }
+
+    @Test
+    void shouldReturnTotalNumberOfContributorsWhenNumberOfContributorsExceedsMaxSize() {
+        var publication = PublicationGenerator.publicationWithIdentifier();
+        var entityDescription = publication.getEntityDescription();
+        entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
+        var summary = PublicationSummary.create(publication);
+        assertThat(summary.getContributorsCount(), is(equalTo(entityDescription.getContributors().size())));
     }
 
     @Test


### PR DESCRIPTION
Jira-task: [NP-49654](https://sikt.atlassian.net/browse/NP-49654)

Tickets were missing the total number of contributors, as the contributor list is limited to only the first five. Inspired by the NVI `PublicationDetail`, I've added a `contributorsCount` field.

Thinking aloud: Is limiting the number of contributors the reason tickets aren't searchable for all contributors?

[NP-49654]: https://sikt.atlassian.net/browse/NP-49654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ