### PR TITLE
fix: Handle failure to resolve NVI status

### DIFF
--- a/expansion/src/main/java/no/unit/nva/expansion/model/IndexDocumentWrapperLinkedData.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/IndexDocumentWrapperLinkedData.java
@@ -46,7 +46,7 @@ public class IndexDocumentWrapperLinkedData {
     private static final Logger logger = LoggerFactory.getLogger(IndexDocumentWrapperLinkedData.class);
     private static final String FRAME_JSON = "frame.json";
     private static final String FETCHING_NVI_CANDIDATE_ERROR_MESSAGE =
-        "Failed to fetch NVI candidate for publication with identifier: {}";
+        "Failed to fetch NVI status for publication with identifier: {}";
     private static final String EXCEPTION = "Exception {}:";
     private static final String ID = "id";
     private static final String SCIENTIFIC_INDEX = "scientific-index";


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49881

Handle failure to resolve NVI status by placing the publication on the recovery queue for later reprocessing and continuing the expansion process without NVI data.

This does not address the underlying reason why the failures happen in the first place, and it is unclear if the reason is intermittent (due to high load during `BatchScan`) or an actual bug.