### PR TITLE
refactor(publication-model): simplify Validatable and use static emptyList

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourcePublishValidator.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourcePublishValidator.java
@@ -1,5 +1,6 @@
 package no.unit.nva.publication.model.business;
 
+import static java.util.Collections.emptyList;
 import static no.unit.nva.model.PublicationStatus.DRAFT;
 import static no.unit.nva.model.PublicationStatus.PUBLISHED_METADATA;
 import static no.unit.nva.model.PublicationStatus.UNPUBLISHED;
@@ -51,6 +52,6 @@ public class ResourcePublishValidator implements Validator<Resource> {
         .filter(PublishValidator.class::isInstance)
         .map(PublishValidator.class::cast)
         .map(PublishValidator::validateForPublish)
-        .orElse(List.of());
+        .orElse(emptyList());
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/researchdata/SoftwareSourceCode.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/researchdata/SoftwareSourceCode.java
@@ -1,9 +1,10 @@
 package no.unit.nva.model.instancetypes.researchdata;
 
+import static java.util.Collections.emptyList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.PublishValidator;
@@ -35,6 +36,6 @@ public record SoftwareSourceCode(
       return List.of(
           new ValidationError(SOFTWARE_VERSION_REQUIRED_MESSAGE, SOFTWARE_VERSION_POINTER));
     }
-    return Collections.emptyList();
+    return emptyList();
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/validation/Validatable.java
+++ b/publication-model/src/main/java/no/unit/nva/model/validation/Validatable.java
@@ -1,6 +1,6 @@
 package no.unit.nva.model.validation;
 
-public interface Validatable<T extends Validatable<T>> {
+public interface Validatable<T> {
 
   ValidationResult validate(Validator<T> validator);
 }

--- a/publication-model/src/main/java/no/unit/nva/model/validation/ValidationException.java
+++ b/publication-model/src/main/java/no/unit/nva/model/validation/ValidationException.java
@@ -1,5 +1,7 @@
 package no.unit.nva.model.validation;
 
+import static java.util.Collections.emptyList;
+
 import java.util.List;
 
 public class ValidationException extends RuntimeException {
@@ -7,7 +9,7 @@ public class ValidationException extends RuntimeException {
   private final List<ValidationError> errors;
 
   public ValidationException(String message) {
-    this(message, List.of());
+    this(message, emptyList());
   }
 
   public ValidationException(String message, List<ValidationError> errors) {


### PR DESCRIPTION
## Summary

Follow-up cleanup on top of #2523 — two small things that didn't make it into the merged PR.

- Drop the F-bound on `Validatable<T extends Validatable<T>>`. Plain `Validatable<T>` works just as well, and the recursive bound was hard to read for nothing real
- Use static `emptyList()` imports in `ValidationException`, `SoftwareSourceCode` and `ResourcePublishValidator` instead of `Collections.emptyList()` / `List.of()`

https://sikt.atlassian.net/browse/NP-51198