### PR TITLE
Rename contributorCount to contributorsCount

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -46,7 +46,7 @@ public class PublicationSummary {
     @JsonProperty
     private List<Contributor> contributors;
     @JsonProperty
-    private int contributorCount;
+    private int contributorsCount;
     @JsonProperty("abstract")
     private String mainLanguageAbstract;
 
@@ -100,12 +100,12 @@ public class PublicationSummary {
     }
 
     public void setContributors(List<Contributor> contributors) {
-        this.contributorCount = contributors.size();
+        this.contributorsCount = contributors.size();
         this.contributors = sortAndLimitNumberOfContributors(contributors);
     }
 
-    public int getContributorCount() {
-        return contributorCount;
+    public int getContributorsCount() {
+        return contributorsCount;
     }
 
     public SortableIdentifier getIdentifier() {
@@ -168,7 +168,7 @@ public class PublicationSummary {
     @JacocoGenerated
     public int hashCode() {
         return Objects.hash(getPublicationId(), getIdentifier(), getTitle(), getOwner(), getStatus(),
-                            getPublicationInstance(), getPublishedDate(), getContributors(), getContributorCount(),
+                            getPublicationInstance(), getPublishedDate(), getContributors(), getContributorsCount(),
                             getAbstract());
     }
 
@@ -189,7 +189,7 @@ public class PublicationSummary {
                && Objects.equals(getPublicationInstance(), that.getPublicationInstance())
                && Objects.equals(getPublishedDate(), that.getPublishedDate())
                && Objects.equals(getContributors(), that.getContributors())
-               && Objects.equals(getContributorCount(), that.getContributorCount())
+               && Objects.equals(getContributorsCount(), that.getContributorsCount())
                && Objects.equals(getAbstract(), that.getAbstract());
     }
 

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -96,7 +96,7 @@ class PublicationSummaryTest extends ResourcesLocalTest {
         var entityDescription = publication.getEntityDescription();
         entityDescription.setContributors(getNumberOfContributors(getRandomNumberOfContributorsLargerThanMaxSize()));
         var summary = PublicationSummary.create(publication);
-        assertThat(summary.getContributorCount(), is(equalTo(entityDescription.getContributors().size())));
+        assertThat(summary.getContributorsCount(), is(equalTo(entityDescription.getContributors().size())));
     }
 
     @Test


### PR DESCRIPTION
Decided to rename `contributorCount` back to `contributorsCount` to match `ExpandedResource`, `Nvi.PublicationDetails` and frontend types.