### PR TITLE
fix(log): Attribute third-party publish to organization with import source #NP-50757

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.model.ImportSource;
+import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.ResourceOwner;
@@ -212,6 +214,16 @@ public class UserInstance implements JsonSerializable {
 
   public Optional<ThirdPartySystem> getThirdPartySystem() {
     return isExternalClient() ? Optional.ofNullable(thirdPartySystem) : Optional.empty();
+  }
+
+  public ImportSource getImportSource() {
+    if (!isExternalClient()) {
+      return null;
+    }
+    return getThirdPartySystem()
+        .map(ThirdPartySystem::toSource)
+        .map(ImportSource::fromSource)
+        .orElse(ImportSource.fromSource(Source.OTHER));
   }
 
   @JacocoGenerated

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -216,14 +216,15 @@ public class UserInstance implements JsonSerializable {
     return isExternalClient() ? Optional.ofNullable(thirdPartySystem) : Optional.empty();
   }
 
-  public ImportSource getImportSource() {
+  public Optional<ImportSource> getImportSource() {
     if (!isExternalClient()) {
-      return null;
+      return Optional.empty();
     }
-    return getThirdPartySystem()
-        .map(ThirdPartySystem::toSource)
-        .map(ImportSource::fromSource)
-        .orElse(ImportSource.fromSource(Source.OTHER));
+    return Optional.of(
+        getThirdPartySystem()
+            .map(ThirdPartySystem::toSource)
+            .map(ImportSource::fromSource)
+            .orElse(ImportSource.fromSource(Source.OTHER)));
   }
 
   @JacocoGenerated

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -16,7 +16,7 @@ public record CreatedResourceEvent(
     URI institution,
     SortableIdentifier identifier,
     ImportSource importSource)
-    implements ResourceEvent {
+    implements ResourceEvent, ImportSourceProvider {
 
   public static CreatedResourceEvent create(UserInstance userInstance, Instant date) {
     return new CreatedResourceEvent(
@@ -24,7 +24,7 @@ public record CreatedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.getImportSource());
+        userInstance.getImportSource().orElse(null));
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/CreatedResourceEvent.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
-import no.unit.nva.model.ImportSource.Source;
-import no.unit.nva.publication.model.business.ThirdPartySystem;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogAgent;
@@ -26,15 +24,7 @@ public record CreatedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.isExternalClient() ? getImportSource(userInstance) : null);
-  }
-
-  private static ImportSource getImportSource(UserInstance userInstance) {
-    return userInstance
-        .getThirdPartySystem()
-        .map(ThirdPartySystem::toSource)
-        .map(ImportSource::fromSource)
-        .orElse(ImportSource.fromSource(Source.OTHER));
+        userInstance.getImportSource());
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -25,7 +25,7 @@ public record FileUploadedEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.getImportSource());
+        userInstance.getImportSource().orElse(null));
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -4,9 +4,7 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
-import no.unit.nva.model.ImportSource.Source;
 import no.unit.nva.publication.model.business.FileEntry;
-import no.unit.nva.publication.model.business.ThirdPartySystem;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
@@ -27,15 +25,7 @@ public record FileUploadedEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.isExternalClient() ? getImportSource(userInstance) : null);
-  }
-
-  private static ImportSource getImportSource(UserInstance userInstance) {
-    return userInstance
-        .getThirdPartySystem()
-        .map(ThirdPartySystem::toSource)
-        .map(ImportSource::fromSource)
-        .orElse(ImportSource.fromSource(Source.OTHER));
+        userInstance.getImportSource());
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/FileUploadedEvent.java
@@ -17,7 +17,7 @@ public record FileUploadedEvent(
     URI institution,
     SortableIdentifier identifier,
     ImportSource importSource)
-    implements FileEvent {
+    implements FileEvent, ImportSourceProvider {
 
   public static FileUploadedEvent create(UserInstance userInstance, Instant timestamp) {
     return new FileUploadedEvent(

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportSourceProvider.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportSourceProvider.java
@@ -1,0 +1,9 @@
+package no.unit.nva.publication.model.business.publicationstate;
+
+import no.unit.nva.model.ImportSource;
+
+@FunctionalInterface
+public interface ImportSourceProvider {
+
+  ImportSource importSource();
+}

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/ImportedResourceEvent.java
@@ -16,7 +16,7 @@ public record ImportedResourceEvent(
     URI institution,
     ImportSource importSource,
     SortableIdentifier identifier)
-    implements ResourceEvent {
+    implements ResourceEvent, ImportSourceProvider {
 
   public static ImportedResourceEvent fromImportSource(
       ImportSource importSource, UserInstance userInstance, Instant date) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/MergedResourceEvent.java
@@ -16,7 +16,7 @@ public record MergedResourceEvent(
     URI institution,
     ImportSource importSource,
     SortableIdentifier identifier)
-    implements ResourceEvent {
+    implements ResourceEvent, ImportSourceProvider {
 
   public static MergedResourceEvent fromImportSource(
       ImportSource importSource, UserInstance userInstance, Instant date) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -3,6 +3,9 @@ package no.unit.nva.publication.model.business.publicationstate;
 import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.ImportSource;
+import no.unit.nva.model.ImportSource.Source;
+import no.unit.nva.publication.model.business.ThirdPartySystem;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogAgent;
@@ -10,7 +13,11 @@ import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 
 public record PublishedResourceEvent(
-    Instant date, User user, URI institution, SortableIdentifier identifier)
+    Instant date,
+    User user,
+    URI institution,
+    SortableIdentifier identifier,
+    ImportSource importSource)
     implements ResourceEvent {
 
   public static PublishedResourceEvent create(UserInstance userInstance, Instant date) {
@@ -18,7 +25,16 @@ public record PublishedResourceEvent(
         date,
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
-        SortableIdentifier.next());
+        SortableIdentifier.next(),
+        userInstance.isExternalClient() ? getImportSource(userInstance) : null);
+  }
+
+  private static ImportSource getImportSource(UserInstance userInstance) {
+    return userInstance
+        .getThirdPartySystem()
+        .map(ThirdPartySystem::toSource)
+        .map(ImportSource::fromSource)
+        .orElse(ImportSource.fromSource(Source.OTHER));
   }
 
   @Override
@@ -29,6 +45,7 @@ public record PublishedResourceEvent(
         .withTopic(LogTopic.PUBLICATION_PUBLISHED)
         .withTimestamp(date)
         .withPerformedBy(user)
+        .withImportSource(importSource)
         .build();
   }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -16,7 +16,7 @@ public record PublishedResourceEvent(
     URI institution,
     SortableIdentifier identifier,
     ImportSource importSource)
-    implements ResourceEvent {
+    implements ResourceEvent, ImportSourceProvider {
 
   public static PublishedResourceEvent create(UserInstance userInstance, Instant date) {
     return new PublishedResourceEvent(
@@ -24,7 +24,7 @@ public record PublishedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.getImportSource());
+        userInstance.getImportSource().orElse(null));
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/PublishedResourceEvent.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
-import no.unit.nva.model.ImportSource.Source;
-import no.unit.nva.publication.model.business.ThirdPartySystem;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogAgent;
@@ -26,15 +24,7 @@ public record PublishedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.isExternalClient() ? getImportSource(userInstance) : null);
-  }
-
-  private static ImportSource getImportSource(UserInstance userInstance) {
-    return userInstance
-        .getThirdPartySystem()
-        .map(ThirdPartySystem::toSource)
-        .map(ImportSource::fromSource)
-        .orElse(ImportSource.fromSource(Source.OTHER));
+        userInstance.getImportSource());
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
@@ -16,7 +16,7 @@ public record UpdatedResourceEvent(
     URI institution,
     SortableIdentifier identifier,
     ImportSource importSource)
-    implements ResourceEvent {
+    implements ResourceEvent, ImportSourceProvider {
 
   public static UpdatedResourceEvent create(UserInstance userInstance, Instant date) {
     return new UpdatedResourceEvent(
@@ -24,7 +24,7 @@ public record UpdatedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.getImportSource());
+        userInstance.getImportSource().orElse(null));
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/publicationstate/UpdatedResourceEvent.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.time.Instant;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.ImportSource;
-import no.unit.nva.model.ImportSource.Source;
-import no.unit.nva.publication.model.business.ThirdPartySystem;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.LogAgent;
@@ -26,15 +24,7 @@ public record UpdatedResourceEvent(
         userInstance.getUser(),
         userInstance.getTopLevelOrgCristinId(),
         SortableIdentifier.next(),
-        userInstance.isExternalClient() ? getImportSource(userInstance) : null);
-  }
-
-  private static ImportSource getImportSource(UserInstance userInstance) {
-    return userInstance
-        .getThirdPartySystem()
-        .map(ThirdPartySystem::toSource)
-        .map(ImportSource::fromSource)
-        .orElse(ImportSource.fromSource(Source.OTHER));
+        userInstance.getImportSource());
   }
 
   @Override

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class ResourceEventTest {
 
+  private static final ImportSource NO_IMPORT_SOURCE = null;
+
   public static Stream<Arguments> stateProvider() {
     return Stream.of(
         Arguments.of(
@@ -35,7 +37,7 @@ public class ResourceEventTest {
                 new User(randomString()),
                 randomUri(),
                 SortableIdentifier.next(),
-                null)),
+                NO_IMPORT_SOURCE)),
         Arguments.of(
             new UnpublishedResourceEvent(
                 Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next())),
@@ -45,7 +47,7 @@ public class ResourceEventTest {
                 new User(randomString()),
                 randomUri(),
                 SortableIdentifier.next(),
-                null)),
+                NO_IMPORT_SOURCE)),
         Arguments.of(
             new DeletedResourceEvent(
                 Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next())),

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/ResourceEventTest.java
@@ -41,7 +41,11 @@ public class ResourceEventTest {
                 Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next())),
         Arguments.of(
             new PublishedResourceEvent(
-                Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next())),
+                Instant.now(),
+                new User(randomString()),
+                randomUri(),
+                SortableIdentifier.next(),
+                null)),
         Arguments.of(
             new DeletedResourceEvent(
                 Instant.now(), new User(randomString()), randomUri(), SortableIdentifier.next())),

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -46,7 +46,11 @@ class ResourceEventTest {
                 ImportSource.fromSource(Source.OTHER)),
             PUBLICATION_CREATED),
         Arguments.of(
-            new PublishedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),
+            new PublishedResourceEvent(
+                Instant.now(), randomUser(), randomUri(), identifier(), null),
+            PUBLICATION_PUBLISHED),
+        Arguments.of(
+            PublishedResourceEvent.create(randomExternalUserInstance(), Instant.now()),
             PUBLICATION_PUBLISHED),
         Arguments.of(
             new UnpublishedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier()),

--- a/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/model/business/publicationstate/ResourceEventTest.java
@@ -32,10 +32,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceEventTest {
 
+  private static final ImportSource NO_IMPORT_SOURCE = null;
+
   public static Stream<Arguments> resourceEventProvider() {
     return Stream.of(
         Arguments.of(
-            new CreatedResourceEvent(Instant.now(), randomUser(), randomUri(), identifier(), null),
+            new CreatedResourceEvent(
+                Instant.now(), randomUser(), randomUri(), identifier(), NO_IMPORT_SOURCE),
             PUBLICATION_CREATED),
         Arguments.of(
             new CreatedResourceEvent(
@@ -47,7 +50,7 @@ class ResourceEventTest {
             PUBLICATION_CREATED),
         Arguments.of(
             new PublishedResourceEvent(
-                Instant.now(), randomUser(), randomUri(), identifier(), null),
+                Instant.now(), randomUser(), randomUri(), identifier(), NO_IMPORT_SOURCE),
             PUBLICATION_PUBLISHED),
         Arguments.of(
             PublishedResourceEvent.create(randomExternalUserInstance(), Instant.now()),

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -96,7 +96,7 @@ public class LogEntryService {
   private LogEntry createLogEntry(Resource resource, ResourceEvent resourceEvent) {
     var performedBy =
         isPerformedBySystem(resourceEvent)
-            ? fetchOrganization(resourceEvent.institution())
+            ? createLogOrganization(resourceEvent.institution())
             : createLogUser(resourceEvent.user(), resourceEvent.institution());
     return resourceEvent.toLogEntry(resource.getIdentifier(), performedBy);
   }
@@ -106,7 +106,7 @@ public class LogEntryService {
         && nonNull(provider.importSource());
   }
 
-  private LogOrganization fetchOrganization(URI organizationId) {
+  private LogOrganization createLogOrganization(URI organizationId) {
     return cristinClient
         .getOrganization(organizationId)
         .map(LogOrganization::fromCristinOrganization)
@@ -116,11 +116,11 @@ public class LogEntryService {
   private void persistFileLogEntry(FileEntry fileEntry) {
     var fileEvent = fileEntry.getFileEvent();
     if (fileEvent instanceof ImportEvent importEvent) {
-      var organization = fetchOrganization(importEvent.institution());
+      var organization = createLogOrganization(importEvent.institution());
       fileEvent.toLogEntry(fileEntry, organization).persist(resourceService);
     } else if (fileEvent instanceof FileUploadedEvent fileUploadedEvent
         && nonNull(fileUploadedEvent.importSource())) {
-      var organization = fetchOrganization(fileUploadedEvent.institution());
+      var organization = createLogOrganization(fileUploadedEvent.institution());
       fileEvent.toLogEntry(fileEntry, organization).persist(resourceService);
     } else {
       var user = createLogUser(fileEvent.user(), null);

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -144,6 +144,11 @@ public class LogEntryService {
           cristinClient.getOrganization(userDto.institutionCristinId()).orElse(null);
       return LogUser.create(cristinPersonDto, cristinOrganizationDto);
     } catch (Exception e) {
+      logger.warn(
+          "Failed to enrich LogUser for user {} (institution {}); falling back to minimal record",
+          user,
+          institution,
+          e);
       return LogUser.fromResourceEvent(user, institution);
     }
   }

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -22,6 +22,7 @@ import no.unit.nva.publication.model.business.publicationstate.FileUploadedEvent
 import no.unit.nva.publication.model.business.publicationstate.ImportEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.UpdatedResourceEvent;
 import no.unit.nva.publication.service.impl.ResourceService;
@@ -101,7 +102,9 @@ public class LogEntryService {
         || resourceEvent instanceof MergedResourceEvent
         || resourceEvent instanceof CreatedResourceEvent event && nonNull(event.importSource())
         || resourceEvent instanceof UpdatedResourceEvent updatedResourceEvent
-            && nonNull(updatedResourceEvent.importSource())) {
+            && nonNull(updatedResourceEvent.importSource())
+        || resourceEvent instanceof PublishedResourceEvent publishedResourceEvent
+            && nonNull(publishedResourceEvent.importSource())) {
       var organization = fetchOrganization(resourceEvent.institution());
       return resourceEvent.toLogEntry(resource.getIdentifier(), organization);
     } else {

--- a/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
+++ b/publication-log/src/main/java/no/unit/nva/publication/log/service/LogEntryService.java
@@ -17,14 +17,10 @@ import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.logentry.LogEntry;
 import no.unit.nva.publication.model.business.logentry.LogOrganization;
 import no.unit.nva.publication.model.business.logentry.LogUser;
-import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.FileUploadedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportEvent;
-import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
-import no.unit.nva.publication.model.business.publicationstate.MergedResourceEvent;
-import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.ImportSourceProvider;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
-import no.unit.nva.publication.model.business.publicationstate.UpdatedResourceEvent;
 import no.unit.nva.publication.service.impl.ResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,26 +87,23 @@ public class LogEntryService {
 
   private void createLogEntry(DoiRequest doiRequest) {
     var ticketEvent = doiRequest.getTicketEvent();
-    var user = createUser(ticketEvent.user(), ticketEvent.institution());
+    var user = createLogUser(ticketEvent.user(), ticketEvent.institution());
     ticketEvent
         .toLogEntry(doiRequest.getResourceIdentifier(), doiRequest.getIdentifier(), user)
         .persist(resourceService);
   }
 
   private LogEntry createLogEntry(Resource resource, ResourceEvent resourceEvent) {
-    if (resourceEvent instanceof ImportedResourceEvent
-        || resourceEvent instanceof MergedResourceEvent
-        || resourceEvent instanceof CreatedResourceEvent event && nonNull(event.importSource())
-        || resourceEvent instanceof UpdatedResourceEvent updatedResourceEvent
-            && nonNull(updatedResourceEvent.importSource())
-        || resourceEvent instanceof PublishedResourceEvent publishedResourceEvent
-            && nonNull(publishedResourceEvent.importSource())) {
-      var organization = fetchOrganization(resourceEvent.institution());
-      return resourceEvent.toLogEntry(resource.getIdentifier(), organization);
-    } else {
-      var user = createUser(resourceEvent.user(), resourceEvent.institution());
-      return resourceEvent.toLogEntry(resource.getIdentifier(), user);
-    }
+    var performedBy =
+        isPerformedBySystem(resourceEvent)
+            ? fetchOrganization(resourceEvent.institution())
+            : createLogUser(resourceEvent.user(), resourceEvent.institution());
+    return resourceEvent.toLogEntry(resource.getIdentifier(), performedBy);
+  }
+
+  private static boolean isPerformedBySystem(ResourceEvent resourceEvent) {
+    return resourceEvent instanceof ImportSourceProvider provider
+        && nonNull(provider.importSource());
   }
 
   private LogOrganization fetchOrganization(URI organizationId) {
@@ -130,7 +123,7 @@ public class LogEntryService {
       var organization = fetchOrganization(fileUploadedEvent.institution());
       fileEvent.toLogEntry(fileEntry, organization).persist(resourceService);
     } else {
-      var user = createUser(fileEvent.user(), null);
+      var user = createLogUser(fileEvent.user(), null);
       fileEvent.toLogEntry(fileEntry, user).persist(resourceService);
     }
     var fileIdentifier = fileEntry.getIdentifier();
@@ -143,7 +136,7 @@ public class LogEntryService {
         resourceIdentifier);
   }
 
-  private LogUser createUser(User user, URI institution) {
+  private LogUser createLogUser(User user, URI institution) {
     try {
       var userDto = getUser(user);
       var cristinPersonDto = cristinClient.getPerson(userDto.cristinId()).orElse(null);

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -11,7 +11,6 @@ import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATI
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -207,7 +206,7 @@ class LogEntryServiceTest extends ResourcesLocalTest {
   }
 
   @Test
-  void shouldPersistPublishedLogEntryAsOrganizationForThirdParty() throws BadRequestException {
+  void shouldPersistLogEntryAsOrganizationForThirdPartyPublish() throws BadRequestException {
     var publication = createPublishedPublication();
     var externalUserInstance =
         UserInstance.createExternalUser(randomResourceOwner(), randomUri(), OTHER);
@@ -222,9 +221,11 @@ class LogEntryServiceTest extends ResourcesLocalTest {
         (PublicationLogEntry)
             Resource.fromPublication(publication).fetchLogEntries(resourceService).getFirst();
 
+    var expectedOrganization =
+        LogOrganization.fromCristinId(externalUserInstance.getTopLevelOrgCristinId());
     assertEquals(PUBLICATION_PUBLISHED, logEntry.topic());
     assertNotNull(logEntry.importSource());
-    assertInstanceOf(LogOrganization.class, logEntry.performedBy());
+    assertEquals(expectedOrganization, logEntry.performedBy());
   }
 
   @Test

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -26,6 +26,7 @@ import no.unit.nva.clients.UserDto;
 import no.unit.nva.clients.cristin.CristinClient;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Publication;
+import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.instancetypes.journal.AcademicArticle;
 import no.unit.nva.publication.model.business.DoiRequest;
 import no.unit.nva.publication.model.business.FileEntry;
@@ -41,7 +42,6 @@ import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.DoiRequestedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
-import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
@@ -207,13 +207,16 @@ class LogEntryServiceTest extends ResourcesLocalTest {
 
   @Test
   void shouldPersistLogEntryAsOrganizationForThirdPartyPublish() throws BadRequestException {
-    var publication = createPublishedPublication();
+    // Simulates a third-party client creating a draft and publishing it through the real publish
+    // path, which stamps the PublishedResourceEvent. In production the log entry is then written
+    // asynchronously by the stream-triggered PersistLogEntryEventHandler; here we invoke
+    // LogEntryService directly since that is the unit under test.
     var externalUserInstance =
         UserInstance.createExternalUser(randomResourceOwner(), randomUri(), OTHER);
-    var resource = Resource.fromPublication(publication);
-    resource.setResourceEvent(PublishedResourceEvent.create(externalUserInstance, Instant.now()));
-    resource.setDoi(randomDoi());
-    resourceService.updateResource(resource, externalUserInstance);
+    var draftPublication =
+        randomPublication(AcademicArticle.class).copy().withStatus(PublicationStatus.DRAFT).build();
+    var publication = resourceService.createPublication(externalUserInstance, draftPublication);
+    Resource.fromPublication(publication).publish(resourceService, externalUserInstance);
 
     logEntryService.persistLogEntry(Resource.fromPublication(publication));
 

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -207,10 +207,10 @@ class LogEntryServiceTest extends ResourcesLocalTest {
 
   @Test
   void shouldPersistLogEntryAsOrganizationForThirdPartyPublish() throws BadRequestException {
-    // Simulates a third-party client creating a draft and publishing it through the real publish
-    // path, which stamps the PublishedResourceEvent. In production the log entry is then written
-    // asynchronously by the stream-triggered PersistLogEntryEventHandler; here we invoke
-    // LogEntryService directly since that is the unit under test.
+    // Simulates a third-party client creating a draft and publishing it, which stamps the
+    // PublishedResourceEvent. In production the log entry is then written asynchronously by the
+    // stream-triggered PersistLogEntryEventHandler; here we invoke LogEntryService directly since
+    // that is the unit under test.
     var externalUserInstance =
         UserInstance.createExternalUser(randomResourceOwner(), randomUri(), OTHER);
     var draftPublication =

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -11,6 +11,7 @@ import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATI
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -229,6 +230,21 @@ class LogEntryServiceTest extends ResourcesLocalTest {
     assertEquals(PUBLICATION_PUBLISHED, logEntry.topic());
     assertNotNull(logEntry.importSource());
     assertEquals(expectedOrganization, logEntry.performedBy());
+  }
+
+  @Test
+  void shouldPersistLogEntryAsPersonForRegularUserPublish() throws BadRequestException {
+    var publication = createPublishedPublication();
+
+    logEntryService.persistLogEntry(Resource.fromPublication(publication));
+
+    var logEntry =
+        (PublicationLogEntry)
+            Resource.fromPublication(publication).fetchLogEntries(resourceService).getFirst();
+
+    assertEquals(PUBLICATION_PUBLISHED, logEntry.topic());
+    assertNull(logEntry.importSource());
+    assertInstanceOf(LogUser.class, logEntry.performedBy());
   }
 
   @Test

--- a/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
+++ b/publication-log/src/test/java/no/unit/nva/publication/log/service/LogEntryServiceTest.java
@@ -11,6 +11,7 @@ import static no.unit.nva.publication.model.business.logentry.LogTopic.PUBLICATI
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,11 +35,14 @@ import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.model.business.logentry.FileLogEntry;
+import no.unit.nva.publication.model.business.logentry.LogOrganization;
 import no.unit.nva.publication.model.business.logentry.LogTopic;
 import no.unit.nva.publication.model.business.logentry.LogUser;
+import no.unit.nva.publication.model.business.logentry.PublicationLogEntry;
 import no.unit.nva.publication.model.business.publicationstate.CreatedResourceEvent;
 import no.unit.nva.publication.model.business.publicationstate.DoiRequestedEvent;
 import no.unit.nva.publication.model.business.publicationstate.ImportedResourceEvent;
+import no.unit.nva.publication.model.business.publicationstate.PublishedResourceEvent;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.publication.service.impl.TicketService;
@@ -200,6 +204,27 @@ class LogEntryServiceTest extends ResourcesLocalTest {
             Resource.fromPublication(publication).fetchLogEntries(resourceService).getFirst();
     assertEquals(FILE_UPLOADED, logEntry.topic());
     assertNotNull(logEntry.importSource());
+  }
+
+  @Test
+  void shouldPersistPublishedLogEntryAsOrganizationForThirdParty() throws BadRequestException {
+    var publication = createPublishedPublication();
+    var externalUserInstance =
+        UserInstance.createExternalUser(randomResourceOwner(), randomUri(), OTHER);
+    var resource = Resource.fromPublication(publication);
+    resource.setResourceEvent(PublishedResourceEvent.create(externalUserInstance, Instant.now()));
+    resource.setDoi(randomDoi());
+    resourceService.updateResource(resource, externalUserInstance);
+
+    logEntryService.persistLogEntry(Resource.fromPublication(publication));
+
+    var logEntry =
+        (PublicationLogEntry)
+            Resource.fromPublication(publication).fetchLogEntries(resourceService).getFirst();
+
+    assertEquals(PUBLICATION_PUBLISHED, logEntry.topic());
+    assertNotNull(logEntry.importSource());
+    assertInstanceOf(LogOrganization.class, logEntry.performedBy());
   }
 
   @Test


### PR DESCRIPTION
When a publication was published by a third-party/backend client-credentials client, the log entry recorded `performedBy.type = "Person"` with the client's acting-user name, instead of attributing it to the organization with an import source. Unlike `CreatedResourceEvent` and `UpdatedResourceEvent`, `PublishedResourceEvent` never captured the client's import source, so `LogEntryService` always fell back to building a `LogUser` ("Person").

- Add an `importSource` field to `PublishedResourceEvent`, populated from the client's `ThirdPartySystem` when the user is an external client (symmetric with create/update events)
- Add a `PublishedResourceEvent` branch in `LogEntryService` so a published event carrying an import source is attributed to a `LogOrganization` ("Organization")
- Add regression test verifying a third-party publish is logged as Organization with a non-null import source

https://sikt.atlassian.net/browse/NP-50757