### PR TITLE
Fix:json-ld context maps alternativeAbstracts correctly and license as IRI

### DIFF
--- a/publication-model/src/main/resources/publication-ontology.ttl
+++ b/publication-model/src/main/resources/publication-ontology.ttl
@@ -1387,11 +1387,18 @@ nva:formatted a rdf:Property ;
   rdfs:domain nva:Ismn ;
   rdfs:range xsd:string .
 
+nva:alternativeAbstract a rdf:Property ;
+    rdfs:comment "An alternative abstract for a document, typically a translation" ;
+    rdfs:label "Alternative abstract" ;
+    rdfs:isDefinedBy nva: ;
+    rdfs:domain nva:EntityDescription ;
+    rdfs:range rdf:langString .
+
 nva:alternativeTitle a rdf:Property ;
   rdfs:comment "" ;
   rdfs:label "" ;
   rdfs:isDefinedBy nva: ;
-  rdfs:domain nva:Publication ;
+  rdfs:domain nva:EntityDescription ;
   rdfs:range rdf:langString .
 
 nva:orcId a rdf:Property ;

--- a/publication-model/src/main/resources/publicationContext.json
+++ b/publication-model/src/main/resources/publicationContext.json
@@ -25,7 +25,7 @@
   },
   "alternativeAbstracts": {
     "@container": "@language",
-    "@id": "alternativeTitle"
+    "@id": "alternativeAbstract"
   },
   "alternativeTitles": {
     "@container": "@language",

--- a/publication-model/src/main/resources/publicationContext.json
+++ b/publication-model/src/main/resources/publicationContext.json
@@ -150,6 +150,9 @@
   "language": {
     "@type": "@id"
   },
+  "license": {
+    "@type": "@id"
+  },
   "link": {
     "@type": "@id"
   },


### PR DESCRIPTION
- Alternative abstracts was mapped to alternativeTitle, which is not correct
- Now mapped to alternativeAbstract, which is correct
- License is added — as an IRI, it was missing.