### PR TITLE
fix: Remove unnecessary PMD exclusions

### DIFF
--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
@@ -74,7 +74,7 @@ public record Customer(
 
   private Entry<Environment, String> getProductionIdentifier() {
     return identifiers.entrySet().stream()
-        .filter(environmentStringEntry -> PROD.equals(environmentStringEntry.getKey()))
+        .filter(environmentStringEntry -> PROD == environmentStringEntry.getKey())
         .findFirst()
         .orElseThrow();
   }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/Customer.java
@@ -94,7 +94,7 @@ public record Customer(
 
     @JsonCreator
     public static Environment fromValue(String value) {
-      return Arrays.stream(Environment.values())
+      return Arrays.stream(values())
           .filter(item -> item.getValue().equals(value))
           .collect(SingletonCollector.collect());
     }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationContextMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationContextMapper.java
@@ -72,7 +72,7 @@ public final class PublicationContextMapper {
 
   private PublicationContextMapper() {}
 
-  @SuppressWarnings({"PMD.NPathComplexity", "PMD.CognitiveComplexity"})
+  @SuppressWarnings("PMD.CognitiveComplexity")
   public static PublicationContext buildPublicationContext(Record brageRecord, URI organizationId)
       throws InvalidIsbnException, InvalidUnconfirmedSeriesException, InvalidIssnException {
     if (shouldBeMappedToBook(brageRecord)) {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationContextMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationContextMapper.java
@@ -314,7 +314,7 @@ public final class PublicationContextMapper {
 
   private static String extractMainTitle(Record brageRecord) {
     return Optional.ofNullable(brageRecord.getEntityDescription())
-        .map(no.sikt.nva.brage.migration.record.EntityDescription::getMainTitle)
+        .map(EntityDescription::getMainTitle)
         .orElse(null);
   }
 
@@ -494,7 +494,7 @@ public final class PublicationContextMapper {
 
   private static PublishingHouse generatePublisher(String publisherPid, String year) {
     return new Publisher(
-        UriWrapper.fromUri(PublicationContextMapper.CHANNEL_REGISTRY_V_2)
+        UriWrapper.fromUri(CHANNEL_REGISTRY_V_2)
             .addChild(ChannelType.PUBLISHER.getType())
             .addChild(publisherPid)
             .addChild(nonNull(year) ? year : CURRENT_YEAR)
@@ -507,7 +507,7 @@ public final class PublicationContextMapper {
 
   private static PublicationContext generateJournal(String journalPid, String year) {
     return new Journal(
-        UriWrapper.fromUri(PublicationContextMapper.CHANNEL_REGISTRY_V_2)
+        UriWrapper.fromUri(CHANNEL_REGISTRY_V_2)
             .addChild(ChannelType.SERIAL_PUBLICATION.getType())
             .addChild(journalPid)
             .addChild(nonNull(year) ? year : CURRENT_YEAR)
@@ -516,7 +516,7 @@ public final class PublicationContextMapper {
 
   private static BookSeries generateSeries(String seriesPid, String year) {
     return new Series(
-        UriWrapper.fromUri(PublicationContextMapper.CHANNEL_REGISTRY_V_2)
+        UriWrapper.fromUri(CHANNEL_REGISTRY_V_2)
             .addChild(ChannelType.SERIAL_PUBLICATION.getType())
             .addChild(seriesPid)
             .addChild(nonNull(year) ? year : CURRENT_YEAR)

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/mapper/PublicationInstanceMapper.java
@@ -103,7 +103,7 @@ public final class PublicationInstanceMapper {
 
   private PublicationInstanceMapper() {}
 
-  @SuppressWarnings({"PMD.NPathComplexity", "PMD.CognitiveComplexity", "PMD.NcssCount"})
+  @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.NcssCount"})
   public static PublicationInstance<? extends Pages> buildPublicationInstance(Record brageRecord) {
     if (isJournalArticle(brageRecord)) {
       return buildPublicationInstanceWhenJournalArticle(brageRecord);

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/AssociatedArtifactsMerger.java
@@ -42,12 +42,12 @@ public final class AssociatedArtifactsMerger {
   }
 
   private static boolean hasPublishedVersion(OpenFile openFile) {
-    return PUBLISHED_VERSION.equals(openFile.getPublisherVersion());
+    return PUBLISHED_VERSION == openFile.getPublisherVersion();
   }
 
   private static boolean isUniqueOpenFileWithPublishedVersion(
       AssociatedArtifactList existing, File file) {
-    return PUBLISHED_VERSION.equals(file.getPublisherVersion())
+    return PUBLISHED_VERSION == file.getPublisherVersion()
         && existing.stream()
             .noneMatch(
                 associatedArtifact ->
@@ -63,7 +63,7 @@ public final class AssociatedArtifactsMerger {
             .filter(File.class::isInstance)
             .map(File.class::cast)
             .filter(OpenFile.class::isInstance)
-            .filter(f -> PUBLISHED_VERSION.equals(f.getPublisherVersion()))
+            .filter(f -> PUBLISHED_VERSION == f.getPublisherVersion())
             .count();
     return count != SINGLETON;
   }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/CristinImportPublicationMerger.java
@@ -95,7 +95,7 @@ public class CristinImportPublicationMerger {
   }
 
   private static boolean isCreator(Contributor contributor) {
-    return CREATOR.equals(contributor.role().getType());
+    return CREATOR == contributor.role().getType();
   }
 
   private static boolean isDublinCore(File file) {
@@ -278,18 +278,18 @@ public class CristinImportPublicationMerger {
 
   private List<Contributor> extractSupervisors() {
     return bragePublicationRepresentation.publication().getContributors().stream()
-        .filter(contributor -> SUPERVISOR.equals(contributor.role().getType()))
+        .filter(contributor -> SUPERVISOR == contributor.role().getType())
         .toList();
   }
 
   private boolean incomingPublicationHasSupervisor() {
     return bragePublicationRepresentation.publication().getContributors().stream()
-        .anyMatch(contributor -> SUPERVISOR.equals(contributor.role().getType()));
+        .anyMatch(contributor -> SUPERVISOR == contributor.role().getType());
   }
 
   private boolean isMissingSupervisor(List<Contributor> contributors) {
     return contributors.stream()
-        .noneMatch(contributor -> SUPERVISOR.equals(contributor.role().getType()));
+        .noneMatch(contributor -> SUPERVISOR == contributor.role().getType());
   }
 
   private List<Contributor> existingContributorsWithUpdatedAffiliation() {

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/DuplicateDetectionCause.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/merger/findexistingpublication/DuplicateDetectionCause.java
@@ -19,7 +19,7 @@ public enum DuplicateDetectionCause {
 
   @JacocoGenerated
   public static DuplicateDetectionCause fromValue(String value) {
-    for (DuplicateDetectionCause cause : DuplicateDetectionCause.values()) {
+    for (DuplicateDetectionCause cause : values()) {
       if (cause.getValue().equalsIgnoreCase(value)) {
         return cause;
       }

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/record/ErrorDetails.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/record/ErrorDetails.java
@@ -41,7 +41,7 @@ public class ErrorDetails {
       return false;
     }
     var errorDetail = (ErrorDetails) o;
-    return this.errorCode.equals(errorDetail.errorCode);
+    return this.errorCode == errorDetail.errorCode;
   }
 
   @Override

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/record/PublicationDate.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/record/PublicationDate.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings("PMD.ShortClassName")
 public class PublicationDate {
 
   private final String brage;

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/record/Type.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/record/Type.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings("PMD.ShortClassName")
 public class Type {
 
   private final List<String> brage;

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/record/WarningDetails.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/record/WarningDetails.java
@@ -63,7 +63,7 @@ public class WarningDetails {
       return false;
     }
     var warningDetail = (WarningDetails) o;
-    return this.warningCode.equals(warningDetail.warningCode);
+    return this.warningCode == warningDetail.warningCode;
   }
 
   @JacocoGenerated

--- a/brage-import/src/main/java/no/sikt/nva/brage/migration/record/license/BrageLicense.java
+++ b/brage-import/src/main/java/no/sikt/nva/brage/migration/record/license/BrageLicense.java
@@ -21,7 +21,7 @@ public enum BrageLicense {
 
   @JacocoGenerated
   public static BrageLicense fromValue(String value) {
-    for (BrageLicense license : BrageLicense.values()) {
+    for (BrageLicense license : values()) {
       if (license.getValue().equalsIgnoreCase(value)) {
         return license;
       }

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -38,9 +38,6 @@
     <exclude name="ImplicitFunctionalInterface"/>
 
     <!-- FIXME: Disabled because of the high number of current violations-->
-    <exclude name="UnusedLocalVariable"/>
-
-    <!-- FIXME: Disabled because of the high number of current violations-->
     <exclude name="RelianceOnDefaultCharset"/>
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -38,9 +38,6 @@
     <exclude name="ImplicitFunctionalInterface"/>
 
     <!-- FIXME: Disabled because of the high number of current violations-->
-    <exclude name="UnnecessaryWarningSuppression"/>
-
-    <!-- FIXME: Disabled because of the high number of current violations-->
     <exclude name="UnusedLocalVariable"/>
 
     <!-- FIXME: Disabled because of the high number of current violations-->

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -63,9 +63,6 @@
     <exclude name="ConfusingTernary"/>
     <exclude name="UseExplicitTypes"/>
 
-    <!-- FIXME: Disabled because of the high number of current violations-->
-    <exclude name="UnnecessaryFullyQualifiedName"/>
-
     <!-- This rule does not allow us the following:
             private static final Logger logger=...
          It requires:

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -41,9 +41,6 @@
     <exclude name="UnusedLocalVariable"/>
 
     <!-- FIXME: Disabled because of the high number of current violations-->
-    <exclude name="EnumComparison"/>
-
-    <!-- FIXME: Disabled because of the high number of current violations-->
     <exclude name="RelianceOnDefaultCharset"/>
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -66,10 +66,6 @@
     <!-- FIXME: Disabled because of the high number of current violations-->
     <exclude name="UnnecessaryFullyQualifiedName"/>
 
-    <!-- FIXME: Disabled because of the high number of current violations-->
-    <exclude name="UnnecessaryInterfaceDeclaration"/>
-
-
     <!-- This rule does not allow us the following:
             private static final Logger logger=...
          It requires:

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinRerunErrorsEventEmitter.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/CristinRerunErrorsEventEmitter.java
@@ -148,7 +148,7 @@ public class CristinRerunErrorsEventEmitter implements RequestStreamHandler {
   private EventReference createEventReferenceForLocation(UnixPath reportLocation) {
     String fileContent = s3Driver.getFile(reportLocation);
     URI fileLocation = getFileLocation(fileContent);
-    return CristinRerunErrorsEventEmitter.toEventReference(fileLocation);
+    return toEventReference(fileLocation);
   }
 
   private URI getFileLocation(String content) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/lambda/PublicationUpdater.java
@@ -224,13 +224,12 @@ public final class PublicationUpdater {
   private static PublicationInstance<? extends Pages> updateJournalArticle(
       JournalArticle existingJournalArticle, JournalArticle incomingJournalArticle) {
     return switch (existingJournalArticle) {
-      case ProfessionalArticle professionalArticle ->
+      case ProfessionalArticle _ ->
           getProfessionalArticle(existingJournalArticle, incomingJournalArticle);
-      case PopularScienceArticle popularScienceArticle ->
+      case PopularScienceArticle _ ->
           getPopularScienceArticle(existingJournalArticle, incomingJournalArticle);
-      case AcademicArticle academicArticle ->
-          getAcademicArticle(existingJournalArticle, incomingJournalArticle);
-      case AcademicLiteratureReview academicLiteratureReview ->
+      case AcademicArticle _ -> getAcademicArticle(existingJournalArticle, incomingJournalArticle);
+      case AcademicLiteratureReview _ ->
           getAcademicLiteratureReview(existingJournalArticle, incomingJournalArticle);
       case null, default -> existingJournalArticle;
     };

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ArtBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ArtBuilder.java
@@ -24,15 +24,15 @@ public class ArtBuilder extends AbstractPublicationInstanceBuilder {
   @Override
   public PublicationInstance<? extends Pages> build() {
     CristinSecondaryCategory secondaryCategory = getCristinObject().getSecondaryCategory();
-    if (CristinSecondaryCategory.FILM_PRODUCTION.equals(secondaryCategory)) {
+    if (CristinSecondaryCategory.FILM_PRODUCTION == secondaryCategory) {
       return createMovingPicture();
     } else if (isMusicalWork(secondaryCategory)) {
       return createMusicPerformance();
-    } else if (CristinSecondaryCategory.VISUAL_ARTS.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.VISUAL_ARTS == secondaryCategory) {
       return createVisualArts();
-    } else if (CristinSecondaryCategory.THEATRICAL_PRODUCTION.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.THEATRICAL_PRODUCTION == secondaryCategory) {
       return createTheatricalProduction();
-    } else if (CristinSecondaryCategory.ARCHITECT_DESIGN.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.ARCHITECT_DESIGN == secondaryCategory) {
       return createArchitecture();
     } else {
       throw unknownSecondaryCategory();

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/BookBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/BookBuilder.java
@@ -35,21 +35,21 @@ public class BookBuilder extends AbstractBookReportBuilder {
   private PublicationInstance<? extends Pages> createMonograph() {
 
     var secondaryCategory = getCristinObject().getSecondaryCategory();
-    if (CristinSecondaryCategory.MONOGRAPH.equals(secondaryCategory)) {
+    if (CristinSecondaryCategory.MONOGRAPH == secondaryCategory) {
       return new AcademicMonograph(createMonographPages());
-    } else if (CristinSecondaryCategory.TEXTBOOK.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.TEXTBOOK == secondaryCategory) {
       return new Textbook(createMonographPages());
-    } else if (CristinSecondaryCategory.NON_FICTION_BOOK.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.NON_FICTION_BOOK == secondaryCategory) {
       return new NonFictionMonograph(createMonographPages());
-    } else if (CristinSecondaryCategory.ENCYCLOPEDIA.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.ENCYCLOPEDIA == secondaryCategory) {
       return new Encyclopedia(createMonographPages());
-    } else if (CristinSecondaryCategory.POPULAR_BOOK.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.POPULAR_BOOK == secondaryCategory) {
       return new PopularScienceMonograph(createMonographPages());
-    } else if (CristinSecondaryCategory.REFERENCE_MATERIAL.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.REFERENCE_MATERIAL == secondaryCategory) {
       return new Encyclopedia(createMonographPages());
-    } else if (CristinSecondaryCategory.EXHIBITION_CATALOG.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.EXHIBITION_CATALOG == secondaryCategory) {
       return new ExhibitionCatalog(createMonographPages());
-    } else if (CristinSecondaryCategory.ACADEMIC_COMMENTARY.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.ACADEMIC_COMMENTARY == secondaryCategory) {
       return new AcademicCommentary(createMonographPages());
     } else {
       throw new UnsupportedSecondaryCategoryException();

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ChapterArticleBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/ChapterArticleBuilder.java
@@ -21,16 +21,16 @@ public class ChapterArticleBuilder extends AbstractPublicationInstanceBuilder {
   public PublicationInstance<? extends Pages> build() {
 
     CristinSecondaryCategory secondaryCategory = getCristinObject().getSecondaryCategory();
-    if (CristinSecondaryCategory.CHAPTER_ACADEMIC.equals(secondaryCategory)) {
+    if (CristinSecondaryCategory.CHAPTER_ACADEMIC == secondaryCategory) {
       return new AcademicChapter(createChapterPages());
-    } else if (CristinSecondaryCategory.CHAPTER.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.CHAPTER == secondaryCategory) {
       return new NonFictionChapter(createChapterPages());
-    } else if (CristinSecondaryCategory.POPULAR_CHAPTER_ARTICLE.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.POPULAR_CHAPTER_ARTICLE == secondaryCategory) {
       return new PopularScienceChapter(createChapterPages());
-    } else if (CristinSecondaryCategory.LEXICAL_IMPORT.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.LEXICAL_IMPORT == secondaryCategory) {
       return new EncyclopediaChapter(createChapterPages());
-    } else if (CristinSecondaryCategory.FOREWORD.equals(secondaryCategory)
-        || CristinSecondaryCategory.INTRODUCTION.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.FOREWORD == secondaryCategory
+        || CristinSecondaryCategory.INTRODUCTION == secondaryCategory) {
       return new Introduction(createChapterPages());
     } else {
       throw unknownSecondaryCategory();

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributor.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributor.java
@@ -192,6 +192,6 @@ public class CristinContributor implements Comparable<CristinContributor> {
   }
 
   private boolean isVerified() {
-    return ContributorVerificationStatus.VERIFIED.equals(extractVerificationStatus());
+    return ContributorVerificationStatus.VERIFIED == extractVerificationStatus();
   }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRoleCode.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinContributorRoleCode.java
@@ -37,7 +37,7 @@ public enum CristinContributorRoleCode {
 
   @JsonCreator
   public static CristinContributorRoleCode fromString(String roleCode) {
-    return Arrays.stream(CristinContributorRoleCode.values())
+    return Arrays.stream(values())
         .filter(role -> role.getStringValue().equalsIgnoreCase(roleCode))
         .findAny()
         .orElseThrow(() -> new UnsupportedRoleException(UNKNOWN_ROLE_ERROR + roleCode));

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -32,58 +32,58 @@ public enum CristinMainCategory {
   }
 
   public static boolean isBook(CristinObject cristinObject) {
-    return CristinMainCategory.BOOK.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.BOOK == cristinObject.getMainCategory();
   }
 
   public static boolean isJournal(CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL.equals(cristinObject.getMainCategory())
-        && !CristinSecondaryCategory.WRITTEN_INTERVIEW.equals(cristinObject.getSecondaryCategory())
-        && !CristinSecondaryCategory.FEATURE_ARTICLE.equals(cristinObject.getSecondaryCategory());
+    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+        && CristinSecondaryCategory.WRITTEN_INTERVIEW != cristinObject.getSecondaryCategory()
+        && CristinSecondaryCategory.FEATURE_ARTICLE != cristinObject.getSecondaryCategory();
   }
 
   public static boolean isReport(CristinObject cristinObject) {
-    return CristinMainCategory.REPORT.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.REPORT == cristinObject.getMainCategory();
   }
 
   public static boolean isChapter(CristinObject cristinObject) {
-    return CristinMainCategory.CHAPTER.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.CHAPTER == cristinObject.getMainCategory();
   }
 
   public static boolean isEvent(CristinObject cristinObject) {
-    return CristinMainCategory.EVENT.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.EVENT == cristinObject.getMainCategory();
   }
 
   public static boolean isArt(CristinObject cristinObject) {
-    return CristinMainCategory.ARTISTIC_PRODUCTION.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.ARTISTIC_PRODUCTION == cristinObject.getMainCategory();
   }
 
   public static boolean isInformationMaterial(CristinObject cristinObject) {
-    return CristinMainCategory.INFORMATION_MATERIAL.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.INFORMATION_MATERIAL == cristinObject.getMainCategory();
   }
 
   public static boolean isExhibition(CristinObject cristinObject) {
-    return CristinMainCategory.EXHIBITION.equals(cristinObject.getMainCategory());
+    return CristinMainCategory.EXHIBITION == cristinObject.getMainCategory();
   }
 
   public static boolean isMediaContribution(CristinObject cristinObject) {
-    return CristinMainCategory.MEDIA_CONTRIBUTION.equals(cristinObject.getMainCategory())
+    return CristinMainCategory.MEDIA_CONTRIBUTION == cristinObject.getMainCategory()
         || mainAndSecondaryCategoryIndicatesWrittenInterview(cristinObject)
         || mainAndSecondaryCategoryIndicatesFeatureArticle(cristinObject);
   }
 
   private static boolean mainAndSecondaryCategoryIndicatesWrittenInterview(
       CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL.equals(cristinObject.getMainCategory())
-        && CristinSecondaryCategory.WRITTEN_INTERVIEW.equals(cristinObject.getSecondaryCategory());
+    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+        && CristinSecondaryCategory.WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
   }
 
   private static boolean mainAndSecondaryCategoryIndicatesFeatureArticle(
       CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL.equals(cristinObject.getMainCategory())
-        && CristinSecondaryCategory.FEATURE_ARTICLE.equals(cristinObject.getSecondaryCategory());
+    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+        && CristinSecondaryCategory.FEATURE_ARTICLE == cristinObject.getSecondaryCategory();
   }
 
   public boolean isUnknownCategory() {
-    return UNMAPPED.equals(this);
+    return UNMAPPED == this;
   }
 }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMainCategory.java
@@ -32,54 +32,54 @@ public enum CristinMainCategory {
   }
 
   public static boolean isBook(CristinObject cristinObject) {
-    return CristinMainCategory.BOOK == cristinObject.getMainCategory();
+    return BOOK == cristinObject.getMainCategory();
   }
 
   public static boolean isJournal(CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+    return JOURNAL == cristinObject.getMainCategory()
         && CristinSecondaryCategory.WRITTEN_INTERVIEW != cristinObject.getSecondaryCategory()
         && CristinSecondaryCategory.FEATURE_ARTICLE != cristinObject.getSecondaryCategory();
   }
 
   public static boolean isReport(CristinObject cristinObject) {
-    return CristinMainCategory.REPORT == cristinObject.getMainCategory();
+    return REPORT == cristinObject.getMainCategory();
   }
 
   public static boolean isChapter(CristinObject cristinObject) {
-    return CristinMainCategory.CHAPTER == cristinObject.getMainCategory();
+    return CHAPTER == cristinObject.getMainCategory();
   }
 
   public static boolean isEvent(CristinObject cristinObject) {
-    return CristinMainCategory.EVENT == cristinObject.getMainCategory();
+    return EVENT == cristinObject.getMainCategory();
   }
 
   public static boolean isArt(CristinObject cristinObject) {
-    return CristinMainCategory.ARTISTIC_PRODUCTION == cristinObject.getMainCategory();
+    return ARTISTIC_PRODUCTION == cristinObject.getMainCategory();
   }
 
   public static boolean isInformationMaterial(CristinObject cristinObject) {
-    return CristinMainCategory.INFORMATION_MATERIAL == cristinObject.getMainCategory();
+    return INFORMATION_MATERIAL == cristinObject.getMainCategory();
   }
 
   public static boolean isExhibition(CristinObject cristinObject) {
-    return CristinMainCategory.EXHIBITION == cristinObject.getMainCategory();
+    return EXHIBITION == cristinObject.getMainCategory();
   }
 
   public static boolean isMediaContribution(CristinObject cristinObject) {
-    return CristinMainCategory.MEDIA_CONTRIBUTION == cristinObject.getMainCategory()
+    return MEDIA_CONTRIBUTION == cristinObject.getMainCategory()
         || mainAndSecondaryCategoryIndicatesWrittenInterview(cristinObject)
         || mainAndSecondaryCategoryIndicatesFeatureArticle(cristinObject);
   }
 
   private static boolean mainAndSecondaryCategoryIndicatesWrittenInterview(
       CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+    return JOURNAL == cristinObject.getMainCategory()
         && CristinSecondaryCategory.WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
   }
 
   private static boolean mainAndSecondaryCategoryIndicatesFeatureArticle(
       CristinObject cristinObject) {
-    return CristinMainCategory.JOURNAL == cristinObject.getMainCategory()
+    return JOURNAL == cristinObject.getMainCategory()
         && CristinSecondaryCategory.FEATURE_ARTICLE == cristinObject.getSecondaryCategory();
   }
 

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMapper.java
@@ -71,12 +71,7 @@ import nva.commons.core.language.LanguageMapper;
 import nva.commons.core.paths.UriWrapper;
 import software.amazon.awssdk.services.s3.S3Client;
 
-@SuppressWarnings({
-  "PMD.GodClass",
-  "PMD.CouplingBetweenObjects",
-  "PMD.ForLoopCanBeForeach",
-  "PMD.ReturnEmptyCollectionRatherThanNull"
-})
+@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
 public class CristinMapper extends CristinMappingModule {
 
   public static final String CRISTIN_INSTITUTION_CODE = "CRIS";

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMediumTypeCode.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinMediumTypeCode.java
@@ -20,7 +20,7 @@ public enum CristinMediumTypeCode {
   }
 
   public static CristinMediumTypeCode fromValue(String value) {
-    return Arrays.stream(CristinMediumTypeCode.values())
+    return Arrays.stream(values())
         .filter(type -> type.getValue().equalsIgnoreCase(value))
         .collect(SingletonCollector.collect());
   }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -85,116 +85,111 @@ public enum CristinSecondaryCategory {
   }
 
   public static boolean isAnthology(CristinObject cristinObject) {
-    return CristinSecondaryCategory.ANTHOLOGY.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.ANTHOLOGY == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMonograph(CristinObject cristinObject) {
-    return CristinSecondaryCategory.MONOGRAPH.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.TEXTBOOK.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.NON_FICTION_BOOK.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.ENCYCLOPEDIA.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.POPULAR_BOOK.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.REFERENCE_MATERIAL.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.EXHIBITION_CATALOG.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.ACADEMIC_COMMENTARY.equals(
-            cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.MONOGRAPH == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.TEXTBOOK == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.NON_FICTION_BOOK == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.ENCYCLOPEDIA == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.POPULAR_BOOK == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.REFERENCE_MATERIAL == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.EXHIBITION_CATALOG == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.ACADEMIC_COMMENTARY == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalLetter(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_LETTER.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.READER_OPINION.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.JOURNAL_LETTER == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.READER_OPINION == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalReview(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_REVIEW.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.JOURNAL_REVIEW == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalLeader(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_LEADER.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.JOURNAL_LEADER == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isAbstract(CristinObject cristinObject) {
-    return CristinSecondaryCategory.ABSTRACT.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.ABSTRACT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalCorrigendum(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_CORRIGENDUM.equals(
-        cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.JOURNAL_CORRIGENDUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalArticle(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_ARTICLE.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.POPULAR_ARTICLE.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.ARTICLE.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.ACADEMIC_REVIEW.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.SHORT_COMMUNICATION.equals(
-            cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.JOURNAL_ARTICLE == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.POPULAR_ARTICLE == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.ARTICLE == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.ACADEMIC_REVIEW == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.SHORT_COMMUNICATION == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isResearchReport(CristinObject cristinObject) {
-    return CristinSecondaryCategory.RESEARCH_REPORT.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.RESEARCH_REPORT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreePhd(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_PHD.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.MAGISTER_THESIS.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.DEGREE_PHD == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.MAGISTER_THESIS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreeMaster(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_MASTER.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.SECOND_DEGREE_THESIS.equals(
-            cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.MEDICAL_THESIS.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.DEGREE_MASTER == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.SECOND_DEGREE_THESIS == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.MEDICAL_THESIS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreeLicentiate(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_LICENTIATE.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.DEGREE_LICENTIATE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isReportWorkingPaper(CristinObject cristinObject) {
-    return CristinSecondaryCategory.COMPENDIUM.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.COMPENDIUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isBriefs(CristinObject cristinObject) {
-    return CristinSecondaryCategory.BRIEFS.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.BRIEFS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isInterview(CristinObject cristinObject) {
-    return CristinSecondaryCategory.INTERVIEW.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.WRITTEN_INTERVIEW.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.INTERVIEW == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMuseum(CristinObject cristinObject) {
-    return CristinSecondaryCategory.MUSEUM.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.MUSEUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isProgramParticipation(CristinObject cristinObject) {
-    return CristinSecondaryCategory.PROGRAM_PARTICIPATION.equals(
-            cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.PROGRAM_MANAGEMENT.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.PROGRAM_PARTICIPATION == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.PROGRAM_MANAGEMENT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMediaFeatureArticle(CristinObject cristinObject) {
-    return CristinSecondaryCategory.FEATURE_ARTICLE.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.FEATURE_ARTICLE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isConferenceLecture(CristinObject cristinObject) {
-    return CristinSecondaryCategory.CONFERENCE_LECTURE.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.CONFERENCE_LECTURE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isConferencePoster(CristinObject cristinObject) {
-    return CristinSecondaryCategory.CONFERENCE_POSTER.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.CONFERENCE_POSTER == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isLecture(CristinObject cristinObject) {
-    return CristinSecondaryCategory.LECTURE.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.POPULAR_SCIENTIFIC_LECTURE.equals(
-            cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.LECTURE == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.POPULAR_SCIENTIFIC_LECTURE
+            == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isOtherPresentation(CristinObject cristinObject) {
-    return CristinSecondaryCategory.OTHER_PRESENTATION.equals(cristinObject.getSecondaryCategory())
-        || CristinSecondaryCategory.INTERNET_EXHIBIT.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.OTHER_PRESENTATION == cristinObject.getSecondaryCategory()
+        || CristinSecondaryCategory.INTERNET_EXHIBIT == cristinObject.getSecondaryCategory();
   }
 
   @JsonValue
@@ -206,7 +201,7 @@ public enum CristinSecondaryCategory {
   }
 
   public boolean isUnknownCategory() {
-    return UNMAPPED.equals(this);
+    return UNMAPPED == this;
   }
 
   public JournalArticleContentType toJournalArticleContentType() {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/CristinSecondaryCategory.java
@@ -85,111 +85,110 @@ public enum CristinSecondaryCategory {
   }
 
   public static boolean isAnthology(CristinObject cristinObject) {
-    return CristinSecondaryCategory.ANTHOLOGY == cristinObject.getSecondaryCategory();
+    return ANTHOLOGY == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMonograph(CristinObject cristinObject) {
-    return CristinSecondaryCategory.MONOGRAPH == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.TEXTBOOK == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.NON_FICTION_BOOK == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.ENCYCLOPEDIA == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.POPULAR_BOOK == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.REFERENCE_MATERIAL == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.EXHIBITION_CATALOG == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.ACADEMIC_COMMENTARY == cristinObject.getSecondaryCategory();
+    return MONOGRAPH == cristinObject.getSecondaryCategory()
+        || TEXTBOOK == cristinObject.getSecondaryCategory()
+        || NON_FICTION_BOOK == cristinObject.getSecondaryCategory()
+        || ENCYCLOPEDIA == cristinObject.getSecondaryCategory()
+        || POPULAR_BOOK == cristinObject.getSecondaryCategory()
+        || REFERENCE_MATERIAL == cristinObject.getSecondaryCategory()
+        || EXHIBITION_CATALOG == cristinObject.getSecondaryCategory()
+        || ACADEMIC_COMMENTARY == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalLetter(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_LETTER == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.READER_OPINION == cristinObject.getSecondaryCategory();
+    return JOURNAL_LETTER == cristinObject.getSecondaryCategory()
+        || READER_OPINION == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalReview(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_REVIEW == cristinObject.getSecondaryCategory();
+    return JOURNAL_REVIEW == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalLeader(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_LEADER == cristinObject.getSecondaryCategory();
+    return JOURNAL_LEADER == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isAbstract(CristinObject cristinObject) {
-    return CristinSecondaryCategory.ABSTRACT == cristinObject.getSecondaryCategory();
+    return ABSTRACT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalCorrigendum(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_CORRIGENDUM == cristinObject.getSecondaryCategory();
+    return JOURNAL_CORRIGENDUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isJournalArticle(CristinObject cristinObject) {
-    return CristinSecondaryCategory.JOURNAL_ARTICLE == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.POPULAR_ARTICLE == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.ARTICLE == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.ACADEMIC_REVIEW == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.SHORT_COMMUNICATION == cristinObject.getSecondaryCategory();
+    return JOURNAL_ARTICLE == cristinObject.getSecondaryCategory()
+        || POPULAR_ARTICLE == cristinObject.getSecondaryCategory()
+        || ARTICLE == cristinObject.getSecondaryCategory()
+        || ACADEMIC_REVIEW == cristinObject.getSecondaryCategory()
+        || SHORT_COMMUNICATION == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isResearchReport(CristinObject cristinObject) {
-    return CristinSecondaryCategory.RESEARCH_REPORT == cristinObject.getSecondaryCategory();
+    return RESEARCH_REPORT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreePhd(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_PHD == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.MAGISTER_THESIS == cristinObject.getSecondaryCategory();
+    return DEGREE_PHD == cristinObject.getSecondaryCategory()
+        || MAGISTER_THESIS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreeMaster(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_MASTER == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.SECOND_DEGREE_THESIS == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.MEDICAL_THESIS == cristinObject.getSecondaryCategory();
+    return DEGREE_MASTER == cristinObject.getSecondaryCategory()
+        || SECOND_DEGREE_THESIS == cristinObject.getSecondaryCategory()
+        || MEDICAL_THESIS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isDegreeLicentiate(CristinObject cristinObject) {
-    return CristinSecondaryCategory.DEGREE_LICENTIATE == cristinObject.getSecondaryCategory();
+    return DEGREE_LICENTIATE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isReportWorkingPaper(CristinObject cristinObject) {
-    return CristinSecondaryCategory.COMPENDIUM == cristinObject.getSecondaryCategory();
+    return COMPENDIUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isBriefs(CristinObject cristinObject) {
-    return CristinSecondaryCategory.BRIEFS == cristinObject.getSecondaryCategory();
+    return BRIEFS == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isInterview(CristinObject cristinObject) {
-    return CristinSecondaryCategory.INTERVIEW == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
+    return INTERVIEW == cristinObject.getSecondaryCategory()
+        || WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMuseum(CristinObject cristinObject) {
-    return CristinSecondaryCategory.MUSEUM == cristinObject.getSecondaryCategory();
+    return MUSEUM == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isProgramParticipation(CristinObject cristinObject) {
-    return CristinSecondaryCategory.PROGRAM_PARTICIPATION == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.PROGRAM_MANAGEMENT == cristinObject.getSecondaryCategory();
+    return PROGRAM_PARTICIPATION == cristinObject.getSecondaryCategory()
+        || PROGRAM_MANAGEMENT == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isMediaFeatureArticle(CristinObject cristinObject) {
-    return CristinSecondaryCategory.FEATURE_ARTICLE == cristinObject.getSecondaryCategory();
+    return FEATURE_ARTICLE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isConferenceLecture(CristinObject cristinObject) {
-    return CristinSecondaryCategory.CONFERENCE_LECTURE == cristinObject.getSecondaryCategory();
+    return CONFERENCE_LECTURE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isConferencePoster(CristinObject cristinObject) {
-    return CristinSecondaryCategory.CONFERENCE_POSTER == cristinObject.getSecondaryCategory();
+    return CONFERENCE_POSTER == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isLecture(CristinObject cristinObject) {
-    return CristinSecondaryCategory.LECTURE == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.POPULAR_SCIENTIFIC_LECTURE
-            == cristinObject.getSecondaryCategory();
+    return LECTURE == cristinObject.getSecondaryCategory()
+        || POPULAR_SCIENTIFIC_LECTURE == cristinObject.getSecondaryCategory();
   }
 
   public static boolean isOtherPresentation(CristinObject cristinObject) {
-    return CristinSecondaryCategory.OTHER_PRESENTATION == cristinObject.getSecondaryCategory()
-        || CristinSecondaryCategory.INTERNET_EXHIBIT == cristinObject.getSecondaryCategory();
+    return OTHER_PRESENTATION == cristinObject.getSecondaryCategory()
+        || INTERNET_EXHIBIT == cristinObject.getSecondaryCategory();
   }
 
   @JsonValue

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/JournalBuilder.java
@@ -106,19 +106,19 @@ public class JournalBuilder extends AbstractPublicationInstanceBuilder {
     Range numberOfPages = new Range(extractPagesBegin(), extractPagesEnd());
 
     var secondaryCategory = getCristinObject().getSecondaryCategory();
-    if (CristinSecondaryCategory.JOURNAL_ARTICLE.equals(secondaryCategory)) {
+    if (CristinSecondaryCategory.JOURNAL_ARTICLE == secondaryCategory) {
       return new ProfessionalArticle(
           numberOfPages, extractVolume(), extractIssue(), extractArticleNumber());
-    } else if (CristinSecondaryCategory.POPULAR_ARTICLE.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.POPULAR_ARTICLE == secondaryCategory) {
       return new PopularScienceArticle(
           numberOfPages, extractVolume(), extractIssue(), extractArticleNumber());
-    } else if (CristinSecondaryCategory.ARTICLE.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.ARTICLE == secondaryCategory) {
       return new AcademicArticle(
           numberOfPages, extractVolume(), extractIssue(), extractArticleNumber());
-    } else if (CristinSecondaryCategory.ACADEMIC_REVIEW.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.ACADEMIC_REVIEW == secondaryCategory) {
       return new AcademicLiteratureReview(
           numberOfPages, extractVolume(), extractIssue(), extractArticleNumber());
-    } else if (CristinSecondaryCategory.SHORT_COMMUNICATION.equals(secondaryCategory)) {
+    } else if (CristinSecondaryCategory.SHORT_COMMUNICATION == secondaryCategory) {
       return new AcademicArticle(
           numberOfPages, extractVolume(), extractIssue(), extractArticleNumber());
     } else {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublishingChannelEntryResolver.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/PublishingChannelEntryResolver.java
@@ -109,7 +109,7 @@ public class PublishingChannelEntryResolver {
 
   private URI toSeriesUri(ChannelRegistryEntry channelRegistryEntry) {
     var uri = getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
-    if (!ChannelType.SERIES.equals(channelRegistryEntry.type())) {
+    if (ChannelType.SERIES != channelRegistryEntry.type()) {
       ErrorReport.exceptionName(WrongChannelTypeException.name())
           .withBody(uri.toString())
           .withCristinId(cristinId)
@@ -131,7 +131,7 @@ public class PublishingChannelEntryResolver {
 
   private URI toJournalUri(ChannelRegistryEntry channelRegistryEntry) {
     var uri = getNsdProxyUri(channelRegistryEntry.getEntryPath(), channelRegistryEntry.id());
-    if (!ChannelType.JOURNAL.equals(channelRegistryEntry.type())) {
+    if (ChannelType.JOURNAL != channelRegistryEntry.type()) {
       ErrorReport.exceptionName(WrongChannelTypeException.class.getSimpleName())
           .withBody(uri.toString())
           .withCristinId(cristinId)

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/artisticproduction/CristinArtisticProduction.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/artisticproduction/CristinArtisticProduction.java
@@ -75,7 +75,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Setter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @JsonIgnoreProperties({"status_bestilt", "produkttype"})
-@SuppressWarnings({"PMD.TooManyFields", "PMD.GodClass", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings({"PMD.TooManyFields", "PMD.CouplingBetweenObjects"})
 public class CristinArtisticProduction implements DescriptionExtractor, MovingPictureExtractor {
 
   @JsonIgnore public static final String YES = "J";

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/channelregistry/ChannelRegistryEntry.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/channelregistry/ChannelRegistryEntry.java
@@ -33,7 +33,7 @@ public record ChannelRegistryEntry(String id, ChannelType type) {
     }
 
     public static ChannelType fromValue(String value) {
-      return Arrays.stream(ChannelType.values())
+      return Arrays.stream(values())
           .filter(type -> type.getValue().equalsIgnoreCase(value))
           .collect(SingletonCollector.collectOrElse(null));
     }

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/NviReport.java
@@ -31,7 +31,7 @@ public record NviReport(
   public static NviReport fromPublicationRepresentation(
       PublicationRepresentations publicationRepresentations) {
     var publication = getPublication(publicationRepresentations);
-    return NviReport.builder()
+    return builder()
         .withPublicationIdentifier(publicationRepresentations.getNvaPublicationIdentifier())
         .withCristinIdentifier(
             publicationRepresentations.getCristinObject().getSourceRecordIdentifier())

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -92,7 +92,6 @@ public class ReferenceBuilder extends CristinMappingModule {
         .build();
   }
 
-  @SuppressWarnings({"PMD.NPathComplexity"})
   private PublicationContext buildPublicationContext()
       throws InvalidIsbnException, InvalidIssnException, InvalidUnconfirmedSeriesException {
     if (isBook(cristinObject)) {

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/ReferenceBuilder.java
@@ -168,7 +168,7 @@ public class ReferenceBuilder extends CristinMappingModule {
   }
 
   private boolean isWrittenInterview(CristinObject cristinObject) {
-    return CristinSecondaryCategory.WRITTEN_INTERVIEW.equals(cristinObject.getSecondaryCategory());
+    return CristinSecondaryCategory.WRITTEN_INTERVIEW == cristinObject.getSecondaryCategory();
   }
 
   private PublicationContext buildPublicationContextWhenMainCategoryIsReport()

--- a/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ExceptionHandling.java
+++ b/cristin-import/src/main/java/no/unit/nva/cristin/mapper/nva/exceptions/ExceptionHandling.java
@@ -8,7 +8,6 @@ public final class ExceptionHandling {
   @JacocoGenerated
   public ExceptionHandling() {}
 
-  @SuppressWarnings("PMD.NPathComplexity")
   public static RuntimeException castToCorrectRuntimeException(Exception exception) {
     if (exception instanceof InvalidIssnRuntimeException) {
       return (InvalidIssnRuntimeException) exception;

--- a/datacite-commons/src/main/java/no/unit/nva/doi/ReserveDoiRequestValidator.java
+++ b/datacite-commons/src/main/java/no/unit/nva/doi/ReserveDoiRequestValidator.java
@@ -33,7 +33,7 @@ public final class ReserveDoiRequestValidator {
   }
 
   private static boolean isNotADraft(Resource resource) {
-    return !PublicationStatus.DRAFT.equals(resource.getStatus());
+    return PublicationStatus.DRAFT != resource.getStatus();
   }
 
   private static void validateReserveDoiRequest(UserInstance userInstance, Resource resource)

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
@@ -18,7 +18,6 @@ import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(ExpandedDoiRequest.TYPE)
-@SuppressWarnings("PMD.TooManyFields")
 public final class ExpandedDoiRequest extends ExpandedTicket {
 
   public static final String TYPE = "DoiRequest";

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedDoiRequest.java
@@ -31,8 +31,7 @@ public final class ExpandedDoiRequest extends ExpandedTicket {
       ResourceService resourceService,
       TicketService ticketService)
       throws NotFoundException {
-    var expandedDoiRequest =
-        ExpandedDoiRequest.fromDoiRequest(doiRequest, resourceService, expansionService);
+    var expandedDoiRequest = fromDoiRequest(doiRequest, resourceService, expansionService);
     expandedDoiRequest.setOrganization(expansionService.getOrganization(doiRequest));
     expandedDoiRequest.setMessages(
         expandMessages(doiRequest.fetchMessages(ticketService), expansionService));

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
@@ -387,8 +387,7 @@ public class ExpandedImportCandidate implements ExpandedDataEntry {
   }
 
   private static boolean isVerifiedContributor(ImportContributor contributor) {
-    return ContributorVerificationStatus.VERIFIED.equals(
-        contributor.identity().getVerificationStatus());
+    return ContributorVerificationStatus.VERIFIED == contributor.identity().getVerificationStatus();
   }
 
   private static URI generateIdentifier(SortableIdentifier identifier) {

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedImportCandidate.java
@@ -49,12 +49,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({
-  "PMD.GodClass",
-  "PMD.ExcessivePublicCount",
-  "PMD.TooManyFields",
-  "PMD.CouplingBetweenObjects"
-})
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyFields", "PMD.CouplingBetweenObjects"})
 @JsonTypeName(ExpandedImportCandidate.TYPE)
 public class ExpandedImportCandidate implements ExpandedDataEntry {
 

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedMessage.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedMessage.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
-import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.expansion.ResourceExpansionService;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.publication.model.business.Message;
@@ -18,7 +17,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(ExpandedMessage.TYPE)
-public class ExpandedMessage implements JsonSerializable, ExpandedDataEntry {
+public class ExpandedMessage implements ExpandedDataEntry {
 
   public static final String TYPE = "Message";
   public static final String TEXT_JSON_NAME = "text";

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import no.unit.nva.auth.uriretriever.RawContentRetriever;
-import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.expansion.ExpansionConfig;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.Publication;
@@ -50,7 +49,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.GodClass")
 @JsonTypeName(ExpandedResource.TYPE)
-public final class ExpandedResource implements JsonSerializable, ExpandedDataEntry {
+public final class ExpandedResource implements ExpandedDataEntry {
   // The ExpandedResource differs from ExpandedDoiRequest and ExpandedMessage
   // because it does not extend the Resource or Publication class,
   // but it contains its data as an inner Json Node.

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedResource.java
@@ -269,7 +269,7 @@ public final class ExpandedResource implements ExpandedDataEntry {
   }
 
   private static URI extractLicenseFromAssociatedArtifactNode(JsonNode node) {
-    return Optional.ofNullable(node.get(ExpandedResource.LICENSE_FIELD))
+    return Optional.ofNullable(node.get(LICENSE_FIELD))
         .map(JsonNode::asText)
         .map(URI::create)
         .orElse(null);

--- a/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedTicketStatus.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/ExpandedTicketStatus.java
@@ -23,7 +23,7 @@ public enum ExpandedTicketStatus {
   }
 
   public static ExpandedTicketStatus parse(String candidate) {
-    return Arrays.stream(ExpandedTicketStatus.values())
+    return Arrays.stream(values())
         .filter(enumValue -> enumValue.filterByNameOrValue(candidate))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow(fail -> handleParsingError());

--- a/expansion/src/main/java/no/unit/nva/expansion/model/License.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/model/License.java
@@ -46,7 +46,7 @@ public record License(URI value, String name, Map<String, String> labels)
     }
 
     public static LicenseType fromUri(URI uri) {
-      return Arrays.stream(LicenseType.values())
+      return Arrays.stream(values())
           .filter(licenseType -> licenseType.hasPathParam(uri))
           .findFirst()
           .orElse(OTHER);

--- a/expansion/src/main/java/no/unit/nva/expansion/utils/AffiliationQueries.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/utils/AffiliationQueries.java
@@ -3,7 +3,6 @@ package no.unit.nva.expansion.utils;
 import java.nio.file.Path;
 import nva.commons.core.ioutils.IoUtils;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class AffiliationQueries {
 
   public static final String TOP_LEVEL_ORGANIZATION =

--- a/expansion/src/main/java/no/unit/nva/expansion/utils/ExpandedTicketStatusMapper.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/utils/ExpandedTicketStatusMapper.java
@@ -24,6 +24,6 @@ public final class ExpandedTicketStatusMapper {
   }
 
   private static boolean isPending(TicketEntry ticketEntry) {
-    return TicketStatus.PENDING.equals(ticketEntry.getStatus());
+    return TicketStatus.PENDING == ticketEntry.getStatus();
   }
 }

--- a/expansion/src/main/java/no/unit/nva/expansion/utils/SearchIndexFrame.java
+++ b/expansion/src/main/java/no/unit/nva/expansion/utils/SearchIndexFrame.java
@@ -13,7 +13,6 @@ import no.unit.nva.model.Publication;
 import no.unit.nva.publication.utils.JsonLdFrameUtil;
 import nva.commons.core.ioutils.IoUtils;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SearchIndexFrame {
 
   public static JsonDocument getFrameWithContext(Path framePath) {

--- a/messages/src/main/java/no/unit/nva/publication/messages/delete/DeleteMessageHandler.java
+++ b/messages/src/main/java/no/unit/nva/publication/messages/delete/DeleteMessageHandler.java
@@ -85,7 +85,7 @@ public class DeleteMessageHandler extends ApiGatewayHandler<Void, Void> {
   }
 
   private static boolean allMessagesAreDeleted(List<Message> messages) {
-    return messages.stream().allMatch(message -> DELETED.equals(message.getStatus()));
+    return messages.stream().allMatch(message -> DELETED == message.getStatus());
   }
 
   private void completeTicketWhenGeneralSupportWithNoActiveMessages(

--- a/publication-commons/src/main/java/no/unit/nva/publication/PublicationServiceConfig.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/PublicationServiceConfig.java
@@ -55,7 +55,7 @@ public final class PublicationServiceConfig {
   @JacocoGenerated
   private static S3Client defaultS3Client() {
     return S3Client.builder()
-        .region(Region.of(PublicationServiceConfig.AWS_REGION))
+        .region(Region.of(AWS_REGION))
         .httpClient(UrlConnectionHttpClient.create())
         .build();
   }

--- a/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
@@ -82,7 +82,6 @@ public final class RequestUtil {
    * @return the owner
    * @throws ApiGatewayException exception thrown if value is missing
    */
-  @SuppressWarnings("PMD.InvalidLogMessageFormat")
   public static String getOwner(RequestInfo requestInfo) throws ApiGatewayException {
     return attempt(requestInfo::getUserName).orElseThrow(fail -> new UnauthorizedException());
   }

--- a/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/RequestUtil.java
@@ -115,7 +115,7 @@ public final class RequestUtil {
 
   private static UserInstance createDataportenUserInstance(RequestInfo requestInfo)
       throws ApiGatewayException {
-    String owner = RequestUtil.getOwner(requestInfo);
+    String owner = getOwner(requestInfo);
     var customerId = requestInfo.getCurrentCustomer();
     var personCristinId = attempt(requestInfo::getPersonCristinId).toOptional().orElse(null);
     var topLevelOrg =

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/FilesApprovalEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/FilesApprovalEntry.java
@@ -196,7 +196,7 @@ public abstract class FilesApprovalEntry extends TicketEntry {
   }
 
   protected boolean canPublishMetadataAndNoFilesToApprove(PublishingWorkflow workflow) {
-    return REGISTRATOR_PUBLISHES_METADATA_ONLY.equals(workflow) && getFilesForApproval().isEmpty();
+    return REGISTRATOR_PUBLISHES_METADATA_ONLY == workflow && getFilesForApproval().isEmpty();
   }
 
   protected FilesApprovalEntry handleMetadataOnlyWorkflow(

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
@@ -56,7 +56,7 @@ public class DoiRequest extends TicketEntry {
   }
 
   public static DoiRequest create(Resource resource, UserInstance userInstance) {
-    if (!PUBLISHED.equals(resource.getStatus())) {
+    if (PUBLISHED != resource.getStatus()) {
       throw new InvalidTicketStatusTransitionException(
           WRONG_PUBLICATION_STATUS_ERROR.formatted(PUBLISHED));
     }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
@@ -28,7 +28,6 @@ import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
-@SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount", "PMD.TooManyFields"})
 public class DoiRequest extends TicketEntry {
 
   public static final String RESOURCE_STATUS_FIELD = "resourceStatus";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/DoiRequest.java
@@ -78,7 +78,7 @@ public class DoiRequest extends TicketEntry {
 
   @Override
   public String getType() {
-    return DoiRequest.TYPE;
+    return TYPE;
   }
 
   @Override
@@ -118,7 +118,7 @@ public class DoiRequest extends TicketEntry {
 
   @Override
   public DoiRequest copy() {
-    return DoiRequest.builder()
+    return builder()
         .withIdentifier(getIdentifier())
         .withResourceIdentifier(getResourceIdentifier())
         .withStatus(getStatus())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FilesApprovalThesis.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FilesApprovalThesis.java
@@ -16,7 +16,6 @@ import no.unit.nva.publication.model.storage.FilesApprovalThesisDao;
 import no.unit.nva.publication.model.storage.TicketDao;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings({"PMD.GodClass"})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName(FilesApprovalThesis.TYPE)
 public class FilesApprovalThesis extends FilesApprovalEntry {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/FilesApprovalThesis.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/FilesApprovalThesis.java
@@ -35,7 +35,7 @@ public class FilesApprovalThesis extends FilesApprovalEntry {
     var fileApproval =
         createFileApproval(
             resource, userInstance, channelOwnerOrganizationId, channelClaimIdentifier, workflow);
-    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(workflow)
+    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES == workflow
         ? (FilesApprovalThesis) fileApproval.completeAndApproveFiles(resource, userInstance)
         : (FilesApprovalThesis)
             fileApproval.handleMetadataOnlyWorkflow(resource, userInstance, workflow);
@@ -44,7 +44,7 @@ public class FilesApprovalThesis extends FilesApprovalEntry {
   public static FilesApprovalThesis createForUserInstitution(
       Resource resource, UserInstance userInstance, PublishingWorkflow workflow) {
     var fileApproval = createFileApproval(resource, userInstance, workflow);
-    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(workflow)
+    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES == workflow
         ? (FilesApprovalThesis) fileApproval.completeAndApproveFiles(resource, userInstance)
         : (FilesApprovalThesis)
             fileApproval.handleMetadataOnlyWorkflow(resource, userInstance, workflow);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Message.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Message.java
@@ -153,7 +153,7 @@ public class Message implements Entity, JsonSerializable {
 
   @Override
   public String getType() {
-    return Message.TYPE;
+    return TYPE;
   }
 
   @Override
@@ -229,7 +229,7 @@ public class Message implements Entity, JsonSerializable {
   }
 
   public Message copy() {
-    return Message.builder()
+    return builder()
         .withStatus(this.getStatus())
         .withCreatedDate(this.getCreatedDate())
         .withCustomerId(this.getCustomerId())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Message.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Message.java
@@ -18,7 +18,6 @@ import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
-@SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 public class Message implements Entity, JsonSerializable {
 
   public static final String TYPE = "Message";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -33,7 +33,7 @@ public class PublishingRequestCase extends FilesApprovalEntry {
   public static PublishingRequestCase create(
       Resource resource, UserInstance userInstance, PublishingWorkflow workflow) {
     var publishingRequestCase = createPublishingRequest(resource, userInstance, workflow);
-    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES.equals(workflow)
+    return REGISTRATOR_PUBLISHES_METADATA_AND_FILES == workflow
         ? (PublishingRequestCase)
             publishingRequestCase.completeAndApproveFiles(resource, userInstance)
         : (PublishingRequestCase)

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingRequestCase.java
@@ -104,7 +104,7 @@ public class PublishingRequestCase extends FilesApprovalEntry {
 
   @Override
   public String getType() {
-    return PublishingRequestCase.TYPE;
+    return TYPE;
   }
 
   @Override

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingWorkflow.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/PublishingWorkflow.java
@@ -41,9 +41,7 @@ public enum PublishingWorkflow {
   @JacocoGenerated
   private static RuntimeException throwException(String value) {
     var validValues =
-        stream(PublishingWorkflow.values())
-            .map(PublishingWorkflow::toString)
-            .collect(joining(DELIMITER));
+        stream(values()).map(PublishingWorkflow::toString).collect(joining(DELIMITER));
     return new IllegalArgumentException(format(ERROR_MESSAGE_TEMPLATE, value, validValues));
   }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -281,7 +281,7 @@ public class Resource implements Entity, Validatable<Resource> {
         .filter(ClaimedPublicationChannel.class::isInstance)
         .map(ClaimedPublicationChannel.class::cast)
         .filter(this::isWithingChannelClaimScope)
-        .filter(publicationChannel -> channelType.equals(publicationChannel.getChannelType()))
+        .filter(publicationChannel -> channelType == publicationChannel.getChannelType())
         .findFirst();
   }
 
@@ -473,7 +473,7 @@ public class Resource implements Entity, Validatable<Resource> {
   }
 
   private boolean isPublished() {
-    return PUBLISHED.equals(this.getStatus());
+    return PUBLISHED == this.getStatus();
   }
 
   public void republish(
@@ -503,7 +503,7 @@ public class Resource implements Entity, Validatable<Resource> {
     return (ticket instanceof FilesApprovalEntry
             || ticket instanceof GeneralSupportRequest
             || ticket instanceof DoiRequest)
-        && NOT_APPLICABLE.equals(ticket.getStatus());
+        && NOT_APPLICABLE == ticket.getStatus();
   }
 
   private void republish(UserInstance userInstance, ResourceService resourceService) {
@@ -512,7 +512,7 @@ public class Resource implements Entity, Validatable<Resource> {
   }
 
   private void republish(UserInstance userInstance) {
-    if (!UNPUBLISHED.equals(this.getStatus())) {
+    if (UNPUBLISHED != this.getStatus()) {
       throw new IllegalStateException("Only unpublished resource can be republished!");
     }
     this.setStatus(PUBLISHED);

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/Resource.java
@@ -332,7 +332,7 @@ public class Resource implements Entity, Validatable<Resource> {
   }
 
   private static Resource convertToResource(Publication publication) {
-    return Resource.builder()
+    return builder()
         .withIdentifier(publication.getIdentifier())
         .withResourceOwner(Owner.fromResourceOwner(publication.getResourceOwner()))
         .withCreatedDate(publication.getCreatedDate())
@@ -754,7 +754,7 @@ public class Resource implements Entity, Validatable<Resource> {
   }
 
   public ResourceBuilder copy() {
-    return Resource.builder()
+    return builder()
         .withIdentifier(getIdentifier())
         .withStatus(getStatus())
         .withResourceOwner(Owner.fromResourceOwner(extractResourceOwner()))

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceBuilder.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceBuilder.java
@@ -20,7 +20,7 @@ import no.unit.nva.model.funding.Funding;
 import no.unit.nva.publication.model.business.publicationchannel.PublicationChannel;
 import no.unit.nva.publication.model.business.publicationstate.ResourceEvent;
 
-@SuppressWarnings({"PMD.TooManyFields", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings("PMD.TooManyFields")
 public final class ResourceBuilder {
 
   private SortableIdentifier identifier;

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceRelationship.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/ResourceRelationship.java
@@ -40,7 +40,7 @@ public record ResourceRelationship(
   }
 
   private static boolean isPublished(Resource resource) {
-    return PUBLISHED.equals(resource.getStatus());
+    return PUBLISHED == resource.getStatus();
   }
 
   private static boolean isPublicationId(URI uri) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -33,7 +33,7 @@ import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.apigateway.exceptions.ForbiddenException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 
-@SuppressWarnings({"PMD.GodClass", "PMD.FinalizeOverloaded", "PMD.ExcessivePublicCount"})
+@SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(name = DoiRequest.TYPE, value = DoiRequest.class),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketEntry.java
@@ -351,7 +351,7 @@ public abstract class TicketEntry implements Entity {
   }
 
   public void validateClosingRequirements() throws ApiGatewayException {
-    if (!getStatus().equals(TicketStatus.PENDING)) {
+    if (getStatus() != TicketStatus.PENDING) {
       var errorMessage =
           String.format(
               "Cannot close a ticket that has any other status than %s", TicketStatus.PENDING);
@@ -365,7 +365,7 @@ public abstract class TicketEntry implements Entity {
   }
 
   public boolean isPending() {
-    return TicketStatus.PENDING.equals(getStatus());
+    return TicketStatus.PENDING == getStatus();
   }
 
   public TicketEntry withOwner(String username) {
@@ -395,7 +395,7 @@ public abstract class TicketEntry implements Entity {
   }
 
   private boolean isNotPending() {
-    return !TicketStatus.PENDING.equals(getStatus());
+    return TicketStatus.PENDING != getStatus();
   }
 
   private boolean isNotTicketOwner(UserInstance userInstance) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketStatus.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/TicketStatus.java
@@ -40,7 +40,7 @@ public enum TicketStatus {
 
   @JsonCreator
   public static TicketStatus parse(String candidate) {
-    return Arrays.stream(TicketStatus.values())
+    return Arrays.stream(values())
         .filter(enumValue -> enumValue.filterByNameOrValue(candidate))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow(fail -> handleParsingError());
@@ -82,7 +82,7 @@ public enum TicketStatus {
   }
 
   private static String validValues() {
-    return Arrays.stream(TicketStatus.values())
+    return Arrays.stream(values())
         .map(TicketStatus::toString)
         .collect(Collectors.joining(SEPARATOR));
   }

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UnpublishRequest.java
@@ -36,7 +36,7 @@ public class UnpublishRequest extends TicketEntry {
     // TODO: Who is ticket owner? Currently publication owner to pass tests
     var owner = extractOwner(publication);
 
-    return UnpublishRequest.builder()
+    return builder()
         .withIdentifier(SortableIdentifier.next())
         .withResourceIdentifier(publication.getIdentifier())
         .withStatus(TicketStatus.PENDING)
@@ -84,7 +84,7 @@ public class UnpublishRequest extends TicketEntry {
 
   @Override
   public TicketEntry copy() {
-    return UnpublishRequest.builder()
+    return builder()
         .withIdentifier(getIdentifier())
         .withResourceIdentifier(getResourceIdentifier())
         .withStatus(getStatus())

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -164,7 +164,7 @@ public class UserInstance implements JsonSerializable {
   }
 
   public static UserInstance fromMessage(Message message) {
-    return UserInstance.create(message.getOwner(), message.getCustomerId());
+    return create(message.getOwner(), message.getCustomerId());
   }
 
   public static UserInstance fromTicket(TicketEntry ticket) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/business/UserInstance.java
@@ -121,11 +121,11 @@ public class UserInstance implements JsonSerializable {
   }
 
   public boolean isExternalClient() {
-    return this.userClientType.equals(UserClientType.EXTERNAL);
+    return this.userClientType == UserClientType.EXTERNAL;
   }
 
   public boolean isBackendClient() {
-    return this.userClientType.equals(UserClientType.BACKEND);
+    return this.userClientType == UserClientType.BACKEND;
   }
 
   public static UserInstance fromRequestInfo(RequestInfo requestInfo) throws UnauthorizedException {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/Dao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/Dao.java
@@ -29,7 +29,6 @@ import no.unit.nva.publication.model.business.User;
 import no.unit.nva.publication.storage.model.DatabaseConstants;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(name = ResourceDao.TYPE, value = ResourceDao.class),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/DoiRequestDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/DoiRequestDao.java
@@ -17,7 +17,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(DoiRequestDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class DoiRequestDao extends TicketDao implements JoinWithResource, JsonSerializable {
+public class DoiRequestDao extends TicketDao implements JsonSerializable {
 
   public static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX =
       TicketDao.ALPHABETICALLY_ORDERED_FIRST_TICKET_TYPE;

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/DoiRequestDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/DoiRequestDao.java
@@ -20,7 +20,7 @@ import nva.commons.core.JacocoGenerated;
 public class DoiRequestDao extends TicketDao implements JsonSerializable {
 
   public static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX =
-      TicketDao.ALPHABETICALLY_ORDERED_FIRST_TICKET_TYPE;
+      ALPHABETICALLY_ORDERED_FIRST_TICKET_TYPE;
   public static final String TYPE = "DoiRequest";
 
   @JacocoGenerated

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FileDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FileDao.java
@@ -40,7 +40,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(FileDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public final class FileDao extends Dao implements DynamoEntryByIdentifier, JoinWithResource {
+public final class FileDao extends Dao implements JoinWithResource {
 
   public static final String TYPE = "File";
   private static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "a";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FilesApprovalThesisDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/FilesApprovalThesisDao.java
@@ -15,8 +15,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(FilesApprovalThesisDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class FilesApprovalThesisDao extends TicketDao
-    implements JoinWithResource, JsonSerializable {
+public class FilesApprovalThesisDao extends TicketDao implements JsonSerializable {
 
   public static final String TYPE = "FilesApprovalThesis";
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/JoinWithResource.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/JoinWithResource.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.util.Map;
 import no.unit.nva.identifiers.SortableIdentifier;
 
-@SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(name = "Resource", value = ResourceDao.class),

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/KeyField.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/KeyField.java
@@ -23,7 +23,7 @@ public enum KeyField {
 
   @JsonCreator
   public static KeyField parse(String candidate) {
-    return Arrays.stream(KeyField.values())
+    return Arrays.stream(values())
         .filter(value -> value.filterByNameOrValue(candidate))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow(fail -> handleParsingError());
@@ -44,9 +44,7 @@ public enum KeyField {
   }
 
   private static String validValues() {
-    return Arrays.stream(KeyField.values())
-        .map(KeyField::toString)
-        .collect(Collectors.joining(SEPARATOR));
+    return Arrays.stream(values()).map(KeyField::toString).collect(Collectors.joining(SEPARATOR));
   }
 
   private boolean filterByNameOrValue(String candidate) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/MessageDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/MessageDao.java
@@ -22,7 +22,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(MessageDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class MessageDao extends Dao implements DynamoEntryByIdentifier, JoinWithResource {
+public class MessageDao extends Dao implements JoinWithResource {
 
   public static final String TYPE = "Message";
   private static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX = "z";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublicationChannelDao.java
@@ -33,7 +33,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonTypeName(PublicationChannelDao.TYPE)
-public class PublicationChannelDao extends Dao implements DynamoEntryByIdentifier {
+public class PublicationChannelDao extends Dao {
 
   public static final String TYPE = "PublicationChannel";
   protected static final String IDENTIFIER = "identifier";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublishingRequestDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/PublishingRequestDao.java
@@ -21,7 +21,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(PublishingRequestDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class PublishingRequestDao extends TicketDao implements JoinWithResource, JsonSerializable {
+public class PublishingRequestDao extends TicketDao implements JsonSerializable {
 
   public static final String BY_RESOURCE_INDEX_ORDER_PREFIX = "c";
   public static final String TYPE = "PublishingRequestCase";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/ResourceDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/ResourceDao.java
@@ -50,8 +50,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(ResourceDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class ResourceDao extends Dao
-    implements JoinWithResource, JsonSerializable, DynamoEntryByIdentifier {
+public class ResourceDao extends Dao implements JoinWithResource, JsonSerializable {
 
   public static final String CRISTIN_SOURCE = "Cristin";
   private static final String NVA_SOURCE = "nva";

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/UnpublishRequestDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/UnpublishRequestDao.java
@@ -12,7 +12,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName(UnpublishRequestDao.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class UnpublishRequestDao extends TicketDao implements JoinWithResource, JsonSerializable {
+public class UnpublishRequestDao extends TicketDao implements JsonSerializable {
 
   public static final String TYPE = "UnpublishRequest";
   public static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX =

--- a/publication-commons/src/main/java/no/unit/nva/publication/model/storage/UnpublishRequestDao.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/storage/UnpublishRequestDao.java
@@ -16,7 +16,7 @@ public class UnpublishRequestDao extends TicketDao implements JsonSerializable {
 
   public static final String TYPE = "UnpublishRequest";
   public static final String JOIN_BY_RESOURCE_INDEX_ORDER_PREFIX =
-      TicketDao.ALPHABETICALLY_ORDERED_LAST_TICKET_TYPE;
+      ALPHABETICALLY_ORDERED_LAST_TICKET_TYPE;
 
   @JacocoGenerated
   public UnpublishRequestDao() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/FileStrategyBase.java
@@ -109,13 +109,11 @@ public class FileStrategyBase {
   }
 
   protected boolean isWriteOrDelete(FileOperation permission) {
-    return permission.equals(WRITE_METADATA) || permission.equals(DELETE);
+    return permission == WRITE_METADATA || permission == DELETE;
   }
 
   protected boolean isWriteOrDeleteOrDownload(FileOperation permission) {
-    return permission.equals(WRITE_METADATA)
-        || permission.equals(DELETE)
-        || permission.equals(DOWNLOAD);
+    return permission == WRITE_METADATA || permission == DELETE || permission == DOWNLOAD;
   }
 
   private boolean haveTopLevelRelationForCurrentFile() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/grant/EveryoneGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/file/grant/EveryoneGrantStrategy.java
@@ -19,7 +19,7 @@ public final class EveryoneGrantStrategy extends FileStrategyBase implements Fil
   @Override
   public boolean allowsAction(FileOperation permission) {
     if (file.getFile() instanceof OpenFile openFile) {
-      return PUBLISHED.equals(resource.getStatus())
+      return PUBLISHED == resource.getStatus()
           && switch (permission) {
             case READ_METADATA -> true;
             case WRITE_METADATA, DELETE -> false;

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/PublicationStrategyBase.java
@@ -138,15 +138,15 @@ public class PublicationStrategyBase {
   }
 
   protected boolean isDraft() {
-    return resource.getStatus().equals(DRAFT);
+    return resource.getStatus() == DRAFT;
   }
 
   protected boolean isUnpublished() {
-    return resource.getStatus().equals(UNPUBLISHED);
+    return resource.getStatus() == UNPUBLISHED;
   }
 
   protected boolean isPublished() {
-    return resource.getStatus().equals(PUBLISHED);
+    return resource.getStatus() == PUBLISHED;
   }
 
   private static Boolean publicationInstanceIsDegree(

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/ClaimedChannelDenyStrategy.java
@@ -29,9 +29,7 @@ public class ClaimedChannelDenyStrategy extends PublicationStrategyBase
   }
 
   private static boolean isDeniedOperation(PublicationOperation operation) {
-    return UPDATE.equals(operation)
-        || UNPUBLISH.equals(operation)
-        || APPROVE_FILES.equals(operation);
+    return UPDATE == operation || UNPUBLISH == operation || APPROVE_FILES == operation;
   }
 
   private boolean isDeniedUserByClaimedChannelWithinScope() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DegreeDenyStrategy.java
@@ -38,7 +38,7 @@ public class DegreeDenyStrategy extends PublicationStrategyBase implements Publi
   }
 
   private static boolean isDeniedOperation(PublicationOperation operation) {
-    return UPDATE.equals(operation) || UNPUBLISH.equals(operation);
+    return UPDATE == operation || UNPUBLISH == operation;
   }
 
   private boolean handleDegree() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/publication/restrict/DeletedUploadDenyStrategy.java
@@ -16,7 +16,6 @@ public class DeletedUploadDenyStrategy extends PublicationStrategyBase
 
   @Override
   public boolean deniesAction(PublicationOperation permission) {
-    return DELETED.equals(resource.getStatus())
-        && permission.equals(PublicationOperation.UPLOAD_FILE);
+    return DELETED == resource.getStatus() && permission == PublicationOperation.UPLOAD_FILE;
   }
 }

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/deny/ClaimedChannelTicketDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/deny/ClaimedChannelTicketDenyStrategy.java
@@ -19,7 +19,7 @@ public class ClaimedChannelTicketDenyStrategy extends TicketStrategyBase
 
   @Override
   public boolean deniesAction(TicketOperation operation) {
-    return TRANSFER.equals(operation) && hasClaimedPublicationChannel();
+    return TRANSFER == operation && hasClaimedPublicationChannel();
   }
 
   private boolean hasClaimedPublicationChannel() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/deny/FinalizedTicketDenyStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/deny/FinalizedTicketDenyStrategy.java
@@ -23,7 +23,7 @@ public class FinalizedTicketDenyStrategy extends TicketStrategyBase implements T
 
   @Override
   public boolean deniesAction(TicketOperation permission) {
-    if (READ.equals(permission)) {
+    if (READ == permission) {
       return false;
     }
     return List.of(CLOSED, COMPLETED, REMOVED, NOT_APPLICABLE).contains(ticket.getStatus());

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/ApproveTicketGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/ApproveTicketGrantStrategy.java
@@ -29,7 +29,7 @@ public class ApproveTicketGrantStrategy extends TicketStrategyBase implements Ti
 
   @Override
   public boolean allowsAction(TicketOperation permission) {
-    if (!permission.equals(APPROVE)) {
+    if (permission != APPROVE) {
       return false;
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/ReadTicketGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/ReadTicketGrantStrategy.java
@@ -29,7 +29,7 @@ public class ReadTicketGrantStrategy extends TicketStrategyBase implements Ticke
 
   @Override
   public boolean allowsAction(TicketOperation permission) {
-    return permission.equals(READ) && userRelatesToTicket();
+    return permission == READ && userRelatesToTicket();
   }
 
   private boolean userRelatesToTicket() {

--- a/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/TransferTicketGrantStrategy.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/permissions/ticket/grant/TransferTicketGrantStrategy.java
@@ -20,7 +20,7 @@ public class TransferTicketGrantStrategy extends TicketStrategyBase implements T
 
   @Override
   public boolean allowsAction(TicketOperation permission) {
-    if (!permission.equals(TRANSFER)) {
+    if (permission != TRANSFER) {
       return false;
     }
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/rightsretention/FileRightsRetentionService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/rightsretention/FileRightsRetentionService.java
@@ -109,7 +109,7 @@ public class FileRightsRetentionService {
 
   /** Simple rule: RRS only applies to accepted academic articles that aren't internal */
   private boolean isRightsRetentionRelevant(File file, Resource resource) {
-    return PublisherVersion.ACCEPTED_VERSION.equals(file.getPublisherVersion())
+    return PublisherVersion.ACCEPTED_VERSION == file.getPublisherVersion()
         && !(file instanceof InternalFile)
         && isAcademicArticle(resource);
   }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DeleteResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/DeleteResourceService.java
@@ -29,7 +29,7 @@ public class DeleteResourceService extends ServiceWithTransactions {
   public void deleteImportCandidate(ImportCandidate candidate) throws BadMethodException {
     var importCandidate =
         readResourceService.getImportCandidateByIdentifier(candidate.getIdentifier()).orElseThrow();
-    if (CandidateStatus.IMPORTED.equals(importCandidate.getImportStatus().candidateStatus())) {
+    if (CandidateStatus.IMPORTED == importCandidate.getImportStatus().candidateStatus()) {
       throw new BadMethodException(CAN_NOT_DELETE_IMPORT_CANDIDATE_MESSAGE);
     } else {
       var primaryKey = getAttributeValue(importCandidate);

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/MessageService.java
@@ -115,12 +115,11 @@ public class MessageService extends ServiceWithTransactions {
 
     var ticket = ticketService.fetchTicketByIdentifier(message.getTicketIdentifier());
     return switch (ticket) {
-      case PublishingRequestCase publishingRequest ->
+      case PublishingRequestCase _ ->
           userInstance.getAccessRights().contains(AccessRight.MANAGE_PUBLISHING_REQUESTS);
-      case GeneralSupportRequest supportRequest ->
-          userInstance.getAccessRights().contains(AccessRight.SUPPORT);
-      case DoiRequest doiRequest -> userInstance.getAccessRights().contains(AccessRight.MANAGE_DOI);
-      case UnpublishRequest unpublishRequest ->
+      case GeneralSupportRequest _ -> userInstance.getAccessRights().contains(AccessRight.SUPPORT);
+      case DoiRequest _ -> userInstance.getAccessRights().contains(AccessRight.MANAGE_DOI);
+      case UnpublishRequest _ ->
           userInstance.getAccessRights().contains(AccessRight.MANAGE_PUBLISHING_REQUESTS);
       default -> false;
     };

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/PublishingService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/PublishingService.java
@@ -66,7 +66,7 @@ public class PublishingService {
   public void publishResource(SortableIdentifier resourceIdentifier, UserInstance userInstance)
       throws ApiGatewayException {
     var resource = getResource(resourceIdentifier);
-    if (PUBLISHED.equals(resource.getStatus())) {
+    if (PUBLISHED == resource.getStatus()) {
       return;
     }
     validatePermissions(resource, userInstance);

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
@@ -58,7 +58,6 @@ import no.unit.nva.publication.model.storage.ResourceRelationshipDao;
 import no.unit.nva.publication.model.storage.TicketDao;
 import no.unit.nva.publication.model.storage.importcandidate.DatabaseEntryWithData;
 import no.unit.nva.publication.model.storage.importcandidate.ImportCandidateDao;
-import no.unit.nva.publication.storage.model.DatabaseConstants;
 
 @SuppressWarnings({"PMD.CouplingBetweenObjects"})
 public class ReadResourceService {
@@ -174,7 +173,7 @@ public class ReadResourceService {
     var queryRequest =
         new QueryRequest()
             .withTableName(RESOURCES_TABLE_NAME)
-            .withIndexName(DatabaseConstants.BY_CUSTOMER_RESOURCE_INDEX_NAME)
+            .withIndexName(BY_CUSTOMER_RESOURCE_INDEX_NAME)
             .withKeyConditionExpression("PK2 = :value")
             .withExpressionAttributeValues(Map.of(":value", new AttributeValue().withS(value)));
 

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ReadResourceService.java
@@ -200,7 +200,7 @@ public class ReadResourceService {
   }
 
   private static boolean isNotRemoved(TicketEntry ticket) {
-    return !TicketStatus.REMOVED.equals(ticket.getStatus());
+    return TicketStatus.REMOVED != ticket.getStatus();
   }
 
   private static Optional<Resource> extractResource(

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -100,7 +100,7 @@ import nva.commons.core.exceptions.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"PMD.GodClass", "PMD.AvoidDuplicateLiterals", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
 public class ResourceService extends ServiceWithTransactions {
 
   public static final int AWAIT_TIME_BEFORE_FETCH_RETRY = 50;

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -56,7 +56,6 @@ import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.additionalidentifiers.CristinIdentifier;
 import no.unit.nva.model.additionalidentifiers.ScopusIdentifier;
 import no.unit.nva.publication.exception.CandidateAlreadyImportedException;
@@ -702,8 +701,8 @@ public class ResourceService extends ServiceWithTransactions {
       throws BadRequestException {
     var status =
         userInstance.isExternalClient()
-            ? Optional.ofNullable(fromPublication.getStatus()).orElse(PublicationStatus.DRAFT)
-            : PublicationStatus.DRAFT;
+            ? Optional.ofNullable(fromPublication.getStatus()).orElse(DRAFT)
+            : DRAFT;
 
     if (PUBLISHED == status) {
       if (!fromPublication.isPublishable()) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -509,7 +509,7 @@ public class ResourceService extends ServiceWithTransactions {
   public void unpublishPublication(Publication publication, UserInstance userInstance)
       throws BadRequestException, NotFoundException {
     var existingPublication = getResourceByIdentifier(publication.getIdentifier()).toPublication();
-    if (!PUBLISHED.equals(existingPublication.getStatus())) {
+    if (PUBLISHED != existingPublication.getStatus()) {
       throw new BadRequestException(ONLY_PUBLISHED_PUBLICATIONS_CAN_BE_UNPUBLISHED_ERROR_MESSAGE);
     }
     var allTicketsForResource = fetchAllTicketsForResource(Resource.fromPublication(publication));
@@ -518,7 +518,7 @@ public class ResourceService extends ServiceWithTransactions {
 
   public void terminateResource(Resource resource, UserInstance userInstance)
       throws BadRequestException {
-    if (!UNPUBLISHED.equals(resource.getStatus())) {
+    if (UNPUBLISHED != resource.getStatus()) {
       throw new BadRequestException(DELETE_PUBLICATION_ERROR_MESSAGE);
     }
     updateResourceService.terminateResource(resource, userInstance);
@@ -705,7 +705,7 @@ public class ResourceService extends ServiceWithTransactions {
             ? Optional.ofNullable(fromPublication.getStatus()).orElse(PublicationStatus.DRAFT)
             : PublicationStatus.DRAFT;
 
-    if (PUBLISHED.equals(status)) {
+    if (PUBLISHED == status) {
       if (!fromPublication.isPublishable()) {
         throw new BadRequestException(NOT_PUBLISHABLE);
       }

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -101,7 +101,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
   public Publication updatePublicationButDoNotChangeStatus(Publication publication) {
     var originalPublication =
         fetchExistingResource(Resource.fromPublication(publication)).toPublication();
-    if (originalPublication.getStatus().equals(publication.getStatus())) {
+    if (originalPublication.getStatus() == publication.getStatus()) {
       return updatePublicationIncludingStatus(publication);
     }
     throw new IllegalStateException(
@@ -114,7 +114,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
         attempt(() -> fetchExistingResource(Resource.fromPublication(publication)))
             .map(Resource::toPublication)
             .orElseThrow(failure -> new NotFoundException(RESOURCE_NOT_FOUND_MESSAGE));
-    if (persistedPublication.getStatus().equals(DRAFT)) {
+    if (persistedPublication.getStatus() == DRAFT) {
       publication.setStatus(PublicationStatus.DRAFT_FOR_DELETION);
       publication.setModifiedDate(clockForTimestamps.instant());
       var resource = Resource.fromPublication(publication);
@@ -429,9 +429,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
             .getResourceByIdentifier(resourceIdentifier)
             .orElseThrow()
             .toPublication();
-    return DELETED.equals(publication.getStatus())
-        ? deletionStatusIsCompleted()
-        : delete(publication);
+    return DELETED == publication.getStatus() ? deletionStatusIsCompleted() : delete(publication);
   }
 
   private static boolean isContributorsChanged(Resource resource, Resource existingResource) {
@@ -446,7 +444,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
   }
 
   private static boolean isNotImported(ImportCandidate importCandidate) {
-    return !importCandidate.getImportStatus().candidateStatus().equals(CandidateStatus.IMPORTED);
+    return importCandidate.getImportStatus().candidateStatus() != CandidateStatus.IMPORTED;
   }
 
   private Publication updatePublicationIncludingStatus(Publication publicationUpdate) {
@@ -485,7 +483,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
   }
 
   private boolean isPendingTicket(TicketEntry ticketEntry) {
-    return TicketStatus.PENDING.equals(ticketEntry.getStatus());
+    return TicketStatus.PENDING == ticketEntry.getStatus();
   }
 
   private TransactWriteItem createPutTransactionItems(TicketDao ticketDao) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/UpdateResourceService.java
@@ -254,7 +254,7 @@ public class UpdateResourceService extends ServiceWithTransactions {
   }
 
   private Optional<ResourceRelationshipDao> createRelationshipDao(Resource resource) {
-    return ResourceRelationship.fromResource(resource).map(ResourceRelationshipDao::from);
+    return fromResource(resource).map(ResourceRelationshipDao::from);
   }
 
   private TransactWriteItem createDeleteTransaction(ResourceRelationshipDao dao) {

--- a/publication-commons/src/main/java/no/unit/nva/publication/utils/CristinUnitsUtilImpl.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/utils/CristinUnitsUtilImpl.java
@@ -81,12 +81,12 @@ public class CristinUnitsUtilImpl implements CristinUnitsUtil {
   }
 
   private static Optional<CristinUnit> findTopLevelUnitOrSelf(String unitId) {
-    var unit = CristinUnitsUtilImpl.allUnits.get(unitId);
+    var unit = allUnits.get(unitId);
     if (isNull(unit)) {
       return Optional.empty();
     }
     while (nonNull(unit.parentUnit())) {
-      unit = CristinUnitsUtilImpl.allUnits.get(unit.parentUnit().id());
+      unit = allUnits.get(unit.parentUnit().id());
     }
     return Optional.of(unit);
   }

--- a/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/utils/RequestUtils.java
@@ -76,11 +76,11 @@ public record RequestUtils(
 
   public boolean isAuthorizedToManage(TicketEntry ticket) {
     return switch (ticket) {
-      case DoiRequest doi -> hasAccessRight(MANAGE_DOI);
-      case PublishingRequestCase publishing -> hasAccessRight(MANAGE_PUBLISHING_REQUESTS);
-      case FilesApprovalThesis thesis -> hasAccessRight(MANAGE_DEGREE);
-      case GeneralSupportRequest support -> hasAccessRight(SUPPORT);
-      case UnpublishRequest unpublish -> true;
+      case DoiRequest _ -> hasAccessRight(MANAGE_DOI);
+      case PublishingRequestCase _ -> hasAccessRight(MANAGE_PUBLISHING_REQUESTS);
+      case FilesApprovalThesis _ -> hasAccessRight(MANAGE_DEGREE);
+      case GeneralSupportRequest _ -> hasAccessRight(SUPPORT);
+      case UnpublishRequest _ -> true;
       case null, default -> false;
     };
   }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
@@ -177,7 +177,7 @@ public class DataEntryUpdateEvent implements JsonSerializable {
   }
 
   private boolean isRemoved() {
-    return !hasNewImage() && OperationType.REMOVE.equals(OperationType.fromValue(action));
+    return !hasNewImage() && OperationType.REMOVE == OperationType.fromValue(action);
   }
 
   private String resolveFileEntryTopic(FileEntry fileEntry) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/bodies/DataEntryUpdateEvent.java
@@ -152,26 +152,25 @@ public class DataEntryUpdateEvent implements JsonSerializable {
   public String getTopic() {
     var type = extractDataEntryType();
     return switch (type) {
-      case Resource resource ->
-          isRemoved() ? RESOURCE_DELETED_EVENT_TOPIC : RESOURCE_UPDATE_EVENT_TOPIC;
-      case DoiRequest doiRequest ->
+      case Resource _ -> isRemoved() ? RESOURCE_DELETED_EVENT_TOPIC : RESOURCE_UPDATE_EVENT_TOPIC;
+      case DoiRequest _ ->
           isRemoved() ? DOI_REQUEST_DELETED_EVENT_TOPIC : DOI_REQUEST_UPDATE_EVENT_TOPIC;
-      case PublishingRequestCase publishingRequestCase ->
+      case PublishingRequestCase _ ->
           isRemoved()
               ? PUBLISHING_REQUEST_DELETED_EVENT_TOPIC
               : PUBLISHING_REQUEST_UPDATE_EVENT_TOPIC;
-      case FilesApprovalThesis filesApprovalThesis ->
+      case FilesApprovalThesis _ ->
           isRemoved()
               ? FILES_APPROVAL_THESIS_DELETED_EVENT_TOPIC
               : FILES_APPROVAL_THESIS_UPDATE_EVENT_TOPIC;
-      case GeneralSupportRequest generalSupportRequest ->
+      case GeneralSupportRequest _ ->
           isRemoved()
               ? GENERAL_SUPPORT_REQUEST_DELETED_EVENT_TOPIC
               : GENERAL_SUPPORT_REQUEST_UPDATE_EVENT_TOPIC;
-      case UnpublishRequest unpublishRequest -> UNPUBLISH_REQUEST_UPDATE_EVENT_TOPIC;
-      case Message message -> MESSAGE_UPDATE_EVENT_TOPIC;
+      case UnpublishRequest _ -> UNPUBLISH_REQUEST_UPDATE_EVENT_TOPIC;
+      case Message _ -> MESSAGE_UPDATE_EVENT_TOPIC;
       case FileEntry fileEntry -> resolveFileEntryTopic(fileEntry);
-      case PublicationChannel publicationChannel -> PUBLICATION_CHANNEL_UPDATED_EVENT_TOPIC;
+      case PublicationChannel _ -> PUBLICATION_CHANNEL_UPDATED_EVENT_TOPIC;
       default -> throw new IllegalArgumentException("Unknown entry type: " + type);
     };
   }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/UpdateVerificationStatusJob.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/jobs/UpdateVerificationStatusJob.java
@@ -151,7 +151,7 @@ public class UpdateVerificationStatusJob extends ServiceWithTransactions
       ContributorVerificationStatus status,
       SortableIdentifier resourceIdentifier) {
     return Optional.of(contributor.identity())
-        .filter(identity -> !status.equals(identity.getVerificationStatus()))
+        .filter(identity -> status != identity.getVerificationStatus())
         .map(identity -> logStatusChange(identity, status, resourceIdentifier))
         .map(identity -> createUpdatedIdentity(identity, status))
         .map(updatedIdentity -> contributor.copy().withIdentity(updatedIdentity).build());

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeletionProcessInitializationHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/delete/DeletionProcessInitializationHandler.java
@@ -42,8 +42,7 @@ public class DeletionProcessInitializationHandler
   }
 
   private boolean isDraftForDeletion(Publication publication) {
-    return publication != null
-        && publication.getStatus().equals(PublicationStatus.DRAFT_FOR_DELETION);
+    return publication != null && publication.getStatus() == PublicationStatus.DRAFT_FOR_DELETION;
   }
 
   private Publication toPublication(Entity dataEntry) {

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/dynamodbstream/DynamodbStreamToEventBridgeHandler.java
@@ -133,10 +133,10 @@ public class DynamodbStreamToEventBridgeHandler
         Optional.ofNullable(dataEntryUpdateEvent.getOldData())
             .orElseGet(dataEntryUpdateEvent::getNewData);
     return switch (entity) {
-      case Resource resource -> RESOURCE;
-      case TicketEntry ticket -> TICKET;
-      case Message message -> MESSAGE;
-      case FileEntry fileEntry -> FILE;
+      case Resource _ -> RESOURCE;
+      case TicketEntry _ -> TICKET;
+      case Message _ -> MESSAGE;
+      case FileEntry _ -> FILE;
       default -> throw new IllegalStateException("Unexpected value: " + entity);
     };
   }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -159,10 +159,10 @@ public class ExpandDataEntriesHandler
         Optional.ofNullable(dataEntryUpdateEvent.getOldData())
             .orElseGet(dataEntryUpdateEvent::getNewData);
     return switch (entity) {
-      case Resource resource -> RESOURCE;
-      case TicketEntry ticket -> TICKET;
-      case Message message -> MESSAGE;
-      case FileEntry fileEntry -> FILE;
+      case Resource _ -> RESOURCE;
+      case TicketEntry _ -> TICKET;
+      case Message _ -> MESSAGE;
+      case FileEntry _ -> FILE;
       default -> throw new IllegalStateException("Unexpected value: " + entity);
     };
   }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/expandresources/ExpandDataEntriesHandler.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class ExpandDataEntriesHandler
     extends DestinationsEventBridgeEventHandler<EventReference, EventReference> {
 

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DynamodbStreamRecordDaoMapper.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/fanout/DynamodbStreamRecordDaoMapper.java
@@ -14,7 +14,6 @@ import no.unit.nva.publication.model.storage.importcandidate.DatabaseEntryWithDa
 import no.unit.nva.publication.model.storage.importcandidate.ImportCandidateDao;
 
 // TODO: rename class to DynamoJsonToInternalModelEventHandler
-@SuppressWarnings({"PMD.ReturnEmptyCollectionRatherThanNull"})
 public final class DynamodbStreamRecordDaoMapper {
 
   private DynamodbStreamRecordDaoMapper() {}

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/recovery/RecoveryRequest.java
@@ -12,7 +12,6 @@ public record RecoveryRequest(Integer count, String queueUrl) implements JsonSer
 
   private static final int DEFAULT_MESSAGES_COUNT = 10;
 
-  @SuppressWarnings("PMD.UnusedAssignment")
   public RecoveryRequest {
     count = isNull(count) ? DEFAULT_MESSAGES_COUNT : count;
   }

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/tickets/AcceptedPublishingRequestEventHandler.java
@@ -220,7 +220,7 @@ public class AcceptedPublishingRequestEventHandler
 
   private void publishWhenPublicationStatusDraft(
       Resource resource, FilesApprovalEntry filesApprovalEntry) {
-    if (PublicationStatus.DRAFT.equals(resource.getStatus())) {
+    if (PublicationStatus.DRAFT == resource.getStatus()) {
       publishResource(resource, filesApprovalEntry);
     }
   }

--- a/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
+++ b/publication-file/src/main/java/no/unit/nva/publication/file/upload/FileService.java
@@ -224,7 +224,7 @@ public class FileService {
 
   private RightsRetentionStrategy createRightsRetentionStrategy(
       RightsRetentionStrategyConfiguration configuration) {
-    if (RIGHTS_RETENTION_STRATEGY.equals(configuration)) {
+    if (RIGHTS_RETENTION_STRATEGY == configuration) {
       return CustomerRightsRetentionStrategy.create(configuration);
     } else {
       return NullRightsRetentionStrategy.create(configuration);

--- a/publication-model/src/main/java/no/unit/nva/api/PublicationResponseElevatedUser.java
+++ b/publication-model/src/main/java/no/unit/nva/api/PublicationResponseElevatedUser.java
@@ -12,7 +12,6 @@ import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifactDto;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings({"PMD.TooManyFields", "PMD.GodClass"})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName("Publication")
 public class PublicationResponseElevatedUser extends PublicationResponse {

--- a/publication-model/src/main/java/no/unit/nva/importcandidate/ImportContributor.java
+++ b/publication-model/src/main/java/no/unit/nva/importcandidate/ImportContributor.java
@@ -10,7 +10,6 @@ import java.util.List;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.role.RoleType;
 
-@SuppressWarnings("PMD.UnusedAssignment")
 @JsonTypeInfo(use = Id.NAME, property = "type")
 public record ImportContributor(
     Identity identity,

--- a/publication-model/src/main/java/no/unit/nva/importcandidate/ImportEntityDescription.java
+++ b/publication-model/src/main/java/no/unit/nva/importcandidate/ImportEntityDescription.java
@@ -15,7 +15,6 @@ import java.util.stream.IntStream;
 import no.unit.nva.model.PublicationDate;
 import no.unit.nva.model.Reference;
 
-@SuppressWarnings("PMD.UnusedAssignment")
 @JsonTypeInfo(use = Id.NAME, property = "type")
 public record ImportEntityDescription(
     String mainTitle,

--- a/publication-model/src/main/java/no/unit/nva/importcandidate/SourceOrganization.java
+++ b/publication-model/src/main/java/no/unit/nva/importcandidate/SourceOrganization.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("PMD.UnusedAssignment")
 @JsonTypeInfo(use = Id.NAME, property = "type")
 public record SourceOrganization(
     SourceOrganizationIdentifier identifier,

--- a/publication-model/src/main/java/no/unit/nva/model/ContributorVerificationStatus.java
+++ b/publication-model/src/main/java/no/unit/nva/model/ContributorVerificationStatus.java
@@ -40,7 +40,7 @@ public enum ContributorVerificationStatus {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         candidate,
-                        stream(ContributorVerificationStatus.values())
+                        stream(values())
                             .map(ContributorVerificationStatus::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/FileOperation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/FileOperation.java
@@ -44,7 +44,7 @@ public enum FileOperation {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(FileOperation.values())
+                        stream(values())
                             .map(FileOperation::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/NameType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/NameType.java
@@ -44,8 +44,6 @@ public enum NameType {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(NameType.values())
-                            .map(NameType::toString)
-                            .collect(joining(DELIMITER)))));
+                        stream(values()).map(NameType::toString).collect(joining(DELIMITER)))));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/Publication.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Publication.java
@@ -18,7 +18,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -232,7 +231,7 @@ public class Publication
 
   @Override
   public List<ResearchProject> getProjects() {
-    return nonNull(projects) ? projects : Collections.emptyList();
+    return nonNull(projects) ? projects : emptyList();
   }
 
   @Override
@@ -242,7 +241,7 @@ public class Publication
 
   @Override
   public List<URI> getSubjects() {
-    return nonNull(subjects) ? subjects : Collections.emptyList();
+    return nonNull(subjects) ? subjects : emptyList();
   }
 
   @Override
@@ -282,7 +281,7 @@ public class Publication
 
   @JsonGetter
   public List<PublicationNoteBase> getPublicationNotes() {
-    return nonNull(publicationNotes) ? publicationNotes : Collections.emptyList();
+    return nonNull(publicationNotes) ? publicationNotes : emptyList();
   }
 
   public void setPublicationNotes(List<PublicationNoteBase> publicationNotes) {
@@ -435,7 +434,7 @@ public class Publication
 
   @Override
   public List<ImportDetail> getImportDetails() {
-    return nonNull(importDetails) ? importDetails : Collections.emptyList();
+    return nonNull(importDetails) ? importDetails : emptyList();
   }
 
   @Override

--- a/publication-model/src/main/java/no/unit/nva/model/Publication.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Publication.java
@@ -418,7 +418,7 @@ public class Publication
 
   @JsonIgnore
   public boolean isPublishable() {
-    return !DRAFT_FOR_DELETION.equals(getStatus()) && hasMainTitle();
+    return DRAFT_FOR_DELETION != getStatus() && hasMainTitle();
   }
 
   public boolean satisfiesFindableDoiRequirements() {

--- a/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/PublicationOperation.java
@@ -55,7 +55,7 @@ public enum PublicationOperation {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(PublicationOperation.values())
+                        stream(values())
                             .map(PublicationOperation::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/PublicationStatus.java
+++ b/publication-model/src/main/java/no/unit/nva/model/PublicationStatus.java
@@ -51,7 +51,7 @@ public enum PublicationStatus {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(PublicationStatus.values())
+                        stream(values())
                             .map(PublicationStatus::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/Revision.java
+++ b/publication-model/src/main/java/no/unit/nva/model/Revision.java
@@ -44,8 +44,6 @@ public enum Revision {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(Revision.values())
-                            .map(Revision::toString)
-                            .collect(joining(DELIMITER)))));
+                        stream(values()).map(Revision::toString).collect(joining(DELIMITER)))));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/TicketOperation.java
+++ b/publication-model/src/main/java/no/unit/nva/model/TicketOperation.java
@@ -44,7 +44,7 @@ public enum TicketOperation {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(TicketOperation.values())
+                        stream(values())
                             .map(TicketOperation::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/additionalidentifiers/SourceName.java
+++ b/publication-model/src/main/java/no/unit/nva/model/additionalidentifiers/SourceName.java
@@ -34,7 +34,6 @@ public record SourceName(String system, String instanceName) {
     return sourceName;
   }
 
-  @SuppressWarnings("PMD.NullAssignment")
   @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
   SourceName(String sourceName) {
     this(

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RightsRetentionStrategyConfiguration.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/RightsRetentionStrategyConfiguration.java
@@ -22,7 +22,7 @@ public enum RightsRetentionStrategyConfiguration {
   }
 
   public static RightsRetentionStrategyConfiguration fromValue(String value) {
-    return Arrays.stream(RightsRetentionStrategyConfiguration.values())
+    return Arrays.stream(values())
         .filter(enumValue -> enumValue.getValue().equalsIgnoreCase(value))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow();

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/FileDto.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/FileDto.java
@@ -11,7 +11,7 @@ import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
 
 public record FileDto(
     @JsonProperty(File.IDENTIFIER_FIELD) SortableIdentifier identifier,
-    @JsonProperty(FileDto.TYPE_NAME_FIELD) String type,
+    @JsonProperty(TYPE_NAME_FIELD) String type,
     @JsonProperty(File.NAME_FIELD) String name,
     @JsonProperty(File.MIME_TYPE_FIELD) String mimeType,
     @JsonProperty(File.SIZE_FIELD) Long size,
@@ -22,7 +22,7 @@ public record FileDto(
     @JsonProperty(File.LEGAL_NOTE_FIELD) String legalNote,
     @JsonProperty(File.PUBLISHED_DATE_FIELD) Instant publishedDate,
     @JsonProperty(File.UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails,
-    @JsonProperty(FileDto.ALLOWED_OPERATIONS_FIELD) Set<FileOperation> allowedOperations)
+    @JsonProperty(ALLOWED_OPERATIONS_FIELD) Set<FileOperation> allowedOperations)
     implements AssociatedArtifactDto {
 
   public static final String ALLOWED_OPERATIONS_FIELD = "allowedOperations";

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/HiddenFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/HiddenFile.java
@@ -82,9 +82,9 @@ public class HiddenFile extends File {
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/ImportUploadDetails.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/ImportUploadDetails.java
@@ -30,7 +30,7 @@ public record ImportUploadDetails(Source source, String archive, Instant uploade
 
     @JsonCreator
     public static Source fromValue(String value) {
-      return Arrays.stream(Source.values())
+      return Arrays.stream(values())
           .filter(enumValue -> enumValue.getValue().equalsIgnoreCase(value))
           .collect(SingletonCollector.tryCollect())
           .orElseThrow(

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/InternalFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/InternalFile.java
@@ -84,10 +84,10 @@ public class InternalFile extends File {
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
-      case InternalFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
+      case InternalFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/OpenFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/OpenFile.java
@@ -85,10 +85,10 @@ public class OpenFile extends File {
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
-      case OpenFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
+      case OpenFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingInternalFile.java
@@ -136,9 +136,9 @@ public class PendingInternalFile extends File implements PendingFile<InternalFil
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingOpenFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/PendingOpenFile.java
@@ -122,9 +122,9 @@ public class PendingOpenFile extends File implements PendingFile<OpenFile, Rejec
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/RejectedFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/RejectedFile.java
@@ -82,10 +82,10 @@ public class RejectedFile extends File {
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
-      case RejectedFile ignore -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
+      case RejectedFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadedFile.java
+++ b/publication-model/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadedFile.java
@@ -59,10 +59,10 @@ public class UploadedFile extends File {
   @Override
   public boolean canBeConvertedTo(File file) {
     return switch (file) {
-      case UploadedFile ignore -> true;
-      case PendingInternalFile ignore -> true;
-      case PendingOpenFile ignore -> true;
-      case HiddenFile ignore -> true;
+      case UploadedFile _ -> true;
+      case PendingInternalFile _ -> true;
+      case PendingOpenFile _ -> true;
+      case HiddenFile _ -> true;
       default -> false;
     };
   }

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/Report.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/Report.java
@@ -6,7 +6,7 @@ import java.util.List;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
 
-public class Report extends Book implements BasicContext {
+public class Report extends Book {
 
   @JsonCreator
   public Report(

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubType.java
@@ -27,7 +27,7 @@ public class MediaSubType {
 
   @JsonCreator
   public static MediaSubType fromJsonString(String type) {
-    return MediaSubType.create(MediaSubTypeEnum.parse(type));
+    return create(MediaSubTypeEnum.parse(type));
   }
 
   public static MediaSubType create(MediaSubTypeEnum type) {

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubType.java
@@ -19,7 +19,7 @@ public class MediaSubType {
   @JsonCreator
   public static MediaSubType fromJson(
       @JsonProperty(TYPE) MediaSubTypeEnum type, @JsonProperty("description") String description) {
-    if (MediaSubTypeEnum.OTHER.equals(type)) {
+    if (MediaSubTypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new MediaSubType(type);

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubTypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/media/MediaSubTypeEnum.java
@@ -22,13 +22,11 @@ public enum MediaSubTypeEnum {
   @Deprecated
   @JsonCreator
   public static MediaSubTypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? MediaSubTypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static MediaSubTypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(MediaSubTypeEnum.values())
+    return Arrays.stream(values())
         .filter(subType -> subType.value.equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/contexttypes/utils/IssnUtil.java
+++ b/publication-model/src/main/java/no/unit/nva/model/contexttypes/utils/IssnUtil.java
@@ -13,7 +13,6 @@ public final class IssnUtil {
    * @return String, validated representation of the ISSN
    * @throws InvalidIssnException Thrown if the ISSN is invalid
    */
-  @SuppressWarnings("PMD.NullAssignment")
   public static String checkIssn(String issn) throws InvalidIssnException {
     if (isNull(issn) || issn.isEmpty()) {
       return null;

--- a/publication-model/src/main/java/no/unit/nva/model/funding/ConfirmedFunding.java
+++ b/publication-model/src/main/java/no/unit/nva/model/funding/ConfirmedFunding.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class ConfirmedFunding extends UnconfirmedFunding implements Funding {
+public class ConfirmedFunding extends UnconfirmedFunding {
 
   private final URI id;
 

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureSubtype.java
@@ -25,7 +25,7 @@ public class ArchitectureSubtype {
   public static ArchitectureSubtype fromJson(
       @JsonProperty(TYPE) ArchitectureSubtypeEnum type,
       @JsonProperty(DESCRIPTION) String description) {
-    if (ArchitectureSubtypeEnum.OTHER.equals(type)) {
+    if (ArchitectureSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new ArchitectureSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/architecture/ArchitectureSubtypeEnum.java
@@ -22,13 +22,11 @@ public enum ArchitectureSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static ArchitectureSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? ArchitectureSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static ArchitectureSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(ArchitectureSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(subType -> subType.getType().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/design/ArtisticDesignSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/design/ArtisticDesignSubtype.java
@@ -19,7 +19,7 @@ public class ArtisticDesignSubtype {
   public static ArtisticDesignSubtype fromJson(
       @JsonProperty(TYPE) ArtisticDesignSubtypeEnum type,
       @JsonProperty("description") String description) {
-    if (ArtisticDesignSubtypeEnum.OTHER.equals(type)) {
+    if (ArtisticDesignSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new ArtisticDesignSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/design/ArtisticDesignSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/design/ArtisticDesignSubtypeEnum.java
@@ -28,14 +28,12 @@ public enum ArtisticDesignSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static ArtisticDesignSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? ArtisticDesignSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   // @JsonCreator
   public static ArtisticDesignSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(ArtisticDesignSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(subType -> subType.getType().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/film/MovingPictureSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/film/MovingPictureSubtypeEnum.java
@@ -27,14 +27,12 @@ public enum MovingPictureSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static MovingPictureSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? MovingPictureSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   //    @JsonCreator
   public static MovingPictureSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(MovingPictureSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getType().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/LiteraryArtsSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/LiteraryArtsSubtype.java
@@ -21,7 +21,7 @@ public class LiteraryArtsSubtype {
   public static LiteraryArtsSubtype fromJson(
       @JsonProperty(TYPE_FIELD) LiteraryArtsSubtypeEnum type,
       @JsonProperty(DESCRIPTION_FIELD) String description) {
-    if (LiteraryArtsSubtypeEnum.OTHER.equals(type)) {
+    if (LiteraryArtsSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new LiteraryArtsSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/LiteraryArtsSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/LiteraryArtsSubtypeEnum.java
@@ -31,14 +31,12 @@ public enum LiteraryArtsSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static LiteraryArtsSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? LiteraryArtsSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   //  @JsonCreator
   public static LiteraryArtsSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(LiteraryArtsSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getName().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsAudioVisualSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsAudioVisualSubtype.java
@@ -49,7 +49,7 @@ public class LiteraryArtsAudioVisualSubtype {
   public static LiteraryArtsAudioVisualSubtype fromJson(
       @JsonProperty(TYPE_FIELD) LiteraryArtsAudioVisualSubtypeEnum type,
       @JsonProperty(DESCRIPTION_FIELD) String description) {
-    if (LiteraryArtsAudioVisualSubtypeEnum.OTHER.equals(type)) {
+    if (LiteraryArtsAudioVisualSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new LiteraryArtsAudioVisualSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsAudioVisualSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsAudioVisualSubtypeEnum.java
@@ -27,14 +27,12 @@ public enum LiteraryArtsAudioVisualSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static LiteraryArtsAudioVisualSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? LiteraryArtsAudioVisualSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   //  @JsonCreator
   public static LiteraryArtsAudioVisualSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(LiteraryArtsAudioVisualSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getType().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsPerformanceSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsPerformanceSubtype.java
@@ -48,7 +48,7 @@ public class LiteraryArtsPerformanceSubtype {
   public static LiteraryArtsPerformanceSubtype fromJson(
       @JsonProperty(TYPE_FIELD) LiteraryArtsPerformanceSubtypeEnum type,
       @JsonProperty(DESCRIPTION_FIELD) String description) {
-    if (LiteraryArtsPerformanceSubtypeEnum.OTHER.equals(type)) {
+    if (LiteraryArtsPerformanceSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new LiteraryArtsPerformanceSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsPerformanceSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/literaryarts/manifestation/LiteraryArtsPerformanceSubtypeEnum.java
@@ -25,13 +25,11 @@ public enum LiteraryArtsPerformanceSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static LiteraryArtsPerformanceSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? LiteraryArtsPerformanceSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static LiteraryArtsPerformanceSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(LiteraryArtsPerformanceSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getName().equals(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicMediaSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicMediaSubtype.java
@@ -23,7 +23,7 @@ public class MusicMediaSubtype {
   public static MusicMediaSubtype fromJson(
       @JsonProperty(TYPE_FIELD) MusicMediaType type,
       @JsonProperty(DESCRIPTION_FIELD) String description) {
-    if (MusicMediaType.OTHER.equals(type)) {
+    if (MusicMediaType.OTHER == type) {
       return createOther(description);
     }
     return new MusicMediaSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicMediaType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/music/MusicMediaType.java
@@ -28,9 +28,7 @@ public enum MusicMediaType {
   @Deprecated
   @JsonCreator
   public static MusicMediaType parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? MusicMediaType.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static MusicMediaType inlineableParseMethod(String candidate) {
@@ -43,7 +41,7 @@ public enum MusicMediaType {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         candidate,
-                        stream(MusicMediaType.values())
+                        stream(values())
                             .map(MusicMediaType::toString)
                             .collect(joining(DELIMITER)))));
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/performingarts/PerformingArtsSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/performingarts/PerformingArtsSubtypeEnum.java
@@ -24,13 +24,11 @@ public enum PerformingArtsSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static PerformingArtsSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? PerformingArtsSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static PerformingArtsSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(PerformingArtsSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getType().equals(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/visualarts/VisualArtsSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/visualarts/VisualArtsSubtype.java
@@ -25,7 +25,7 @@ public class VisualArtsSubtype {
   public static VisualArtsSubtype fromJson(
       @JsonProperty(TYPE_FIELD) VisualArtsSubtypeEnum type,
       @JsonProperty(DESCRIPTION_FIELD) String description) {
-    if (VisualArtsSubtypeEnum.OTHER.equals(type)) {
+    if (VisualArtsSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new VisualArtsSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/visualarts/VisualArtsSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/artistic/visualarts/VisualArtsSubtypeEnum.java
@@ -31,13 +31,11 @@ public enum VisualArtsSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static VisualArtsSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? VisualArtsSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static VisualArtsSubtypeEnum inlineableParseMethod(String candidate) {
-    return Arrays.stream(VisualArtsSubtypeEnum.values())
+    return Arrays.stream(values())
         .filter(value -> value.getType().equals(candidate))
         .collect(SingletonCollector.collect());
   }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/book/BookMonograph.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/book/BookMonograph.java
@@ -25,17 +25,17 @@ public class BookMonograph implements PublicationInstance<MonographPages> {
   public static BookMonograph fromJson(
       @JsonProperty(PAGES_FIELD) MonographPages pages,
       @JsonProperty(CONTENT_TYPE_FIELD) BookMonographContentType contentType) {
-    if (BookMonographContentType.ACADEMIC_MONOGRAPH.equals(contentType)) {
+    if (BookMonographContentType.ACADEMIC_MONOGRAPH == contentType) {
       return new AcademicMonograph(pages);
-    } else if (BookMonographContentType.ENCYCLOPEDIA.equals(contentType)) {
+    } else if (BookMonographContentType.ENCYCLOPEDIA == contentType) {
       return new Encyclopedia(pages);
-    } else if (BookMonographContentType.EXHIBITION_CATALOG.equals(contentType)) {
+    } else if (BookMonographContentType.EXHIBITION_CATALOG == contentType) {
       return new ExhibitionCatalog(pages);
-    } else if (BookMonographContentType.NON_FICTION_MONOGRAPH.equals(contentType)) {
+    } else if (BookMonographContentType.NON_FICTION_MONOGRAPH == contentType) {
       return new NonFictionMonograph(pages);
-    } else if (BookMonographContentType.POPULAR_SCIENCE_MONOGRAPH.equals(contentType)) {
+    } else if (BookMonographContentType.POPULAR_SCIENCE_MONOGRAPH == contentType) {
       return new PopularScienceMonograph(pages);
-    } else if (BookMonographContentType.TEXTBOOK.equals(contentType)) {
+    } else if (BookMonographContentType.TEXTBOOK == contentType) {
       return new Textbook(pages);
     } else if (isNull(contentType)) {
       return new AcademicMonograph(pages);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/book/BookMonographContentType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/book/BookMonographContentType.java
@@ -63,8 +63,6 @@ public enum BookMonographContentType {
     return format(
         ERROR_MESSAGE_TEMPLATE,
         value,
-        stream(BookMonographContentType.values())
-            .map(BookMonographContentType::toString)
-            .collect(joining(DELIMITER)));
+        stream(values()).map(BookMonographContentType::toString).collect(joining(DELIMITER)));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/chapter/ChapterArticle.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/chapter/ChapterArticle.java
@@ -24,19 +24,19 @@ public class ChapterArticle implements PublicationInstance<Range> {
   public static ChapterArticle fromJson(
       @JsonProperty(PAGES_FIELD) Range pages,
       @JsonProperty("contentType") ChapterArticleContentType contentType) {
-    if (ChapterArticleContentType.ACADEMIC_CHAPTER.equals(contentType)) {
+    if (ChapterArticleContentType.ACADEMIC_CHAPTER == contentType) {
       return new AcademicChapter(pages);
-    } else if (ChapterArticleContentType.ENCYCLOPEDIA_CHAPTER.equals(contentType)) {
+    } else if (ChapterArticleContentType.ENCYCLOPEDIA_CHAPTER == contentType) {
       return new EncyclopediaChapter(pages);
-    } else if (ChapterArticleContentType.EXHIBITION_CATALOG_CHAPTER.equals(contentType)) {
+    } else if (ChapterArticleContentType.EXHIBITION_CATALOG_CHAPTER == contentType) {
       return new ExhibitionCatalogChapter(pages);
-    } else if (ChapterArticleContentType.INTRODUCTION.equals(contentType)) {
+    } else if (ChapterArticleContentType.INTRODUCTION == contentType) {
       return new Introduction(pages);
-    } else if (ChapterArticleContentType.NON_FICTION_CHAPTER.equals(contentType)) {
+    } else if (ChapterArticleContentType.NON_FICTION_CHAPTER == contentType) {
       return new NonFictionChapter(pages);
-    } else if (ChapterArticleContentType.POPULAR_SCIENCE_CHAPTER.equals(contentType)) {
+    } else if (ChapterArticleContentType.POPULAR_SCIENCE_CHAPTER == contentType) {
       return new PopularScienceChapter(pages);
-    } else if (ChapterArticleContentType.TEXTBOOK_CHAPTER.equals(contentType)) {
+    } else if (ChapterArticleContentType.TEXTBOOK_CHAPTER == contentType) {
       return new TextbookChapter(pages);
     } else if (isNull(contentType)) {
       return new AcademicChapter(pages);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/chapter/ChapterArticleContentType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/chapter/ChapterArticleContentType.java
@@ -65,8 +65,6 @@ public enum ChapterArticleContentType {
     return format(
         ERROR_MESSAGE_TEMPLATE,
         value,
-        stream(ChapterArticleContentType.values())
-            .map(ChapterArticleContentType::toString)
-            .collect(joining(DELIMITER)));
+        stream(values()).map(ChapterArticleContentType::toString).collect(joining(DELIMITER)));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/ExhibitionProductionSubtype.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/ExhibitionProductionSubtype.java
@@ -25,7 +25,7 @@ public class ExhibitionProductionSubtype {
   public static ExhibitionProductionSubtype fromJson(
       @JsonProperty(TYPE) ExhibitionProductionSubtypeEnum type,
       @JsonProperty(DESCRIPTION) String description) {
-    if (ExhibitionProductionSubtypeEnum.OTHER.equals(type)) {
+    if (ExhibitionProductionSubtypeEnum.OTHER == type) {
       return createOther(description);
     }
     return new ExhibitionProductionSubtype(type);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/ExhibitionProductionSubtypeEnum.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/exhibition/ExhibitionProductionSubtypeEnum.java
@@ -30,9 +30,7 @@ public enum ExhibitionProductionSubtypeEnum {
   @Deprecated
   @JsonCreator
   public static ExhibitionProductionSubtypeEnum parse(String candidate) {
-    return "Other".equalsIgnoreCase(candidate)
-        ? ExhibitionProductionSubtypeEnum.OTHER
-        : inlineableParseMethod(candidate);
+    return "Other".equalsIgnoreCase(candidate) ? OTHER : inlineableParseMethod(candidate);
   }
 
   public static ExhibitionProductionSubtypeEnum inlineableParseMethod(String candidate) {

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/journal/JournalArticle.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/journal/JournalArticle.java
@@ -36,17 +36,17 @@ public class JournalArticle implements PublicationInstance<Range> {
       @JsonProperty(ISSUE_FIELD) String issue,
       @JsonProperty(ARTICLE_NUMBER_FIELD) String articleNumber,
       @JsonProperty(CONTENT_TYPE_FIELD) JournalArticleContentType contentType) {
-    if (JournalArticleContentType.ACADEMIC_ARTICLE.equals(contentType)) {
+    if (JournalArticleContentType.ACADEMIC_ARTICLE == contentType) {
       return new AcademicArticle(pages, volume, issue, articleNumber);
-    } else if (JournalArticleContentType.ACADEMIC_LITERATURE_REVIEW.equals(contentType)) {
+    } else if (JournalArticleContentType.ACADEMIC_LITERATURE_REVIEW == contentType) {
       return new AcademicLiteratureReview(pages, volume, issue, articleNumber);
-    } else if (JournalArticleContentType.CASE_REPORT.equals(contentType)) {
+    } else if (JournalArticleContentType.CASE_REPORT == contentType) {
       return new CaseReport(pages, volume, issue, articleNumber);
-    } else if (JournalArticleContentType.POPULAR_SCIENCE_ARTICLE.equals(contentType)) {
+    } else if (JournalArticleContentType.POPULAR_SCIENCE_ARTICLE == contentType) {
       return new PopularScienceArticle(pages, volume, issue, articleNumber);
-    } else if (JournalArticleContentType.PROFESSIONAL_ARTICLE.equals(contentType)) {
+    } else if (JournalArticleContentType.PROFESSIONAL_ARTICLE == contentType) {
       return new ProfessionalArticle(pages, volume, issue, articleNumber);
-    } else if (JournalArticleContentType.STUDY_PROTOCOL.equals(contentType)) {
+    } else if (JournalArticleContentType.STUDY_PROTOCOL == contentType) {
       return new StudyProtocol(pages, volume, issue, articleNumber);
     } else if (isNull(contentType)) {
       return new AcademicArticle(pages, volume, issue, articleNumber);

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/journal/JournalArticleContentType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/journal/JournalArticleContentType.java
@@ -56,8 +56,6 @@ public enum JournalArticleContentType {
     return format(
         ERROR_MESSAGE_TEMPLATE,
         value,
-        stream(JournalArticleContentType.values())
-            .map(JournalArticleContentType::toString)
-            .collect(joining(DELIMITER)));
+        stream(values()).map(JournalArticleContentType::toString).collect(joining(DELIMITER)));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/instancetypes/researchdata/SoftwareSourceCode.java
+++ b/publication-model/src/main/java/no/unit/nva/model/instancetypes/researchdata/SoftwareSourceCode.java
@@ -14,8 +14,8 @@ import nva.commons.core.StringUtils;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public record SoftwareSourceCode(
-    @JsonProperty(SoftwareSourceCode.SOFTWARE_VERSION_FIELD) String softwareVersion,
-    @JsonProperty(SoftwareSourceCode.CODE_REPOSITORY_FIELD) URI codeRepository)
+    @JsonProperty(SOFTWARE_VERSION_FIELD) String softwareVersion,
+    @JsonProperty(CODE_REPOSITORY_FIELD) URI codeRepository)
     implements PublicationInstance<NullPages>, PublishValidator {
 
   public static final String SOFTWARE_VERSION_FIELD = "softwareVersion";

--- a/publication-model/src/main/java/no/unit/nva/model/role/Role.java
+++ b/publication-model/src/main/java/no/unit/nva/model/role/Role.java
@@ -102,7 +102,7 @@ public enum Role {
   @JsonCreator
   public static Role parse(String value) {
     // TODO: inline "else" method following migration
-    return isDeprecatedRole(value) ? Role.OTHER : inlineableParseMethod(value);
+    return isDeprecatedRole(value) ? OTHER : inlineableParseMethod(value);
   }
 
   private static boolean isDeprecatedRole(String value) {
@@ -119,6 +119,6 @@ public enum Role {
                     format(
                         ERROR_MESSAGE_TEMPLATE,
                         value,
-                        stream(Role.values()).map(Role::toString).collect(joining(DELIMITER)))));
+                        stream(values()).map(Role::toString).collect(joining(DELIMITER)))));
   }
 }

--- a/publication-model/src/main/java/no/unit/nva/model/role/RoleType.java
+++ b/publication-model/src/main/java/no/unit/nva/model/role/RoleType.java
@@ -21,7 +21,7 @@ public class RoleType {
   @JsonCreator
   public static RoleType fromJson(
       @JsonProperty(TYPE_FIELD) Role type, @JsonProperty(DESCRIPTION_FIELD) String description) {
-    return Role.OTHER.equals(type) && StringUtils.isNotBlank(description)
+    return Role.OTHER == type && StringUtils.isNotBlank(description)
         ? new RoleTypeOther(Role.OTHER, description)
         : new RoleType(type);
   }

--- a/publication-model/src/main/java/no/unit/nva/model/time/Time.java
+++ b/publication-model/src/main/java/no/unit/nva/model/time/Time.java
@@ -33,7 +33,7 @@ public interface Time {
   }
 
   static java.time.Instant convertToInstant(String candidate) {
-    return Time.isInstant(candidate)
+    return isInstant(candidate)
         ? java.time.Instant.parse(candidate)
         : java.time.Instant.parse(candidate + ZEROED_MILLISECONDS_IN_TZ);
   }

--- a/publication-rest/src/main/java/no/unit/nva/publication/create/ImportCandidateValidator.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/create/ImportCandidateValidator.java
@@ -18,7 +18,7 @@ public final class ImportCandidateValidator {
 
   public static void validate(ImportCandidate candidate, CreatePublicationRequest input)
       throws BadRequestException {
-    if (CandidateStatus.IMPORTED.equals(candidate.getImportStatus().candidateStatus())) {
+    if (CandidateStatus.IMPORTED == candidate.getImportStatus().candidateStatus()) {
       throw new BadRequestException(RESOURCE_HAS_ALREADY_BEEN_IMPORTED);
     }
     if (candidate.getScopusIdentifier().isEmpty()) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/download/PresignedUri.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/download/PresignedUri.java
@@ -23,7 +23,7 @@ public record PresignedUri(
   public static final String TYPE = "PresignedUrl";
 
   public static PresignedUri fromS3Key(UUID fileIdentifier) {
-    return PresignedUri.builder().withFileIdentifier(fileIdentifier).build();
+    return builder().withFileIdentifier(fileIdentifier).build();
   }
 
   public static Builder builder() {
@@ -42,7 +42,7 @@ public record PresignedUri(
   }
 
   public PresignedUri fromS3PresignerResponse(PresignedGetObjectRequest response) {
-    return PresignedUri.builder()
+    return builder()
         .withFileIdentifier(fileIdentifier)
         .withSignedUri(attempt(() -> response.url().toURI()).orElseThrow())
         .withExpiration(response.expiration())

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -125,7 +125,7 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
 
     if (eTagMatches(requestInfo, resource)) {
       statusCode = HttpURLConnection.HTTP_NOT_MODIFIED;
-      return FetchPublicationHandler.NO_BODY;
+      return NO_BODY;
     }
 
     return switch (resource.getStatus()) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/fetch/FetchPublicationHandler.java
@@ -194,7 +194,7 @@ public class FetchPublicationHandler extends ApiGatewayHandler<Void, String> {
 
   private boolean userWithAccessRequestsUnpublishedResource(
       Resource resource, RequestInfo requestInfo) {
-    return userCanUpdateResource(requestInfo, resource) && UNPUBLISHED.equals(resource.getStatus());
+    return userCanUpdateResource(requestInfo, resource) && UNPUBLISHED == resource.getStatus();
   }
 
   private boolean shouldRedirect(RequestInfo requestInfo) {

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/PublishingRequestResolver.java
@@ -63,7 +63,7 @@ public final class PublishingRequestResolver {
   }
 
   private static boolean isPending(TicketEntry ticketEntry) {
-    return TicketStatus.PENDING.equals(ticketEntry.getStatus());
+    return TicketStatus.PENDING == ticketEntry.getStatus();
   }
 
   private void handlePublishingRequest(Resource oldImage, Resource newImage)
@@ -232,6 +232,6 @@ public final class PublishingRequestResolver {
 
   private boolean isAlreadyPublished(Resource resource) {
     var status = resource.getStatus();
-    return PUBLISHED.equals(status) || PUBLISHED_METADATA.equals(status);
+    return PUBLISHED == status || PUBLISHED_METADATA == status;
   }
 }

--- a/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/update/UpdatePublicationHandler.java
@@ -65,7 +65,7 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
-@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class UpdatePublicationHandler
     extends ApiGatewayHandler<PublicationRequest, PublicationResponse> {
 

--- a/publication-rest/src/main/java/no/unit/nva/publication/validation/ETag.java
+++ b/publication-rest/src/main/java/no/unit/nva/publication/validation/ETag.java
@@ -41,7 +41,7 @@ public final class ETag {
     if (isBlank(value)) {
       throw new IllegalArgumentException(ETAG_MISSING_VALUE_EXCEPTION);
     }
-    return ETag.create(extractUsername(value), extractVersion(value));
+    return create(extractUsername(value), extractVersion(value));
   }
 
   @JacocoGenerated

--- a/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
+++ b/publication-rest/src/test/java/no/unit/nva/publication/update/UpdatePublicationHandlerTest.java
@@ -584,8 +584,7 @@ class UpdatePublicationHandlerTest extends ResourcesLocalTest {
                 associatedLink.description(),
                 associatedLink.relation())));
 
-    var persisted =
-        resourceService.getResourceByIdentifier(savedPublication.getIdentifier());
+    var persisted = resourceService.getResourceByIdentifier(savedPublication.getIdentifier());
     assertThat(persisted.getAssociatedArtifacts(), hasItem(associatedLink));
   }
 

--- a/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriResponse.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriResponse.java
@@ -49,7 +49,6 @@ import no.unit.nva.publication.model.business.Resource;
 import no.unit.nva.publication.model.business.TicketEntry;
 import no.unit.nva.publication.model.business.UserInstance;
 import no.unit.nva.publication.service.impl.ResourceService;
-import nva.commons.apigateway.MediaType;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 
@@ -145,7 +144,7 @@ public final class FakeUriResponse {
       FakeUriRetriever fakeUriRetriever, int statusCode, Publication publication, String response) {
     var id = PublicationResponse.fromPublication(publication).getId();
     fakeUriRetriever.registerResponse(
-        createNviCandidateUri(id.toString()), statusCode, MediaType.JSON_UTF_8, response);
+        createNviCandidateUri(id.toString()), statusCode, JSON_UTF_8, response);
   }
 
   public static URI constructCristinOrgUri(String identifier) {
@@ -160,7 +159,7 @@ public final class FakeUriResponse {
     fakeUriRetriever.registerResponse(
         toFetchCustomerByCristinIdUri(HARD_CODED_TOP_LEVEL_ORG_URI),
         SC_OK,
-        MediaType.JSON_UTF_8,
+        JSON_UTF_8,
         createCustomerApiResponse());
   }
 

--- a/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriRetriever.java
+++ b/publication-testing/src/main/java/no/unit/nva/publication/uriretriever/FakeUriRetriever.java
@@ -55,7 +55,7 @@ public final class FakeUriRetriever implements RawContentRetriever {
     return returnValue;
   }
 
-  @SuppressWarnings({"PMD.UnusedAssignment", "PMD.UnusedFormalParameter"})
+  @SuppressWarnings("PMD.UnusedFormalParameter")
   private static boolean matchesMedia(String mediaType, HttpResponse<String> response) {
     // TODO: For now, we don't match anything. We should when we design the interface properly.
 

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ApplicationConstants.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/ApplicationConstants.java
@@ -29,7 +29,7 @@ public final class ApplicationConstants {
   @JacocoGenerated
   public static S3Client defaultS3Client() {
     return S3Client.builder()
-        .region(ApplicationConstants.AWS_REGION)
+        .region(AWS_REGION)
         .httpClient(UrlConnectionHttpClient.create())
         .build();
   }
@@ -37,7 +37,7 @@ public final class ApplicationConstants {
   @JacocoGenerated
   public static EventBridgeClient defaultEventBridgeClient() {
     return EventBridgeClient.builder()
-        .region(ApplicationConstants.AWS_REGION)
+        .region(AWS_REGION)
         .httpClient(UrlConnectionHttpClient.create())
         .build();
   }

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/DcValue.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/DcValue.java
@@ -66,6 +66,6 @@ public class DcValue {
   }
 
   public boolean isAbstract() {
-    return Element.DESCRIPTION.equals(getElement()) && Qualifier.ABSTRACT.equals(getQualifier());
+    return Element.DESCRIPTION == getElement() && Qualifier.ABSTRACT == getQualifier();
   }
 }

--- a/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FileEntriesEventEmitter.java
+++ b/s3-import-commons/src/main/java/no/unit/nva/publication/s3imports/FileEntriesEventEmitter.java
@@ -163,7 +163,6 @@ public class FileEntriesEventEmitter extends EventHandler<EventReference, PutSqs
     objectNode.set(lowerCaseName, child);
   }
 
-  @SuppressWarnings("PMD.UnnecessaryCaseChange")
   private void addIfHasUpperCase(String name, List<String> fieldNames) {
     if (!name.toLowerCase(Locale.ROOT).equals(name)) {
       fieldNames.add(name);

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -234,7 +234,7 @@ public class ScopusConverter {
   }
 
   private boolean isOriginalAbstract(AbstractTp abstractTp) {
-    return YesnoAtt.Y.equals(abstractTp.getOriginal());
+    return YesnoAtt.Y == abstractTp.getOriginal();
   }
 
   private List<String> generateTags() {
@@ -297,7 +297,7 @@ public class ScopusConverter {
    */
   private Optional<TitletextTp> getCitationTextTpWhenErCitationType() {
     var citationtypeAtt = getCitationtypeAtt();
-    return citationtypeAtt.isPresent() && ER.equals(citationtypeAtt.get())
+    return citationtypeAtt.isPresent() && ER == citationtypeAtt.get()
         ? getCitationTitleTextTp()
         : Optional.empty();
   }
@@ -323,11 +323,11 @@ public class ScopusConverter {
   }
 
   private boolean isTitleOriginal(TitletextTp titletextTp) {
-    return nonNull(titletextTp) && titletextTp.getOriginal().equals(YesnoAtt.Y);
+    return nonNull(titletextTp) && titletextTp.getOriginal() == YesnoAtt.Y;
   }
 
   private boolean isTitleNonOriginal(TitletextTp titletextTp) {
-    return nonNull(titletextTp) && titletextTp.getOriginal().equals(YesnoAtt.N);
+    return nonNull(titletextTp) && titletextTp.getOriginal() == YesnoAtt.N;
   }
 
   private Set<AdditionalIdentifierBase> generateAdditionalIdentifiers() {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/ScopusConverter.java
@@ -57,7 +57,7 @@ import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class ScopusConverter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScopusConverter.class);

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/ContributorExtractor.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/ContributorExtractor.java
@@ -30,7 +30,6 @@ import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
 import nva.commons.core.StringUtils;
 
-@SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
 public class ContributorExtractor {
 
   public static final String FIRST_NAME_CRISTIN_FIELD_NAME = "FirstName";

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PiaConnection.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PiaConnection.java
@@ -169,7 +169,7 @@ public class PiaConnection {
   }
 
   private UriWrapper createUriWrapper(String hostString) {
-    return UriWrapper.fromUri(PiaConnection.HTTPS_SCHEME + hostString);
+    return UriWrapper.fromUri(HTTPS_SCHEME + hostString);
   }
 
   private HttpRequest createRequest(URI uri) {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationContextCreator.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationContextCreator.java
@@ -138,7 +138,7 @@ public class PublicationContextCreator {
         .map(CitationInfoTp::getCitationType)
         .orElse(Collections.emptyList())
         .stream()
-        .anyMatch(citationType -> CitationtypeAtt.CH.equals(citationType.getCode()));
+        .anyMatch(citationType -> CitationtypeAtt.CH == citationType.getCode());
   }
 
   private boolean isBook() {

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationContextCreator.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationContextCreator.java
@@ -36,7 +36,7 @@ import no.unit.nva.model.contexttypes.UnconfirmedPublisher;
 import no.unit.nva.model.contexttypes.UnconfirmedSeries;
 import nva.commons.core.SingletonCollector;
 
-@SuppressWarnings({"PMD.PrematureDeclaration", "PMD.UnusedLocalVariable", "PMD.GodClass"})
+@SuppressWarnings("PMD.GodClass")
 public class PublicationContextCreator {
 
   private static final String UNSUPPORTED_SOURCE_TYPE = "Unsupported source type %s, in %s";

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationDateExtractor.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/PublicationDateExtractor.java
@@ -16,7 +16,7 @@ public final class PublicationDateExtractor {
 
   public static PublicationDate extractPublicationDate(DocTp docTp) {
     return getPublicationDateFromOaAccessEffectiveDate(docTp)
-        .orElseGet(() -> PublicationDateExtractor.getPublicationDateFromDateSort(docTp));
+        .orElseGet(() -> getPublicationDateFromDateSort(docTp));
   }
 
   private static Optional<PublicationDate> getPublicationDateFromOaAccessEffectiveDate(

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/ScopusFileConverter.java
@@ -207,7 +207,7 @@ public class ScopusFileConverter {
   }
 
   private static boolean hasSameVersion(CrossrefLink crossrefLink, License license) {
-    return license.getContentVersion().equals(crossrefLink.getContentVersion());
+    return license.getContentVersion() == crossrefLink.getContentVersion();
   }
 
   private static boolean isElsevierPlainTextResource(CrossrefLink crossrefLink) {
@@ -303,9 +303,9 @@ public class ScopusFileConverter {
   }
 
   private PublisherVersion determinePublisherVersion(CrossrefLink crossrefLink) {
-    if (VOR.equals(crossrefLink.getContentVersion())) {
+    if (VOR == crossrefLink.getContentVersion()) {
       return PublisherVersion.PUBLISHED_VERSION;
-    } else if (AM.equals(crossrefLink.getContentVersion())) {
+    } else if (AM == crossrefLink.getContentVersion()) {
       return PublisherVersion.ACCEPTED_VERSION;
     } else {
       return null;

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/CrossrefResponse.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/files/model/CrossrefResponse.java
@@ -126,7 +126,7 @@ public class CrossrefResponse implements JsonSerializable {
     }
 
     public boolean hasUnspecifiedContentVersion() {
-      return ContentVersion.UNSPECIFIED.equals(contentVersion);
+      return ContentVersion.UNSPECIFIED == contentVersion;
     }
   }
 

--- a/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/model/cristin/Role.java
+++ b/scopus-import/src/main/java/no/sikt/nva/scopus/conversion/model/cristin/Role.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
-@SuppressWarnings("PMD.ShortClassName")
 @JacocoGenerated
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Role {

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/MessageDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/MessageDto.java
@@ -65,7 +65,7 @@ public class MessageDto implements JsonSerializable {
   }
 
   private static String getMessageText(Message message) {
-    return MessageStatus.ACTIVE.equals(message.getStatus()) ? message.getText() : NO_TEXT;
+    return MessageStatus.ACTIVE == message.getStatus() ? message.getText() : NO_TEXT;
   }
 
   public static URI constructMessageId(Message message) {

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDto.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDto.java
@@ -142,7 +142,7 @@ public abstract class TicketDto implements JsonSerializable {
       Collection<URI> availableInstitutions,
       TicketPermissions ticketPermissions) {
     var messageDtos = messages.stream().map(MessageDto::fromMessage).collect(Collectors.toList());
-    return TicketDto.builder()
+    return builder()
         .withCreatedDate(ticket.getCreatedDate())
         .withStatus(getTicketDtoStatus(ticket))
         .withModifiedDate(ticket.getModifiedDate())

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/TicketDtoStatus.java
@@ -24,7 +24,7 @@ public enum TicketDtoStatus {
   }
 
   public static TicketDtoStatus parse(String candidate) {
-    return Arrays.stream(TicketDtoStatus.values())
+    return Arrays.stream(values())
         .filter(enumValue -> enumValue.filterByNameOrValue(candidate))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow(fail -> handleParsingError());

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/create/TicketResolver.java
@@ -50,9 +50,8 @@ public class TicketResolver {
 
     var ticket =
         switch (ticketDto) {
-          case DoiRequestDto ignore -> DoiRequest.create(resource, userInstance);
-          case GeneralSupportRequestDto ignore ->
-              GeneralSupportRequest.create(resource, userInstance);
+          case DoiRequestDto _ -> DoiRequest.create(resource, userInstance);
+          case GeneralSupportRequestDto _ -> GeneralSupportRequest.create(resource, userInstance);
           default -> throw new BadRequestException("Not supported ticket type");
         };
     return ticket.persistNewTicket(ticketService);

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/read/GetTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/read/GetTicketHandler.java
@@ -51,7 +51,7 @@ public class GetTicketHandler extends ApiGatewayHandler<Void, TicketDto> {
     if (!ticket.getResourceIdentifier().equals(publicationIdentifier)) {
       throw new NotFoundException(TICKET_NOT_FOUND);
     }
-    if (TicketStatus.REMOVED.equals(ticket.getStatus())) {
+    if (TicketStatus.REMOVED == ticket.getStatus()) {
       throw new GoneException("Ticket has beem removed!");
     }
   }

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/update/UpdateTicketHandler.java
@@ -170,7 +170,7 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
 
   private static boolean statusHasBeenUpdated(
       TicketEntry ticket, UpdateTicketRequest ticketRequest) {
-    return nonNull(ticketRequest.status()) && !ticketRequest.status().equals(ticket.getStatus());
+    return nonNull(ticketRequest.status()) && ticketRequest.status() != ticket.getStatus();
   }
 
   private static boolean assigneeHasBeenUpdated(
@@ -290,9 +290,9 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
 
   private void markTicketForCurator(
       UpdateTicketRequest ticketRequest, TicketEntry ticket, String userName) {
-    if (ViewStatus.READ.equals(ticketRequest.viewStatus())) {
+    if (ViewStatus.READ == ticketRequest.viewStatus()) {
       ticket.markReadByUser(new User(userName)).persistUpdate(ticketService);
-    } else if (ViewStatus.UNREAD.equals(ticketRequest.viewStatus())) {
+    } else if (ViewStatus.UNREAD == ticketRequest.viewStatus()) {
       ticket.markReadByUser(new User(userName)).persistUpdate(ticketService);
     } else {
       throw new UnsupportedOperationException(UNKNOWN_VIEWED_STATUS_MESSAGE);
@@ -305,9 +305,9 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
   }
 
   private void markTicketForOwner(UpdateTicketRequest input, TicketEntry ticket) {
-    if (ViewStatus.READ.equals(input.viewStatus())) {
+    if (ViewStatus.READ == input.viewStatus()) {
       ticket.markReadByOwner().persistUpdate(ticketService);
-    } else if (ViewStatus.UNREAD.equals(input.viewStatus())) {
+    } else if (ViewStatus.UNREAD == input.viewStatus()) {
       ticket.markUnreadByOwner().persistUpdate(ticketService);
     } else {
       throw new UnsupportedOperationException(UNKNOWN_VIEWED_STATUS_MESSAGE);
@@ -316,9 +316,9 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
 
   private void markTicketForAssignee(UpdateTicketRequest input, TicketEntry ticket) {
 
-    if (ViewStatus.READ.equals(input.viewStatus())) {
+    if (ViewStatus.READ == input.viewStatus()) {
       ticket.markReadForAssignee().persistUpdate(ticketService);
-    } else if (ViewStatus.UNREAD.equals(input.viewStatus())) {
+    } else if (ViewStatus.UNREAD == input.viewStatus()) {
       ticket.markUnReadForAssignee().persistUpdate(ticketService);
     } else {
       throw new UnsupportedOperationException(UNKNOWN_VIEWED_STATUS_MESSAGE);
@@ -343,7 +343,7 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
   }
 
   private boolean incomingUpdateIsStatus(TicketEntry ticket, UpdateTicketRequest ticketRequest) {
-    return nonNull(ticketRequest.status()) && !ticket.getStatus().equals(ticketRequest.status());
+    return nonNull(ticketRequest.status()) && ticket.getStatus() != ticketRequest.status();
   }
 
   private boolean hasEffectiveChanges(TicketEntry ticket, UpdateTicketRequest ticketRequest) {
@@ -361,10 +361,10 @@ public class UpdateTicketHandler extends TicketHandler<TicketRequest, Void> {
     var status = input.status();
     var publication = getResource(requestUtils.publicationIdentifier()).toPublication();
     var requestingCustomer = requestUtils.customerId();
-    if (TicketStatus.COMPLETED.equals(status)) {
+    if (TicketStatus.COMPLETED == status) {
       findableDoiTicketSideEffects(requestingCustomer, publication);
     }
-    if (CLOSED.equals(status) && hasDoi(publication)) {
+    if (CLOSED == status && hasDoi(publication)) {
       deleteDoiTicketSideEffects(requestingCustomer, publication);
     }
   }

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/update/ViewStatus.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/update/ViewStatus.java
@@ -17,7 +17,7 @@ public enum ViewStatus {
 
   @JsonCreator
   public static ViewStatus parse(String candidate) {
-    return Arrays.stream(ViewStatus.values())
+    return Arrays.stream(values())
         .filter(value -> value.toString().equalsIgnoreCase(candidate))
         .collect(SingletonCollector.tryCollect())
         .orElseThrow();

--- a/tickets/src/main/java/no/unit/nva/publication/ticket/utils/TicketDtoStatusMapper.java
+++ b/tickets/src/main/java/no/unit/nva/publication/ticket/utils/TicketDtoStatusMapper.java
@@ -22,6 +22,6 @@ public final class TicketDtoStatusMapper {
   }
 
   private static boolean isPending(TicketEntry ticketEntry) {
-    return TicketStatus.PENDING.equals(ticketEntry.getStatus());
+    return TicketStatus.PENDING == ticketEntry.getStatus();
   }
 }


### PR DESCRIPTION
Automated refactoring to fix trivial linter issues, so that we can re-enable the relevant PMD rules globally. Changes are split into one commit per PMD rule.


Changes:

- [fix: Remove PMD exclusion UnnecessaryWarningSuppression](https://github.com/BIBSYSDEV/nva-publication-api/pull/2542/commits/89727046bff2c3d73fefa33f86dab3e28575df52)
- [fix: Remove PMD exclusion EnumComparison](https://github.com/BIBSYSDEV/nva-publication-api/pull/2542/commits/3074f08c4fe64b4f9c03f262f496266072b703c6)
- [fix: Remove PMD exclusion UnusedLocalVariable](https://github.com/BIBSYSDEV/nva-publication-api/pull/2542/commits/2a833d2c550f1de654de394e91238644d0afc015)
- [fix: Remove PMD exclusion UnusedLocalVariable](https://github.com/BIBSYSDEV/nva-publication-api/pull/2542/commits/600f1d758e79cbc8a0da1042c6f91902d46cf2fe)
- [fix: Remove PMD exclusion UnnecessaryFullyQualifiedName](https://github.com/BIBSYSDEV/nva-publication-api/pull/2542/commits/51594066f023467d6ea42920cbd41585a88b6db5)
