### PR TITLE
adding alias for course/courseCode for degree

### DIFF
--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/Degree.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/Degree.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
+import java.util.Objects;
 import no.unit.nva.model.Course;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
+import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Degree extends Book {
@@ -36,6 +38,25 @@ public class Degree extends Book {
 
     public Course getCourse() {
         return course;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), course);
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        Degree degree = (Degree) o;
+        return Objects.equals(course, degree.course);
     }
 
     public static final class Builder {

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/Degree.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/Degree.java
@@ -1,6 +1,7 @@
 package no.unit.nva.model.contexttypes;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -13,6 +14,7 @@ import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
 public class Degree extends Book {
 
     public static final String JSON_PROPERTY_COURSE_CODE = "courseCode";
+    public static final String JSON_PROPERTY_COURSE = "course";
     private final Course course;
 
     @JsonCreator
@@ -21,7 +23,8 @@ public class Degree extends Book {
                   @JsonProperty(JSON_PROPERTY_SERIES_NUMBER) String seriesNumber,
                   @JsonProperty(JSON_PROPERTY_PUBLISHER) PublishingHouse publisher,
                   @JsonProperty(JSON_PROPERTY_ISBN_LIST) List<String> isbnList,
-                  @JsonProperty(JSON_PROPERTY_COURSE_CODE) Course course) throws InvalidUnconfirmedSeriesException {
+                  @JsonProperty(JSON_PROPERTY_COURSE) @JsonAlias(JSON_PROPERTY_COURSE_CODE) Course course)
+        throws InvalidUnconfirmedSeriesException {
         super(series, unconfirmedSeriesTitle, seriesNumber, publisher, isbnList, null);
         this.course = course;
     }

--- a/publication-model/src/test/java/no/unit/nva/model/contexttypes/DegreeTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/contexttypes/DegreeTest.java
@@ -1,0 +1,38 @@
+package no.unit.nva.model.contexttypes;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.model.UnconfirmedCourse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class DegreeTest {
+
+    @ParameterizedTest(name = "should consume course from JSON field: {0}")
+    @MethodSource("courseFieldNames")
+    void shouldConsumeCourseFromJson(String fieldName) throws JsonProcessingException {
+        var value = randomString();
+        var json = """
+            {
+                "type": "Degree",
+                "%s": {
+                    "type": "UnconfirmedCourse",
+                    "code": "%s"
+                }
+            }
+            """.formatted(fieldName, value);
+
+        var degree = JsonUtils.dtoObjectMapper.readValue(json, Degree.class);
+
+        var course = (UnconfirmedCourse) degree.getCourse();
+        assertEquals(value, course.code());
+    }
+
+    private static Stream<Arguments> courseFieldNames() {
+        return Stream.of(Arguments.of("course"), Arguments.of("courseCode"));
+    }
+}

--- a/publication-model/src/test/java/no/unit/nva/model/contexttypes/DegreeTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/contexttypes/DegreeTest.java
@@ -26,8 +26,8 @@ public class DegreeTest {
             }
             """.formatted(fieldName, value);
 
-        var degree = JsonUtils.dtoObjectMapper.readValue(json, Degree.class);
-
+        var book = JsonUtils.dtoObjectMapper.readValue(json, Book.class);
+        var degree = (Degree) book;
         var course = (UnconfirmedCourse) degree.getCourse();
         assertEquals(value, course.code());
     }


### PR DESCRIPTION
**Problem**
The Degree class has a JSON serialization/deserialization mismatch:
Serialization (outgoing):

The backend serves the field as "course" in JSON responses
Example from production data:
```
{
  "type": "Degree",
  "course": {
    "type": "UnconfirmedCourse",
    "code": "BVSOSBV"
  }
}
```
**Deserialization (incoming):**
The @JsonProperty annotation specifies JSON_PROPERTY_COURSE_CODE = "courseCode"
This means the class expects to consume "courseCode" from incoming JSON
This creates an asymmetry: we send "course" but expect to receive "courseCode"


**Root Cause**
The constant JSON_PROPERTY_COURSE_CODE was incorrectly named. The Java property is course, and the JSON field should consistently be "course" in both directions.


**Solution**
Adding json alias to support both `courseCode` and `course`