### PR TITLE
ci: Fix CodeBuild structure

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -34,12 +34,10 @@ phases:
           echo "AWS SAM CLI is not installed, installing now";
           pip3 install aws-sam-cli
         fi
-  pre_build:
+  build:
     commands:
       # Triggering a manual run of tests so that reports end up in the expected folders (sam build doesn't re-run the task)
       - ./gradlew test
-  build:
-    commands:
       - sam build
       - sam package --s3-bucket $S3_BUCKET --output-template-file packaged_raw.yaml
   post_build:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -14,11 +14,6 @@ reports:
     files:
       - '*/build/test-results/test/TEST-*.xml'
     file-format: JUNITXML
-  sam-build:
-    files:
-      - '/tmp/*/build/test-results/test/TEST-*.xml'
-      - '/tmp/*/*/build/test-results/test/TEST-*.xml'
-    file-format: JUNITXML
 
 phases:
   install:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -16,7 +16,7 @@ reports:
     file-format: JUNITXML
   sam-build:
     files:
-      - '/tmp/*/build/test-results/test/TEST-*.xml'                                                                                                                  │ │
+      - '/tmp/*/build/test-results/test/TEST-*.xml'
       - '/tmp/*/*/build/test-results/test/TEST-*.xml'
     file-format: JUNITXML
 

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -14,6 +14,11 @@ reports:
     files:
       - '*/build/test-results/test/TEST-*.xml'
     file-format: JUNITXML
+  sam-build:
+    files:
+      - '/tmp/*/build/test-results/test/TEST-*.xml'                                                                                                                  │ │
+      - '/tmp/*/*/build/test-results/test/TEST-*.xml'
+    file-format: JUNITXML
 
 phases:
   install:


### PR DESCRIPTION
Move `./gradlew test` to build phase so that test reports are generated on failure.