### PR TITLE
fixing comparison of references when only type changes

### DIFF
--- a/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
+++ b/brage-import/src/test/java/no/sikt/nva/brage/migration/testutils/ReferenceGenerator.java
@@ -76,6 +76,7 @@ import no.unit.nva.model.instancetypes.journal.JournalIssue;
 import no.unit.nva.model.instancetypes.journal.JournalLeader;
 import no.unit.nva.model.instancetypes.journal.PopularScienceArticle;
 import no.unit.nva.model.instancetypes.journal.ProfessionalArticle;
+import no.unit.nva.model.instancetypes.media.MediaFeatureArticle;
 import no.unit.nva.model.instancetypes.media.MediaInterview;
 import no.unit.nva.model.instancetypes.media.MediaReaderOpinion;
 import no.unit.nva.model.instancetypes.report.ConferenceReport;
@@ -449,7 +450,7 @@ public final class ReferenceGenerator {
     }
 
     private static PublicationInstance<? extends Pages> generatePublicationInstanceForFeatureArticle(Builder builder) {
-        return new FeatureArticle.Builder().withPages(generateRange(builder)).build();
+        return new MediaFeatureArticle(builder.getVolume(), builder.getIssue(), builder.getArticleNumber(), generateRange(builder));
     }
 
     private static Range generateRange(Builder builder) {

--- a/publication-model/src/main/java/no/unit/nva/model/Reference.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Reference.java
@@ -3,6 +3,7 @@ package no.unit.nva.model;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.Pages;
@@ -75,21 +76,22 @@ public class Reference {
     @JacocoGenerated
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Reference)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Reference that = (Reference) o;
-        return Objects.equals(getPublicationContext(), that.getPublicationContext())
-                && Objects.equals(getDoi(), that.getDoi())
-                && Objects.equals(getPublicationInstance(), that.getPublicationInstance());
+        Reference reference = (Reference) o;
+        return Objects.equals(publicationContext, reference.getPublicationContext())
+               && Objects.equals(Optional.ofNullable(publicationContext).map(PublicationContext::getClass),
+                                 Optional.ofNullable(reference.getPublicationContext()).map(PublicationContext::getClass))
+               && Objects.equals(doi, reference.doi)
+               && Objects.equals(publicationInstance, reference.getPublicationInstance())
+               && Objects.equals(Optional.ofNullable(publicationInstance).map(PublicationInstance::getClass),
+                      Optional.ofNullable(reference.getPublicationInstance()).map(PublicationInstance::getClass));
     }
 
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(getPublicationContext(), getDoi(), getPublicationInstance());
+        return Objects.hash(publicationContext, doi, publicationInstance);
     }
 }

--- a/publication-model/src/test/java/no/unit/nva/model/ReferenceTest.java
+++ b/publication-model/src/test/java/no/unit/nva/model/ReferenceTest.java
@@ -1,0 +1,103 @@
+package no.unit.nva.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ReferenceTest {
+
+    public static Stream<Arguments> contextTypePairs() {
+        var contextTypes = List.of(
+            "Book",
+            "Report",
+            "Degree",
+            "Anthology",
+            "UnconfirmedJournal",
+            "Event",
+            "Artistic",
+            "ResearchData",
+            "GeographicalContent",
+            "ExhibitionContent"
+        );
+        return IntStream.range(0, contextTypes.size())
+                   .boxed()
+                   .flatMap(i -> IntStream.range(i + 1, contextTypes.size())
+                                     .mapToObj(j -> Arguments.of(contextTypes.get(i), contextTypes.get(j)))
+                   );
+    }
+
+    @ParameterizedTest(name = "References with instance type {0} and {1} are not equal")
+    @MethodSource("instanceTypePairs")
+    void referenceWithTwoDifferentInstanceTypesShouldNotBeEqual(String instanceTypeOne, String instanceTypeTwo) throws JsonProcessingException {
+        var oldJson = """
+            {
+              "type": "Reference",
+              "publicationInstance": {
+                "type": "%s"
+              }
+            }
+            """.formatted(instanceTypeOne);
+        var json = """
+            {
+              "type": "Reference",
+              "publicationInstance": {
+                "type": "%s"
+              }
+            }
+            """.formatted(instanceTypeTwo);
+
+        var old = JsonUtils.dtoObjectMapper.readValue(oldJson, Reference.class);
+        var updated = JsonUtils.dtoObjectMapper.readValue(json, Reference.class);
+
+        assertNotEquals(old, updated);
+    }
+
+    @ParameterizedTest(name = "References with context type {0} and {1} are not equal")
+    @MethodSource("contextTypePairs")
+    void referenceWithTwoDifferentContextTypesShouldNotBeEqual(String eventOne, String eventTwo) throws JsonProcessingException {
+        var oldJson = """
+            {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "%s"
+              }
+            }
+            """.formatted(eventOne);
+        var json = """
+            {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "%s"
+              }
+            }
+            """.formatted(eventTwo);
+
+        var old = JsonUtils.dtoObjectMapper.readValue(oldJson, Reference.class);
+        var updated = JsonUtils.dtoObjectMapper.readValue(json, Reference.class);
+
+        assertNotEquals(old, updated);
+    }
+
+    @Test
+    void referenceMissingContextTypeAndInstanceTypeShouldNotFailOnEquals() {
+        var reference = new Reference();
+        assertDoesNotThrow(() -> reference.equals(new Reference()));
+    }
+
+    private static Stream<Arguments> instanceTypePairs() {
+        var types = List.of("ConferenceLecture", "OtherPresentation", "ConferencePoster", "Lecture");
+
+        return IntStream.range(0, types.size())
+                   .boxed()
+                   .flatMap(i -> IntStream.range(i + 1, types.size())
+                                     .mapToObj(j -> Arguments.of(types.get(i), types.get(j))));
+    }
+}


### PR DESCRIPTION
**Problem**
The Reference class's equals() method was incorrectly returning true when comparing two references that differed only in their PublicationContext or PublicationInstance implementation types.
Example of the bug: