### PR TITLE
feat(template): Grant NIB cross-account read access to Scopus buckets

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -84,7 +84,7 @@ Parameters:
   NibExternalAccountId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/NVA/ExternalAWSAccounts/NIB"
-    Description: AWS account id for NIB, granted read-only access to the Scopus XML bucket
+    Description: AWS account id for NIB, granted read-only access to the selected buckets
   ScopusImportReportBucketName:
     Type: "String"
     Default: "scopus-import-reports"

--- a/template.yaml
+++ b/template.yaml
@@ -81,6 +81,10 @@ Parameters:
     Type: String
     Default: "scopus-xml-files-v2"
     Description: Name of bucket for unzipped scopus xml files
+  NibExternalAccountId:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/NVA/ExternalAWSAccounts/NIB"
+    Description: AWS account id for NIB, granted read-only access to the Scopus XML bucket
   ScopusImportReportBucketName:
     Type: "String"
     Default: "scopus-import-reports"
@@ -2796,6 +2800,52 @@ Resources:
           Value: "false"
       VersioningConfiguration:
         Status: Enabled
+
+  ScopusXmlBucketCrossAccountReadPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ScopusXmlBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: NibReadObjects
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${NibExternalAccountId}:root"
+            Action:
+              - s3:GetObject
+              - s3:GetObjectVersion
+            Resource: !Sub "${ScopusXmlBucket.Arn}/*"
+          - Sid: NibListBucket
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${NibExternalAccountId}:root"
+            Action:
+              - s3:ListBucket
+            Resource: !GetAtt ScopusXmlBucket.Arn
+
+  ScopusZipBucketCrossAccountReadPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ScopusZipBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: NibReadObjects
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${NibExternalAccountId}:root"
+            Action:
+              - s3:GetObject
+              - s3:GetObjectVersion
+            Resource: !Sub "${ScopusZipBucket.Arn}/*"
+          - Sid: NibListBucket
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${NibExternalAccountId}:root"
+            Action:
+              - s3:ListBucket
+            Resource: !GetAtt ScopusZipBucket.Arn
 
   ImportCandidateStorageBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
Grants the NIB AWS account read-only access to the Scopus XML and zip buckets, so NIB can fetch the source files directly from their own account.

- Add `NibExternalAccountId` parameter resolved from the SSM parameter `/NVA/ExternalAWSAccounts/NIB`
- Add bucket policies on `ScopusXmlBucket` and `ScopusZipBucket` allowing the NIB account `s3:GetObject`, `s3:GetObjectVersion` and `s3:ListBucket`

## Dependency
Depends on BIBSYSDEV/NVA-infrastructure#308, which documents `/NVA/ExternalAWSAccounts/NIB`. The SSM parameter must be created in every environment before this is deployed, otherwise the deploy fails when the parameter is resolved.

https://sikt.atlassian.net/browse/NP-51296