### PR TITLE
fix: Preserve scan start marker in batch job continuation events

### DIFF
--- a/publication-commons/src/main/java/no/unit/nva/publication/model/ScanResultWrapper.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/model/ScanResultWrapper.java
@@ -7,4 +7,5 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 public record ScanResultWrapper(
     Collection<Map<String, AttributeValue>> items,
     Map<String, AttributeValue> nextKey,
-    boolean isTruncated) {}
+    boolean isTruncated,
+    int scannedCount) {}

--- a/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
+++ b/publication-commons/src/main/java/no/unit/nva/publication/service/impl/ResourceService.java
@@ -355,7 +355,8 @@ public class ResourceService extends ServiceWithTransactions {
             pageSize, startMarker, types, segment, totalSegments);
     var scanResult = getClient().scan(scanRequest);
     var isTruncated = thereAreMorePagesToScan(scanResult);
-    return new ScanResultWrapper(scanResult.items(), scanResult.lastEvaluatedKey(), isTruncated);
+    return new ScanResultWrapper(
+        scanResult.items(), scanResult.lastEvaluatedKey(), isTruncated, scanResult.scannedCount());
   }
 
   public void refreshResources(List<Entity> dataEntries) {

--- a/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
+++ b/publication-commons/src/test/java/no/unit/nva/publication/service/impl/ResourceServiceTest.java
@@ -1869,6 +1869,7 @@ class ResourceServiceTest extends ResourcesLocalTest {
     assertFalse(result.items().isEmpty());
     assertTrue(
         result.items().stream().allMatch(item -> item.containsKey(PRIMARY_KEY_PARTITION_KEY_NAME)));
+    assertTrue(result.scannedCount() >= result.items().size());
   }
 
   @Test

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbRequest.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbRequest.java
@@ -1,6 +1,8 @@
 package no.unit.nva.publication.events.handlers.batch.dynamodb;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toMap;
 
 import java.time.Instant;
 import java.util.List;
@@ -12,20 +14,58 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
 public record LoadDynamodbRequest(
     String jobType,
-    Map<String, AttributeValue> startMarker,
+    Map<String, String> startMarker,
     List<KeyField> types,
     Integer segment,
     Integer totalSegments,
-    BatchFilter filter)
+    BatchFilter filter,
+    Integer itemsProcessed)
     implements JsonSerializable {
+
+  public LoadDynamodbRequest(
+      String jobType,
+      Map<String, String> startMarker,
+      List<KeyField> types,
+      Integer segment,
+      Integer totalSegments,
+      BatchFilter filter) {
+    this(jobType, startMarker, types, segment, totalSegments, filter, null);
+  }
 
   public boolean isSegmentedScan() {
     return nonNull(segment) && nonNull(totalSegments);
   }
 
-  public LoadDynamodbRequest withStartMarker(Map<String, AttributeValue> newStartMarker) {
+  public int currentItemsProcessed() {
+    return isNull(itemsProcessed) ? 0 : itemsProcessed;
+  }
+
+  public Map<String, AttributeValue> toDynamodbStartMarker() {
+    Map<String, AttributeValue> dynamodbStartMarker = null;
+    if (nonNull(startMarker)) {
+      dynamodbStartMarker =
+          startMarker.entrySet().stream()
+              .collect(
+                  toMap(
+                      Map.Entry::getKey,
+                      entry -> AttributeValue.builder().s(entry.getValue()).build()));
+    }
+    return dynamodbStartMarker;
+  }
+
+  public LoadDynamodbRequest nextPageRequest(
+      Map<String, AttributeValue> lastEvaluatedKey, int scannedItemCount) {
+    var jsonSafeStartMarker =
+        lastEvaluatedKey.entrySet().stream()
+            .collect(toMap(Map.Entry::getKey, entry -> entry.getValue().s()));
     return new LoadDynamodbRequest(
-        this.jobType, newStartMarker, this.types, this.segment, this.totalSegments, this.filter);
+        jobType,
+        jsonSafeStartMarker,
+        types,
+        segment,
+        totalSegments,
+        filter,
+        currentItemsProcessed() + scannedItemCount);
   }
 
   public PutEventsRequestEntry createNewEventEntry(

--- a/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbResourceBatchJobHandler.java
+++ b/publication-event-handlers/src/main/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbResourceBatchJobHandler.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.publication.model.ScanResultWrapper;
 import no.unit.nva.publication.service.impl.ResourceService;
 import nva.commons.core.CollectionUtils;
 import nva.commons.core.Environment;
@@ -41,6 +42,7 @@ public class LoadDynamodbResourceBatchJobHandler
   private static final String TOTAL_SEGMENTS_ENV = "TOTAL_SEGMENTS";
   public static final String DETAIL_TYPE =
       "PublicationService.DataEntry.LoadDynamodbResourceBatchJob";
+  public static final int MAX_SCANNED_ITEMS_PER_SEGMENT = 10_000_000;
 
   private final SqsClient sqsClient;
   private final EventBridgeClient eventBridgeClient;
@@ -145,7 +147,7 @@ public class LoadDynamodbResourceBatchJobHandler
     var scan =
         resourceService.scanResourcesRaw(
             scanPageSize,
-            input.startMarker(),
+            input.toDynamodbStartMarker(),
             input.types(),
             input.segment(),
             input.totalSegments());
@@ -162,8 +164,19 @@ public class LoadDynamodbResourceBatchJobHandler
         workItems.size(),
         messagesQueued);
 
-    if (scan.isTruncated()) {
-      sendEventForNextBatch(input, scan.nextKey(), context);
+    var totalItemsScanned = input.currentItemsProcessed() + scan.scannedCount();
+    if (scan.isTruncated() && totalItemsScanned >= MAX_SCANNED_ITEMS_PER_SEGMENT) {
+      logger.error(
+          "Segment {} of {} for job type {} has scanned {} items, reaching the maximum of {}."
+              + " Stopping the continuation chain to prevent an infinite loop;"
+              + " remaining items in this segment will not be processed.",
+          input.segment(),
+          input.totalSegments(),
+          input.jobType(),
+          totalItemsScanned,
+          MAX_SCANNED_ITEMS_PER_SEGMENT);
+    } else if (scan.isTruncated()) {
+      sendEventForNextBatch(input, scan, context);
     } else {
       logger.info(
           "Completed segment {} of {} for job type: {}",
@@ -258,8 +271,8 @@ public class LoadDynamodbResourceBatchJobHandler
   }
 
   private void sendEventForNextBatch(
-      LoadDynamodbRequest input, Map<String, AttributeValue> lastEvaluatedKey, Context context) {
-    var nextRequest = input.withStartMarker(lastEvaluatedKey);
+      LoadDynamodbRequest input, ScanResultWrapper scan, Context context) {
+    var nextRequest = input.nextPageRequest(scan.nextKey(), scan.scannedCount());
 
     var nextEvent =
         nextRequest.createNewEventEntry(

--- a/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbResourceBatchJobHandlerTest.java
+++ b/publication-event-handlers/src/test/java/no/unit/nva/publication/events/handlers/batch/dynamodb/LoadDynamodbResourceBatchJobHandlerTest.java
@@ -6,10 +6,14 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -24,7 +28,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
@@ -38,6 +44,7 @@ import no.unit.nva.publication.model.storage.KeyField;
 import no.unit.nva.publication.service.ResourcesLocalTest;
 import no.unit.nva.publication.service.impl.ResourceService;
 import no.unit.nva.stubs.FakeEventBridgeClient;
+import nva.commons.logutils.LogRecorder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,6 +66,8 @@ class LoadDynamodbResourceBatchJobHandlerTest extends ResourcesLocalTest {
   private static final String PROCESSING_DISABLED = "false";
   private static final int SQS_BATCH_SIZE = 10;
   private static final int SCAN_PAGE_SIZE = 1000;
+  private static final int SMALL_SCAN_PAGE_SIZE = 10;
+  private static final int MAX_EXPECTED_CONTINUATION_EVENTS = 50;
   private static final int TOTAL_SEGMENTS = 2;
   private static final int SEGMENT = 0;
   private static final int ONE_TOTAL_SEGMENTS = 1;
@@ -129,7 +138,7 @@ class LoadDynamodbResourceBatchJobHandlerTest extends ResourcesLocalTest {
   }
 
   @Test
-  void shouldTriggerNextBatchWhenMoreItemsExist() {
+  void shouldTriggerNextBatchWithIntactStartMarkerWhenMoreItemsExist() {
     when(context.getInvokedFunctionArn()).thenReturn(TEST_FUNCTION_ARN);
     var request = getRequest();
 
@@ -139,23 +148,83 @@ class LoadDynamodbResourceBatchJobHandlerTest extends ResourcesLocalTest {
         .when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
         .thenAnswer(this::createSendMessageBatchResponse);
 
-    var smallScanPAge = 10;
-
-    handler =
-        new LoadDynamodbResourceBatchJobHandler(
-            sqsClient,
-            eventBridgeClient,
-            TEST_QUEUE_URL,
-            PROCESSING_ENABLED,
-            resourceService,
-            new BatchFilterService(),
-            smallScanPAge,
-            SQS_BATCH_SIZE,
-            TOTAL_SEGMENTS);
+    handler = createHandlerWithScanPageSize(SMALL_SCAN_PAGE_SIZE);
 
     handler.processInput(request, event, context);
 
     assertThat(eventBridgeClient.getRequestEntries().size(), is(greaterThanOrEqualTo(1)));
+
+    var continuationRequest =
+        parseRequest(eventBridgeClient.getRequestEntries().getFirst().detail());
+    assertThat(continuationRequest.startMarker(), is(notNullValue()));
+    assertThat(continuationRequest.startMarker().isEmpty(), is(false));
+    assertThat(continuationRequest.itemsProcessed(), is(equalTo(SMALL_SCAN_PAGE_SIZE)));
+  }
+
+  @Test
+  void shouldPreserveStartMarkerWhenContinuationEventIsSerialized() {
+    var startMarker =
+        Map.of(
+            "PK0", randomString(),
+            "SK0", randomString(),
+            "PK2", randomString(),
+            "SK2", randomString());
+    var request =
+        new LoadDynamodbRequest(
+            TEST_JOB_TYPE,
+            startMarker,
+            List.of(KeyField.RESOURCE),
+            SEGMENT,
+            ONE_TOTAL_SEGMENTS,
+            null);
+
+    var eventEntry = request.createNewEventEntry("eventBusName", "detailType", TEST_FUNCTION_ARN);
+    var deserializedRequest = parseRequest(eventEntry.detail());
+
+    assertThat(deserializedRequest.startMarker(), is(equalTo(startMarker)));
+  }
+
+  @Test
+  void shouldProcessEveryItemExactlyOnceWhenReplayingContinuationEventsUntilCompletion() {
+    when(context.getInvokedFunctionArn()).thenReturn(TEST_FUNCTION_ARN);
+    var itemCount = 25;
+    createTestItems(itemCount);
+
+    lenient()
+        .when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
+        .thenAnswer(this::createSendMessageBatchResponse);
+
+    var smallPageHandler = createHandlerWithScanPageSize(SMALL_SCAN_PAGE_SIZE);
+
+    var itemsProcessed = runToCompletion(smallPageHandler, getRequest());
+
+    assertThat(itemsProcessed, is(equalTo(itemCount)));
+  }
+
+  @Test
+  void shouldStopContinuationChainLoudlyWhenMaxScannedItemsReached() {
+    var logRecorder = LogRecorder.forClass(LoadDynamodbResourceBatchJobHandler.class);
+    createTestItems(21);
+
+    lenient()
+        .when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
+        .thenAnswer(this::createSendMessageBatchResponse);
+
+    var smallPageHandler = createHandlerWithScanPageSize(SMALL_SCAN_PAGE_SIZE);
+    var request =
+        new LoadDynamodbRequest(
+            TEST_JOB_TYPE,
+            null,
+            List.of(KeyField.RESOURCE),
+            SEGMENT,
+            ONE_TOTAL_SEGMENTS,
+            null,
+            LoadDynamodbResourceBatchJobHandler.MAX_SCANNED_ITEMS_PER_SEGMENT);
+
+    smallPageHandler.processInput(request, event, context);
+
+    assertThat(eventBridgeClient.getRequestEntries(), is(empty()));
+    assertThat(logRecorder.messages(), hasItem(containsString("maximum")));
   }
 
   @Test
@@ -503,6 +572,46 @@ class LoadDynamodbResourceBatchJobHandlerTest extends ResourcesLocalTest {
   private static LoadDynamodbRequest getRequest() {
     return new LoadDynamodbRequest(
         TEST_JOB_TYPE, null, List.of(KeyField.RESOURCE), SEGMENT, ONE_TOTAL_SEGMENTS, null);
+  }
+
+  private LoadDynamodbResourceBatchJobHandler createHandlerWithScanPageSize(int pageSize) {
+    return new LoadDynamodbResourceBatchJobHandler(
+        sqsClient,
+        eventBridgeClient,
+        TEST_QUEUE_URL,
+        PROCESSING_ENABLED,
+        resourceService,
+        new BatchFilterService(),
+        pageSize,
+        SQS_BATCH_SIZE,
+        TOTAL_SEGMENTS);
+  }
+
+  private static LoadDynamodbRequest parseRequest(String detail) {
+    return attempt(() -> JsonUtils.dtoObjectMapper.readValue(detail, LoadDynamodbRequest.class))
+        .orElseThrow();
+  }
+
+  private int runToCompletion(
+      LoadDynamodbResourceBatchJobHandler handlerUnderTest, LoadDynamodbRequest initialRequest) {
+    var itemsProcessed =
+        handlerUnderTest.processInput(initialRequest, event, context).itemsProcessed();
+    var replayedEvents = 0;
+    while (!eventBridgeClient.getRequestEntries().isEmpty()) {
+      var pendingEvents = new ArrayList<>(eventBridgeClient.getRequestEntries());
+      eventBridgeClient.getRequestEntries().clear();
+      replayedEvents += pendingEvents.size();
+      assertThat(
+          "Continuation events keep repeating, indicating the start marker is lost in transit",
+          replayedEvents,
+          is(lessThan(MAX_EXPECTED_CONTINUATION_EVENTS)));
+      for (var pendingEvent : pendingEvents) {
+        var continuationRequest = parseRequest(pendingEvent.detail());
+        itemsProcessed +=
+            handlerUnderTest.processInput(continuationRequest, event, context).itemsProcessed();
+      }
+    }
+    return itemsProcessed;
   }
 
   private SendMessageBatchResponse createSendMessageBatchResponse(InvocationOnMock invocation) {

--- a/template.yaml
+++ b/template.yaml
@@ -3146,6 +3146,32 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${LoadDynamodbResourceBatchJobHandler}
       RetentionInDays: 14
 
+  LoadDynamodbResourceBatchJobErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref LoadDynamodbResourceBatchJobLambdaLogGroup
+      FilterPattern: ERROR
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: PublicationApi/BatchJob
+          MetricName: LoadDynamodbResourceBatchJobErrors
+
+  LoadDynamodbResourceBatchJobErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: LoadDynamodbResourceBatchJobErrorAlarm in publication-api
+      AlarmDescription: If this alarm is triggered, a batch job logged an error, such as failed SQS sends or a segment stopped at the max scanned items safety limit; check LoadDynamodbResourceBatchJobHandler logs in publication-api (NP-51512)
+      MetricName: LoadDynamodbResourceBatchJobErrors
+      Namespace: PublicationApi/BatchJob
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref SlackSnsArn
+
   #============================Text extraction==========================================================
 
   TextExtractionQueue:


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51512

The `startMarker` in `LoadDynamodbRequest` was a `Map<String, AttributeValue>`, which Jackson cannot serialize. The `NON_EMPTY` mapper behind `JsonSerializable` silently dropped the property, so every continuation event arrived with a null marker and each segment rescanned its first page forever, queueing duplicate work messages indefinitely.

The marker is now a JSON-safe `Map<String, String>`, converted to and from `AttributeValue` at the DynamoDB boundary. Continuation events also carry an iteration counter, and the handler stops the chain with an error log once a segment exceeds 10 million scanned items, so a similar serialization bug can no longer loop unbounded.

New tests cover the JSON round trip through the production mapper and replay continuation events through the handler until the scan completes.