### PR TITLE
feature(event-handlers): add sqs based batch job handler for processing DynamoDB resources

### DIFF
--- a/publication-constants/src/main/java/no/unit/nva/publication/storage/model/DatabaseConstants.java
+++ b/publication-constants/src/main/java/no/unit/nva/publication/storage/model/DatabaseConstants.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.storage.model;
 
+import java.util.Map;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
@@ -28,6 +29,14 @@ public final class DatabaseConstants {
     public static final String BY_TYPE_AND_IDENTIFIER_INDEX_SORT_KEY_NAME = "SK3";
     public static final String RESOURCES_BY_CRISTIN_ID_INDEX_PARTITION_KEY_NAME = "PK4";
     public static final String RESOURCES_BY_CRISTIN_ID_INDEX_SORT_KEY_NAME = "SK4";
+
+    // Map of GSI names to their corresponding partition and sort keys
+    public static final Map<String, DynamoDbKey> GSI_KEY_PAIRS = Map.of(
+        GSI_1_INDEX_NAME, new DynamoDbKey(GSI_1_PARTITION_KEY_NAME, GSI_1_SORT_KEY_NAME),
+        BY_CUSTOMER_RESOURCE_INDEX_NAME, new DynamoDbKey(BY_CUSTOMER_RESOURCE_INDEX_PARTITION_KEY_NAME, BY_CUSTOMER_RESOURCE_INDEX_SORT_KEY_NAME),
+        BY_TYPE_AND_IDENTIFIER_INDEX_NAME, new DynamoDbKey(BY_TYPE_AND_IDENTIFIER_INDEX_PARTITION_KEY_NAME, BY_TYPE_AND_IDENTIFIER_INDEX_SORT_KEY_NAME),
+        RESOURCE_BY_CRISTIN_ID_INDEX_NAME, new DynamoDbKey(RESOURCES_BY_CRISTIN_ID_INDEX_PARTITION_KEY_NAME, RESOURCES_BY_CRISTIN_ID_INDEX_SORT_KEY_NAME)
+    );
     
     public static final String CUSTOMER_INDEX_FIELD_PREFIX = "Customer";
     public static final String RESOURCE_INDEX_FIELD_PREFIX = "Resource";
@@ -70,4 +79,6 @@ public final class DatabaseConstants {
             DEFAULT_RESOURCES_TABLE_NAME
         );
     }
+
+    public record DynamoDbKey(String partitionKey, String sortKey) {}
 }

--- a/publication-event-handlers/build.gradle
+++ b/publication-event-handlers/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(":publication-constants")
     implementation project(":publication-doi-commons")
     implementation project(":expansion")
     implementation project(":publication-commons")

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/BatchWorkItem.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/BatchWorkItem.java
@@ -2,4 +2,8 @@ package no.unit.nva.publication.events.handlers.batch.dynamodb;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public record BatchWorkItem(DynamodbResourceBatchDynamoDbKey dynamoDbKey, String jobType, JsonNode parameters) { }
+public record BatchWorkItem(DynamodbResourceBatchDynamoDbKey dynamoDbKey, String jobType, JsonNode parameters) {
+    public BatchWorkItem(DynamodbResourceBatchDynamoDbKey dynamoDbKey, String jobType) {
+        this(dynamoDbKey, jobType, null);
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/BatchWorkItem.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/BatchWorkItem.java
@@ -1,0 +1,5 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record BatchWorkItem(DynamodbResourceBatchDynamoDbKey dynamoDbKey, String jobType, JsonNode parameters) { }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchDynamoDbKey.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchDynamoDbKey.java
@@ -3,6 +3,10 @@ package no.unit.nva.publication.events.handlers.batch.dynamodb;
 import nva.commons.core.JacocoGenerated;
 
 public record DynamodbResourceBatchDynamoDbKey(String partitionKey, String sortKey, String indexName) {
+    public DynamodbResourceBatchDynamoDbKey(String partitionKey, String sortKey) {
+        this(partitionKey, sortKey, null);
+    }
+
     public boolean isGsiQuery() {
         return indexName != null;
     }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchDynamoDbKey.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchDynamoDbKey.java
@@ -1,0 +1,19 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb;
+
+import nva.commons.core.JacocoGenerated;
+
+public record DynamodbResourceBatchDynamoDbKey(String partitionKey, String sortKey, String indexName) {
+    public boolean isGsiQuery() {
+        return indexName != null;
+    }
+
+    @JacocoGenerated
+    @Override
+    public String toString() {
+        if (isGsiQuery()) {
+            return String.format("DynamoDbKey{index='%s', pk='%s', sk='%s'}",
+                                 indexName, partitionKey, sortKey);
+        }
+        return String.format("DynamoDbKey{pk='%s', sk='%s'}", partitionKey, sortKey);
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobExecutor.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobExecutor.java
@@ -1,0 +1,9 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb;
+
+import java.util.List;
+
+// Add job implementations to DynamodbResourceBatchJobHandler.JOBS to register it
+public interface DynamodbResourceBatchJobExecutor {
+    void executeBatch(List<BatchWorkItem> workItems);
+    String getJobType();
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -29,6 +29,7 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
     private static final String ERROR_COUNT_ATTRIBUTE = "ErrorCount";
     private static final String LAST_ERROR_TIMESTAMP_ATTRIBUTE = "LastErrorTimestamp";
     private static final String STACK_TRACE_ATTRIBUTE = "StackTrace";
+    private static final String MESSAGE_BODY_ATTRIBUTE = "MessageBody";
     private static final DynamodbResourceBatchJobExecutor[] JOBS = {new ReindexRecordJob()};
 
     private final Map<String, DynamodbResourceBatchJobExecutor> jobHandlers;
@@ -89,6 +90,7 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
 
         var errorAttributes = new HashMap<String, String>();
         errorAttributes.put(ERROR_MESSAGE_ATTRIBUTE, exception.getMessage());
+        errorAttributes.put(MESSAGE_BODY_ATTRIBUTE, message.getBody());
         var stringWriter = new StringWriter();
         exception.printStackTrace(new PrintWriter(stringWriter));
         errorAttributes.put(STACK_TRACE_ATTRIBUTE, stringWriter.toString());

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -128,7 +128,7 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
             executor.executeBatch(workItems);
 
             logger.info("Successfully processed batch of {} items for job type: {}", workItems.size(), jobType);
-            return List.of();
+            return emptyList();
 
         } catch (Exception e) {
             logger.error("Failed to process batch for job type: {}", jobType, e);

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -112,7 +112,7 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
         logger.info("Processing batch of {} messages for job type: {}", messages.size(), jobType);
         
         var executor = jobHandlers.get(jobType);
-        if (executor == null) {
+        if (isNull(executor)) {
             logger.error("No executor found for job type: {}", jobType);
             return messages.stream()
                 .map(m -> createBatchItemFailure(m.message, 

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -1,0 +1,157 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.jobs.ReindexRecordJob;
+import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
+
+    private static final Logger logger = LoggerFactory.getLogger(DynamodbResourceBatchJobHandler.class);
+    private static final String ERROR_MESSAGE_ATTRIBUTE = "ErrorMessage";
+    private static final String ERROR_COUNT_ATTRIBUTE = "ErrorCount";
+    private static final String LAST_ERROR_TIMESTAMP_ATTRIBUTE = "LastErrorTimestamp";
+    private static final String STACK_TRACE_ATTRIBUTE = "StackTrace";
+    private static final DynamodbResourceBatchJobExecutor[] JOBS = {new ReindexRecordJob()};
+
+    private final Map<String, DynamodbResourceBatchJobExecutor> jobHandlers;
+
+    @JacocoGenerated
+    public DynamodbResourceBatchJobHandler() {
+        this(initializeDefaultJobHandlers());
+    }
+
+    public DynamodbResourceBatchJobHandler(Map<String, DynamodbResourceBatchJobExecutor> jobHandlers) {
+        this.jobHandlers = jobHandlers;
+    }
+
+    @JacocoGenerated
+    private static Map<String, DynamodbResourceBatchJobExecutor> initializeDefaultJobHandlers() {
+        return Stream.of(JOBS).collect(Collectors.toMap(
+            DynamodbResourceBatchJobExecutor::getJobType,
+            Function.identity()
+        ));
+    }
+
+    @Override
+    public SQSBatchResponse handleRequest(SQSEvent sqsEvent, Context context) {
+        logger.info("Processing batch of {} messages", sqsEvent.getRecords().size());
+
+        // Group messages by job type
+        Map<String, List<MessageWithWorkItem>> messagesByJobType = new HashMap<>();
+        List<SQSBatchResponse.BatchItemFailure> parseFailures = new ArrayList<>();
+
+        // Parse all messages and group by job type
+        for (SQSMessage message : sqsEvent.getRecords()) {
+            try {
+                BatchWorkItem workItem = parseWorkItem(message.getBody());
+                messagesByJobType.computeIfAbsent(workItem.jobType(), k -> new ArrayList<>())
+                    .add(new MessageWithWorkItem(message, workItem));
+            } catch (Exception e) {
+                logger.error("Failed to parse message: {}", message.getMessageId(), e);
+                parseFailures.add(createBatchItemFailure(message, e));
+            }
+        }
+
+        // Process each job type batch
+        List<SQSBatchResponse.BatchItemFailure> executionFailures = messagesByJobType.entrySet().stream()
+            .flatMap(entry -> processBatch(entry.getKey(), entry.getValue()).stream())
+            .toList();
+
+        // Combine all failures
+        List<SQSBatchResponse.BatchItemFailure> allFailures = new ArrayList<>();
+        allFailures.addAll(parseFailures);
+        allFailures.addAll(executionFailures);
+
+        logger.info("Processed batch with {} failures out of {} messages",
+                    allFailures.size(), sqsEvent.getRecords().size());
+
+        return SQSBatchResponse.builder()
+                   .withBatchItemFailures(allFailures)
+                   .build();
+    }
+
+    private SQSBatchResponse.BatchItemFailure createBatchItemFailure(SQSMessage message, Exception exception) {
+        // Create failure with message ID
+        var failure = new SQSBatchResponse.BatchItemFailure(message.getMessageId());
+
+        // Add error metadata to message attributes for debugging
+        var errorAttributes = new HashMap<String, String>();
+        errorAttributes.put(ERROR_MESSAGE_ATTRIBUTE, exception.getMessage());
+        var stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        errorAttributes.put(STACK_TRACE_ATTRIBUTE, stringWriter.toString());
+        errorAttributes.put(ERROR_COUNT_ATTRIBUTE, getErrorCount(message));
+        errorAttributes.put(LAST_ERROR_TIMESTAMP_ATTRIBUTE, String.valueOf(System.currentTimeMillis()));
+
+        // Log the error details for monitoring
+        logger.info("Message {} failed with attributes: {}", message.getMessageId(), errorAttributes);
+
+        return failure;
+    }
+
+    private String getErrorCount(SQSMessage message) {
+        // Get approximate receive count from message attributes if available
+        if (message.getAttributes() != null && message.getAttributes().containsKey("ApproximateReceiveCount")) {
+            return message.getAttributes().get("ApproximateReceiveCount");
+        }
+        return "1";
+    }
+
+    private List<SQSBatchResponse.BatchItemFailure> processBatch(String jobType, List<MessageWithWorkItem> messages) {
+        logger.info("Processing batch of {} messages for job type: {}", messages.size(), jobType);
+        
+        var executor = jobHandlers.get(jobType);
+        if (executor == null) {
+            logger.error("No executor found for job type: {}", jobType);
+            return messages.stream()
+                .map(m -> createBatchItemFailure(m.message, 
+                    new UnsupportedOperationException("Unsupported job type: " + jobType)))
+                .toList();
+        }
+
+        try {
+            // Extract work items for batch execution
+            var workItems = messages.stream()
+                .map(m -> m.workItem)
+                .toList();
+
+            // Execute the entire batch as a transaction
+            executor.executeBatch(workItems);
+
+            logger.info("Successfully processed batch of {} items for job type: {}", workItems.size(), jobType);
+            // All succeeded
+            return List.of();
+
+        } catch (Exception e) {
+            logger.error("Failed to process batch for job type: {}", jobType, e);
+            // If batch execution fails, all messages in the batch fail
+            return messages.stream()
+                .map(m -> createBatchItemFailure(m.message, e))
+                .toList();
+        }
+    }
+
+    private BatchWorkItem parseWorkItem(String body) throws JsonProcessingException {
+        return JsonUtils.dtoObjectMapper.readValue(body, BatchWorkItem.class);
+    }
+
+    private record MessageWithWorkItem(SQSMessage message, BatchWorkItem workItem) {
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -58,7 +58,7 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
         var messagesByJobType = new HashMap<String, List<MessageWithWorkItem>>();
         var parseFailures = new ArrayList<SQSBatchResponse.BatchItemFailure>();
 
-        for (SQSMessage message : sqsEvent.getRecords()) {
+        for (var message : sqsEvent.getRecords()) {
             try {
                 var workItem = parseWorkItem(message.getBody());
                 messagesByJobType.computeIfAbsent(workItem.jobType(), k -> new ArrayList<>())

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -1,5 +1,7 @@
 package no.unit.nva.publication.events.handlers.batch.dynamodb;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/DynamodbResourceBatchJobHandler.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,10 +101,9 @@ public class DynamodbResourceBatchJobHandler implements RequestHandler<SQSEvent,
     }
 
     private String getErrorCount(SQSMessage message) {
-        if (message.getAttributes() != null && message.getAttributes().containsKey("ApproximateReceiveCount")) {
-            return message.getAttributes().get("ApproximateReceiveCount");
-        }
-        return "1";
+        return Optional.ofNullable(message.getAttributes())
+                   .map(attrs -> attrs.get("ApproximateReceiveCount"))
+                   .orElse("1");
     }
 
     private List<SQSBatchResponse.BatchItemFailure> processBatch(String jobType, List<MessageWithWorkItem> messages) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/NoGsiResultsException.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/NoGsiResultsException.java
@@ -1,0 +1,8 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb.jobs;
+
+public class NoGsiResultsException extends RuntimeException {
+    public NoGsiResultsException(String indexName, String partitionKey, String sortKey) {
+        super(String.format("No items found for GSI query on index: %s with partitionKey: %s and sortKey: %s",
+            indexName, partitionKey, sortKey));
+    }
+}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -168,7 +168,7 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
         
         // Check if the exception provides details about which items failed
         var message = e.getMessage();
-        var causeMessage = e.getCause() != null ? e.getCause().getMessage() : "";
+        var causeMessage = nonNull(e.getCause()) ? e.getCause().getMessage() : EMPTY_STRING;
         
         if (message != null && message.contains("ConditionalCheckFailed")
             || causeMessage != null && causeMessage.contains("ConditionalCheckFailed")

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -171,7 +171,7 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
         var causeMessage = nonNull(e.getCause()) ? e.getCause().getMessage() : EMPTY_STRING;
         
         if (noNull(message) && message.contains("ConditionalCheckFailed")
-            || causeMessage != null && causeMessage.contains("ConditionalCheckFailed")
+            || nonNull(causeMessage) && causeMessage.contains("ConditionalCheckFailed")
             || e instanceof ConditionalCheckFailedException
             || e.getCause() instanceof ConditionalCheckFailedException) {
             // When condition checks fail, typically it means the record doesn't exist

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -24,10 +24,6 @@ import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Executor for REINDEX_RECORD job type.
- * Updates the version field with a new UUID to trigger reindexing of records in DynamoDB.
- */
 public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
     private static final String REINDEX_RECORD = "REINDEX_RECORD";
     private static final Logger logger = LoggerFactory.getLogger(ReindexRecordJob.class);
@@ -138,12 +134,10 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
                 .withLimit(100);
             
             try {
-                QueryResult result = dynamoDbClient.query(queryRequest);
+                var result = dynamoDbClient.query(queryRequest);
                 
-                // Create new work items with primary keys
                 createWorkItems(gsiItem, result, resolvedItems);
 
-                // Handle pagination if needed
                 while (result.getLastEvaluatedKey() != null && !result.getLastEvaluatedKey().isEmpty()) {
                     queryRequest.setExclusiveStartKey(result.getLastEvaluatedKey());
                     result = dynamoDbClient.query(queryRequest);
@@ -165,8 +159,8 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
 
     private static void createWorkItems(BatchWorkItem gsiItem, QueryResult result, ArrayList<BatchWorkItem> resolvedItems) {
         for (Map<String, AttributeValue> item : result.getItems()) {
-            String primaryPk = item.get(PK_0).getS();
-            String primarySk = item.get(SK_0).getS();
+            var primaryPk = item.get(PK_0).getS();
+            var primarySk = item.get(SK_0).getS();
 
             var primaryKey = new DynamodbResourceBatchDynamoDbKey(primaryPk, primarySk, null);
             resolvedItems.add(new BatchWorkItem(primaryKey, gsiItem.jobType(), gsiItem.parameters()));

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -170,7 +170,7 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
         var message = e.getMessage();
         var causeMessage = nonNull(e.getCause()) ? e.getCause().getMessage() : EMPTY_STRING;
         
-        if (message != null && message.contains("ConditionalCheckFailed")
+        if (noNull(message) && message.contains("ConditionalCheckFailed")
             || causeMessage != null && causeMessage.contains("ConditionalCheckFailed")
             || e instanceof ConditionalCheckFailedException
             || e.getCause() instanceof ConditionalCheckFailedException) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -214,7 +214,7 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
                 var initialSize = resolvedItems.size();
                 createWorkItems(gsiItem, result, resolvedItems);
 
-                while (result.getLastEvaluatedKey() != null && !result.getLastEvaluatedKey().isEmpty()) {
+                while (nonNull(result.getLastEvaluatedKey()) && !result.getLastEvaluatedKey().isEmpty()) {
                     queryRequest.setExclusiveStartKey(result.getLastEvaluatedKey());
                     result = dynamoDbClient.query(queryRequest);
 

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJob.java
@@ -170,10 +170,10 @@ public class ReindexRecordJob implements DynamodbResourceBatchJobExecutor {
         var message = e.getMessage();
         var causeMessage = e.getCause() != null ? e.getCause().getMessage() : "";
         
-        if ((message != null && message.contains("ConditionalCheckFailed")) 
-            || (causeMessage != null && causeMessage.contains("ConditionalCheckFailed"))
+        if (message != null && message.contains("ConditionalCheckFailed")
+            || causeMessage != null && causeMessage.contains("ConditionalCheckFailed")
             || e instanceof ConditionalCheckFailedException
-            || (e.getCause() instanceof ConditionalCheckFailedException)) {
+            || e.getCause() instanceof ConditionalCheckFailedException) {
             // When condition checks fail, typically it means the record doesn't exist
             // Transaction failed due to conditional check - all items in batch are considered failed
             logger.warn("Conditional check failed - likely non-existent records in batch");

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
@@ -1,0 +1,274 @@
+package no.unit.nva.publication.events.handlers.batch;
+
+import static java.util.Objects.nonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.BatchWorkItem;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchDynamoDbKey;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchJobExecutor;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchJobHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DynamodbResourceBatchJobHandlerTest {
+
+    private static final String TEST_PARTITION_KEY = "USER#123";
+    private static final String TEST_SORT_KEY = "PROFILE";
+    private static final ObjectMapper objectMapper = JsonUtils.dtoObjectMapper;
+    private static final String TEST_JOB_NAME = "TEST_JOB_NAME";
+
+    @Mock
+    private DynamodbResourceBatchJobExecutor mockExecutor;
+    
+    @Mock
+    private Context context;
+    
+    private DynamodbResourceBatchJobHandler handler;
+    
+    @BeforeEach
+    void setUp() {
+        // Create handler with mocked executor for testing
+        Map<String, DynamodbResourceBatchJobExecutor> handlers = new HashMap<>();
+        handlers.put(TEST_JOB_NAME, mockExecutor);
+        handler = new DynamodbResourceBatchJobHandler(handlers);
+    }
+    
+    @Test
+    void shouldProcessCreateRecordSuccessfully() throws Exception {
+        // Given
+        var workItem = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "John", "email", "john@example.com")
+        );
+        var sqsEvent = createSqsEvent(workItem);
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(0));
+        verify(mockExecutor).executeBatch(any(List.class));
+    }
+    
+    @Test
+    void shouldReportBatchItemFailureWhenExecutorThrows() throws Exception {
+        // Given
+        var workItem = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "John")
+        );
+        var sqsEvent = createSqsEvent(workItem);
+        
+        doThrow(new RuntimeException("Execution failed"))
+            .when(mockExecutor).executeBatch(any(List.class));
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
+                  equalTo("message-id-1"));
+    }
+    
+    @Test
+    void shouldReportBatchItemFailureWhenUnsupportedJobType() throws JsonProcessingException {
+        // Given - handler with no executors registered
+        handler = new DynamodbResourceBatchJobHandler(new HashMap<>());
+        
+        var workItem = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "John")
+        );
+        var sqsEvent = createSqsEvent(workItem);
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
+                  equalTo("message-id-1"));
+    }
+    
+    @Test
+    void shouldReportBatchItemFailureWhenInvalidJson() {
+        // Given
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        message.setMessageId("invalid-message");
+        message.setBody("{ invalid json }");
+        sqsEvent.setRecords(List.of(message));
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
+                  equalTo("invalid-message"));
+    }
+    
+    @Test
+    void shouldProcessMultipleMessagesInBatch() throws JsonProcessingException {
+        // Given
+        var workItem1 = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "John")
+        );
+        var workItem2 = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "Jane")
+        );
+        
+        var sqsEvent = createSqsEventWithMultipleMessages(
+            List.of(workItem1, workItem2)
+        );
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(0));
+        // Verify batch was processed as single transaction
+        verify(mockExecutor, times(1)).executeBatch(any(List.class));
+    }
+    
+    @Test
+    void shouldProcessWorkItemWithGsiKeys() throws JsonProcessingException {
+        // Given
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey("AUTHOR#123", "PUBLICATION#2024", "AuthorIndex");
+        var workItem = new BatchWorkItem(dynamoDbKey,
+                                         TEST_JOB_NAME,
+                                         objectMapper.valueToTree(Map.of("title", "Test Publication")));
+        
+        var sqsEvent = createSqsEvent(workItem);
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(0));
+        verify(mockExecutor).executeBatch(any(List.class));
+        
+        // Verify the key is recognized as GSI query
+        assertThat(workItem.dynamoDbKey().isGsiQuery(), equalTo(true));
+    }
+    
+    @Test
+    void shouldIncludeErrorMetadataInFailure() {
+        // Given
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        message.setMessageId("error-message");
+        message.setBody("{ invalid json }");
+        
+        // Add message attributes
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("ApproximateReceiveCount", "2");
+        message.setAttributes(attributes);
+        
+        sqsEvent.setRecords(List.of(message));
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
+                  equalTo("error-message"));
+    }
+    
+    @Test
+    void shouldHandlePartialBatchFailure() throws JsonProcessingException {
+        // Given
+        var successWorkItem = createWorkItem(
+            TEST_JOB_NAME,
+            Map.of("name", "John")
+        );
+        
+        var sqsEvent = new SQSEvent();
+        var successMessage = new SQSMessage();
+        successMessage.setMessageId("success-message");
+        successMessage.setBody(objectMapper.writeValueAsString(successWorkItem));
+        
+        var failureMessage = new SQSMessage();
+        failureMessage.setMessageId("failure-message");
+        failureMessage.setBody("{ invalid json }");
+        
+        sqsEvent.setRecords(List.of(successMessage, failureMessage));
+        
+        // When
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        // Then
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(1));
+        assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
+                  equalTo("failure-message"));
+    }
+    
+    private BatchWorkItem createWorkItem(String jobType, Map<String, Object> parameters) {
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
+
+        return new BatchWorkItem(
+            dynamoDbKey,
+            jobType,
+            nonNull(parameters) ? objectMapper.valueToTree(parameters) : null
+        );
+    }
+    
+    private SQSEvent createSqsEvent(BatchWorkItem workItem)
+            throws JsonProcessingException {
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        message.setMessageId("message-id-1");
+        message.setBody(objectMapper.writeValueAsString(workItem));
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+    
+    private SQSEvent createSqsEventWithMultipleMessages(
+            List<BatchWorkItem> workItems)
+            throws JsonProcessingException {
+        
+        var sqsEvent = new SQSEvent();
+        var messages = new java.util.ArrayList<SQSMessage>();
+        
+        for (int i = 0; i < workItems.size(); i++) {
+            var message = new SQSMessage();
+            message.setMessageId("message-id-" + (i + 1));
+            message.setBody(objectMapper.writeValueAsString(workItems.get(i)));
+            messages.add(message);
+        }
+        
+        sqsEvent.setRecords(messages);
+        return sqsEvent;
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
@@ -54,17 +54,14 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldProcessCreateRecordSuccessfully() throws Exception {
-        // Given
         var workItem = createWorkItem(
             TEST_JOB_NAME,
             Map.of("name", "John", "email", "john@example.com")
         );
         var sqsEvent = createSqsEvent(workItem);
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(0));
         verify(mockExecutor).executeBatch(any(List.class));
@@ -72,7 +69,6 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldReportBatchItemFailureWhenExecutorThrows() throws Exception {
-        // Given
         var workItem = createWorkItem(
             TEST_JOB_NAME,
             Map.of("name", "John")
@@ -82,10 +78,8 @@ class DynamodbResourceBatchJobHandlerTest {
         doThrow(new RuntimeException("Execution failed"))
             .when(mockExecutor).executeBatch(any(List.class));
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
@@ -94,7 +88,6 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldReportBatchItemFailureWhenUnsupportedJobType() throws JsonProcessingException {
-        // Given - handler with no executors registered
         handler = new DynamodbResourceBatchJobHandler(new HashMap<>());
         
         var workItem = createWorkItem(
@@ -103,10 +96,8 @@ class DynamodbResourceBatchJobHandlerTest {
         );
         var sqsEvent = createSqsEvent(workItem);
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
@@ -115,17 +106,14 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldReportBatchItemFailureWhenInvalidJson() {
-        // Given
         var sqsEvent = new SQSEvent();
         var message = new SQSMessage();
         message.setMessageId("invalid-message");
         message.setBody("{ invalid json }");
         sqsEvent.setRecords(List.of(message));
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
@@ -134,7 +122,6 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldProcessMultipleMessagesInBatch() throws JsonProcessingException {
-        // Given
         var workItem1 = createWorkItem(
             TEST_JOB_NAME,
             Map.of("name", "John")
@@ -148,19 +135,15 @@ class DynamodbResourceBatchJobHandlerTest {
             List.of(workItem1, workItem2)
         );
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(0));
-        // Verify batch was processed as single transaction
         verify(mockExecutor, times(1)).executeBatch(any(List.class));
     }
     
     @Test
     void shouldProcessWorkItemWithGsiKeys() throws JsonProcessingException {
-        // Given
         var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey("AUTHOR#123", "PUBLICATION#2024", "AuthorIndex");
         var workItem = new BatchWorkItem(dynamoDbKey,
                                          TEST_JOB_NAME,
@@ -168,21 +151,17 @@ class DynamodbResourceBatchJobHandlerTest {
         
         var sqsEvent = createSqsEvent(workItem);
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(0));
         verify(mockExecutor).executeBatch(any(List.class));
         
-        // Verify the key is recognized as GSI query
         assertThat(workItem.dynamoDbKey().isGsiQuery(), equalTo(true));
     }
     
     @Test
     void shouldIncludeErrorMetadataInFailure() {
-        // Given
         var sqsEvent = new SQSEvent();
         var message = new SQSMessage();
         message.setMessageId("error-message");
@@ -194,10 +173,8 @@ class DynamodbResourceBatchJobHandlerTest {
         
         sqsEvent.setRecords(List.of(message));
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
@@ -206,7 +183,6 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @Test
     void shouldHandlePartialBatchFailure() throws JsonProcessingException {
-        // Given
         var successWorkItem = createWorkItem(
             TEST_JOB_NAME,
             Map.of("name", "John")
@@ -223,18 +199,96 @@ class DynamodbResourceBatchJobHandlerTest {
         
         sqsEvent.setRecords(List.of(successMessage, failureMessage));
         
-        // When
         var response = handler.handleRequest(sqsEvent, context);
         
-        // Then
         assertThat(response, notNullValue());
         assertThat(response.getBatchItemFailures(), hasSize(1));
         assertThat(response.getBatchItemFailures().getFirst().getItemIdentifier(),
                   equalTo("failure-message"));
     }
     
+    @Test
+    void shouldProcessWorkItemWithKeyValueParameters() throws JsonProcessingException {
+        var parameters = objectMapper.createObjectNode();
+        parameters.put("action", "reindex");
+        parameters.put("priority", 1);
+        parameters.put("dryRun", false);
+        parameters.put("timestamp", System.currentTimeMillis());
+        
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
+        var workItem = new BatchWorkItem(dynamoDbKey, TEST_JOB_NAME, parameters);
+        
+        var sqsEvent = createSqsEvent(workItem);
+        
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(0));
+        
+        var captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(mockExecutor).executeBatch(captor.capture());
+        
+        var capturedItems = (List<BatchWorkItem>) captor.getValue();
+        assertThat(capturedItems, hasSize(1));
+        
+        var capturedItem = capturedItems.getFirst();
+        assertThat(capturedItem.parameters(), notNullValue());
+        assertThat(capturedItem.parameters().get("action").asText(), equalTo("reindex"));
+        assertThat(capturedItem.parameters().get("priority").asInt(), equalTo(1));
+        assertThat(capturedItem.parameters().get("dryRun").asBoolean(), equalTo(false));
+        assertThat(capturedItem.parameters().has("timestamp"), equalTo(true));
+    }
+    
+    @Test
+    void shouldProcessWorkItemWithArrayParameters() throws JsonProcessingException {
+        var parameters = objectMapper.createObjectNode();
+        parameters.put("operation", "bulk-update");
+        
+        var idsArray = parameters.putArray("resourceIds");
+        idsArray.add("resource-001");
+        idsArray.add("resource-002");
+        idsArray.add("resource-003");
+        
+        var tagsArray = parameters.putArray("tags");
+        tagsArray.add("published");
+        tagsArray.add("verified");
+        
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
+        var workItem = new BatchWorkItem(dynamoDbKey, TEST_JOB_NAME, parameters);
+        
+        var sqsEvent = createSqsEvent(workItem);
+        
+        var response = handler.handleRequest(sqsEvent, context);
+        
+        assertThat(response, notNullValue());
+        assertThat(response.getBatchItemFailures(), hasSize(0));
+        
+        var captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(mockExecutor).executeBatch(captor.capture());
+        
+        var capturedItems = (List<BatchWorkItem>) captor.getValue();
+        assertThat(capturedItems, hasSize(1));
+        
+        var capturedItem = capturedItems.getFirst();
+        assertThat(capturedItem.parameters(), notNullValue());
+        assertThat(capturedItem.parameters().get("operation").asText(), equalTo("bulk-update"));
+        
+        var resourceIds = capturedItem.parameters().get("resourceIds");
+        assertThat(resourceIds.isArray(), equalTo(true));
+        assertThat(resourceIds.size(), equalTo(3));
+        assertThat(resourceIds.get(0).asText(), equalTo("resource-001"));
+        assertThat(resourceIds.get(1).asText(), equalTo("resource-002"));
+        assertThat(resourceIds.get(2).asText(), equalTo("resource-003"));
+        
+        var tags = capturedItem.parameters().get("tags");
+        assertThat(tags.isArray(), equalTo(true));
+        assertThat(tags.size(), equalTo(2));
+        assertThat(tags.get(0).asText(), equalTo("published"));
+        assertThat(tags.get(1).asText(), equalTo("verified"));
+    }
+    
     private BatchWorkItem createWorkItem(String jobType, Map<String, Object> parameters) {
-        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
 
         return new BatchWorkItem(
             dynamoDbKey,

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/DynamodbResourceBatchJobHandlerTest.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +47,7 @@ class DynamodbResourceBatchJobHandlerTest {
     
     @BeforeEach
     void setUp() {
-        // Create handler with mocked executor for testing
-        Map<String, DynamodbResourceBatchJobExecutor> handlers = new HashMap<>();
+        var handlers = new HashMap<String, DynamodbResourceBatchJobExecutor>();
         handlers.put(TEST_JOB_NAME, mockExecutor);
         handler = new DynamodbResourceBatchJobHandler(handlers);
     }
@@ -188,8 +188,7 @@ class DynamodbResourceBatchJobHandlerTest {
         message.setMessageId("error-message");
         message.setBody("{ invalid json }");
         
-        // Add message attributes
-        Map<String, String> attributes = new HashMap<>();
+        var attributes = new HashMap<String, String>();
         attributes.put("ApproximateReceiveCount", "2");
         message.setAttributes(attributes);
         
@@ -259,7 +258,7 @@ class DynamodbResourceBatchJobHandlerTest {
             throws JsonProcessingException {
         
         var sqsEvent = new SQSEvent();
-        var messages = new java.util.ArrayList<SQSMessage>();
+        var messages = new ArrayList<SQSMessage>();
         
         for (int i = 0; i < workItems.size(); i++) {
             var message = new SQSMessage();

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
@@ -51,14 +51,13 @@ class ReindexRecordJobTest {
         reindexRecordJob = new ReindexRecordJob(mockDynamoDbClient, TEST_TABLE_NAME);
     }
     
-    // Helper methods for creating test data
     private static BatchWorkItem createWorkItem(String partitionKey, String sortKey) {
         return createWorkItem(partitionKey, sortKey, null);
     }
     
     private static BatchWorkItem createWorkItem(String partitionKey, String sortKey, String indexName) {
         var key = new DynamodbResourceBatchDynamoDbKey(partitionKey, sortKey, indexName);
-        return new BatchWorkItem(key, "REINDEX_RECORD", null);
+        return new BatchWorkItem(key, "REINDEX_RECORD");
     }
     
     private static Map<String, AttributeValue> createDynamoItem(String pk, String sk) {
@@ -130,8 +129,8 @@ class ReindexRecordJobTest {
     
     @Test
     void shouldPropagateExceptionWhenDynamoDbUpdateFails() {
-        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
-        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD");
         
         when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
             .thenThrow(new RuntimeException("DynamoDB error"));
@@ -214,7 +213,7 @@ class ReindexRecordJobTest {
             "Resource:Failed",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
-        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD");
         
         when(mockDynamoDbClient.query(any(QueryRequest.class)))
             .thenThrow(new AmazonDynamoDBException("Query failed"));
@@ -239,7 +238,7 @@ class ReindexRecordJobTest {
                 "Resource",
                 null
             );
-            workItems.add(new BatchWorkItem(key, "REINDEX_RECORD", null));
+            workItems.add(new BatchWorkItem(key, "REINDEX_RECORD"));
         }
         
         when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
@@ -261,10 +260,10 @@ class ReindexRecordJobTest {
             "Resource:Empty",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
-        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD");
         
         var queryResult = new QueryResult();
-        queryResult.setItems(List.of()); // Empty result
+        queryResult.setItems(List.of());
         
         when(mockDynamoDbClient.query(any(QueryRequest.class)))
             .thenReturn(queryResult);
@@ -293,8 +292,8 @@ class ReindexRecordJobTest {
             RESOURCE_BY_CRISTIN_ID_INDEX_NAME
         );
         
-        var workItem1 = new BatchWorkItem(gsiKey1, "REINDEX_RECORD", null);
-        var workItem2 = new BatchWorkItem(gsiKey2, "REINDEX_RECORD", null);
+        var workItem1 = new BatchWorkItem(gsiKey1, "REINDEX_RECORD");
+        var workItem2 = new BatchWorkItem(gsiKey2, "REINDEX_RECORD");
         
         var queryResult1 = new QueryResult();
         var item1 = Map.of(
@@ -336,8 +335,8 @@ class ReindexRecordJobTest {
     
     @Test
     void shouldVerifyTransactionContainsCorrectUpdateExpression() {
-        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
-        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD");
         
         when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
             .thenReturn(new TransactWriteItemsResult());
@@ -362,7 +361,7 @@ class ReindexRecordJobTest {
         
         var newVersion = update.getExpressionAttributeValues().get(":newVersion").getS();
         assertThat(newVersion, notNullValue());
-        assertThat(newVersion.length(), equalTo(36)); // UUID length
+        assertThat(newVersion.length(), equalTo(36));
     }
 
     @Test
@@ -401,8 +400,8 @@ class ReindexRecordJobTest {
 
     @Test
     void shouldIncludeReturnValuesOnConditionCheckFailureInUpdate() {
-        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
-        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD");
 
         when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
             .thenReturn(new TransactWriteItemsResult());
@@ -425,8 +424,7 @@ class ReindexRecordJobTest {
         var workItem1 = createWorkItem("Resource:exists", "Resource");
         var workItem2 = createWorkItem("Resource:does-not-exist", "Resource");
         
-        // Mock partial success - only one key was successfully updated
-        var existingKey = new DynamodbResourceBatchDynamoDbKey("Resource:exists", "Resource", null);
+        var existingKey = new DynamodbResourceBatchDynamoDbKey("Resource:exists", "Resource");
         org.mockito.Mockito.doReturn(Set.of(existingKey))
             .when(spyJob)
             .updateVersionBatchByTransaction(any());

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
@@ -35,7 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ReindexRecordJobTest {
 
     private static final String TEST_TABLE_NAME = "test-table";
-    private static final String TEST_PARTITION_KEY = "Resource#0190e0e7-5eef-7d23-b716-02c670833fcd";
+    private static final String TEST_PARTITION_KEY = "Resource:0190e0e7-5eef-7d23-b716-02c670833fcd";
     private static final String TEST_SORT_KEY = "Resource";
     
     @Mock
@@ -87,8 +87,8 @@ class ReindexRecordJobTest {
     void shouldResolveGsiQueryToPrimaryKeys() {
         // Given
         var gsiKey = new DynamodbResourceBatchDynamoDbKey(
-            "Customer#123", 
-            "Resource#2024", 
+            "Customer:123", 
+            "Resource:2024", 
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
         var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
@@ -96,10 +96,10 @@ class ReindexRecordJobTest {
         // Mock GSI query response
         var queryResult = new QueryResult();
         var item1 = new java.util.HashMap<String, AttributeValue>();
-        item1.put("PK0", new AttributeValue().withS("Resource#123"));
+        item1.put("PK0", new AttributeValue().withS("Resource:123"));
         item1.put("SK0", new AttributeValue().withS("Resource"));
         var item2 = new java.util.HashMap<String, AttributeValue>();
-        item2.put("PK0", new AttributeValue().withS("Resource#456"));
+        item2.put("PK0", new AttributeValue().withS("Resource:456"));
         item2.put("SK0", new AttributeValue().withS("Resource"));
         queryResult.setItems(List.of(item1, item2));
         
@@ -148,12 +148,12 @@ class ReindexRecordJobTest {
     void shouldProcessBatchWithTransaction() {
         // Given
         var dynamoDbKey1 = new DynamodbResourceBatchDynamoDbKey(
-            "Resource#0190e0e7-5eef-7d23-b716-02c670833fcd",
+            "Resource:0190e0e7-5eef-7d23-b716-02c670833fcd",
             "Resource",
             null
         );
         var dynamoDbKey2 = new DynamodbResourceBatchDynamoDbKey(
-            "Resource#0190e0e7-5eef-7d23-b716-02c670833fce", 
+            "Resource:0190e0e7-5eef-7d23-b716-02c670833fce", 
             "Resource",
             null
         );
@@ -196,7 +196,7 @@ class ReindexRecordJobTest {
         );
         var gsiKey = new DynamodbResourceBatchDynamoDbKey(
             "CristinIdentifier#12345",
-            "Resource#2024",
+            "Resource:2024",
             RESOURCE_BY_CRISTIN_ID_INDEX_NAME
         );
         
@@ -206,7 +206,7 @@ class ReindexRecordJobTest {
         // Mock GSI query response
         var queryResult = new QueryResult();
         var item = new java.util.HashMap<String, AttributeValue>();
-        item.put("PK0", new AttributeValue().withS("Resource#789"));
+        item.put("PK0", new AttributeValue().withS("Resource:789"));
         item.put("SK0", new AttributeValue().withS("Resource"));
         queryResult.setItems(List.of(item));
         
@@ -233,8 +233,8 @@ class ReindexRecordJobTest {
     void shouldHandleGsiQueryWithPagination() {
         // Given
         var gsiKey = new DynamodbResourceBatchDynamoDbKey(
-            "Customer#456",
-            "Resource#Article",
+            "Customer:456",
+            "Resource:Article",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
         var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
@@ -242,7 +242,7 @@ class ReindexRecordJobTest {
         // First page
         var firstResult = new QueryResult();
         var item1 = Map.of(
-            "PK0", new AttributeValue().withS("Resource#001"),
+            "PK0", new AttributeValue().withS("Resource:001"),
             "SK0", new AttributeValue().withS("Resource")
         );
         firstResult.setItems(List.of(item1));
@@ -251,7 +251,7 @@ class ReindexRecordJobTest {
         // Second page
         var secondResult = new QueryResult();
         var item2 = Map.of(
-            "PK0", new AttributeValue().withS("Resource#002"),
+            "PK0", new AttributeValue().withS("Resource:002"),
             "SK0", new AttributeValue().withS("Resource")
         );
         secondResult.setItems(List.of(item2));
@@ -280,8 +280,8 @@ class ReindexRecordJobTest {
     void shouldPropagateExceptionWhenGsiQueryFails() {
         // Given
         var gsiKey = new DynamodbResourceBatchDynamoDbKey(
-            "Customer#999",
-            "Resource#Failed",
+            "Customer:999",
+            "Resource:Failed",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
         var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
@@ -308,7 +308,7 @@ class ReindexRecordJobTest {
         var workItems = new java.util.ArrayList<BatchWorkItem>();
         for (int i = 0; i < 25; i++) {
             var key = new DynamodbResourceBatchDynamoDbKey(
-                "Resource#" + String.format("%03d", i),
+                "Resource:" + String.format("%03d", i),
                 "Resource",
                 null
             );
@@ -333,8 +333,8 @@ class ReindexRecordJobTest {
     void shouldHandleGsiQueryReturningNoResults() {
         // Given
         var gsiKey = new DynamodbResourceBatchDynamoDbKey(
-            "Customer#NoResults",
-            "Resource#Empty",
+            "Customer:NoResults",
+            "Resource:Empty",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
         var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
@@ -359,13 +359,13 @@ class ReindexRecordJobTest {
     void shouldHandleMultipleGsiQueries() {
         // Given - two different GSI queries
         var gsiKey1 = new DynamodbResourceBatchDynamoDbKey(
-            "Customer#111",
-            "Resource#Type1",
+            "Customer:111",
+            "Resource:Type1",
             BY_CUSTOMER_RESOURCE_INDEX_NAME
         );
         var gsiKey2 = new DynamodbResourceBatchDynamoDbKey(
             "CristinIdentifier#222",
-            "Resource#Type2",
+            "Resource:Type2",
             RESOURCE_BY_CRISTIN_ID_INDEX_NAME
         );
         
@@ -375,14 +375,14 @@ class ReindexRecordJobTest {
         // Mock GSI query responses
         var queryResult1 = new QueryResult();
         var item1 = Map.of(
-            "PK0", new AttributeValue().withS("Resource#AAA"),
+            "PK0", new AttributeValue().withS("Resource:AAA"),
             "SK0", new AttributeValue().withS("Resource")
         );
         queryResult1.setItems(List.of(item1));
         
         var queryResult2 = new QueryResult();
         var item2 = Map.of(
-            "PK0", new AttributeValue().withS("Resource#BBB"),
+            "PK0", new AttributeValue().withS("Resource:BBB"),
             "SK0", new AttributeValue().withS("Resource")
         );
         queryResult2.setItems(List.of(item2));

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
@@ -1,0 +1,450 @@
+package no.unit.nva.publication.events.handlers.batch.dynamodb.jobs;
+
+import static no.unit.nva.publication.storage.model.DatabaseConstants.BY_CUSTOMER_RESOURCE_INDEX_NAME;
+import static no.unit.nva.publication.storage.model.DatabaseConstants.RESOURCE_BY_CRISTIN_ID_INDEX_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
+import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsResult;
+import java.util.List;
+import java.util.Map;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.BatchWorkItem;
+import no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchDynamoDbKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReindexRecordJobTest {
+
+    private static final String TEST_TABLE_NAME = "test-table";
+    private static final String TEST_PARTITION_KEY = "Resource#0190e0e7-5eef-7d23-b716-02c670833fcd";
+    private static final String TEST_SORT_KEY = "Resource";
+    
+    @Mock
+    private AmazonDynamoDB mockDynamoDbClient;
+    
+    private ReindexRecordJob reindexRecordJob;
+    
+    @BeforeEach
+    void setUp() {
+        reindexRecordJob = new ReindexRecordJob(mockDynamoDbClient, TEST_TABLE_NAME);
+    }
+    
+    @Test
+    void shouldReturnCorrectJobType() {
+        assertThat(reindexRecordJob.getJobType(), equalTo("REINDEX_RECORD"));
+    }
+    
+    @Test
+    void shouldUpdateSingleVersionWithNewUuid() {
+        // Given
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem)));
+        
+        // Then
+        ArgumentCaptor<TransactWriteItemsRequest> requestCaptor = ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(requestCaptor.capture());
+        
+        TransactWriteItemsRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getTransactItems(), notNullValue());
+        assertThat(capturedRequest.getTransactItems().size(), equalTo(1));
+        
+        var update = capturedRequest.getTransactItems().getFirst().getUpdate();
+        assertThat(update.getTableName(), equalTo(TEST_TABLE_NAME));
+        assertThat(update.getKey().get("PK0").getS(), equalTo(TEST_PARTITION_KEY));
+        assertThat(update.getKey().get("SK0").getS(), equalTo(TEST_SORT_KEY));
+        assertThat(update.getUpdateExpression(), 
+                  equalTo("SET #version = :newVersion"));
+        assertThat(update.getExpressionAttributeNames().get("#version"), equalTo("version"));
+        assertThat(update.getExpressionAttributeValues().get(":newVersion"), notNullValue());
+    }
+    
+    @Test
+    void shouldResolveGsiQueryToPrimaryKeys() {
+        // Given
+        var gsiKey = new DynamodbResourceBatchDynamoDbKey(
+            "Customer#123", 
+            "Resource#2024", 
+            BY_CUSTOMER_RESOURCE_INDEX_NAME
+        );
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        
+        // Mock GSI query response
+        var queryResult = new QueryResult();
+        var item1 = new java.util.HashMap<String, AttributeValue>();
+        item1.put("PK0", new AttributeValue().withS("Resource#123"));
+        item1.put("SK0", new AttributeValue().withS("Resource"));
+        var item2 = new java.util.HashMap<String, AttributeValue>();
+        item2.put("PK0", new AttributeValue().withS("Resource#456"));
+        item2.put("SK0", new AttributeValue().withS("Resource"));
+        queryResult.setItems(List.of(item1, item2));
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenReturn(queryResult);
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem)));
+        
+        // Then
+        verify(mockDynamoDbClient).query(argThat(request -> 
+            BY_CUSTOMER_RESOURCE_INDEX_NAME.equals(request.getIndexName()) &&
+            TEST_TABLE_NAME.equals(request.getTableName())
+        ));
+        
+        ArgumentCaptor<TransactWriteItemsRequest> transactCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(transactCaptor.capture());
+        
+        // Should have 2 items in transaction (one for each resolved primary key)
+        assertThat(transactCaptor.getValue().getTransactItems().size(), equalTo(2));
+    }
+    
+    @Test
+    void shouldPropagateExceptionWhenDynamoDbUpdateFails() {
+        // Given
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenThrow(new RuntimeException("DynamoDB error"));
+        
+        // When & Then
+        var exception = assertThrows(
+            RuntimeException.class,
+            () -> reindexRecordJob.executeBatch(List.of(workItem))
+        );
+        
+        assertThat(exception.getMessage(), equalTo("Failed to update batch for reindexing"));
+        assertThat(exception.getCause().getMessage(), equalTo("DynamoDB error"));
+    }
+    
+    @Test
+    void shouldProcessBatchWithTransaction() {
+        // Given
+        var dynamoDbKey1 = new DynamodbResourceBatchDynamoDbKey(
+            "Resource#0190e0e7-5eef-7d23-b716-02c670833fcd",
+            "Resource",
+            null
+        );
+        var dynamoDbKey2 = new DynamodbResourceBatchDynamoDbKey(
+            "Resource#0190e0e7-5eef-7d23-b716-02c670833fce", 
+            "Resource",
+            null
+        );
+        
+        var workItem1 = new BatchWorkItem(dynamoDbKey1, "REINDEX_RECORD", null);
+        var workItem2 = new BatchWorkItem(dynamoDbKey2, "REINDEX_RECORD", null);
+        
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem1, workItem2)));
+        
+        // Then
+        ArgumentCaptor<TransactWriteItemsRequest> requestCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(requestCaptor.capture());
+        
+        TransactWriteItemsRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getTransactItems(), notNullValue());
+        assertThat(capturedRequest.getTransactItems().size(), equalTo(2));
+    }
+    
+    @Test
+    void shouldHandleEmptyBatch() {
+        // When & Then
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of()));
+        
+        // Verify no DynamoDB calls were made
+        verify(mockDynamoDbClient, times(0)).transactWriteItems(any(TransactWriteItemsRequest.class));
+    }
+    
+    @Test
+    void shouldHandleMixedPrimaryAndGsiKeys() {
+        // Given - mix of primary key and GSI key items
+        var primaryKey = new DynamodbResourceBatchDynamoDbKey(
+            TEST_PARTITION_KEY,
+            TEST_SORT_KEY,
+            null
+        );
+        var gsiKey = new DynamodbResourceBatchDynamoDbKey(
+            "CristinIdentifier#12345",
+            "Resource#2024",
+            RESOURCE_BY_CRISTIN_ID_INDEX_NAME
+        );
+        
+        var primaryWorkItem = new BatchWorkItem(primaryKey, "REINDEX_RECORD", null);
+        var gsiWorkItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        
+        // Mock GSI query response
+        var queryResult = new QueryResult();
+        var item = new java.util.HashMap<String, AttributeValue>();
+        item.put("PK0", new AttributeValue().withS("Resource#789"));
+        item.put("SK0", new AttributeValue().withS("Resource"));
+        queryResult.setItems(List.of(item));
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenReturn(queryResult);
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(primaryWorkItem, gsiWorkItem)));
+        
+        // Then
+        verify(mockDynamoDbClient).query(any(QueryRequest.class)); // For GSI resolution
+        
+        ArgumentCaptor<TransactWriteItemsRequest> transactCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(transactCaptor.capture());
+        
+        // Should have 2 items in transaction (1 primary + 1 resolved from GSI)
+        assertThat(transactCaptor.getValue().getTransactItems().size(), equalTo(2));
+    }
+    
+    @Test
+    void shouldHandleGsiQueryWithPagination() {
+        // Given
+        var gsiKey = new DynamodbResourceBatchDynamoDbKey(
+            "Customer#456",
+            "Resource#Article",
+            BY_CUSTOMER_RESOURCE_INDEX_NAME
+        );
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        
+        // First page
+        var firstResult = new QueryResult();
+        var item1 = Map.of(
+            "PK0", new AttributeValue().withS("Resource#001"),
+            "SK0", new AttributeValue().withS("Resource")
+        );
+        firstResult.setItems(List.of(item1));
+        firstResult.setLastEvaluatedKey(Map.of("dummy", new AttributeValue().withS("key")));
+        
+        // Second page
+        var secondResult = new QueryResult();
+        var item2 = Map.of(
+            "PK0", new AttributeValue().withS("Resource#002"),
+            "SK0", new AttributeValue().withS("Resource")
+        );
+        secondResult.setItems(List.of(item2));
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenReturn(firstResult)
+            .thenReturn(secondResult);
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem)));
+        
+        // Then
+        verify(mockDynamoDbClient, times(2)).query(any(QueryRequest.class)); // Two queries for pagination
+        
+        ArgumentCaptor<TransactWriteItemsRequest> transactCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(transactCaptor.capture());
+        
+        // Should have 2 items from both pages
+        assertThat(transactCaptor.getValue().getTransactItems().size(), equalTo(2));
+    }
+    
+    @Test
+    void shouldPropagateExceptionWhenGsiQueryFails() {
+        // Given
+        var gsiKey = new DynamodbResourceBatchDynamoDbKey(
+            "Customer#999",
+            "Resource#Failed",
+            BY_CUSTOMER_RESOURCE_INDEX_NAME
+        );
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenThrow(new AmazonDynamoDBException("Query failed"));
+        
+        // When & Then
+        var exception = assertThrows(
+            RuntimeException.class,
+            () -> reindexRecordJob.executeBatch(List.of(workItem))
+        );
+        
+        assertThat(exception.getMessage(), equalTo("Failed to resolve GSI to primary keys"));
+        assertThat(exception.getCause().getClass(), equalTo(AmazonDynamoDBException.class));
+        
+        // Verify transaction was never attempted
+        verify(mockDynamoDbClient, never()).transactWriteItems(any(TransactWriteItemsRequest.class));
+    }
+    
+    @Test
+    void shouldHandleLargeBatchOfPrimaryKeys() {
+        // Given - batch of 25 items (max DynamoDB transaction limit)
+        var workItems = new java.util.ArrayList<BatchWorkItem>();
+        for (int i = 0; i < 25; i++) {
+            var key = new DynamodbResourceBatchDynamoDbKey(
+                "Resource#" + String.format("%03d", i),
+                "Resource",
+                null
+            );
+            workItems.add(new BatchWorkItem(key, "REINDEX_RECORD", null));
+        }
+        
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(workItems));
+        
+        // Then
+        ArgumentCaptor<TransactWriteItemsRequest> requestCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(requestCaptor.capture());
+        
+        assertThat(requestCaptor.getValue().getTransactItems().size(), equalTo(25));
+    }
+    
+    @Test
+    void shouldHandleGsiQueryReturningNoResults() {
+        // Given
+        var gsiKey = new DynamodbResourceBatchDynamoDbKey(
+            "Customer#NoResults",
+            "Resource#Empty",
+            BY_CUSTOMER_RESOURCE_INDEX_NAME
+        );
+        var workItem = new BatchWorkItem(gsiKey, "REINDEX_RECORD", null);
+        
+        // Mock empty GSI query response
+        var queryResult = new QueryResult();
+        queryResult.setItems(List.of()); // Empty result
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenReturn(queryResult);
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem)));
+        
+        // Then
+        verify(mockDynamoDbClient).query(any(QueryRequest.class));
+        // No transaction should be attempted since there are no items to update
+        verify(mockDynamoDbClient, never()).transactWriteItems(any(TransactWriteItemsRequest.class));
+    }
+    
+    @Test
+    void shouldHandleMultipleGsiQueries() {
+        // Given - two different GSI queries
+        var gsiKey1 = new DynamodbResourceBatchDynamoDbKey(
+            "Customer#111",
+            "Resource#Type1",
+            BY_CUSTOMER_RESOURCE_INDEX_NAME
+        );
+        var gsiKey2 = new DynamodbResourceBatchDynamoDbKey(
+            "CristinIdentifier#222",
+            "Resource#Type2",
+            RESOURCE_BY_CRISTIN_ID_INDEX_NAME
+        );
+        
+        var workItem1 = new BatchWorkItem(gsiKey1, "REINDEX_RECORD", null);
+        var workItem2 = new BatchWorkItem(gsiKey2, "REINDEX_RECORD", null);
+        
+        // Mock GSI query responses
+        var queryResult1 = new QueryResult();
+        var item1 = Map.of(
+            "PK0", new AttributeValue().withS("Resource#AAA"),
+            "SK0", new AttributeValue().withS("Resource")
+        );
+        queryResult1.setItems(List.of(item1));
+        
+        var queryResult2 = new QueryResult();
+        var item2 = Map.of(
+            "PK0", new AttributeValue().withS("Resource#BBB"),
+            "SK0", new AttributeValue().withS("Resource")
+        );
+        queryResult2.setItems(List.of(item2));
+        
+        when(mockDynamoDbClient.query(any(QueryRequest.class)))
+            .thenAnswer(invocation -> {
+                QueryRequest request = invocation.getArgument(0);
+                if (BY_CUSTOMER_RESOURCE_INDEX_NAME.equals(request.getIndexName())) {
+                    return queryResult1;
+                } else if (RESOURCE_BY_CRISTIN_ID_INDEX_NAME.equals(request.getIndexName())) {
+                    return queryResult2;
+                }
+                return new QueryResult();
+            });
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        assertDoesNotThrow(() -> reindexRecordJob.executeBatch(List.of(workItem1, workItem2)));
+        
+        // Then
+        verify(mockDynamoDbClient, times(2)).query(any(QueryRequest.class));
+        
+        ArgumentCaptor<TransactWriteItemsRequest> transactCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(transactCaptor.capture());
+        
+        // Should have 2 items (one from each GSI query)
+        assertThat(transactCaptor.getValue().getTransactItems().size(), equalTo(2));
+    }
+    
+    @Test
+    void shouldVerifyTransactionContainsCorrectUpdateExpression() {
+        // Given
+        var dynamoDbKey = new DynamodbResourceBatchDynamoDbKey(TEST_PARTITION_KEY, TEST_SORT_KEY, null);
+        var workItem = new BatchWorkItem(dynamoDbKey, "REINDEX_RECORD", null);
+        
+        when(mockDynamoDbClient.transactWriteItems(any(TransactWriteItemsRequest.class)))
+            .thenReturn(new TransactWriteItemsResult());
+        
+        // When
+        reindexRecordJob.executeBatch(List.of(workItem));
+        
+        // Then
+        ArgumentCaptor<TransactWriteItemsRequest> requestCaptor = 
+            ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
+        verify(mockDynamoDbClient).transactWriteItems(requestCaptor.capture());
+        
+        var update = requestCaptor.getValue().getTransactItems().getFirst().getUpdate();
+        
+        // Verify all required fields are present
+        assertThat(update.getTableName(), equalTo(TEST_TABLE_NAME));
+        assertThat(update.getKey().size(), equalTo(2));
+        assertThat(update.getKey().containsKey("PK0"), equalTo(true));
+        assertThat(update.getKey().containsKey("SK0"), equalTo(true));
+        assertThat(update.getUpdateExpression(), notNullValue());
+        assertThat(update.getExpressionAttributeNames(), notNullValue());
+        assertThat(update.getExpressionAttributeValues(), notNullValue());
+        
+        // Verify version is being updated with a UUID
+        var newVersion = update.getExpressionAttributeValues().get(":newVersion").getS();
+        assertThat(newVersion, notNullValue());
+        assertThat(newVersion.length(), equalTo(36)); // UUID length
+    }
+}

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/ReindexRecordJobTest.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsResult;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import no.unit.nva.publication.events.handlers.batch.dynamodb.BatchWorkItem;
 import no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchDynamoDbKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -415,26 +414,5 @@ class ReindexRecordJobTest {
         var update = requestCaptor.getValue().getTransactItems().getFirst().getUpdate();
 
         assertThat(update.getReturnValuesOnConditionCheckFailure(), equalTo("ALL_OLD"));
-    }
-    
-    @Test
-    void shouldFailWithDetailedErrorWhenSomeRecordsDoNotExist() {
-        var spyJob = org.mockito.Mockito.spy(reindexRecordJob);
-        
-        var workItem1 = createWorkItem("Resource:exists", "Resource");
-        var workItem2 = createWorkItem("Resource:does-not-exist", "Resource");
-        
-        var existingKey = new DynamodbResourceBatchDynamoDbKey("Resource:exists", "Resource");
-        org.mockito.Mockito.doReturn(Set.of(existingKey))
-            .when(spyJob)
-            .updateVersionBatchByTransaction(any());
-        
-        var exception = assertThrows(
-            RuntimeException.class,
-            () -> spyJob.executeBatch(List.of(workItem1, workItem2))
-        );
-        
-        assertThat(exception.getMessage(), containsString("Failed to update 1 records"));
-        assertThat(exception.getMessage(), containsString("records do not exist in database"));
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -2939,13 +2939,13 @@ Resources:
     Properties:
       QueueName: DynamodbResourceBatchJobDlq
       MessageRetentionPeriod: 1209600
-      VisibilityTimeoutSeconds: 60
+      VisibilityTimeout: 60
 
   DynamodbResourceBatchJobWorkQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: DynamodbResourceBatchJobWorkQueue
-      VisibilityTimeoutSeconds: 360 # Should be at least 6 times the Lambda timeout
+      VisibilityTimeout: 360 # Should be at least 6 times the Lambda timeout
       MessageRetentionPeriod: 1209600 # 14 days
       ReceiveMessageWaitTimeSeconds: 20
       RedrivePolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -2932,3 +2932,61 @@ Resources:
                 responsePayload:
                   topic:
                     - PublicationService.Resource.Deleted
+
+  # DynamoDB Batch Job Processing Resources
+  DynamodbResourceBatchJobDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: DynamodbResourceBatchJobDlq
+      MessageRetentionPeriod: 1209600
+      VisibilityTimeoutSeconds: 60
+
+  DynamodbResourceBatchJobWorkQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: DynamodbResourceBatchJobWorkQueue
+      VisibilityTimeoutSeconds: 360 # Should be at least 6 times the Lambda timeout
+      MessageRetentionPeriod: 1209600 # 14 days
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DynamodbResourceBatchJobDLQ.Arn
+        maxReceiveCount: 3
+      RedriveAllowPolicy:
+        redrivePermission: allowAll
+        sourceQueueArns:
+          - !GetAtt DynamodbResourceBatchJobDLQ.Arn
+
+  DynamodbResourceBatchJobFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: DynamodbResourceBatchJob
+      Handler: no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchJobHandler::handleRequest
+      CodeUri: publication-event-handlers
+      Policies:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !GetAtt ResourceServiceAccessManagedPolicy.PolicyArn
+        - !GetAtt EventsLambdaManagedPolicy.PolicyArn
+      Runtime: java21
+      MemorySize: 1024
+      Timeout: 60 # if changing, also change the visibility timeout of the SQS queue
+      Environment:
+        Variables:
+          WORK_QUEUE_URL: !Ref DynamodbResourceBatchJobWorkQueue
+          TABLE_NAME: !Ref NvaResourcesTable
+      Events:
+        SQSEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt DynamodbResourceBatchJobWorkQueue.Arn
+            BatchSize: 10
+            MaximumBatchingWindowInSeconds: 5
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            ScalingConfig:
+              MaximumConcurrency: 10
+
+  DynamodbResourceBatchJobLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${DynamodbResourceBatchJobFunction}
+      RetentionInDays: 14

--- a/template.yaml
+++ b/template.yaml
@@ -2933,19 +2933,16 @@ Resources:
                   topic:
                     - PublicationService.Resource.Deleted
 
-  # DynamoDB Batch Job Processing Resources
   DynamodbResourceBatchJobDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: DynamodbResourceBatchJobDlq
       MessageRetentionPeriod: 1209600
       VisibilityTimeout: 60
 
   DynamodbResourceBatchJobWorkQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: DynamodbResourceBatchJobWorkQueue
-      VisibilityTimeout: 360 # Should be at least 6 times the Lambda timeout
+      VisibilityTimeout: 360 # 6 times the Lambda timeout
       MessageRetentionPeriod: 1209600 # 14 days
       ReceiveMessageWaitTimeSeconds: 20
       RedrivePolicy:
@@ -2959,7 +2956,6 @@ Resources:
   DynamodbResourceBatchJobFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: DynamodbResourceBatchJob
       Handler: no.unit.nva.publication.events.handlers.batch.dynamodb.DynamodbResourceBatchJobHandler::handleRequest
       CodeUri: publication-event-handlers
       Policies:

--- a/template.yaml
+++ b/template.yaml
@@ -2952,7 +2952,7 @@ Resources:
         deadLetterTargetArn: !GetAtt DynamodbResourceBatchJobDLQ.Arn
         maxReceiveCount: 3
       RedriveAllowPolicy:
-        redrivePermission: allowAll
+        redrivePermission: byQueue
         sourceQueueArns:
           - !GetAtt DynamodbResourceBatchJobDLQ.Arn
 

--- a/template.yaml
+++ b/template.yaml
@@ -2962,8 +2962,6 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - !GetAtt ResourceServiceAccessManagedPolicy.PolicyArn
         - !GetAtt EventsLambdaManagedPolicy.PolicyArn
-      Runtime: java21
-      MemorySize: 1024
       Timeout: 60 # if changing, also change the visibility timeout of the SQS queue
       Environment:
         Variables:


### PR DESCRIPTION
# DynamoDB Batch Job Handler System

**Motivation:** We want to allow specialized one-off jobs like a targeted "batch scan"/reindex in a structured way with DLQ, "rate limiting" and with logs. Idea is to have a sqs work queue where we just dump pairs of db keys and task identifiers.

**Alternative implementation considerations:** Not using SQS was considered with the advantage of allowing us to batch 700 items in each write transaction, but was deemed impractical since we want to dump the whole job to sqs and allow to adjust the speed, not bringing down our application or not mess up by running from laptop and something stops it unexpected.

## Architecture
- **SQS Queue**: Receives batch work items (up to 10 per batch)
- **Lambda Handler**: Processes messages in batches grouped by job type
- **DLQ**: Failed messages after 3 retries
- **DynamoDB Transactions**: Atomic batch updates

## Key Components

### 1. DynamodbResourceBatchJobHandler
Main Lambda handler that:
- Groups SQS messages by job type
- Executes entire batches as single transactions
- Reports individual message failures for retry
- Adds error metadata for debugging

### 2. BatchWorkItem
Record class representing a work item:
```java
record BatchWorkItem(
    DynamodbResourceBatchDynamoDbKey dynamoDbKey,
    String jobType,
    JsonNode parameters
)
```

### 3. DynamodbResourceBatchDynamoDbKey
Supports both primary keys and GSI queries:
```java
record DynamodbResourceBatchDynamoDbKey(
    String partitionKey,
    String sortKey,
    String indexName  // null for primary key, GSI name for GSI queries
)
```

### 4. ReindexRecordJob
Implementation that updates version fields to trigger reindexing:
- **Primary Key Support**: Direct updates using PK0/SK0
- **GSI Query Support**: Resolves GSI queries to primary keys first
- **Batch Transactions**: All updates in single transaction
- **Pagination**: Handles large GSI query results

## Usage

### Queue Message Format
```json
{
  "dynamoDbKey": {
    "partitionKey": "Resource:14d49ab7-4d1d-464d-b732-54b5c46ce6cc:34322@20754.0.0.0",
    "sortKey": "Resource:01995cfe7bce-c1b5a50c-c2a9-4502-8fa6-3790cdb0bfee"
  },
  "jobType": "REINDEX_RECORD",
  "parameters": {}
}
```

For GSI queries:
```json
{
  "dynamoDbKey": {
    "partitionKey": "Resource:01995cfe7bce-c1b5a50c-c2a9-4502-8fa6-3790cdb0bfee",
    "sortKey": "Resource:01995cfe7bce-c1b5a50c-c2a9-4502-8fa6-3790cdb0bfee",
    "indexName": "ResourcesByIdentifier"
  },
  "jobType": "REINDEX_RECORD",
  "parameters": {}
}
```

### Adding New Job Types

1. Implement `DynamodbResourceBatchJobExecutor`:
```java
public class MyCustomJob implements DynamodbResourceBatchJobExecutor {
    @Override
    public void executeBatch(List<BatchWorkItem> workItems) {
        // Process entire batch
        // Use transactions for atomicity
    }

    @Override
    public String getJobType() {
        return "MY_CUSTOM_JOB";
    }
}
```

2. Register in `DynamodbResourceBatchJobHandler.JOBS` array:
```java
private static final DynamodbResourceBatchJobExecutor[] JOBS = {
    new ReindexRecordJob(),
    new MyCustomJob()  // Add your job here
};
```