### PR TITLE
NP-49788 Increase number of contributors in ticket response

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/PublicationSummary.java
@@ -27,7 +27,7 @@ import nva.commons.core.paths.UriWrapper;
 public class PublicationSummary {
 
     public static final String TYPE = "Publication";
-    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 5;
+    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 10;
 
     @JsonProperty("id")
     private URI publicationId;

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/PublicationSummaryTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 class PublicationSummaryTest extends ResourcesLocalTest {
 
-    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 5;
+    private static final int MAX_SIZE_CONTRIBUTOR_LIST = 10;
 
     @BeforeEach
     public void setup() {


### PR DESCRIPTION
`ExpandedResource` previews 10 contributors, while ticket previews 5. Changing ticket to match `ExpandedResource`. Could this number be higher? Is there a reason 10 was chosen for `ExpandedResource`? With more contributors in the response, more contributors are searchable? Can probably not return all, because of mega publications.