### PR TITLE
fix(publish): Allow external clients to publish via client credentials #NP-50757

### DIFF
--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishPublicationHandler.java
@@ -4,9 +4,9 @@ import static java.net.HttpURLConnection.HTTP_ACCEPTED;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.List;
+import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.model.validation.ValidationException;
 import no.unit.nva.publication.RequestUtil;
-import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.PublishingService;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -20,15 +20,20 @@ import nva.commons.core.JacocoGenerated;
 public class PublishPublicationHandler extends ApiGatewayHandler<Void, Void> {
 
   private final PublishingService publishingService;
+  private final IdentityServiceClient identityServiceClient;
 
   @JacocoGenerated
   public PublishPublicationHandler() {
-    this(PublishingService.defaultService(), new Environment());
+    this(PublishingService.defaultService(), IdentityServiceClient.prepare(), new Environment());
   }
 
-  public PublishPublicationHandler(PublishingService publishingService, Environment environment) {
+  public PublishPublicationHandler(
+      PublishingService publishingService,
+      IdentityServiceClient identityServiceClient,
+      Environment environment) {
     super(Void.class, environment);
     this.publishingService = publishingService;
+    this.identityServiceClient = identityServiceClient;
   }
 
   @Override
@@ -41,7 +46,8 @@ public class PublishPublicationHandler extends ApiGatewayHandler<Void, Void> {
   protected Void processInput(Void unused, RequestInfo requestInfo, Context context)
       throws ApiGatewayException {
     var resourceIdentifier = RequestUtil.getIdentifier(requestInfo);
-    var userInstance = UserInstance.fromRequestInfo(requestInfo);
+    var userInstance =
+        RequestUtil.createUserInstanceFromRequest(requestInfo, identityServiceClient);
     try {
       publishingService.publishResource(resourceIdentifier, userInstance);
     } catch (Exception e) {

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/PublishPublicationHandlerTest.java
@@ -12,6 +12,7 @@ import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsG
 import static no.unit.nva.publication.PublicationServiceConfig.PUBLICATION_IDENTIFIER_PATH_PARAMETER_NAME;
 import static no.unit.nva.publication.PublicationServiceConfig.dtoObjectMapper;
 import static no.unit.nva.publication.model.business.PublishingWorkflow.REGISTRATOR_PUBLISHES_METADATA_ONLY;
+import static no.unit.nva.testutils.HandlerRequestBuilder.CLIENT_ID_CLAIM;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import no.unit.nva.clients.CustomerDto;
+import no.unit.nva.clients.GetExternalClientResponse;
 import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
@@ -58,10 +60,15 @@ import org.zalando.problem.Problem;
 
 class PublishPublicationHandlerTest extends ResourcesLocalTest {
 
+  private static final String EXTERNAL_CLIENT_ID = "external-client-id";
+  private static final String SCOPES_THIRD_PARTY_PUBLICATION_UPSERT =
+      "https://api.nva.unit.no/scopes/third-party/publication-upsert";
+
   private Context context;
   private ByteArrayOutputStream output;
   private ResourceService resourceService;
   private TicketService ticketService;
+  private IdentityServiceClient identityServiceClient;
   private PublishPublicationHandler handler;
 
   @BeforeEach
@@ -71,12 +78,13 @@ class PublishPublicationHandlerTest extends ResourcesLocalTest {
     output = new ByteArrayOutputStream();
     resourceService = getResourceService(client);
     ticketService = getTicketService();
-    var identityServiceClient = mock(IdentityServiceClient.class);
+    identityServiceClient = mock(IdentityServiceClient.class);
     when(identityServiceClient.getCustomerById(any()))
         .thenReturn(customerWithWorkflow(REGISTRATOR_PUBLISHES_METADATA_ONLY.getValue()));
     var publishingService =
         new PublishingService(resourceService, ticketService, identityServiceClient);
-    handler = new PublishPublicationHandler(publishingService, new Environment());
+    handler =
+        new PublishPublicationHandler(publishingService, identityServiceClient, new Environment());
   }
 
   @Test
@@ -185,6 +193,7 @@ class PublishPublicationHandlerTest extends ResourcesLocalTest {
         new PublishPublicationHandler(
             new PublishingService(
                 resourceService, ticketService, mock(IdentityServiceClient.class)),
+            identityServiceClient,
             new Environment());
     publishPublicationHandler.handleRequest(request, output, context);
 
@@ -197,6 +206,19 @@ class PublishPublicationHandlerTest extends ResourcesLocalTest {
   void shouldReturnOkWhenPublishingPublication() throws IOException, BadRequestException {
     var publication = createPublication();
     var request = createRequestWithUserWithPermissionsToPublishPublication(publication);
+
+    handler.handleRequest(request, output, context);
+
+    var response = GatewayResponse.fromOutputStream(output, Void.class);
+
+    assertEquals(HTTP_ACCEPTED, response.getStatusCode());
+  }
+
+  @Test
+  void shouldPublishWhenExternalClientOwnsResource()
+      throws IOException, BadRequestException, NotFoundException {
+    var publication = createPublication();
+    var request = createExternalClientRequest(publication);
 
     handler.handleRequest(request, output, context);
 
@@ -260,6 +282,23 @@ class PublishPublicationHandlerTest extends ResourcesLocalTest {
         .withPersonCristinId(randomUri())
         .withTopLevelCristinOrgId(publication.getResourceOwner().getOwnerAffiliation())
         .withAccessRights(publication.getPublisher().getId(), AccessRight.MANAGE_RESOURCES_STANDARD)
+        .build();
+  }
+
+  private InputStream createExternalClientRequest(Publication publication)
+      throws JsonProcessingException, NotFoundException {
+    var externalClientResponse =
+        new GetExternalClientResponse(
+            EXTERNAL_CLIENT_ID,
+            publication.getResourceOwner().getOwner().getValue(),
+            publication.getPublisher().getId(),
+            publication.getResourceOwner().getOwnerAffiliation());
+    when(identityServiceClient.getExternalClient(any())).thenReturn(externalClientResponse);
+
+    return new HandlerRequestBuilder<Void>(dtoObjectMapper)
+        .withPathParameters(publicationIdentifierPathParam(publication.getIdentifier()))
+        .withScope(SCOPES_THIRD_PARTY_PUBLICATION_UPSERT)
+        .withAuthorizerClaim(CLIENT_ID_CLAIM, EXTERNAL_CLIENT_ID)
         .build();
   }
 


### PR DESCRIPTION
External (third-party) and backend client-credential clients received `401 Unauthorized` when calling `POST /{publicationIdentifier}/publish`. The handler built the user via `UserInstance.fromRequestInfo`, which unconditionally requires a username claim and hardcodes the client type to `INTERNAL`. Client-credential tokens have no username, so `getUserName()` threw `UnauthorizedException` before the permission check was ever reached.

- Inject `IdentityServiceClient` into `PublishPublicationHandler` and resolve the user via `RequestUtil.createUserInstanceFromRequest`, consistent with `UpdatePublicationHandler`
- This routes third-party/backend clients through the client-credentials flow (`getExternalClient`), producing an `EXTERNAL`/`BACKEND` `UserInstance` whose acting user comes from the client registry
- Add reproduction test `shouldPublishWhenExternalClientOwnsResource` (failed with 401 before the fix, passes after)

https://sikt.atlassian.net/browse/NP-50757