### PR TITLE
feat(publication-commons): add DLR as third party system

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/ThirdPartySystem.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/ThirdPartySystem.java
@@ -9,6 +9,7 @@ public enum ThirdPartySystem {
   WISE_FLOW("WISEflow"),
   INSPERA("Inspera"),
   AVHANDLINGSPORTALEN("Avhandlingsportalen"),
+  DLR("DLR"),
   OTHER("Other");
 
   private final String value;
@@ -29,6 +30,7 @@ public enum ThirdPartySystem {
       case INSPERA -> Source.INSPERA;
       case WISE_FLOW -> Source.WISE_FLOW;
       case AVHANDLINGSPORTALEN -> Source.AVHANDLINGSPORTALEN;
+      case DLR -> Source.DLR;
       case OTHER -> Source.OTHER;
     };
   }

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ThirdPartySystemTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ThirdPartySystemTest.java
@@ -26,6 +26,7 @@ class ThirdPartySystemTest {
   private static Stream<Arguments> thirdPartySystemProvider() {
     return Stream.of(
         Arguments.of(" wiSEfloW ", ThirdPartySystem.WISE_FLOW),
-        Arguments.of(" INSperA ", ThirdPartySystem.INSPERA));
+        Arguments.of(" INSperA ", ThirdPartySystem.INSPERA),
+        Arguments.of(" dLR ", ThirdPartySystem.DLR));
   }
 }


### PR DESCRIPTION
Add DLR to the `ThirdPartySystem` enum so external API clients can identify imports from DLR via the `System` header on publication API POST.

- Add `DLR("DLR")` to `ThirdPartySystem`
- Map `DLR` to `ImportSource.Source.DLR` in `toSource()`
- Cover with a parametrized case in `ThirdPartySystemTest`

https://sikt.atlassian.net/browse/NP-50757