### PR TITLE
fix: Prevent automated deletion of resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -177,7 +177,7 @@ Resources:
   NvaResourcesTable:
     Type: AWS::DynamoDB::Table
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Delete # DeletionPolicy should be added on main branch stacks through use of stack policy
+    DeletionPolicy: Retain
     Properties:
       TableName: !Sub nva-resources-${AWS::StackName}
       BillingMode: PAY_PER_REQUEST
@@ -252,7 +252,7 @@ Resources:
   NvaImportCandidatesTable:
     Type: AWS::DynamoDB::Table
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Delete # DeletionPolicy should be added on main branch stacks through use of stack policy
+    DeletionPolicy: Retain
     Properties:
       TableName: !Sub nva-import-candidates-${AWS::StackName}
       BillingMode: PAY_PER_REQUEST
@@ -2775,6 +2775,8 @@ Resources:
 
   BrageMigrationInputBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "${BrageMigrationInputBucketName}-${AWS::AccountId}"
       LifecycleConfiguration:
@@ -2794,6 +2796,8 @@ Resources:
 
   BrageMigrationErrorBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "${BrageMigrationErrorBucketName}-${AWS::AccountId}"
       LifecycleConfiguration:
@@ -2810,6 +2814,8 @@ Resources:
 
   ScopusZipBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "${ScopusZipBucketName}-${AWS::AccountId}"
       LifecycleConfiguration:
@@ -2845,6 +2851,8 @@ Resources:
 
   ImportCandidateStorageBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub "${ImportCandidateStorageBucketName}-${AWS::AccountId}"
       LifecycleConfiguration:

--- a/template.yaml
+++ b/template.yaml
@@ -2832,6 +2832,8 @@ Resources:
 
   ScopusXmlBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
     Properties:
       BucketName: !Sub "${ScopusXmlBucketName}-${AWS::AccountId}"
       LifecycleConfiguration:
@@ -2869,8 +2871,13 @@ Resources:
 
   ScopusImportReportBucket:
     Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
     Properties:
       BucketName: !Sub "${ScopusImportReportBucketName}-${AWS::AccountId}"
+      Tags:
+        - Key: IncludedInBackup
+          Value: "false"
 
   #============================Alarms===============================================================
 


### PR DESCRIPTION
Prevents important resources from being deleted automatically (e.g. if stack deleted or resource modified). See https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html for details.

Changes:

- [fix: Set policies to prevent automatic deletion of tables/buckets](https://github.com/BIBSYSDEV/nva-publication-api/pull/2518/commits/a98aab1038ce8911308a8f77a0228334431b9cb3)
- [refactor: Set default values as explicit policies](https://github.com/BIBSYSDEV/nva-publication-api/pull/2518/commits/35597ae65f0b3e339181dca807ae818e58fc3e70)
